### PR TITLE
Add workflow_dispatch to allow for manual builds

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,6 +1,7 @@
 name: Build & Test
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - master


### PR DESCRIPTION
From docs of `workflow_dispatch`:
`workflow_dispatch` - "You can now create workflows that are manually triggered with the new workflow_dispatch event. You will then see a 'Run workflow' button on the Actions tab, enabling you to easily trigger a run."
Thanks @svetlasyrimis for pointing this out.

Co-authored-by: Svetla Syrimis <svetla@wire.network>
