### PR TITLE
Remove verbose logging

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -874,23 +874,15 @@ bool is_system_account(const account_name& name) {
 }
 
 void apply_context::add_ram_usage( account_name payer, int64_t ram_delta ) {
-   ilog("System account status: Payer ${payer} ${payer_sys}, receiver ${receiver} ${receiver_sys}", ("payer", payer)("payer_sys", is_system_account(payer))("receiver", receiver)("receiver_sys", is_system_account(receiver)));
-
    if (payer != receiver && ram_delta > 0) {
-      ilog("Payer is not receiver (${receiver}) or system account and ram_delta is positive, checking authorization for payer ${payer}", ("receiver", receiver)("payer", payer));
       if (receiver == config::system_account_name) {
-         wlog("Receiver is system account, no need to check authorization for payer ${payer}", ("payer", payer));
       } else if (payer == config::system_account_name && is_privileged()) {
-         wlog("Payer is system account and receiver is privileged, no need to check authorization for payer ${payer}", ("payer", payer));
       } else {
-         wlog("We need authorization to charge RAM to payer ${payer}", ("payer", payer));
          auto payer_found = false;
          // search act->authorization for a payer permission role
          for( const auto& auth : act->authorization ) {
-            wlog("Authorization actor: ${actor}, permission: ${permission}, actor is system: ${sys}", ("actor", auth.actor)("permission", auth.permission)("sys", is_system_account(auth.actor)));
             if( auth.actor == payer && auth.permission == config::sysio_payer_name ) {
                payer_found = true;
-               wlog("We are authorized!");
                break;
             }
             if ( auth.actor == config::system_account_name ) {
@@ -898,7 +890,6 @@ void apply_context::add_ram_usage( account_name payer, int64_t ram_delta ) {
                // This avoids a lot of changes for tests and sysio should not be calling untrusted contracts
                // or spending user's RAM unexpectedly.
                payer_found = true;
-               wlog("System account authorized, no need to provide explicit payer authorization");
                break;
             }
          }

--- a/unittests/test_contract_action_match.cpp
+++ b/unittests/test_contract_action_match.cpp
@@ -9,7 +9,6 @@ using namespace sysio;
 using namespace sysio::chain;
 
 BOOST_AUTO_TEST_CASE(exact_match) {
-   fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::info);
    using namespace sysio;
    using namespace sysio::chain;
    // Test the suffix matcher
@@ -28,7 +27,6 @@ BOOST_AUTO_TEST_CASE(exact_match) {
 }
 
 BOOST_AUTO_TEST_CASE(suffix_match) {
-   fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::info);
    using namespace sysio;
    using namespace sysio::chain;
    // Test the suffix match matcher
@@ -49,7 +47,6 @@ BOOST_AUTO_TEST_CASE(suffix_match) {
 }
 
 BOOST_AUTO_TEST_CASE(prefix_match) {
-   fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::info);
    // Test the suffix match matcher
    contract_action_match matcher("s"_n, "test"_n, contract_action_match::match_type::prefix);
 
@@ -70,8 +67,6 @@ BOOST_AUTO_TEST_CASE(prefix_match) {
 }
 
 BOOST_AUTO_TEST_CASE(malformed_contract_names) {
-   fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::info);
-
    // Test no empty names
    BOOST_CHECK_EXCEPTION(contract_action_match("s"_n, ""_n, contract_action_match::match_type::prefix), chain::producer_exception,
       [&](const fc::exception &e) {
@@ -100,7 +95,6 @@ BOOST_AUTO_TEST_CASE(malformed_contract_names) {
    }
 
    BOOST_AUTO_TEST_CASE(action_match) {
-      fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::info);
       // Test the suffix match matcher
       contract_action_match matcher("s"_n, "test"_n, contract_action_match::match_type::prefix);
       matcher.add_action("add.match"_n, contract_action_match::match_type::exact);


### PR DESCRIPTION
- Remove debug logging left in `apply_context::add_ram_usage`.
- Remove explicit set of log level in [nittests/test_contract_action_match.cpp](https://github.com/Wire-Network/wire-sysio/compare/rm-verbose-logging?expand=1#diff-7c750180a52b4c19b92aa92f0f71fdfb4445a6144660c9558eb255b5d91356ce)
   - Note you can enable verbose logging in tests via: `./unit_test -t "contract_action_match_tests/*" -- --verbose` 