### PR TITLE
FIX: New template library support (specifically Ubuntu 24.04)

### DIFF
--- a/libraries/chain/include/sysio/chain/wast_to_wasm.hpp
+++ b/libraries/chain/include/sysio/chain/wast_to_wasm.hpp
@@ -1,6 +1,8 @@
 #pragma once
-#include <vector>
+
+#include <cstdint>
 #include <string>
+#include <vector>
 
 namespace sysio { namespace chain {
 

--- a/programs/clio/main.cpp
+++ b/programs/clio/main.cpp
@@ -3149,9 +3149,9 @@ int main( int argc, char** argv ) {
         fc::path cpath = fc::canonical(fc::path(contractPath));
 
         if( wasmPath.empty() ) {
-           wasmPath = (cpath / (cpath.filename().generic_string()+".wasm")).generic_string();
+           wasmPath = (cpath / fc::path(cpath.filename().generic_string()+".wasm")).generic_string();
         } else if ( boost::filesystem::path(wasmPath).is_relative() ) {
-           wasmPath = (cpath / wasmPath).generic_string();
+           wasmPath = (cpath / fc::path(wasmPath)).generic_string();
         }
 
         std::cerr << localized(("Reading WASM from " + wasmPath + "...").c_str()) << std::endl;
@@ -3203,9 +3203,9 @@ int main( int argc, char** argv ) {
         fc::path cpath = fc::canonical(fc::path(contractPath));
 
         if( abiPath.empty() ) {
-           abiPath = (cpath / (cpath.filename().generic_string()+".abi")).generic_string();
+           abiPath = (cpath / fc::path(cpath.filename().generic_string()+".abi")).generic_string();
         } else if ( boost::filesystem::path(abiPath).is_relative() ) {
-           abiPath = (cpath / abiPath).generic_string();
+           abiPath = (cpath / fc::path(abiPath)).generic_string();
         }
 
         SYS_ASSERT( fc::exists( abiPath ), abi_file_not_found, "no abi file found ${f}", ("f", abiPath)  );


### PR DESCRIPTION
Fixed issues related to building with slightly newer template libraries

- including <cstdint> in `wast_to_wasm.cpp`
- forcing template inference to `path` instead of string in `clio`