### PR TITLE
Avoid including eos-vm-oc.hpp which includes types.hpp, so the c++17 compilation doesn't propagate throughout

### DIFF
--- a/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/memory.hpp
+++ b/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/memory.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
 #include <sysio/chain/wasm_sysio_constraints.hpp>
-#include <sysio/chain/webassembly/sys-vm-oc/sys-vm-oc.hpp>
+#include <sysio/chain/webassembly/sys-vm-oc/sys-vm-oc.h>
 #include <sysio/chain/webassembly/sys-vm-oc/intrinsic_mapping.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/gs_seg_helpers.h>
+#include <fc/exception/exception.hpp>
 
 #include <stdint.h>
 #include <stddef.h>
 
-namespace sysio { namespace chain { namespace sysvmoc {
+namespace sysio::chain::sysvmoc {
 
 class memory {
       static constexpr uint64_t intrinsic_count                   = intrinsic_table_size();
@@ -66,7 +67,7 @@ class memory {
       uint8_t* fullpage_base;
 };
 
-}}}
+}
 
 #define OFFSET_OF_CONTROL_BLOCK_MEMBER(M) (-(int)sysio::chain::sysvmoc::memory::cb_offset + (int)offsetof(sysio::chain::sysvmoc::control_block, M))
 #define OFFSET_OF_FIRST_INTRINSIC ((int)-sysio::chain::sysvmoc::memory::first_intrinsic_offset)

--- a/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/sys-vm-oc.h
+++ b/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/sys-vm-oc.h
@@ -7,7 +7,10 @@
 #ifdef __cplusplus
 #include <vector>
 #include <list>
-namespace sysio { namespace chain {class apply_context;}}
+#include <exception>
+namespace sysio::chain {
+   class apply_context;
+}
 #endif
 
 struct sys_vm_oc_control_block {
@@ -38,3 +41,9 @@ struct sys_vm_oc_control_block {
    int64_t max_linear_memory_pages;
    void* globals;
 };
+
+#ifdef __cplusplus
+namespace sysio::chain::sysvmoc {
+   using control_block = sys_vm_oc_control_block;
+}
+#endif

--- a/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/sys-vm-oc.hpp
+++ b/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/sys-vm-oc.hpp
@@ -12,13 +12,7 @@
 #include <vector>
 #include <list>
 
-namespace sysio { namespace chain {
-
-class apply_context;
-
-namespace sysvmoc {
-
-using control_block = sys_vm_oc_control_block;
+namespace sysio::chain::sysvmoc {
 
 struct no_offset{};
 struct code_offset {
@@ -52,7 +46,7 @@ enum sysvmoc_exitcode : int {
 
 static constexpr uint8_t current_codegen_version = 1;
 
-}}}
+}
 
 FC_REFLECT(sysio::chain::sysvmoc::no_offset, );
 FC_REFLECT(sysio::chain::sysvmoc::code_offset, (offset));


### PR DESCRIPTION
See https://github.com/AntelopeIO/leap/pull/1807