### PR TITLE
Remove thread hop to producer thread for trx signature recovery

### DIFF
--- a/libraries/chain/include/sysio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/sysio/chain/transaction_metadata.hpp
@@ -83,6 +83,12 @@ class transaction_metadata {
       start_recover_keys( packed_transaction_ptr trx, boost::asio::io_context& thread_pool,
                           const chain_id_type& chain_id, fc::microseconds time_limit,
                           trx_type t, uint32_t max_variable_sig_size = UINT32_MAX );
+      /// Thread safe.
+      /// @returns transaction_metadata_ptr or throws
+      static transaction_metadata_ptr
+      recover_keys( packed_transaction_ptr trx,
+                    const chain_id_type& chain_id, fc::microseconds time_limit,
+                    trx_type t, uint32_t max_variable_sig_size = UINT32_MAX );
 
       /// @returns constructed transaction_metadata with no key recovery (sig_cpu_usage=0, recovered_pub_keys=empty)
       static transaction_metadata_ptr

--- a/libraries/chain/transaction_metadata.cpp
+++ b/libraries/chain/transaction_metadata.cpp
@@ -12,15 +12,23 @@ recover_keys_future transaction_metadata::start_recover_keys( packed_transaction
                                                               uint32_t max_variable_sig_size )
 {
    return post_async_task( thread_pool, [trx{std::move(trx)}, chain_id, time_limit, t, max_variable_sig_size]() mutable {
-         fc::time_point deadline = time_limit == fc::microseconds::maximum() ?
-                                   fc::time_point::maximum() : fc::time_point::now() + time_limit;
-         check_variable_sig_size( trx, max_variable_sig_size );
-         const signed_transaction& trn = trx->get_signed_transaction();
-         flat_set<public_key_type> recovered_pub_keys;
-         fc::microseconds cpu_usage = trn.get_signature_keys( chain_id, deadline, recovered_pub_keys );
-         return std::make_shared<transaction_metadata>( private_type(), std::move( trx ), cpu_usage, std::move( recovered_pub_keys ), t );
-      }
-   );
+      return recover_keys( std::move(trx), chain_id, time_limit, t, max_variable_sig_size );
+   });
+}
+
+transaction_metadata_ptr transaction_metadata::recover_keys( packed_transaction_ptr trx,
+                                                              const chain_id_type& chain_id,
+                                                              fc::microseconds time_limit,
+                                                              trx_type t,
+                                                              uint32_t max_variable_sig_size )
+{
+   fc::time_point deadline = time_limit == fc::microseconds::maximum() ?
+                             fc::time_point::maximum() : fc::time_point::now() + time_limit;
+   check_variable_sig_size( trx, max_variable_sig_size );
+   const signed_transaction& trn = trx->get_signed_transaction();
+   flat_set<public_key_type> recovered_pub_keys;
+   fc::microseconds cpu_usage = trn.get_signature_keys( chain_id, deadline, recovered_pub_keys );
+   return std::make_shared<transaction_metadata>( private_type(), std::move( trx ), cpu_usage, std::move( recovered_pub_keys ), t );
 }
 
 size_t transaction_metadata::get_estimated_size() const {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -396,13 +396,12 @@ public:
                                   int64_t                                     sub_bill,
                                   uint32_t                                    prev_billed_cpu_time_us);
 
