### PR TITLE
Proposal: Allow RAM move

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -100,30 +100,7 @@ void apply_context::exec_one()
                   control.get_wasm_interface().apply( receiver_account->code_hash, receiver_account->vm_type, receiver_account->vm_version, *this );
                } catch( const wasm_exit& ) {}
             }
-
-            if( !privileged ) {
-               const size_t checktime_interval = 10;
-               size_t counter = 0;
-               bool not_in_notify_context = (receiver == act->account);
-               const auto end = _account_ram_deltas.end();
-               for( auto itr = _account_ram_deltas.begin(); itr != end; ++itr, ++counter ) {
-                  // wlog("pending RAM delta: ${account} ${delta}", ("account", itr->account)("delta", itr->delta) );
-                  if( counter == checktime_interval ) {
-                     trx_context.checktime();
-                     counter = 0;
-                  }
-                  if( itr->delta > 0 && itr->account != receiver ) {
-                     SYS_ASSERT( not_in_notify_context, unauthorized_ram_usage_increase,
-                                 "unprivileged contract cannot increase RAM usage of another account within a notify context: ${account}",
-                                 ("account", itr->account)
-                     );
-                     SYS_ASSERT( has_authorization( itr->account ), unauthorized_ram_usage_increase,
-                                 "unprivileged contract cannot increase RAM usage of another account that has not authorized the action: ${account}",
-                                 ("account", itr->account)
-                     );
-                  }
-               }
-            }
+            validate_account_ram_deltas();
          }
       } FC_RETHROW_EXCEPTIONS( warn, "${receiver} <= ${account}::${action} pending console output: ${console}", ("console", _pending_console_output)("account", act->account)("action", act->name)("receiver", receiver) )
 
@@ -185,6 +162,55 @@ void apply_context::exec_one()
    if( auto dm_logger = control.get_deep_mind_logger(trx_context.is_transient()))
    {
       dm_logger->on_end_action();
+   }
+}
+
+void apply_context::validate_account_ram_deltas() {
+   const size_t checktime_interval = 10;
+   size_t counter = 0;
+   bool not_in_notify_context = (receiver == act->account);
+   const auto end = _account_ram_deltas.end();
+   for( auto itr = _account_ram_deltas.begin(); itr != end; ++itr, ++counter ) {
+      // wlog("pending RAM delta: ${account} ${delta}", ("account", itr->account)("delta", itr->delta) );
+      if( counter == checktime_interval ) {
+         trx_context.checktime();
+         counter = 0;
+      }
+      if( !privileged && itr->delta > 0 && itr->account != receiver ) {
+         SYS_ASSERT( not_in_notify_context, unauthorized_ram_usage_increase,
+                     "unprivileged contract cannot increase RAM usage of another account within a notify context: ${account}",
+                     ("account", itr->account)
+         );
+         SYS_ASSERT( has_authorization( itr->account ), unauthorized_ram_usage_increase,
+                     "unprivileged contract cannot increase RAM usage of another account that has not authorized the action: ${account}",
+                     ("account", itr->account)
+         );
+      }
+      auto& payer = itr->account;
+      auto& ram_delta = itr->delta;
+      if (payer != receiver && ram_delta > 0) {
+         if (receiver == config::system_account_name) {
+         } else if (payer == config::system_account_name && is_privileged()) {
+         } else {
+            auto payer_found = false;
+            // search act->authorization for a payer permission role
+            for( const auto& auth : act->authorization ) {
+               if( auth.actor == payer && auth.permission == config::sysio_payer_name ) {
+                  payer_found = true;
+                  break;
+               }
+               if ( auth.actor == config::system_account_name ) {
+                  // If the payer is the system account, we don't enforce explicit payer authorization.
+                  // This avoids a lot of changes for tests and sysio should not be calling untrusted contracts
+                  // or spending user's RAM unexpectedly.
+                  payer_found = true;
+                  break;
+               }
+            }
+            SYS_ASSERT(payer_found, unsatisfied_authorization,
+                       "Requested payer ${p} did not authorize payment. Missing ${m}.", ("p", payer)("m", config::sysio_payer_name));
+         }
+      }
    }
 }
 
