### PR TITLE
ubuntu 24 - build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,33 @@
-FROM ubuntu:22.04 as tester
+# Multi-stage Dockerfile
+# Stages:
+#   1) distro-deps   - Install OS-level toolchain and libraries (base for all other stages)
+#   2) source-deps   - Install source-built dependencies (LLVM 11) on top of distro-deps
+#   3) app-source-*  - Prepare application sources (from local context or remote repo)
+#   4) app-build-*   - Build the application from the chosen app-source-* stage
+#
+# Use `--target` at build time to select which final build stage to produce:
+#   docker build --target=app-build-local -t wire-sysio:local .
+#   docker build --target=app-build-repo  -t wire-sysio:repo  .
 
-ARG BRANCH=master
-ARG REPO=https://github.com/Wire-Network/wire-sysio
+# Stage 1: distro-deps
+# Base image with system packages required for building (compilers, cmake, Python, etc.)
+FROM ubuntu:24.04 AS distro-deps
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Core package tools and repository helpers
 RUN apt-get update
 RUN apt-get install -y \
         lsb-release \
         wget \
-        software-properties-common \
+        software-properties-common
+
+# Enable Python 3.12 PPA and refresh indexes
+RUN add-apt-repository ppa:deadsnakes/ppa -y
+RUN apt-get update
+
+# Build toolchain and development libraries needed by the application
+RUN apt-get install -y \
         gnupg \
         build-essential \
         cmake \
@@ -18,7 +36,6 @@ RUN apt-get install -y \
         vim \
         sudo \
         doxygen \
-        llvm-11 \
         libboost-all-dev \
         libcurl4-openssl-dev \
         libgmp-dev \
@@ -30,20 +47,72 @@ RUN apt-get install -y \
         libbz2-dev \
         liblzma-dev \
         libncurses5-dev \
-        libzstd-dev
-RUN add-apt-repository ppa:deadsnakes/ppa -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install python3.12 -y
+        libzstd-dev \
+    		python3.12
+
+# Make Python 3.12 the default python3
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
 