-   void        log_trx_results(const transaction_metadata_ptr& trx, const transaction_trace_ptr& trace, const fc::time_point& start);
+   void        log_trx_results(const transaction_metadata_ptr& trx, const transaction_trace_ptr& trace);
    void        log_trx_results(const transaction_metadata_ptr& trx, const fc::exception_ptr& except_ptr);
    void        log_trx_results(const packed_transaction_ptr& trx,
                                const transaction_trace_ptr&  trace,
                                const fc::exception_ptr&      except_ptr,
                                uint32_t                      billed_cpu_us,
-                               const fc::time_point&         start,
                                bool                          is_transient);
 
    void        add_greylist_accounts(const producer_plugin::greylist_params& params) {
@@ -494,8 +493,6 @@ public:
    block_timing_util::producer_watermarks            _producer_watermarks;
    pending_block_mode                                _pending_block_mode = pending_block_mode::speculating;
    unapplied_transaction_queue                       _unapplied_transactions;
-   size_t                                            _thread_pool_size = config::default_controller_thread_pool_size;
-   named_thread_pool<struct prod>                    _thread_pool;
    std::atomic<int32_t>                              _max_transaction_time_ms; // modified by app thread, read by net_plugin thread pool
    std::atomic<uint32_t>                             _received_block{0};       // modified by net_plugin thread pool
    fc::microseconds                                  _max_irreversible_block_age_us;
@@ -798,16 +795,8 @@ public:
          return;
       }
 
-      chain::controller& chain             = chain_plug->chain();
       const auto         max_trx_time_ms   = (trx_type == transaction_metadata::trx_type::read_only) ? -1 : _max_transaction_time_ms.load();
       fc::microseconds   max_trx_cpu_usage = max_trx_time_ms < 0 ? fc::microseconds::maximum() : fc::milliseconds(max_trx_time_ms);
-
-      auto future = transaction_metadata::start_recover_keys(trx,
-                                                             chain.get_thread_pool(),
-                                                             chain.get_chain_id(),
-                                                             fc::microseconds(max_trx_cpu_usage),
-                                                             trx_type,
-                                                             chain.configured_subjective_signature_length_limit());
 
       auto is_transient = (trx_type == transaction_metadata::trx_type::read_only || trx_type == transaction_metadata::trx_type::dry_run);
       if (!is_transient) {
@@ -825,38 +814,60 @@ public:
          };
       }
 
