### PR TITLE
Tests: Explicit shutdown since atexit not called on error

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -1,4 +1,3 @@
-import atexit
 import copy
 import subprocess
 import time
@@ -82,7 +81,6 @@ class Cluster(object):
         keepRunning: [True|False] If true, leave nodes running when Cluster is destroyed. Implies keepLogs.
         keepLogs: [True|False] If true, retain log files after cluster shuts down.
         """
-        atexit.register(self.shutdown)
         self.accounts=[]
         self.nodes=[]
         self.unstartedNodes=[]

--- a/tests/TestHarness/TestHelper.py
+++ b/tests/TestHarness/TestHelper.py
@@ -190,3 +190,5 @@ class TestHelper(object):
         cluster.testFailed = not testSuccessful
         if walletMgr:
             walletMgr.testFailed = not testSuccessful
+
+        cluster.shutdown()

--- a/tests/trace_plugin_test.py
+++ b/tests/trace_plugin_test.py
@@ -117,6 +117,7 @@ class TraceApiPluginTest(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         TraceApiPluginTest.cluster.testFailed = not testSuccessful
+        TraceApiPluginTest.cluster.shutdown()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
From: https://github.com/AntelopeIO/leap/pull/2192

Python does not call `atexit` on error. Revert back to calling `shutdown` explicitly from `TestHelper.shutdown`.
`trace_plugin_test.py` was the only test not already explicitly calling `TestHelper.shutdown`.