-RUN mkdir /wire
+# Stage 2: source-deps
+# Install dependencies built from source (LLVM 11) on top of distro-deps.
+FROM distro-deps AS source-deps
+
+# Install LLVM 11 from provided scripts into /opt/llvm/llvm-11
+RUN mkdir -p /opt/llvm/scripts
+RUN mkdir -p /opt/llvm/llvm-11
+COPY scripts/llvm-11/* /opt/llvm/scripts/
+
+# Build and install LLVM 11 using the helper script
+RUN BASE_DIR=/opt/llvm /opt/llvm/scripts/llvm-11-ubuntu-build-source.sh
+
+# Stage 3a: app-source-local
+# Use local build context as the application source.
+FROM source-deps AS app-source-local
+
+RUN mkdir -p /wire/wire-sysio
+WORKDIR /wire/wire-sysio
+COPY . /wire/wire-sysio/
+
+# Stage 3b: app-source-repo
+# Fetch application source from a remote repository (branch configurable via ARGs).
+FROM source-deps AS app-source-repo
+ARG BRANCH=master
+ARG REPO=https://github.com/Wire-Network/wire-sysio
+
+RUN mkdir -p /wire
 WORKDIR /wire
 
-RUN git clone -b ${BRANCH} ${REPO} /wire/wire-sysio
+# Clone the selected branch with submodules, then ensure full submodule initialization
+RUN git clone --recursive -b ${BRANCH} ${REPO} /wire/wire-sysio
 WORKDIR /wire/wire-sysio
-
 RUN git submodule update --init --recursive
 
+# Stage 4a: app-build-local
+# Configure and build the application from local sources.
+## BUILD WITH LOCAL SOURCE CODE
+FROM app-source-local AS app-build-local
+WORKDIR /wire/wire-sysio
 RUN mkdir build
 WORKDIR /wire/wire-sysio/build
+RUN cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=gcc-10 \
+    -DCMAKE_CXX_COMPILER=g++-10 \
+    -DCMAKE_PREFIX_PATH=/opt/llvm/llvm-11 .. \
+    && \
+    make -j$([[ "$(nproc)" -gt 16 ]] && echo 16 || nproc)
 
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/llvm-11 .. && make -j$(nproc)
+# Stage 4b: app-build-repo
+# Configure and build the application from sources cloned from the repository.
+## BUILD WITH LOCAL SOURCE CODE
+FROM app-source-repo AS app-build-repo
+WORKDIR /wire/wire-sysio
+RUN mkdir build
+WORKDIR /wire/wire-sysio/build
+RUN cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=gcc-10 \
+    -DCMAKE_CXX_COMPILER=g++-10 \
+    -DCMAKE_PREFIX_PATH=/opt/llvm/llvm-11 .. \
+    && \
+    make -j$([[ "$(nproc)" -gt 8 ]] && echo 8 || nproc)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Wire Sysio
 
-Wire Sysio is a fork of Leap, a C++ implementation of the [Antelope](https://github.com/AntelopeIO) protocol. It contains blockchain node software and supporting tools for developers and node operators.
+Wire Sysio is a fork of Leap, a C++ implementation of the [Antelope](https://github.com/AntelopeIO) protocol. It
+contains blockchain node software and supporting tools for developers and node operators.
 
 ## Branches
 
@@ -10,27 +11,39 @@ The `master` branch is the latest stable branch.
 
 We currently support the following operating systems.
 
-| **Operating Systems**           |
-|---------------------------------|
-| Ubuntu 22.04 Jammy              |
-| Ubuntu 20.04 Focal              |
+| **Operating Systems** |
+|-----------------------|
+| Ubuntu 24.04 Jammy    |
+| Ubuntu 22.04 Jammy    |
+| Ubuntu 20.04 Focal    |
 
 <!-- TODO: needs to add and test build on unsupported environments -->
 
-## Installation 
+## Installation
 
-In the future, we plan to support downloading Debian packages directly from our [release page](https://github.com/Wire-Network/wire-sysio/releases), providing a more streamlined and convenient setup process. However, for the time being, installation requires *building the software from source*.
+In the future, we plan to support downloading Debian packages directly from
+our [release page](https://github.com/Wire-Network/wire-sysio/releases), providing a more streamlined and convenient
+setup process. However, for the time being, installation requires *building the software from source*.
 
 Finally, verify Wire Sysio was installed correctly:
+
 ```bash
 nodeop --full-version
 ```
-You should see a [semantic version](https://semver.org) string followed by a `git` commit hash with no errors. For example:
+
+You should see a [semantic version](https://semver.org) string followed by a `git` commit hash with no errors. For
+example:
+
 ```
 v3.1.2-0b64f879e3ebe2e4df09d2e62f1fc164cc1125d1
 ```
 
 ## Building from source
+
+> For ubuntu 24.04,
+> use [scripts/llvm-11/llvm-11-ubuntu-build-source.sh](scripts/llvm-11/llvm-11-ubuntu-build-source.sh).
+> additionally this script should enable support for most major distros, like Arch, Fedora, etc. to be built on
+> regardless of version.
 
 ### Prerequisites
 
@@ -49,9 +62,12 @@ You will need to build on a [supported operating system](#supported-operating-sy
 - python3-numpy
 - zlib
 
+
+
 ### Step 1 - Clone
 
-If you don't have the `wire-sysio` repo cloned to your computer yet, [open a terminal](https://itsfoss.com/open-terminal-ubuntu) and navigate to the folder where you want to clone it:
+If you don't have the `wire-sysio` repo cloned to your computer
+yet, [open a terminal](https://itsfoss.com/open-terminal-ubuntu) and navigate to the folder where you want to clone it:
 
 ```bash
 cd ~/Downloads
@@ -84,10 +100,16 @@ cd wire-sysio
 Select build instructions below based on OS.
 
 > ⚠️ **A Warning On Parallel Compilation Jobs (`-j` flag)** ⚠️  
-When building C/C++ software, often the build is performed in parallel via a command such as `make -j "$(nproc)"` which uses all available CPU threads. However, be aware that some compilation units (`*.cpp` files) in Wire Sysion will consume nearly 4GB of memory. Failures due to memory exhaustion will typically, but not always, manifest as compiler crashes. Using all available CPU threads may also prevent you from doing other things on your computer during compilation. For these reasons, consider reducing this value.
+> When building C/C++ software, often the build is performed in parallel via a command such as `make -j "$(nproc)"` which
+> uses all available CPU threads. However, be aware that some compilation units (`*.cpp` files) in Wire Sysion will
+> consume nearly 4GB of memory. Failures due to memory exhaustion will typically, but not always, manifest as compiler
+> crashes. Using all available CPU threads may also prevent you from doing other things on your computer during
+> compilation. For these reasons, consider reducing this value.
 
 > 🐋 **Docker and `sudo`** 🐋  
-If you are in an Ubuntu docker container, omit `sudo` from all commands because you run as `root` by default. Most other docker containers also exclude `sudo`, especially Debian-family containers. If your shell prompt is a hash tag (`#`), omit `sudo`.
+> If you are in an Ubuntu docker container, omit `sudo` from all commands because you run as `root` by default. Most other
+> docker containers also exclude `sudo`, especially Debian-family containers. If your shell prompt is a hash tag (`#`),
+> omit `sudo`.
 
 #### Build
 
@@ -109,7 +131,6 @@ sudo apt-get install -y \
 
 To build, make sure you are in the root of the `wire-sysio` repo, then run the following commands:
 
-
 ```bash
 mkdir -p build
 cd build
@@ -123,13 +144,15 @@ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/llvm-11 ..
 make -j "$(nproc)" package
 ```
 
-Now you can optionally [test](#step-4---test) your build, or [install](#step-3---install) the `*.deb` binary packages, which will be in the root of your build directory.
+Now you can optionally [test](#step-4---test) your build, or [install](#step-3---install) the `*.deb` binary packages,
+which will be in the root of your build directory.
 
 ### Step 3 - Install
 
 Once you have [built](#build) Wire Sysio and [tested](#step-4---test) your build, you can install it on your system.
 
-We recommend installing the binary package you just built. Navigate to your build directory in a terminal and run this command:
+We recommend installing the binary package you just built. Navigate to your build directory in a terminal and run this
+command:
 
 ```bash
 sudo apt-get update
@@ -146,18 +169,21 @@ sudo make install
 
 Wire Sysio supports the following test suites:
 
-Test Suite | Test Type | [Test Size](https://testing.googleblog.com/2010/12/test-sizes.html) | Notes
----|:---:|:---:|---
-[Parallelizable tests](#parallelizable-tests) | Unit tests | Small
-[WASM spec tests](#wasm-spec-tests) | Unit tests | Small | Unit tests for our WASM runtime, each short but *very* CPU-intensive
-[Serial tests](#serial-tests) | Component/Integration | Medium
-[Long-running tests](#long-running-tests) | Integration | Medium-to-Large | Tests which take an extraordinarily long amount of time to run
+ Test Suite                                    |       Test Type       | [Test Size](https://testing.googleblog.com/2010/12/test-sizes.html) | Notes                                                                
+-----------------------------------------------|:---------------------:|:-------------------------------------------------------------------:|----------------------------------------------------------------------
+ [Parallelizable tests](#parallelizable-tests) |      Unit tests       |                                Small                                
+ [WASM spec tests](#wasm-spec-tests)           |      Unit tests       |                                Small                                | Unit tests for our WASM runtime, each short but *very* CPU-intensive 
+ [Serial tests](#serial-tests)                 | Component/Integration |                               Medium                                
+ [Long-running tests](#long-running-tests)     |      Integration      |                           Medium-to-Large                           | Tests which take an extraordinarily long amount of time to run       
 
 When building from source, we recommended running at least the [parallelizable tests](#parallelizable-tests).
 
 #### Parallelizable Tests
 
-This test suite consists of any test that does not require shared resources, such as file descriptors, specific folders, or ports, and can therefore be run concurrently in different threads without side effects (hence, easily parallelized). These are mostly unit tests and [small tests](https://testing.googleblog.com/2010/12/test-sizes.html) which complete in a short amount of time.
+This test suite consists of any test that does not require shared resources, such as file descriptors, specific folders,
+or ports, and can therefore be run concurrently in different threads without side effects (hence, easily parallelized).
+These are mostly unit tests and [small tests](https://testing.googleblog.com/2010/12/test-sizes.html) which complete in
+a short amount of time.
 
 You can invoke them by running `ctest` from a terminal in your build directory and specifying the following arguments:
 
@@ -167,23 +193,32 @@ ctest -j "$(nproc)" -LE _tests
 
 Since Wire resource handling changes caused considerable changes for unit test setup, some tests have been turned off
 till they can be fixed, so that the core set of tests can be successfully validated. To include these tests in running
-the above ctest command, the following flag must be passed to cmake before compiling and running: "-DDONT_SKIP_TESTS=TRUE"
+the above ctest command, the following flag must be passed to cmake before compiling and running: "
+-DDONT_SKIP_TESTS=TRUE"
 
 #### WASM Spec Tests
 
-The WASM spec tests verify that our WASM execution engine is compliant with the web assembly standard. These are very [small](https://testing.googleblog.com/2010/12/test-sizes.html), very fast unit tests. However, there are over a thousand of them so the suite can take a little time to run. These tests are extremely CPU-intensive.
+The WASM spec tests verify that our WASM execution engine is compliant with the web assembly standard. These are
+very [small](https://testing.googleblog.com/2010/12/test-sizes.html), very fast unit tests. However, there are over a
+thousand of them so the suite can take a little time to run. These tests are extremely CPU-intensive.
 
-You can invoke them by running `ctest` from a terminal in your Wire Sysio build directory and specifying the following arguments:
+You can invoke them by running `ctest` from a terminal in your Wire Sysio build directory and specifying the following
+arguments:
 
 ```bash
 ctest -j "$(nproc)" -L wasm_spec_tests
 ```
 
-We have observed severe performance issues when multiple virtual machines are running this test suite on the same physical host at the same time, for example in a CICD system. This can be resolved by disabling hyperthreading on the host.
+We have observed severe performance issues when multiple virtual machines are running this test suite on the same
+physical host at the same time, for example in a CICD system. This can be resolved by disabling hyperthreading on the
+host.
 
 #### Serial Tests
 
-The serial test suite consists of [medium](https://testing.googleblog.com/2010/12/test-sizes.html) component or integration tests that use specific paths, ports, rely on process names, or similar, and cannot be run concurrently with other tests. Serial tests can be sensitive to other software running on the same host and they may `SIGKILL` other `nodeop` processes. These tests take a moderate amount of time to complete, but we recommend running them.
+The serial test suite consists of [medium](https://testing.googleblog.com/2010/12/test-sizes.html) component or
+integration tests that use specific paths, ports, rely on process names, or similar, and cannot be run concurrently with
+other tests. Serial tests can be sensitive to other software running on the same host and they may `SIGKILL` other
+`nodeop` processes. These tests take a moderate amount of time to complete, but we recommend running them.
 
 You can invoke them by running `ctest` from a terminal in your build directory and specifying the following arguments:
 
@@ -193,7 +228,8 @@ ctest -L "nonparallelizable_tests"
 
 #### Long-Running Tests
 
-The long-running tests are [medium-to-large](https://testing.googleblog.com/2010/12/test-sizes.html) integration tests that rely on shared resources and take a very long time to run.
+The long-running tests are [medium-to-large](https://testing.googleblog.com/2010/12/test-sizes.html) integration tests
+that rely on shared resources and take a very long time to run.
 
 You can invoke them by running `ctest` from a terminal in your `build` directory and specifying the following arguments:
 

--- a/scripts/llvm-11/llvm-11-ubuntu-build-source.sh
+++ b/scripts/llvm-11/llvm-11-ubuntu-build-source.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Build LLVM 11 (branch release/11.x) on Ubuntu 24.04, including:
+#   - clang, clang-tools-extra, lld
+#   - libc++, libc++abi, libunwind
+#   - compiler-rt (builtins/crt; sanitizers optional)
+# Targets: X86, WebAssembly (plus AArch64 optional).
+#
+# Suitable for Antelope / EOSIO / Spring / Leap toolchains.
+#
+# Usage:
+#   bash build-llvm11-release-11x.sh [--prefix /opt/llvm-11] [--jobs N] [--with-sanitizers]
+#                                     [--targets X86;WebAssembly;AArch64]
+# Notes:
+#   * First run on a clean build dir (script wipes its own).
+#   * Re-run safe; it reclones shallow at the desired branch.
+#   * Produces -11 convenience symlinks in $PREFIX/bin.
+set -euo pipefail
+
+BASE_DIR=${BASE_DIR:-$PWD}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LLVM_SRC_DIR="${BASE_DIR}/llvm-project"
+BUILD_DIR="${BASE_DIR}/llvm-11-build-gpt"
+PREFIX="${LLVM_11_PREFIX:-/opt/llvm/llvm-11}"
+
+### ---------- Config (overridable by flags) ----------
+
+if which nproc >/dev/null 2>&1; then
+  echo "nproc is installed"
+  NPROC=$(nproc)
+fi
+
+if [[ "${NPROC}" -gt 0 ]]; then
+  if [[ "${NPROC}" -gt 32 ]]; then
+    JOBS="32"
+  else
+    JOBS="${NPROC}"
+  fi
+else
+  JOBS="4"
+fi
+
+echo "Configured to use ${JOBS} jobs for build"
+
+WANT_SANITIZERS=0
+TARGETS="X86;WebAssembly"
+BRANCH="release/11.x"
+
+# Projects: clang toolchain + linker + C++ libs + compiler-rt (host)
+PROJECTS="clang;clang-tools-extra;lld;compiler-rt;libcxx;libcxxabi;libunwind"
+
+INSTALL_RUNTIMES_VIA_TOPLEVEL=1
+
+### ---------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --prefix)
+    PREFIX="${2:?}"
+    shift 2
+    ;;
+  --jobs)
+    JOBS="${2:?}"
+    shift 2
+    ;;
+  --with-sanitizers)
+    WANT_SANITIZERS=1
+    shift
+    ;;
+  --targets)
+    TARGETS="${2:?}"
+    shift 2
+    ;;
+  *)
+    echo "Unknown arg: $1"
+    exit 2
+    ;;
+  esac
+done
+
+echo "[+] Using:"
+echo "    PREFIX        = ${PREFIX}"
+echo "    JOBS          = ${JOBS}"
+echo "    TARGETS       = ${TARGETS}"
+echo "    SANITIZERS    = ${WANT_SANITIZERS}"
+echo "    BRANCH        = ${BRANCH}"
+
+echo "[+] Checking & installing deps (sudo)…"
+. "${SCRIPT_DIR}/llvm-11-ubuntu-deps.sh"
+
+# Clean env that might force freestanding or odd sysroots
+unset CFLAGS CXXFLAGS LDFLAGS CPPFLAGS
+
+# echo "[+] Fetching llvm-project (${BRANCH})…"
+rm -rf "${LLVM_SRC_DIR}" "${BUILD_DIR}"
+# rm -rf "${BUILD_DIR}"
+git clone --depth=1 -b "${BRANCH}" https://github.com/llvm/llvm-project.git "${LLVM_SRC_DIR}"
+
+# Base CMake flags
+declare -a CMAKE_FLAGS=(
+  -G Ninja
+  -DCMAKE_BUILD_TYPE=Release
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+  -DLLVM_ENABLE_PROJECTS="${PROJECTS}"
+  -DLLVM_TARGETS_TO_BUILD="${TARGETS}"
+  -DLLVM_INCLUDE_TESTS=OFF
+  -DLLVM_INCLUDE_EXAMPLES=OFF
+  -DLLVM_ENABLE_ASSERTIONS=ON
+  -DLLVM_ENABLE_RTTI=ON
+  -DLLVM_ENABLE_EH=ON
+
+  # Prefer gold/ld.lld if present later; keep link portable
+  -DCMAKE_C_COMPILER=gcc-10
+  -DCMAKE_CXX_COMPILER=g++-10
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+  # libc++ family for host
+  -DLIBCXX_ENABLE_SHARED=ON
+  -DLIBCXX_ENABLE_STATIC=ON
+  -DLIBCXX_ENABLE_ABI_LINKER_SCRIPT=OFF
+  -DLIBCXXABI_ENABLE_SHARED=ON
+  -DLIBCXXABI_ENABLE_STATIC=ON
+  -DLIBUNWIND_ENABLE_SHARED=ON
+  -DLIBUNWIND_ENABLE_STATIC=ON
+
+  # compiler-rt: build essentials for host; sanitizers optional
+  -DCOMPILER_RT_BUILD_BUILTINS=ON
+  -DCOMPILER_RT_BUILD_CRT=ON
+  -DCOMPILER_RT_BUILD_PROFILE=OFF
+  -DCOMPILER_RT_BUILD_XRAY=OFF
+  -DCOMPILER_RT_BUILD_LIBFUZZER=OFF
+  -DCOMPILER_RT_BUILD_MEMPROF=OFF
+  -DCOMPILER_RT_BUILD_GWP_ASAN=OFF
+)
+
+if [[ "${WANT_SANITIZERS}" -eq 1 ]]; then
+  CMAKE_FLAGS+=(-DCOMPILER_RT_BUILD_SANITIZERS=ON)
+else
+  CMAKE_FLAGS+=(-DCOMPILER_RT_BUILD_SANITIZERS=OFF)
+fi
+
+# Build & Install (top-level)
+echo "[+] Configuring (top-level)…"
+cmake -S "${LLVM_SRC_DIR}/llvm" -B "${BUILD_DIR}" "${CMAKE_FLAGS[@]}"
+
+echo "[+] Building…"
+ninja -C "${BUILD_DIR}" -j "${JOBS}"
+
+echo "[+] Installing (sudo)…"
+sudo mkdir -p "${PREFIX}"
+sudo ninja -C "${BUILD_DIR}" install
+
+# Convenience -11 symlinks (clang-11, clang++-11, llvm-config-11, etc.)
+# echo "[+] Creating -11 convenience symlinks…"
+# sudo bash -c "cd '${PREFIX}/bin' && \
+#   for b in clang clang++ clang-cl clang-cpp lld llvm-ar llvm-as llvm-config \
+#            llvm-nm llvm-objcopy llvm-objdump llvm-size llvm-strip llvm-symbolizer; do

--- a/scripts/llvm-11/llvm-11-ubuntu-deps.sh
+++ b/scripts/llvm-11/llvm-11-ubuntu-deps.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "[+] Installing build deps (sudo)…"
+sudo apt-get update
+sudo apt-get install -y \
+ build-essential cmake ninja-build git python3-dev \
+ zlib1g-dev libffi-dev libedit-dev libxml2-dev \
+ libncurses-dev libtinfo-dev libzstd-dev \
+ libssl-dev ccache \
+ gcc-10 g++-10


### PR DESCRIPTION
The core issue was the need for `llvm-11` source compilation with the correct options/features enabled.  To do so, required `gcc-10`, which may need to be built from source itself in the near future, once installed and CMAKE was configured to use it as the compiler and with an install prefix path configured, everything worked:

```sh
cmake \
-DCMAKE_C_COMPILER=gcc-10 \
-DCMAKE_CXX_COMPILER=g++-10 \
-DCMAKE_INSTALL_PREFIX=/opt/llvm/llvm-11 \
-DCMAKE_PREFIX_PATH=/opt/llvm/llvm-11 \
...
```
The scripts for building llvm properly are under `scripts/llvm-11`.

The Dockerfile was also updated to build on Ubuntu 24.04. Additionally it was made multi-stage for build performance and efficiency