### PR TITLE
Fix a couple perf issues in `fc::raw::pack` and add tuple support.

### DIFF
--- a/libraries/libfc/include/fc/io/raw.hpp
+++ b/libraries/libfc/include/fc/io/raw.hpp
@@ -42,9 +42,14 @@ namespace fc {
     template<typename Stream, typename T> void unpack( Stream& s,  boost::multiprecision::number<T>& n );
 
     template<typename Stream, typename Arg0, typename... Args>
-    inline void pack( Stream& s, const Arg0& a0, Args... args ) {
+    inline void pack( Stream& s, const Arg0& a0, const Args&... args ) {
        pack( s, a0 );
        pack( s, args... );
+    }
+    template<typename Stream, typename Arg0, typename... Args>
+    inline void unpack( Stream& s, Arg0& a0, Args&... args ) {
+       unpack( s, a0 );
+       unpack( s, args... );
     }
 
     template<typename Stream>
@@ -249,7 +254,12 @@ namespace fc {
        FC_ASSERT( vi == tmp );
     }
 
-    template<typename Stream> inline void pack( Stream& s, const char* v ) { fc::raw::pack( s, std::string(v) ); }
+    template<typename Stream> inline void pack( Stream& s, const char* v ) {
+       size_t sz = std::strlen(v);
+       FC_ASSERT( sz <= MAX_SIZE_OF_BYTE_ARRAYS );
+       fc::raw::pack( s, unsigned_int(sz));
+       if( sz ) s.write( v, sz );
+    }
 
     template<typename Stream, typename T>
     void pack( Stream& s, const safe<T>& v ) { fc::raw::pack( s, v.value ); }
@@ -464,6 +474,16 @@ namespace fc {
       }
     }
 
+    template<typename Stream, typename... Ts >
+    inline void pack( Stream& s, const std::tuple<Ts...>& tup ) {
+       auto l = [&s](const auto&... v) { fc::raw::pack( s, v... ); };
+       std::apply(l, tup);
+    }
+    template<typename Stream, typename... Ts >
+    inline void unpack( Stream& s, std::tuple<Ts...>& tup ) {
+       auto l = [&s](auto&... v) { fc::raw::unpack( s, v... ); };
+       std::apply(l, tup);
+    }
 
     template<typename Stream, typename K, typename V>
     inline void pack( Stream& s, const std::pair<K,V>& value ) {


### PR DESCRIPTION
See https://github.com/AntelopeIO/leap/pull/1917
* pack parameters were passed by value causing unneeded copies.
* packing a char* was unnecessarily allocating a temp std::string.
* added std::tuple support for pack, so that we can provide lists longer than pairs, so we don't have to do [this](https://github.com/AntelopeIO/leap/blob/4b34cf572886dda4641c650d36a142bd2aeea3bc/libraries/chain/include/eosio/chain/hotstuff.hpp#L17-L18).