### PR TITLE
Minor cleanups to `memfd_create()`

### DIFF
--- a/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/ipc_helpers.hpp
+++ b/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/ipc_helpers.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <sysio/chain/webassembly/sys-vm-oc/ipc_protocol.hpp>
+#include <sysio/chain/webassembly/sys-vm-oc/memfd_helpers.hpp>
 
 #include <boost/asio/local/datagram_protocol.hpp>
 
 #include <vector>
 
-#include <linux/memfd.h>
-
-namespace sysio { namespace chain { namespace sysvmoc {
+namespace sysio { namespace chain { namespace eosvmoc {
 
 class wrapped_fd {
    public:
@@ -53,7 +52,7 @@ bool write_message_with_fds(int fd_to_send_to, const sysvmoc_message& message, c
 
 template<typename T>
 wrapped_fd memfd_for_bytearray(const T& bytes) {
-   int fd = memfd_create("sysvmoc_code", MFD_CLOEXEC);
+   int fd = exec_sealed_memfd_create("sysvmoc_code");
    FC_ASSERT(fd >= 0, "Failed to create memfd");
    FC_ASSERT(ftruncate(fd, bytes.size()) == 0, "failed to grow memfd");
    if(bytes.size()) {

--- a/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/ipc_helpers.hpp
+++ b/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/ipc_helpers.hpp
@@ -7,7 +7,7 @@
 
 #include <vector>
 
-namespace sysio { namespace chain { namespace eosvmoc {
+namespace sysio { namespace chain { namespace sysvmoc {
 
 class wrapped_fd {
    public:

--- a/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/ipc_helpers.hpp
+++ b/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/ipc_helpers.hpp
@@ -6,7 +6,6 @@
 
 #include <vector>
 
-#include <sys/syscall.h>
 #include <linux/memfd.h>
 
 namespace sysio { namespace chain { namespace sysvmoc {
@@ -54,7 +53,7 @@ bool write_message_with_fds(int fd_to_send_to, const sysvmoc_message& message, c
 
 template<typename T>
 wrapped_fd memfd_for_bytearray(const T& bytes) {
-   int fd = syscall(SYS_memfd_create, "sysvmoc_code", MFD_CLOEXEC);
+   int fd = memfd_create("sysvmoc_code", MFD_CLOEXEC);
    FC_ASSERT(fd >= 0, "Failed to create memfd");
    FC_ASSERT(ftruncate(fd, bytes.size()) == 0, "failed to grow memfd");
    if(bytes.size()) {

--- a/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/memfd_helpers.hpp
+++ b/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/memfd_helpers.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <linux/memfd.h>
+#include <sys/mman.h>
+
+namespace sysio::chain::sysvmoc {
+
+// added in glibc 2.38
+#ifndef MFD_NOEXEC_SEAL
+#define MFD_NOEXEC_SEAL 8U
+#endif
+
+inline int exec_sealed_memfd_create(const char* name) {
+   //kernels 6.3 through 6.6 by default warn when neither MFD_NOEXEC_SEAL nor MFD_EXEC are passed; optionally 6.3+
+   // may enforce MFD_NOEXEC_SEAL. Prior to 6.3 these flags will EINVAL.
+   if(int ret = memfd_create(name, MFD_CLOEXEC | MFD_NOEXEC_SEAL); ret >= 0 || errno != EINVAL)
+      return ret;
+   return memfd_create(name, MFD_CLOEXEC);
+}
+
+}

--- a/libraries/chain/webassembly/runtimes/sys-vm-oc/memory.cpp
+++ b/libraries/chain/webassembly/runtimes/sys-vm-oc/memory.cpp
@@ -1,19 +1,19 @@
 #include <sysio/chain/webassembly/sys-vm-oc/memory.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/intrinsic.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/intrinsic_mapping.hpp>
+#include <sysio/chain/webassembly/sys-vm-oc/memfd_helpers.hpp>
 
 #include <fc/scoped_exit.hpp>
 
 #include <unistd.h>
 #include <sys/mman.h>
-#include <linux/memfd.h>
 
 namespace sysio { namespace chain { namespace sysvmoc {
 
 memory::memory(uint64_t sliced_pages) {
    uint64_t number_slices = sliced_pages + 1;
    uint64_t wasm_memory_size = sliced_pages * wasm_constraints::wasm_page_size;
-   int fd = memfd_create("sysvmoc_mem", MFD_CLOEXEC);
+   int fd = exec_sealed_memfd_create("sysvmoc_mem");
    FC_ASSERT(fd >= 0, "Failed to create memory memfd");
    auto cleanup_fd = fc::make_scoped_exit([&fd](){close(fd);});
    int ret = ftruncate(fd, wasm_memory_size+memory_prologue_size);

--- a/libraries/chain/webassembly/runtimes/sys-vm-oc/memory.cpp
+++ b/libraries/chain/webassembly/runtimes/sys-vm-oc/memory.cpp
@@ -5,7 +5,6 @@
 #include <fc/scoped_exit.hpp>
 
 #include <unistd.h>
-#include <sys/syscall.h>
 #include <sys/mman.h>
 #include <linux/memfd.h>
 
@@ -14,7 +13,7 @@ namespace sysio { namespace chain { namespace sysvmoc {
 memory::memory(uint64_t sliced_pages) {
    uint64_t number_slices = sliced_pages + 1;
    uint64_t wasm_memory_size = sliced_pages * wasm_constraints::wasm_page_size;
-   int fd = syscall(SYS_memfd_create, "sysvmoc_mem", MFD_CLOEXEC);
+   int fd = memfd_create("sysvmoc_mem", MFD_CLOEXEC);
    FC_ASSERT(fd >= 0, "Failed to create memory memfd");
    auto cleanup_fd = fc::make_scoped_exit([&fd](){close(fd);});
    int ret = ftruncate(fd, wasm_memory_size+memory_prologue_size);


### PR DESCRIPTION
From https://github.com/AntelopeIO/leap/pull/2114

> Two small tweaks,
> 
> When `memfd_create()` was first used in EOSIO 2.0, RHEL7 was a targeted platform. Despite RHEL7's kernel shipping with memfd support, its glibc did not as it was too old. So instead, a direct `syscall()` was used. Now that we don't care about RHEL7 any longer we can just use `memfd_create()` proper; both Ubuntu 18.04 and RHEL8 have a new enough glibc that includes support.
> 
> As of Linux 6.3 the kernel starts to log a warning about nodeos,
> 
> `nodeos[266224]: memfd_create() called without MFD_EXEC or MFD_NOEXEC_SEAL set`
>
> This warning has actually been walked back and completely removed as of Linux 6.7. Still, using the new `MFD_NOEXEC_SEAL` seems like good behavior for future proofing as environments may one day set the new memfd_noexec knob to enforce `MFD_NOEXEC_SEAL` usage. Sadly, the `MFD_NOEXEC_SEAL` define is only available out of the box on the very latest glibc 2.38 (released July 2023), and Linux prior to 6.3 will `EINVAL` on `MFD_NOEXEC_SEAL` so we need a little bit of fluff to gracefully handle these variations.