@@ -800,28 +826,6 @@ bool is_system_account(const account_name& name) {
 }
 
 void apply_context::add_ram_usage( account_name payer, int64_t ram_delta ) {
-   if (payer != receiver && ram_delta > 0) {
-      if (receiver == config::system_account_name) {
-      } else if (payer == config::system_account_name && is_privileged()) {
-      } else {
-         auto payer_found = false;
-         // search act->authorization for a payer permission role
-         for( const auto& auth : act->authorization ) {
-            if( auth.actor == payer && auth.permission == config::sysio_payer_name ) {
-               payer_found = true;
-               break;
-            }
-            if ( auth.actor == config::system_account_name ) {
-               // If the payer is the system account, we don't enforce explicit payer authorization.
-               // This avoids a lot of changes for tests and sysio should not be calling untrusted contracts
-               // or spending user's RAM unexpectedly.
-               payer_found = true;
-               break;
-            }
-         }
-         SYS_ASSERT(payer_found, unsatisfied_authorization, "Requested payer ${payer} did not authorize payment", ("payer", payer));
-      }
-   }
    trx_context.add_ram_usage( payer, ram_delta );
 
    auto p = _account_ram_deltas.emplace( payer, ram_delta );

--- a/libraries/chain/include/sysio/chain/apply_context.hpp
+++ b/libraries/chain/include/sysio/chain/apply_context.hpp
@@ -573,6 +573,7 @@ class apply_context {
 
       int  db_store_i64( name code, name scope, name table, const account_name& payer, uint64_t id, const char* buffer, size_t buffer_size );
 
+      void validate_account_ram_deltas();
 
    /// Misc methods:
    public:

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -567,10 +567,11 @@ BOOST_AUTO_TEST_CASE(ram_billing_in_notify_tests) { try {
    chain.set_code( "testapi2"_n, test_contracts::test_api_wasm() );
    chain.produce_blocks(1);
 
+   // wire-sysio does not have protocol feature ram_restrictions, ram restrictions are enforced from genesis
    BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify",
                                               fc::raw::pack( ((unsigned __int128)"testapi2"_n.to_uint64_t() << 64) | "testapi"_n.to_uint64_t() ) ),
-                          subjective_block_production_exception,
-                          fc_exception_message_is("Cannot charge RAM to other accounts during notify.")
+                          unauthorized_ram_usage_increase,
+                          fc_exception_message_is("unprivileged contract cannot increase RAM usage of another account within a notify context: testapi")
    );
 
 

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -600,10 +600,10 @@ BOOST_AUTO_TEST_CASE( get_sender_test ) { try {
    );
 } FC_LOG_AND_RETHROW() }
 
-BOOST_AUTO_TEST_CASE(steal_my_ram) {
+BOOST_AUTO_TEST_CASE(move_my_ram) {
    try {
       tester c(setup_policy::full);
-      wlog("Starting STEAL MY RAM TEST");
+      wlog("Starting MVOE MY RAM TEST");
 
       const auto &tester1_account = account_name("tester1");
       const auto &alice_account = account_name("alice");
@@ -628,14 +628,10 @@ BOOST_AUTO_TEST_CASE(steal_my_ram) {
       );
 
       wlog("Moving data around with bob's authorization...");
-      BOOST_REQUIRE_EXCEPTION(
-         c.push_action(tester1_account, "setdata"_n, bob_account, mutable_variant_object()
-            ("len1", 0)
-            ("len2", 10)
-            ("payer", alice_account)
-         ),
-         unsatisfied_authorization,
-         fc_exception_message_is("Requested payer alice did not authorize payment")
+      c.push_action(tester1_account, "setdata"_n, bob_account, mutable_variant_object()
+         ("len1", 0)
+         ("len2", 10)
+         ("payer", alice_account)
       );
 
       c.produce_block();
@@ -805,7 +801,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_with_roa_test ) { try {
          ("payer", alice_account)
       ),
       unsatisfied_authorization,
-      fc_exception_message_is( "Requested payer alice did not authorize payment" )
+      fc_exception_message_starts_with( "Requested payer alice did not authorize payment" )
    );
 
    wlog("B");
@@ -817,7 +813,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_with_roa_test ) { try {
       ("payer", alice_account)
       ),
       unsatisfied_authorization,
-      fc_exception_message_is( "Requested payer alice did not authorize payment" )
+      fc_exception_message_starts_with( "Requested payer alice did not authorize payment" )
    );
    BOOST_REQUIRE_EXCEPTION(
    c.push_action( tester1_account, "setdata"_n, bob_account, mutable_variant_object()
@@ -826,7 +822,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_with_roa_test ) { try {
       ("payer", bob_account)
       ),
       unsatisfied_authorization,
-      fc_exception_message_is( "Requested payer bob did not authorize payment" )
+      fc_exception_message_starts_with( "Requested payer bob did not authorize payment" )
    );
    // But if you pay for the new data, you can remove the old data, but only if you are willing to pay for it...
    c.push_action( tester1_account, "setdata"_n, bob_payer, mutable_variant_object()
@@ -911,7 +907,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_with_roa_test ) { try {
          ("payer", alice_account)
       ),
       unsatisfied_authorization,
-      fc_exception_message_is( "Requested payer alice did not authorize payment" )
+      fc_exception_message_starts_with( "Requested payer alice did not authorize payment" )
    );
 
    c.produce_block();
@@ -981,7 +977,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_with_roa_test ) { try {
          ("payer", alice_account)
       ),
       unsatisfied_authorization,
-      fc_exception_message_is( "Requested payer alice did not authorize payment" )
+      fc_exception_message_starts_with( "Requested payer alice did not authorize payment" )
    );
    wlog("M");
 
@@ -1002,7 +998,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_with_roa_test ) { try {
       ("payer", alice_account)
       ),
       unsatisfied_authorization,
-      fc_exception_message_is( "Requested payer alice did not authorize payment" )
+      fc_exception_message_starts_with( "Requested payer alice did not authorize payment" )
    );
 
    // Now also cannot migrate data from table2 to table1 paid by another account
@@ -1015,7 +1011,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_with_roa_test ) { try {
       ("payer", "alice")
       ),
       unsatisfied_authorization,
-      fc_exception_message_is( "Requested payer alice did not authorize payment" )
+      fc_exception_message_starts_with( "Requested payer alice did not authorize payment" )
    );
 
    wlog("OO");
@@ -1029,7 +1025,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_with_roa_test ) { try {
       ("payer", "alice")
       ),
       unsatisfied_authorization,
-      fc_exception_message_is( "Requested payer alice did not authorize payment" )
+      fc_exception_message_starts_with( "Requested payer alice did not authorize payment" )
    );
    wlog("PP");
 