-      boost::asio::post(_thread_pool.get_executor(),
-                        [self = this, future{std::move(future)}, api_trx, is_transient, return_failure_traces,
-                         next{std::move(next)}, trx = trx]() mutable {
-                           if (future.valid()) {
-                              future.wait();
-                              app().executor().post(priority::low, exec_queue::read_write,
-                                 [self, future{std::move(future)}, api_trx, is_transient, next{std::move(next)}, trx{std::move(trx)},
-                                  return_failure_traces]() mutable {
-                                    auto start       = fc::time_point::now();
-                                    auto idle_time   = self->_time_tracker.add_idle_time(start);
-                                    auto trx_tracker = self->_time_tracker.start_trx(is_transient, start);
-                                    fc_tlog(_log, "Time since last trx: ${t}us", ("t", idle_time));
+      boost::asio::post(
+              chain_plug->chain().get_thread_pool(), // use chain thread pool for key recovery
+              [this, trx{trx}, time_limit{max_trx_cpu_usage}, trx_type, is_transient, next{std::move(next)}, api_trx, return_failure_traces]() mutable {
 
-                                    auto exception_handler =
-                                       [self, is_transient, &next, trx{std::move(trx)}, &start](fc::exception_ptr ex) {
-                                          self->log_trx_results(trx, nullptr, ex, 0, start, is_transient);
-                                          next(std::move(ex));
-                                       };
-                                    try {
-                                       auto result = future.get();
-                                       if (!self->process_incoming_transaction_async(result, api_trx, return_failure_traces, trx_tracker, next)) {
-                                          if (self->in_producing_mode()) {
-                                             self->schedule_maybe_produce_block(true);
-                                          } else {
-                                             self->restart_speculative_block();
-                                          }
-                                       }
-                                    }
-                                    CATCH_AND_CALL(exception_handler);
-                                 });
-                           }
-                        });
+                 chain::controller& chain = chain_plug->chain();
+                 transaction_metadata_ptr trx_meta;
+                 try {
+                    trx_meta = transaction_metadata::recover_keys(trx, chain.get_chain_id(), time_limit, trx_type,
+                                                                  chain.configured_subjective_signature_length_limit());
+                 } catch (...) {
+                    // use read_write when read is likely fine; maintains previous behavior of next() always being called from the main thread
+                    app().executor().post(
+                            priority::low, exec_queue::read_write,
+                            [this, ex_ptr{std::current_exception()}, trx{std::move(trx)}, is_transient, next{std::move(next)}]() {
+                               auto start       = fc::time_point::now();
+                               auto idle_time   = _time_tracker.add_idle_time(start);
+                               auto trx_tracker = _time_tracker.start_trx(is_transient, start);
+                               fc_tlog(_log, "Time since last trx: ${t}us", ("t", idle_time));
+                               auto ex_handler = [this, is_transient, &next, &trx](fc::exception_ptr ex) {
+                                  log_trx_results(trx, nullptr, ex, 0, is_transient);
+                                  next(std::move(ex));
+                               };
+                               try {
+                                  std::rethrow_exception(ex_ptr);
+                               } CATCH_AND_CALL(ex_handler)
+                            });
+                    return;
+                 }
+
+                 // key recovery complete, continue execution on the main thread
+                 app().executor().post(
+                         priority::low, exec_queue::read_write,
+                         [this, trx_meta{std::move(trx_meta)}, is_transient, next{std::move(next)}, api_trx, return_failure_traces]() {
+                            auto start       = fc::time_point::now();
+                            auto idle_time   = _time_tracker.add_idle_time(start);
+                            auto trx_tracker = _time_tracker.start_trx(is_transient, start);
+                            fc_tlog(_log, "Time since last trx: ${t}us", ("t", idle_time));
+
+                            auto exception_handler = [this, is_transient, &next, &trx_meta](fc::exception_ptr ex) {
+                               log_trx_results(trx_meta->packed_trx(), nullptr, ex, 0, is_transient);
+                               next(std::move(ex));
+                            };
+                            try {
+                               if (!process_incoming_transaction_async(trx_meta, api_trx, return_failure_traces, trx_tracker, next)) {
+                                  if (in_producing_mode()) {
+                                     schedule_maybe_produce_block(true);
+                                  } else {
+                                     restart_speculative_block();
+                                  }
+                               }
+                            }
+                            CATCH_AND_CALL(exception_handler);
+                         });
+              });
    }
 
    bool process_incoming_transaction_async(const transaction_metadata_ptr&             trx,
@@ -1068,8 +1079,6 @@ void producer_plugin::set_program_options(
           "Disable subjective CPU billing for P2P transactions")
          ("disable-subjective-api-billing", bpo::value<bool>()->default_value(true),
           "Disable subjective CPU billing for API transactions")
-         ("producer-threads", bpo::value<uint16_t>()->default_value(my->_thread_pool_size),
-          "Number of worker threads in producer thread pool")
          ("snapshots-dir", bpo::value<std::filesystem::path>()->default_value("snapshots"),
           "the location of the snapshots directory (absolute path or relative to application data dir)")
          ("read-only-threads", bpo::value<uint32_t>(),
@@ -1186,9 +1195,6 @@ void producer_plugin_impl::plugin_initialize(const boost::program_options::varia
       if (_disable_subjective_api_billing)
          ilog("Subjective CPU billing of API trxs disabled ");
    }
-
-   _thread_pool_size = options.at("producer-threads").as<uint16_t>();
-   SYS_ASSERT(_thread_pool_size > 0, plugin_config_exception, "producer-threads ${num} must be greater than 0", ("num", _thread_pool_size));
 
    if (options.count("snapshots-dir")) {
       auto sd = options.at("snapshots-dir").as<std::filesystem::path>();
@@ -1317,12 +1323,6 @@ void producer_plugin_impl::plugin_startup() {
       try {
          ilog("producer plugin:  plugin_startup() begin");
 
-         _thread_pool.start(_thread_pool_size, [](const fc::exception& e) {
-            fc_elog(_log, "Exception in producer thread pool, exiting: ${e}", ("e", e.to_detail_string()));
-            app().quit();
-         });
-
-
          chain::controller& chain = chain_plug->chain();
          SYS_ASSERT(_producers.empty() || chain.get_read_mode() != chain::db_read_mode::IRREVERSIBLE, plugin_config_exception,
                     "node cannot have any producer-name configured because block production is impossible when read_mode is \"irreversible\"");
@@ -1402,7 +1402,6 @@ void producer_plugin_impl::plugin_shutdown() {
    _ro_timer.cancel(ec);
    app().executor().stop();
    _ro_thread_pool.stop();
-   _thread_pool.stop();
    _unapplied_transactions.clear();
 
    app().executor().post(0, [me = shared_from_this()]() {}); // keep my pointer alive until queue is drained
@@ -2040,22 +2039,20 @@ inline std::string get_detailed_contract_except_info(const packed_transaction_pt
 }
 
 void producer_plugin_impl::log_trx_results(const transaction_metadata_ptr& trx,
-                                           const transaction_trace_ptr&    trace,
-                                           const fc::time_point&           start) {
+                                           const transaction_trace_ptr&    trace) {
    uint32_t billed_cpu_time_us = (trace && trace->receipt) ? trace->receipt->cpu_usage_us : 0;
-   log_trx_results(trx->packed_trx(), trace, nullptr, billed_cpu_time_us, start, trx->is_transient());
+   log_trx_results(trx->packed_trx(), trace, nullptr, billed_cpu_time_us, trx->is_transient());
 }
 
 void producer_plugin_impl::log_trx_results(const transaction_metadata_ptr& trx, const fc::exception_ptr& except_ptr) {
    uint32_t billed_cpu_time_us = trx ? trx->billed_cpu_time_us : 0;
-   log_trx_results(trx->packed_trx(), nullptr, except_ptr, billed_cpu_time_us, fc::time_point::now(), trx->is_transient());
+   log_trx_results(trx->packed_trx(), nullptr, except_ptr, billed_cpu_time_us, trx->is_transient());
 }
 
 void producer_plugin_impl::log_trx_results(const packed_transaction_ptr& trx,
                                            const transaction_trace_ptr&  trace,
                                            const fc::exception_ptr&      except_ptr,
                                            uint32_t                      billed_cpu_us,
-                                           const fc::time_point&         start,
                                            bool                          is_transient) {
    chain::controller& chain = chain_plug->chain();
 
@@ -2223,7 +2220,7 @@ producer_plugin_impl::handle_push_result(const transaction_metadata_ptr&        
             if (!disable_subjective_enforcement) // subjectively bill failure when producing since not in objective cpu account billing
                subjective_bill.subjective_bill_failure(first_auth, trace->elapsed, fc::time_point::now());
 
-            log_trx_results(trx, trace, start);
+            log_trx_results(trx, trace);
             // this failed our configured maximum transaction time, we don't want to replay it
             fc_tlog(_log, "Failed ${c} trx, auth: ${a}, prev billed: ${p}us, ran: ${r}us, id: ${id}, except: ${e}",
                     ("c", e.code())("a", first_auth)("p", prev_billed_cpu_time_us)("r", end - start)("id", trx->id())("e", e));
@@ -2242,7 +2239,7 @@ producer_plugin_impl::handle_push_result(const transaction_metadata_ptr&        
    } else {
       fc_tlog(_log, "Subjective bill for success ${a}: ${b} elapsed ${t}us, time ${r}us",
               ("a", first_auth)("b", sub_bill)("t", trace->elapsed)("r", end - start));
-      log_trx_results(trx, trace, start);
+      log_trx_results(trx, trace);
       // if producing then trx is in objective cpu account billing
       if (!disable_subjective_enforcement && !in_producing_mode()) {
          subjective_bill.subjective_bill(trx->id(), trx->packed_trx()->expiration(), first_auth, trace->elapsed);

--- a/tests/PerformanceHarness/README.md
+++ b/tests/PerformanceHarness/README.md
@@ -371,7 +371,6 @@ Operational Modes:
 
 ```
 usage: PerformanceHarnessScenarioRunner.py findMax testBpOpMode [--skip-tps-test]
-                                                                [--calc-producer-threads {none,lmax,full}]
                                                                 [--calc-chain-threads {none,lmax,full}]
                                                                 [--calc-net-threads {none,lmax,full}]
                                                                 [--del-test-report]
@@ -398,22 +397,6 @@ Performance Harness:
 
   --skip-tps-test       Determines whether to skip the max TPS measurement
                         tests
-  --calc-producer-threads {none,lmax,full}
-                        Determines whether to calculate number of worker
-                        threads to use in producer thread pool ("none",
-                        "lmax", or "full"). In "none" mode, the default, no
-                        calculation will be attempted and the configured
-                        --producer-threads value will be used. In "lmax" mode,
-                        producer threads will incrementally be tested,
-                        starting at plugin default, until the performance rate
-                        ceases to increase with the addition of additional
-                        threads. In "full" mode producer threads will
-                        incrementally be tested from plugin default..num
-                        logical processors, recording each performance and
-                        choosing the local max performance (same value as
-                        would be discovered in "lmax" mode). Useful for
-                        graphing the full performance impact of each available
-                        thread.
   --calc-chain-threads {none,lmax,full}
                         Determines whether to calculate number of worker
                         threads to use in chain thread pool ("none", "lmax",
@@ -505,7 +488,6 @@ usage: PerformanceHarnessScenarioRunner.py findMax testBpOpMode overrideBasicTes
        [--net-threads NET_THREADS]
        [--disable-subjective-billing DISABLE_SUBJECTIVE_BILLING]
        [--produce-block-offset-ms PRODUCE_BLOCK_OFFSET_MS]
-       [--producer-threads PRODUCER_THREADS]
        [--read-only-write-window-time-us READ_ONLY_WRITE_WINDOW_TIME_US]
        [--read-only-read-window-time-us READ_ONLY_READ_WINDOW_TIME_US]
        [--http-max-in-flight-requests HTTP_MAX_IN_FLIGHT_REQUESTS]
@@ -582,8 +564,6 @@ Performance Test Basic Base:
   --produce-block-offset-ms PRODUCE_BLOCK_OFFSET_MS
                         The number of milliseconds early the last block of a production round should
                         be produced.
-  --producer-threads PRODUCER_THREADS
-                        Number of worker threads in producer thread pool
   --read-only-write-window-time-us READ_ONLY_WRITE_WINDOW_TIME_US
                         Time in microseconds the write window lasts.
   --read-only-read-window-time-us READ_ONLY_READ_WINDOW_TIME_US
@@ -665,7 +645,6 @@ The following classes and scripts are typically used by the Performance Harness 
                                   [--net-threads NET_THREADS]
                                   [--disable-subjective-billing DISABLE_SUBJECTIVE_BILLING]
                                   [--produce-block-offset-ms PRODUCE_BLOCK_OFFSET_MS]
-                                  [--producer-threads PRODUCER_THREADS]
                                   [--http-max-in-flight-requests HTTP_MAX_IN_FLIGHT_REQUESTS]
                                   [--http-max-response-time-ms HTTP_MAX_RESPONSE_TIME_MS]
                                   [--http-max-bytes-in-flight-mb HTTP_MAX_BYTES_IN_FLIGHT_MB]
@@ -746,8 +725,6 @@ Performance Test Basic Base:
   --produce-block-offset-ms PRODUCE_BLOCK_OFFSET_MS
                         The number of milliseconds early the last block of a production round should
                         be produced.
-  --producer-threads PRODUCER_THREADS
-                        Number of worker threads in producer thread pool (default: 2)
   --http-max-in-flight-requests HTTP_MAX_IN_FLIGHT_REQUESTS
                         Maximum number of requests http_plugin should use for processing http requests. 429 error response when exceeded. -1 for unlimited (default: -1)
   --http-max-response-time-ms HTTP_MAX_RESPONSE_TIME_MS
@@ -879,7 +856,7 @@ The Performance Harness Scenario Runner, through the `PerformanceTest` and `Perf
 Command used to run test and generate report:
 
 ``` bash
-./tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-producer-threads lmax --calc-chain-threads lmax --calc-net-threads lmax
+./tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-chain-threads lmax --calc-net-threads lmax
 ```
 
 ### Report Breakdown
@@ -1255,7 +1232,7 @@ Finally, the full detail test report for each of the determined max TPS throughp
     "analysisFinish": "2023-08-18T17:39:08.002767"
   },
   "args": {
-    "rawCmdLine ": "tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-producer-threads lmax --calc-chain-threads lmax --calc-net-threads lmax",
+    "rawCmdLine ": "tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-chain-threads lmax --calc-net-threads lmax",
     "dumpErrorDetails": false,
     "delay": 1,
     "nodesFile": null,
@@ -1621,9 +1598,6 @@ Finally, the full detail test report for each of the determined max TPS throughp
         "disableSubjectiveApiBilling": true,
         "_disableSubjectiveApiBillingNodeopDefault": 1,
         "_disableSubjectiveApiBillingNodeopArg": "--disable-subjective-api-billing",
-        "producerThreads": 2,
-        "_producerThreadsNodeopDefault": 2,
-        "_producerThreadsNodeopArg": "--producer-threads",
         "snapshotsDir": null,
         "_snapshotsDirNodeopDefault": "\"snapshots\"",
         "_snapshotsDirNodeopArg": "--snapshots-dir",
@@ -1771,7 +1745,6 @@ Finally, the full detail test report for each of the determined max TPS throughp
     "quiet": false,
     "logDirRoot": ".",
     "skipTpsTests": false,
-    "calcProducerThreads": "lmax",
     "calcChainThreads": "lmax",
     "calcNetThreads": "lmax",
     "userTrxDataFile": null,
@@ -1915,7 +1888,7 @@ The Performance Test Basic generates, by default, a report that details results 
     }
   },
   "args": {
-    "rawCmdLine ": "tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-producer-threads lmax --calc-chain-threads lmax --calc-net-threads lmax",
+    "rawCmdLine ": "tests/PerformanceHarnessScenarioRunner.py findMax testBpOpMode --test-iteration-duration-sec 10 --final-iterations-duration-sec 30 --calc-chain-threads lmax --calc-net-threads lmax",
     "dumpErrorDetails": false,
     "delay": 1,
     "nodesFile": null,
@@ -2281,9 +2254,6 @@ The Performance Test Basic generates, by default, a report that details results 
         "disableSubjectiveApiBilling": true,
         "_disableSubjectiveApiBillingNodeopDefault": 1,
         "_disableSubjectiveApiBillingNodeopArg": "--disable-subjective-api-billing",
-        "producerThreads": 2,
-        "_producerThreadsNodeopDefault": 2,
-        "_producerThreadsNodeopArg": "--producer-threads",
         "snapshotsDir": null,
         "_snapshotsDirNodeopDefault": "\"snapshots\"",
         "_snapshotsDirNodeopArg": "--snapshots-dir",

--- a/tests/PerformanceHarness/performance_test.py
+++ b/tests/PerformanceHarness/performance_test.py
@@ -49,7 +49,6 @@ class PerformanceTest:
         quiet: bool=False
         logDirRoot: Path=Path(".")
         skipTpsTests: bool=False
-        calcProducerThreads: str="none"
         calcChainThreads: str="none"
         calcNetThreads: str="none"
         userTrxDataFile: Path=None
@@ -374,18 +373,6 @@ class PerformanceTest:
         self.testDirsCleanup()
         self.testDirsSetup()
 
-        prodResults = None
-        if self.ptConfig.calcProducerThreads != "none":
-            print(f"Performing Producer Thread Optimization Tests")
-            if self.ptConfig.calcProducerThreads == "full":
-                optType = PerformanceTest.PluginThreadOptRunType.FULL
-            else:
-                optType = PerformanceTest.PluginThreadOptRunType.LOCAL_MAX
-            prodResults = self.optimizePluginThreadCount(optPlugin=PerformanceTest.PluginThreadOpt.PRODUCER, optType=optType,
-                                                         minThreadCount=self.clusterConfig.extraNodeopArgs.producerPluginArgs._producerThreadsNodeopDefault)
-            print(f"Producer Thread Optimization results: {prodResults}")
-            self.clusterConfig.extraNodeopArgs.producerPluginArgs.threads = prodResults.recommendedThreadCount
-
         chainResults = None
         if self.ptConfig.calcChainThreads != "none":
             print(f"Performing Chain Thread Optimization Tests")
@@ -419,7 +406,7 @@ class PerformanceTest:
 
         self.testsFinish = datetime.now(UTC)
 
-        self.report = self.createReport(producerThreadResult=prodResults, chainThreadResult=chainResults, netThreadResult=netResults, tpsTestResult=tpsTestResult, nodeopVers=self.clusterConfig.nodeopVers)
+        self.report = self.createReport(chainThreadResult=chainResults, netThreadResult=netResults, tpsTestResult=tpsTestResult, nodeopVers=self.clusterConfig.nodeopVers)
         jsonReport = JsonReportHandler.reportAsJSON(self.report)
 
         if not self.ptConfig.quiet:
@@ -445,12 +432,6 @@ class PerfTestArgumentsHandler(object):
             ptGrpDescription="Performance Harness testing configuration items."
             ptParserGroup = ptParser.add_argument_group(title=None if suppressHelp else ptGrpTitle, description=None if suppressHelp else ptGrpDescription)
             ptParserGroup.add_argument("--skip-tps-test", help=argparse.SUPPRESS if suppressHelp else "Determines whether to skip the max TPS measurement tests", action='store_true')
-            ptParserGroup.add_argument("--calc-producer-threads", type=str, help=argparse.SUPPRESS if suppressHelp else "Determines whether to calculate number of worker threads to use in producer thread pool (\"none\", \"lmax\", or \"full\"). \
-                                                                        In \"none\" mode, the default, no calculation will be attempted and the configured --producer-threads value will be used. \
-                                                                        In \"lmax\" mode, producer threads will incrementally be tested, starting at plugin default, until the performance rate ceases to increase with the addition of additional threads. \
-                                                                        In \"full\" mode producer threads will incrementally be tested from plugin default..num logical processors, recording each performance and choosing the local max performance (same value as would be discovered in \"lmax\" mode). \
-                                                                        Useful for graphing the full performance impact of each available thread.",
-                                                                        choices=["none", "lmax", "full"], default="none")
             ptParserGroup.add_argument("--calc-chain-threads", type=str, help=argparse.SUPPRESS if suppressHelp else "Determines whether to calculate number of worker threads to use in chain thread pool (\"none\", \"lmax\", or \"full\"). \
                                                                         In \"none\" mode, the default, no calculation will be attempted and the configured --chain-threads value will be used. \
                                                                         In \"lmax\" mode, producer threads will incrementally be tested, starting at plugin default, until the performance rate ceases to increase with the addition of additional threads. \

--- a/tests/PerformanceHarness/performance_test_basic.py
+++ b/tests/PerformanceHarness/performance_test_basic.py
@@ -670,7 +670,7 @@ class PerformanceTestBasic:
         producerPluginArgs = ProducerPluginArgs(disableSubjectiveApiBilling=args.disable_subjective_billing,
                                                 disableSubjectiveP2pBilling=args.disable_subjective_billing,
                                                 produceBlockOffsetMs=args.produce_block_offset_ms,
-                                                producerThreads=args.producer_threads, maxTransactionTime=-1,
+                                                maxTransactionTime=-1,
                                                 readOnlyWriteWindowTimeUs=args.read_only_write_window_time_us,
                                                 readOnlyReadWindowTimeUs=args.read_only_read_window_time_us)
         httpPluginArgs = HttpPluginArgs(httpMaxBytesInFlightMb=args.http_max_bytes_in_flight_mb, httpMaxInFlightRequests=args.http_max_in_flight_requests,
@@ -727,7 +727,6 @@ class PtbArgumentsHandler(object):
         ptbBaseParserGroup.add_argument("--net-threads", type=int, help=argparse.SUPPRESS if suppressHelp else "Number of worker threads in net_plugin thread pool", default=4)
         ptbBaseParserGroup.add_argument("--disable-subjective-billing", type=bool, help=argparse.SUPPRESS if suppressHelp else "Disable subjective CPU billing for API/P2P transactions", default=True)
         ptbBaseParserGroup.add_argument("--produce-block-offset-ms", type=int, help=argparse.SUPPRESS if suppressHelp else "The minimum time to reserve at the end of a production round for blocks to propagate to the next block producer.", default=0)
-        ptbBaseParserGroup.add_argument("--producer-threads", type=int, help=argparse.SUPPRESS if suppressHelp else "Number of worker threads in producer thread pool", default=2)
         ptbBaseParserGroup.add_argument("--read-only-write-window-time-us", type=int, help=argparse.SUPPRESS if suppressHelp else "Time in microseconds the write window lasts.", default=200000)
         ptbBaseParserGroup.add_argument("--read-only-read-window-time-us", type=int, help=argparse.SUPPRESS if suppressHelp else "Time in microseconds the read window lasts.", default=60000)
         ptbBaseParserGroup.add_argument("--http-max-in-flight-requests", type=int, help=argparse.SUPPRESS if suppressHelp else "Maximum number of requests http_plugin should use for processing http requests. 429 error response when exceeded. -1 for unlimited", default=-1)

--- a/tests/PerformanceHarnessScenarioRunner.py
+++ b/tests/PerformanceHarnessScenarioRunner.py
@@ -82,7 +82,6 @@ def main():
                                             quiet=args.quiet,
                                             logDirRoot=Path("."),
                                             skipTpsTests=args.skip_tps_test,
-                                            calcProducerThreads=args.calc_producer_threads,
                                             calcChainThreads=args.calc_chain_threads,
                                             calcNetThreads=args.calc_net_threads,
                                             userTrxDataFile=Path(args.user_trx_data_file) if args.user_trx_data_file is not None else None,

--- a/tests/p2p_high_latency_test.py
+++ b/tests/p2p_high_latency_test.py
@@ -68,7 +68,7 @@ specificExtraNodeopArgs[syncingNodeId]="--p2p-peer-address 0.0.0.0:{}".format(98
 
 try:
     TestHelper.printSystemInfo("BEGIN")
-    traceNodeopArgs=" --plugin sysio::producer_plugin --produce-block-offset-ms 0 --producer-threads 1 --plugin sysio::net_plugin --net-threads 1"
+    traceNodeopArgs=" --plugin sysio::producer_plugin --produce-block-offset-ms 0 --plugin sysio::net_plugin --net-threads 1"
     if cluster.launch(pnodes=1, totalNodes=totalNodes, totalProducers=1, specificExtraNodeopArgs=specificExtraNodeopArgs, extraNodeopArgs=traceNodeopArgs) is False:
         Utils.cmdError("launcher")
         Utils.errorExit("Failed to stand up sys cluster.")


### PR DESCRIPTION
Cherry-pick from: https://github.com/AntelopeIO/leap/pull/1859

Remove the use of a `std::future` and `wait` in producer thread pool. Now after signature recovery is complete the chain thread posts directly to the main application thread. This improves the eosio token transfer per second (TPS) tests from ~31K TPS to ~36K TPS.

Transaction now transitions from net-thread => chain-thread => main-thread.

Removing the thread hop to chain-thread and performing key recovery on the net thread is possible (net-thread => main-thread), but testing shows it easily overwhelms the main-thread. Instead I think we need to create a memory pool of trxs that the main thread can pull from instead of pushing low priority tasks for trx execution to the main thread. That would greatly reduce the contention on the app post call and on the main thread priority queue. See https://github.com/AntelopeIO/leap/issues/1860

This builds off the improvement of https://github.com/AntelopeIO/leap/pull/1846

Removes `--producer-threads` option as there is now no use for the producer thread pool.