### PR TITLE
Wcore 59 packed digest changes

### DIFF
--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -228,15 +228,6 @@ namespace sysio { namespace chain {
          );
       }
 
-      // Add s_root_extension to header extensions if present & relevant
-      if (s_header) {
-         emplace_extension(
-            h.header_extensions,
-            s_root_extension::extension_id(),
-            fc::raw::pack( s_root_extension ( *s_header ))
-         );
-      }
-
       return h;
    }
 

--- a/libraries/chain/include/sysio/chain/block.hpp
+++ b/libraries/chain/include/sysio/chain/block.hpp
@@ -38,8 +38,8 @@ namespace sysio { namespace chain {
 
       std::variant<transaction_id_type, packed_transaction> trx;
    private:
-      enum packing_type { uncompressed, compressed};
-      digest_type get_digest(packing_type packing)const {
+      enum trx_digest_type { uncompressed_digest, compressed_digest};
+      digest_type get_digest(trx_digest_type packing)const {
          digest_type::encoder enc;
          fc::raw::pack( enc, status );
          fc::raw::pack( enc, cpu_usage_us );
@@ -47,7 +47,7 @@ namespace sysio { namespace chain {
          if( std::holds_alternative<transaction_id_type>(trx) )
             fc::raw::pack( enc, std::get<transaction_id_type>(trx) );
          else {
-            if (packing == packing_type::compressed)
+            if (packing == trx_digest_type::compressed_digest)
                fc::raw::pack( enc, std::get<packed_transaction>(trx).packed_digest() );
             else
                fc::raw::pack( enc, std::get<packed_transaction>(trx).digest() );
@@ -56,11 +56,11 @@ namespace sysio { namespace chain {
       }
    public:
       digest_type digest()const {
-         return get_digest(packing_type::uncompressed);
+         return get_digest(trx_digest_type::uncompressed_digest);
       }
 
       digest_type packed_digest()const {
-         return get_digest(packing_type::compressed);
+         return get_digest(trx_digest_type::compressed_digest);
       }
    };
 

--- a/libraries/chain/include/sysio/chain/protocol_feature_manager.hpp
+++ b/libraries/chain/include/sysio/chain/protocol_feature_manager.hpp
@@ -39,6 +39,7 @@ enum class builtin_protocol_feature_t : uint32_t {
    bls_primitives = 22,
    disable_deferred_trxs_stage_1 = 23,
    disable_deferred_trxs_stage_2 = 24,
+   disable_compression_in_transaction_merkle = 25,
    reserved_private_fork_protocol_features = 500000,
 };
 

--- a/libraries/chain/include/sysio/chain/transaction.hpp
+++ b/libraries/chain/include/sysio/chain/transaction.hpp
@@ -169,6 +169,7 @@ namespace sysio { namespace chain {
       size_t get_estimated_size()const;
 
       digest_type packed_digest()const;
+      digest_type digest()const;
 
       const transaction_id_type& id()const { return trx_id; }
       bytes               get_raw_transaction()const;

--- a/libraries/chain/protocol_feature_manager.cpp
+++ b/libraries/chain/protocol_feature_manager.cpp
@@ -319,6 +319,20 @@ retires a deferred transaction is invalid.
 */
             {builtin_protocol_feature_t::disable_deferred_trxs_stage_1}
          } )
+         (  builtin_protocol_feature_t::disable_compression_in_transaction_merkle, builtin_protocol_feature_spec{
+            "DISABLE_COMPRESSION_IN_TRANSACTION_MERKLE",
+            fc::variant("d73c676578a75fcf8cddf8a6646cb7f9960db50167804809669b19783a96f586").as<digest_type>(),
+            // SHA256 hash of the raw message below within the comment delimiters (do not modify message below).
+/*
+Builtin protocol feature: DISABLE_COMPRESSION_IN_TRANSACTION_MERKLE
+Depends on: DISABLE_DEFERRED_TRXS_STAGE_2
+
+Once this is turned on, the transaction_mroot will no longer be computed using
+the compressed transaction. It will instead include the transaction via its id,
+which is derived by its own digest.
+*/
+            {builtin_protocol_feature_t::disable_deferred_trxs_stage_2}
+         } )
    ;
 
 

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -161,6 +161,19 @@ size_t packed_transaction::get_estimated_size()const {
 
 
 digest_type packed_transaction::packed_digest()const {
+   digest_type::encoder prunable;
+   fc::raw::pack( prunable, signatures );
+   fc::raw::pack( prunable, packed_context_free_data );
+
+   digest_type::encoder enc;
+   fc::raw::pack( enc, compression );
+   fc::raw::pack( enc, packed_trx  );
+   fc::raw::pack( enc, prunable.result() );
+
+   return enc.result();
+}
+
+digest_type packed_transaction::digest()const {
    digest_type::encoder enc;
    fc::raw::pack( enc, signatures );
    fc::raw::pack( enc, packed_context_free_data );

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -161,14 +161,11 @@ size_t packed_transaction::get_estimated_size()const {
 
 
 digest_type packed_transaction::packed_digest()const {
-   digest_type::encoder prunable;
-   fc::raw::pack( prunable, signatures );
-   fc::raw::pack( prunable, packed_context_free_data );
-
    digest_type::encoder enc;
+   fc::raw::pack( enc, signatures );
+   fc::raw::pack( enc, packed_context_free_data );
    fc::raw::pack( enc, compression );
-   fc::raw::pack( enc, packed_trx  );
-   fc::raw::pack( enc, prunable.result() );
+   fc::raw::pack( enc, trx_id  );   // all of transaction is represented by trx id/digest
 
    return enc.result();
 }

--- a/libraries/testing/include/sysio/testing/tester.hpp
+++ b/libraries/testing/include/sysio/testing/tester.hpp
@@ -442,6 +442,7 @@ namespace sysio { namespace testing {
 
          void             _start_block(fc::time_point block_time);
          signed_block_ptr _finish_block();
+         virtual bool     shouldAllowBlockProtocolChanges() const { return true; }
 
       // Fields:
       protected:
@@ -673,6 +674,8 @@ namespace sysio { namespace testing {
 
         return ok;
       }
+
+      bool     shouldAllowBlockProtocolChanges() const override { return false; }
 
       unique_ptr<controller>   validating_node;
       uint32_t                 num_blocks_to_producer_before_shutdown = 0;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1291,6 +1291,9 @@ namespace sysio { namespace testing {
    std::vector<builtin_protocol_feature_t> base_tester::get_all_builtin_protocol_features() {
       std::vector<builtin_protocol_feature_t> builtins;
       for( const auto& f : builtin_protocol_feature_codenames ) {
+         if ( f.first ==  builtin_protocol_feature_t::disable_compression_in_transaction_merkle && !shouldAllowBlockProtocolChanges() ) {
+            continue;
+         }
          builtins.push_back( f.first );
       }
 
@@ -1315,6 +1318,9 @@ namespace sysio { namespace testing {
          // maintained. Excluding DISABLE_DEFERRED_TRXS_STAGE_1 and DISABLE_DEFERRED_TRXS_STAGE_2
          // from full protocol feature list such that existing tests can run.
          if( f ==  builtin_protocol_feature_t::disable_deferred_trxs_stage_1 || f  == builtin_protocol_feature_t::disable_deferred_trxs_stage_2 ) {
+            continue;
+         }
+         else if ( f ==  builtin_protocol_feature_t::disable_compression_in_transaction_merkle && !shouldAllowBlockProtocolChanges() ) {
             continue;
          }
 

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -244,7 +244,7 @@ class Cluster(object):
             time.sleep(2)
         loggingLevelDictString = json.dumps(self.loggingLevelDict, separators=(',', ':'))
         args=(f'-p {pnodes} -n {totalNodes} -d {delay} '
-              f'-i {datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]} -f {producerFlag} '
+              f'-i {datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]} -f {producerFlag} '
               f'--unstarted-nodes {unstartedNodes} --logging-level {self.loggingLevel} '
               f'--logging-level-map {loggingLevelDictString}')
         argsArr=args.split()

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -363,6 +363,8 @@ def stepSetSystemContract():
     # DISABLE_DEFERRED_TRXS_STAGE_2 - PREVENT PREVIOUSLY SCHEDULED DEFERRED TRANSACTIONS FROM REACHING OTHER NODE
     # THIS DEPENDS ON DISABLE_DEFERRED_TRXS_STAGE_1
     retry(args.clio + 'push action sysio activate \'["09e86cb0accf8d81c9e85d34bea4b925ae936626d00c984e4691186891f5bc16"]\' -p sysio@active')
+    # DISABLE_COMPRESSION_IN_TRANSACTION_MERKLE
+    retry(args.clio + 'push action sysio activate \'["d73c676578a75fcf8cddf8a6646cb7f9960db50167804809669b19783a96f586"]\' -p sysio@active')
     sleep(1)
 
     # install sysio.system latest version

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -114,7 +114,7 @@ std::pair<signed_block_ptr, signed_block_ptr> corrupt_trx_in_block(validating_te
    deque<digest_type> trx_digests;
    const auto& trxs = copy_b->transactions;
    for( const auto& a : trxs )
-      trx_digests.emplace_back( a.digest() );
+      trx_digests.emplace_back( a.packed_digest() ); // validating_tester is not allowing the conversion from packed_digest to digest
    copy_b->transaction_mroot = merkle( std::move(trx_digests) );
 
    // Re-sign the block


### PR DESCRIPTION
<NOTE: Don't review till leap5 merge is complete>

Changing the transaction merkle calculation to use the already calculated transaction digest (i.e. id) instead of the packed transaction to represent the transaction data's contribution to the hash to prevent needing compression to validate it.

Part of what this review needs is to verify that the new algorithm contains the same inputs to the old algorithm, just in a different algorithm.