@@ -1077,7 +1073,6 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_with_roa_test ) { try {
  */
 
 BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
-   SKIP_TEST
    tester c( setup_policy::preactivate_feature_and_new_bios );
 
    const auto& tester1_account = account_name("tester1");
@@ -1094,96 +1089,45 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    c.produce_block();
 
    // Basic setup
-   c.push_action( tester1_account, "setdata"_n, alice_account, mutable_variant_object()
+   vector<permission_level> alice_auths;
+   alice_auths.push_back( permission_level{alice_account, config::active_name} );
+   alice_auths.push_back( permission_level{alice_account, config::sysio_payer_name} );
+   c.push_action( tester1_account, "setdata"_n, alice_auths, mutable_variant_object()
       ("len1", 10)
       ("len2", 0)
       ("payer", alice_account)
    );
 
    // Cannot bill more RAM to another account that has not authorized the action.
+   vector<permission_level> bob_auths;
+   bob_auths.push_back( permission_level{bob_account, config::active_name} );
+   bob_auths.push_back( permission_level{bob_account, config::sysio_payer_name} );
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, "setdata"_n, bob_account, mutable_variant_object()
+      c.push_action( tester1_account, "setdata"_n, bob_auths, mutable_variant_object()
          ("len1", 20)
          ("len2", 0)
          ("payer", alice_account)
       ),
-      missing_auth_exception,
-      fc_exception_message_starts_with( "missing authority" )
-   );
-
-   // Cannot migrate data from table1 to table2 paid by another account
-   // in a RAM usage neutral way without the authority of that account.
-   BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, "setdata"_n, bob_account, mutable_variant_object()
-         ("len1", 0)
-         ("len2", 10)
-         ("payer", alice_account)
-      ),
-      missing_auth_exception,
-      fc_exception_message_starts_with( "missing authority" )
+      unauthorized_ram_usage_increase,
+      fc_exception_message_is( "unprivileged contract cannot increase RAM usage of another account that has not authorized the action: alice" )
    );
 
    // Cannot bill more RAM to another account within a notification
    // even if the account authorized the original action.
