### PR TITLE
Update to `wire-vcpkg-registry` with `secp256k1` version `0.7.0`.

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
-      "baseline": "315947a8cb23b89eea290f52d52cdd6b34eb6242",
+      "baseline": "7dc586d8cc7c5dacc5aa16e33ea7dd28fa9c5bb3",
       "packages": [
         "softfloat",
         "libsodium",


### PR DESCRIPTION
Upgrade to 0.7.0 of secp256k1 from 0.4.0.
Uses `bitcoin-core` repo directly now instead of Wire fork.