### PR TITLE
Wcore 75 open block state log

### DIFF
--- a/libraries/chain/include/sysio/chain/block_log.hpp
+++ b/libraries/chain/include/sysio/chain/block_log.hpp
@@ -95,8 +95,6 @@ namespace sysio { namespace chain {
 
          static bool contains_chain_id(uint32_t version, uint32_t first_block_num);
 
-         static bool is_supported_version(uint32_t version);
-
          static bool is_pruned_log(const std::filesystem::path& data_dir);
 
          static void extract_block_range(const std::filesystem::path& block_dir, const std::filesystem::path&output_dir, block_num_type start, block_num_type end);

--- a/libraries/chain/include/sysio/chain/block_log.hpp
+++ b/libraries/chain/include/sysio/chain/block_log.hpp
@@ -104,7 +104,7 @@ namespace sysio { namespace chain {
 
          // used for unit test to generate older version blocklog
          static void set_initial_version(uint32_t);
-         uint32_t    version() const;
+         std::optional<uint32_t> version() const;
          uint64_t get_block_pos(uint32_t block_num) const;
 
          /**

--- a/libraries/chain/include/sysio/chain/log_catalog.hpp
+++ b/libraries/chain/include/sysio/chain/log_catalog.hpp
@@ -91,8 +91,7 @@ struct log_catalog {
          auto path_without_extension = log_path.parent_path() / log_path.stem().string();
 
          LogData log;
-         const StoredType* const just_to_derive_type = nullptr;
-         log.open(log_path, just_to_derive_type);
+         log.open(log_path);
 
          verifier.verify(log, log_path);
 
@@ -149,8 +148,7 @@ struct log_catalog {
 
          if (block_num <= it->second.last_block_num) {
             auto name = it->second.filename_base;
-            const StoredType* const just_to_derive_type = nullptr;
-            log_data.open(name.replace_extension("log"), just_to_derive_type);
+            log_data.open(name.replace_extension("log"));
             log_index.open(name.replace_extension("index"));
             active_index = std::distance(collection.begin(), it);
             return log_index.nth_block_position(block_num - log_data.first_block_num());

--- a/libraries/chain/transaction.cpp
+++ b/libraries/chain/transaction.cpp
@@ -177,7 +177,7 @@ digest_type packed_transaction::digest()const {
    digest_type::encoder enc;
    fc::raw::pack( enc, signatures );
    fc::raw::pack( enc, packed_context_free_data );
-   fc::raw::pack( enc, compression );
+   // compression is set by the node, so not actually necessary
    fc::raw::pack( enc, trx_id  );   // all of transaction is represented by trx id/digest
 
    return enc.result();

--- a/libraries/state_history/include/sysio/state_history/log.hpp
+++ b/libraries/state_history/include/sysio/state_history/log.hpp
@@ -178,10 +178,9 @@ class state_history_log_data : public chain::log_data_base<state_history_log_dat
 
  public:
    state_history_log_data() = default;
- //  explicit state_history_log_data(const std::filesystem::path& path) { open(path); }
+   explicit state_history_log_data(const std::filesystem::path& path) { open(path); }
 
-   template<typename StoredType>
-   void open(const std::filesystem::path& path, const StoredType* const stored_type = nullptr) {
+   void open(const std::filesystem::path& path) {
       if (file.is_open())
          file.close();
       file.set_file_path(path);

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -573,7 +573,7 @@ void chain_plugin_impl::plugin_initialize(const variables_map& options) {
             state_dir = sd;
       }
 
-      if( options.count( "state-log" )) {
+      if( options.at( "state-log" ).as<bool>()) {
          state_log = true;
       }
 
@@ -2493,7 +2493,8 @@ read_only::get_account_return_t read_only::get_account( const get_account_params
          core_symbol = *(params.expected_core_symbol);
 
       // Check balance of core symbol in sysio.token::accounts table
-      if (const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(token_code, params.account_name, "accounts"_n))) {
+      const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( token_code, params.account_name, "accounts"_n ));
+      if( t_id != nullptr ) {
          const auto &idx = d.get_index<key_value_index, by_scope_primary>();
          auto it = idx.find(boost::make_tuple(t_id->id, core_symbol.to_symbol_code()));
          if (it != idx.end() && it->value.size() >= sizeof(asset)) {

--- a/unittests/partitioned_block_log_tests.cpp
+++ b/unittests/partitioned_block_log_tests.cpp
@@ -536,7 +536,9 @@ void trim_blocklog_front(uint32_t version) {
    signed_block_log old_log(blocks_dir, chain.get_config().blog);
    signed_block_log new_log(temp1.path());
    // double check if the version has been set to the desired version
-   BOOST_CHECK(old_log.version() == version);
+   const auto old_log_version = old_log.version()
+   BOOST_CHECK(old_log_version.has_value());
+   BOOST_CHECK(*old_log_version == version);
    BOOST_CHECK(new_log.first_block_num() == 10u);
    BOOST_CHECK(new_log.head()->block_num() == old_log.head()->block_num());
 
@@ -576,8 +578,9 @@ BOOST_AUTO_TEST_CASE(test_blocklog_split_then_merge) {
    std::filesystem::remove(blocks_dir / "blocks.index");
 
    signed_block_log blog(blocks_dir, sysio::chain::partitioned_blocklog_config{ .retained_dir = retained_dir });
-
-   BOOST_CHECK(blog.version() != 0);
+   const auto version = blog.version();
+   BOOST_CHECK(version.has_value());
+   BOOST_CHECK(*version != 0);
    BOOST_CHECK_EQUAL(blog.head()->block_num(), 150u);
 
    // test blocklog merge


### PR DESCRIPTION
There were 2 major bugs.
1. Since the "state-log" flag was defaulted to false, I should not have used the count("state-log") method, since the flag will always be present, needed to instead just always check the value
2. There were several paths where the block state log was not being initialized correctly.

Added a needed_for_replay() method to allow the legacy block log to still require a genesis if starting from 1, but not for a block state log, since it won't be used to recreate anything.

Cleanup in Block_log:
Removed unnecessary differences with leap.
Made common-protocol namespace to create common protocol values that are used by any storage instance of the block_log.