-   // This is due to the subjective mitigation in place.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
+      c.push_action( tester2_account, "notifysetdat"_n, alice_auths, mutable_variant_object()
          ("acctonotify", tester1_account)
          ("len1", 20)
          ("len2", 0)
          ("payer", alice_account)
       ),
-      subjective_block_production_exception,
-      fc_exception_message_is( "Cannot charge RAM to other accounts during notify." )
+      unauthorized_ram_usage_increase,
+      fc_exception_message_is( "unprivileged contract cannot increase RAM usage of another account within a notify context: alice" )
    );
-
-   // Cannot migrate data from table1 to table2 paid by another account
-   // in a RAM usage neutral way within a notification.
-   // This is due to the subjective mitigation in place.
-   BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
-         ("acctonotify", tester1_account)
-         ("len1", 0)
-         ("len2", 10)
-         ("payer", alice_account)
-      ),
-      subjective_block_production_exception,
-      fc_exception_message_is( "Cannot charge RAM to other accounts during notify." )
-   );
-
-   // Cannot send deferred transaction paid by another account that has not authorized the action.
-   BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, "senddefer"_n, bob_account, mutable_variant_object()
-         ("senderid", 123)
-         ("payer", alice_account)
-      ),
-      missing_auth_exception,
-      fc_exception_message_starts_with( "missing authority" )
-   );
-
-   // Cannot send deferred transaction paid by another account within a notification
-   // even if the account authorized the original action.
-   // This is due to the subjective mitigation in place.
-   BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, "notifydefer"_n, alice_account, mutable_variant_object()
-         ("acctonotify", tester1_account)
-         ("senderid", 123)
-         ("payer", alice_account)
-      ),
-      subjective_block_production_exception,
-      fc_exception_message_is( "Cannot charge RAM to other accounts during notify." )
-   );
-
-   // Can send deferred transaction paid by another account if it has authorized the action.
-   c.push_action( tester1_account, "senddefer"_n, alice_account, mutable_variant_object()
-      ("senderid", 123)
-      ("payer", alice_account)
-   );
-   c.produce_block();
 
    // Can migrate data from table1 to table2 paid by another account
    // in a RAM usage neutral way with the authority of that account.
-   c.push_action( tester1_account, "setdata"_n, alice_account, mutable_variant_object()
+   c.push_action( tester1_account, "setdata"_n, alice_auths, mutable_variant_object()
       ("len1", 0)
       ("len2", 10)
       ("payer", alice_account)
@@ -1191,88 +1135,35 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
 
    c.produce_block();
 
-   // Disable the subjective mitigation
-   c.close();
-   auto cfg = c.get_config();
-   c.init( cfg );
-
-   c.produce_block();
-
-   // Without the subjective mitigation, it is now possible to bill more RAM to another account
-   // within a notification if the account authorized the original action.
-   // This is due to the subjective mitigation in place.
-   c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
-      ("acctonotify", tester1_account)
-      ("len1", 10)
-      ("len2", 10)
-      ("payer", alice_account)
-   );
-
    // Reset back to the original state.
-   c.push_action( tester1_account, "setdata"_n, alice_account, mutable_variant_object()
+   c.push_action( tester1_account, "setdata"_n, alice_auths, mutable_variant_object()
       ("len1", 10)
       ("len2", 0)
       ("payer", alice_account)
    );
    c.produce_block();
 
-   // Re-enable the subjective mitigation
-   c.close();
-   c.init( cfg );
-
-   c.produce_block();
-
    // Still cannot bill more RAM to another account within a notification
    // even if the account authorized the original action.
    // This is due to the subjective mitigation in place.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
+      c.push_action( tester2_account, "notifysetdat"_n, alice_auths, mutable_variant_object()
          ("acctonotify", tester1_account)
          ("len1", 10)
          ("len2", 10)
          ("payer", alice_account)
       ),
-      subjective_block_production_exception,
-      fc_exception_message_is( "Cannot charge RAM to other accounts during notify." )
+      unauthorized_ram_usage_increase,
+      fc_exception_message_is( "unprivileged contract cannot increase RAM usage of another account within a notify context: alice" )
    );
 
-   //const auto& pfm = c.control->get_protocol_feature_manager();
-   // now always enforced
-   //const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::ram_restrictions );
-
-   // Activate RAM_RESTRICTIONS protocol feature (this would also disable the subjective mitigation).
-   //c.preactivate_protocol_features( {*d} );
    c.produce_block();
-
-   // Cannot send deferred transaction paid by another account that has not authorized the action.
-   // This still fails objectively, but now with another error message.
-   BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, "senddefer"_n, bob_account, mutable_variant_object()
-         ("senderid", 123)
-         ("payer", alice_account)
-      ),
-      action_validate_exception,
-      fc_exception_message_starts_with( "cannot bill RAM usage of deferred transaction to another account that has not authorized the action" )
-   );
-
-   // Cannot send deferred transaction paid by another account within a notification
-   // even if the account authorized the original action.
-   // This now fails with an objective error.
-   BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, "notifydefer"_n, alice_account, mutable_variant_object()
-         ("acctonotify", tester1_account)
-         ("senderid", 123)
-         ("payer", alice_account)
-      ),
-      action_validate_exception,
-      fc_exception_message_is( "cannot bill RAM usage of deferred transactions to another account within notify context" )
-   );
 
    // Cannot bill more RAM to another account within a notification
    // even if the account authorized the original action.
    // This now fails with an objective error.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
