### PR TITLE
Stop using `datetime.utcnow()`

### DIFF
--- a/tests/PerformanceHarness/performance_test_basic.py
+++ b/tests/PerformanceHarness/performance_test_basic.py
@@ -22,6 +22,12 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from platform import release, system
 
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+    UTC = timezone.utc
+
 class PerformanceTestBasic:
     @dataclass
     class PtbTpsTestResult:
@@ -186,7 +192,7 @@ class PerformanceTestBasic:
     @dataclass
     class LoggingConfig:
         logDirBase: Path = Path(".")/PurePath(PurePath(__file__).name).stem
-        logDirTimestamp: str = f"{datetime.utcnow().strftime('%Y-%m-%d_%H-%M-%S')}"
+        logDirTimestamp: str = f"{datetime.now(UTC).strftime('%Y-%m-%d_%H-%M-%S')}"
         logDirTimestampedOptSuffix: str = ""
         logDirPath: Path = field(default_factory=Path, init=False)
 
@@ -208,7 +214,7 @@ class PerformanceTestBasic:
         self.errorExit = Utils.errorExit
         self.emptyBlockGoal = 1
 
-        self.testStart = datetime.utcnow()
+        self.testStart = datetime.now(UTC)
         self.testEnd = self.testStart
         self.testNamePath = testNamePath
         self.loggingConfig = PerformanceTestBasic.LoggingConfig(logDirBase=Path(self.ptbConfig.logDirRoot)/f"{self.testNamePath}Logs",
@@ -566,7 +572,7 @@ class PerformanceTestBasic:
                                                  numBlocksToPrune=self.ptbConfig.numAddlBlocksToPrune, numTrxGensUsed=testResult.numGeneratorsUsed, targetTpsPerGenList=testResult.targetTpsPerGenList,
                                                  quiet=self.ptbConfig.quiet, printMissingTransactions=self.ptbConfig.printMissingTransactions)
         self.logAnalysis = analyzeLogResults(data=self.data, tpsTestConfig=tpsTestConfig, artifacts=artifactsLocate)
-        self.testEnd = datetime.utcnow()
+        self.testEnd = datetime.now(UTC)
 
         self.testResult = PerformanceTestBasic.PerfTestBasicResult(targetTPS=self.ptbConfig.targetTps, resultAvgTps=self.logAnalysis.tpsStats.avg, expectedTxns=self.ptbConfig.expectedTransactionsSent,
                                                                    resultTxns=self.logAnalysis.trxLatencyStats.samples, testRunCompleted=self.ptbTpsTestResult.completedRun,

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -8,12 +8,18 @@ import os
 import re
 import string
 import signal
-import datetime
+from datetime import datetime
 import sys
 import random
 import json
 import socket
 from pathlib import Path
+
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+    UTC = timezone.utc
 
 from .core_symbol import CORE_SYMBOL
 from .accounts import Account, createAccountKeys
@@ -244,7 +250,7 @@ class Cluster(object):
             time.sleep(2)
         loggingLevelDictString = json.dumps(self.loggingLevelDict, separators=(',', ':'))
         args=(f'-p {pnodes} -n {totalNodes} -d {delay} '
-              f'-i {datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]} -f {producerFlag} '
+              f'-i {datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]} -f {producerFlag} '
               f'--unstarted-nodes {unstartedNodes} --logging-level {self.loggingLevel} '
               f'--logging-level-map {loggingLevelDictString}')
         argsArr=args.split()

--- a/tests/TestHarness/TestHelper.py
+++ b/tests/TestHarness/TestHelper.py
@@ -4,6 +4,12 @@ from .WalletMgr import WalletMgr
 from datetime import datetime
 import platform
 
+try:
+    from datetime import UTC
+except ImportError:
+    from datetime import timezone
+    UTC=timezone.utc
+
 import argparse
 
 class AppArgs:
@@ -141,7 +147,7 @@ class TestHelper(object):
         if prefix:
             Utils.Print(str(prefix))
         clientVersion=Cluster.getClientVersion()
-        Utils.Print("UTC time: %s" % str(datetime.utcnow()))
+        Utils.Print("UTC time: %s" % str(datetime.now(UTC)))
         Utils.Print("SYS Client version: %s" % (clientVersion))
         Utils.Print("Processor: %s" % (platform.processor()))
         Utils.Print("OS name: %s" % (platform.platform()))


### PR DESCRIPTION
Use `datetime.now(UTC)` instead of `datetime.utcnow()`  (deprecated on 3.12) 
In 3.12, we can directly import `datetime.UTC`, but in 3.10 we have to use `datetime.timezone.utc`