+      c.push_action( tester2_account, "notifysetdat"_n, alice_auths, mutable_variant_object()
          ("acctonotify", tester1_account)
          ("len1", 20)
          ("len2", 0)
@@ -1285,7 +1176,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // Cannot bill more RAM to another account that has not authorized the action.
    // This still fails objectively, but now with another error message.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, "setdata"_n, bob_account, mutable_variant_object()
+      c.push_action( tester1_account, "setdata"_n, bob_auths, mutable_variant_object()
          ("len1", 20)
          ("len2", 0)
          ("payer", alice_account)
@@ -1294,16 +1185,9 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
       fc_exception_message_starts_with( "unprivileged contract cannot increase RAM usage of another account that has not authorized the action" )
    );
 
-   // Still can send deferred transaction paid by another account if it has authorized the action.
-   c.push_action( tester1_account, "senddefer"_n, alice_account, mutable_variant_object()
-      ("senderid", 123)
-      ("payer", alice_account)
-   );
-   c.produce_block();
-
    // Now can migrate data from table1 to table2 paid by another account
    // in a RAM usage neutral way without the authority of that account.
-   c.push_action( tester1_account, "setdata"_n, bob_account, mutable_variant_object()
+   c.push_action( tester1_account, "setdata"_n, bob_auths, mutable_variant_object()
       ("len1", 0)
       ("len2", 10)
       ("payer", alice_account)
@@ -1311,7 +1195,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
 
    // Now can also migrate data from table2 to table1 paid by another account
    // in a RAM usage neutral way even within a notification .
-   c.push_action( tester2_account, "notifysetdat"_n, bob_account, mutable_variant_object()
+   c.push_action( tester2_account, "notifysetdat"_n, bob_auths, mutable_variant_object()
       ("acctonotify", "tester1")
       ("len1", 10)
       ("len2", 0)
@@ -1320,7 +1204,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
 
    // Of course it should also be possible to migrate data from table1 to table2 paid by another account
    // in a way that reduces RAM usage as well, even within a notification.
-   c.push_action( tester2_account, "notifysetdat"_n, bob_account, mutable_variant_object()
+   c.push_action( tester2_account, "notifysetdat"_n, bob_auths, mutable_variant_object()
       ("acctonotify", "tester1")
       ("len1", 0)
       ("len2", 5)
@@ -1330,7 +1214,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // It should also still be possible for the receiver to take over payment of the RAM
    // if it is necessary to increase RAM usage without the authorization of the original payer.
    // This should all be possible to do even within a notification.
-   c.push_action( tester2_account, "notifysetdat"_n, bob_account, mutable_variant_object()
+   c.push_action( tester2_account, "notifysetdat"_n, bob_auths, mutable_variant_object()
       ("acctonotify", "tester1")
       ("len1", 10)
       ("len2", 10)


### PR DESCRIPTION
Change will be discussed in a meeting on 9/16/2025.

Allow RAM movement as long as the delta of RAM usage for a user does not increase.