### PR TITLE
Add precompiled header support for fc and sysio_chain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(GNUInstallDirs)
 include(MASSigning)
 include(AddTestHelpers)
+include(precompiled-headers)
 
 # Options
 option(ENABLE_WERROR "Enable `-Werror` compilation flag." Off)

--- a/cmake/include/sysio-pch.hpp
+++ b/cmake/include/sysio-pch.hpp
@@ -1,0 +1,168 @@
+// sysio-pch.hpp — precompiled header for fc and sysio_chain targets.
+//
+// This file is consumed by target_precompile_headers() in
+// cmake/precompiled-headers.cmake.  Both targets share a single source
+// file; headers that are only available in the chain target's include
+// path are guarded with __has_include so the fc PCH compilation
+// silently skips them.
+//
+// Header selection criteria:
+//   - Frequently included across many TUs in the target
+//   - Rarely or never modified (Boost/STL are ideal)
+//   - Heavy parse cost (boost/multiprecision, boost/asio, boost/beast)
+//   - Project headers only when stable and included in >25% of TUs
+//
+// Maintenance notes:
+//   - boost/range headers are intentionally excluded because they
+//     conflict with <ranges> (ADL ambiguity: boost::range::find vs
+//     std::ranges::find).  Prefer std::ranges in new code.
+//   - Adding a header here that changes frequently will hurt
+//     incremental builds — any PCH header change forces recompilation
+//     of every TU in the target.
+
+#pragma once
+
+// =====================================================================
+// C++ standard library
+// =====================================================================
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <ranges>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// =====================================================================
+// Boost: multiprecision
+// =====================================================================
+#include <boost/multiprecision/cpp_int.hpp>
+
+// =====================================================================
+// Boost: multi_index
+// =====================================================================
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index_container_fwd.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/multi_index/global_fun.hpp>
+#if __has_include(<boost/multi_index/random_access_index.hpp>)
+#include <boost/multi_index/random_access_index.hpp>
+#endif
+
+// =====================================================================
+// Boost: iostreams
+// =====================================================================
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/device/array.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include <boost/iostreams/categories.hpp>
+#include <boost/iostreams/pipeline.hpp>
+#include <boost/iostreams/positioning.hpp>
+
+// =====================================================================
+// Boost: asio
+// =====================================================================
+#include <boost/asio.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/thread_pool.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/use_future.hpp>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/random_access_file.hpp>
+#include <boost/asio/local/datagram_protocol.hpp>
+
+// =====================================================================
+// Boost: interprocess
+// =====================================================================
+#include <boost/interprocess/file_mapping.hpp>
+#include <boost/interprocess/mapped_region.hpp>
+#include <boost/interprocess/exceptions.hpp>
+
+// =====================================================================
+// Boost: beast
+// =====================================================================
+#include <boost/beast.hpp>
+
+// =====================================================================
+// Boost: preprocessor (used by fc::reflect macros)
+// =====================================================================
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/seq/enum.hpp>
+#include <boost/preprocessor/seq/size.hpp>
+#include <boost/preprocessor/seq/seq.hpp>
+#include <boost/preprocessor/stringize.hpp>
+
+// =====================================================================
+// Boost: signals2
+// =====================================================================
+#include <boost/signals2/signal.hpp>
+
+// =====================================================================
+// Boost: misc utilities
+// =====================================================================
+#include <boost/lexical_cast.hpp>
+#include <boost/core/typeinfo.hpp>
+#include <boost/core/demangle.hpp>
+#include <boost/core/ignore_unused.hpp>
+#include <boost/exception/diagnostic_information.hpp>
+#include <boost/scoped_array.hpp>
+#include <boost/dll/runtime_symbol_info.hpp>
+#include <boost/crc.hpp>
+#include <boost/pool/singleton_pool.hpp>
+#include <boost/container/flat_set.hpp>
+#include <boost/unordered/unordered_flat_map.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/hana/string.hpp>
+#include <boost/hana/equal.hpp>
+#include <boost/rational.hpp>
+#include <boost/tuple/tuple_io.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/assign/list_of.hpp>
+
+// =====================================================================
+// fc project headers (stable foundation, included across most TUs)
+// =====================================================================
+#include <fc/exception/exception.hpp>
+#include <fc/log/logger.hpp>
+#include <fc/variant.hpp>
+#include <fc/variant_object.hpp>
+#include <fc/reflect/reflect.hpp>
+#include <fc/crypto/hex.hpp>
+#include <fc/io/json.hpp>
+#include <fc/io/raw.hpp>
+#include <fc/io/datastream.hpp>
+#include <fc/string.hpp>
+#include <fc/fwd_impl.hpp>
+#include <fc/time.hpp>
+#include <fc/bitutil.hpp>
+
+// =====================================================================
+// chain project headers (only available when building sysio_chain)
+// =====================================================================
+#if __has_include(<sysio/chain/exceptions.hpp>)
+#include <sysio/chain/exceptions.hpp>
+#include <sysio/chain/apply_context.hpp>
+#include <sysio/chain/controller.hpp>
+#include <sysio/chain/account_object.hpp>
+#include <sysio/chain/global_property_object.hpp>
+#include <sysio/chain/transaction_context.hpp>
+#include <sysio/chain/authorization_manager.hpp>
+#include <sysio/chain/deep_mind.hpp>
+#include <sysio/chain/resource_limits.hpp>
+#endif

--- a/cmake/precompiled-headers.cmake
+++ b/cmake/precompiled-headers.cmake
@@ -3,29 +3,17 @@
 # Precompiled header (PCH) support for fc and sysio_chain targets.
 # Toggle with -DENABLE_PCH=ON|OFF (default ON).
 #
+# The actual header list lives in cmake/include/sysio-pch.hpp.
+# Both targets share a single file; chain-only headers are guarded
+# with __has_include so the fc PCH compilation silently skips them.
+#
 # Benchmarked on fc + sysio_chain clean build (12-core, clang-18, Debug):
 #   Without PCH: 2m 55s wall / 3014s CPU
 #   With PCH:    1m 36s wall / 1129s CPU  (45% wall-time reduction)
-#
-# Header selection criteria:
-#   - Frequently included across many TUs in the target
-#   - Rarely or never modified (Boost/STL are ideal — zero local edits)
-#   - Heavy parse cost (boost/multiprecision, boost/asio, boost/beast)
-#   - Project headers only when stable and included in >25% of TUs
-#
-# Maintenance notes:
-#   - boost/range headers are intentionally excluded from the chain PCH
-#     because they conflict with <ranges> (ADL ambiguity between
-#     boost::range::find and std::ranges::find). Prefer std::ranges in
-#     new code; see authority_checker.hpp and parallel_markers.hpp.
-#   - The chain target mixes C and C++ sources. The C file
-#     (gs_seg_helpers.c) must be excluded via SKIP_PRECOMPILE_HEADERS
-#     since this PCH is C++ only.
-#   - Adding a header here that changes frequently will hurt incremental
-#     builds — any PCH header change forces recompilation of every TU
-#     in the target.
 
 option(ENABLE_PCH "Enable precompiled headers for faster builds" ON)
+
+set(SYSIO_PCH_HEADER "${CMAKE_SOURCE_DIR}/cmake/include/sysio-pch.hpp")
 
 # ---------------------------------------------------------------------------
 # fc (foundation library, ~70 TUs)
@@ -35,86 +23,7 @@ function(configure_fc_pch target)
       return()
    endif()
 
-   target_precompile_headers(${target} PRIVATE
-      # --- C++ standard library ---
-      <algorithm>
-      <fstream>
-      <iostream>
-      <limits>
-      <memory>
-      <ranges>
-      <sstream>
-      <string>
-      <string_view>
-      <vector>
-
-      # --- Boost: multiprecision (single heaviest header; used by variant, datastream, raw, int256) ---
-      <boost/multiprecision/cpp_int.hpp>
-
-      # --- Boost: multi_index (used by tracked_storage, various indices) ---
-      <boost/multi_index_container.hpp>
-      <boost/multi_index_container_fwd.hpp>
-      <boost/multi_index/ordered_index.hpp>
-      <boost/multi_index/hashed_index.hpp>
-      <boost/multi_index/member.hpp>
-      <boost/multi_index/mem_fun.hpp>
-      <boost/multi_index/composite_key.hpp>
-      <boost/multi_index/global_fun.hpp>
-
-      # --- Boost: iostreams (used by json.cpp, zlib.cpp, random_access_file) ---
-      <boost/iostreams/filtering_stream.hpp>
-      <boost/iostreams/device/back_inserter.hpp>
-      <boost/iostreams/device/array.hpp>
-      <boost/iostreams/device/mapped_file.hpp>
-      <boost/iostreams/stream.hpp>
-      <boost/iostreams/filter/zlib.hpp>
-      <boost/iostreams/categories.hpp>
-      <boost/iostreams/pipeline.hpp>
-      <boost/iostreams/positioning.hpp>
-
-      # --- Boost: asio (used by listener, message_buffer, mock_time) ---
-      <boost/asio/ip/tcp.hpp>
-      <boost/asio/deadline_timer.hpp>
-      <boost/asio/random_access_file.hpp>
-
-      # --- Boost: interprocess (used by exception.hpp, cfile.hpp, random_access_file) ---
-      <boost/interprocess/file_mapping.hpp>
-      <boost/interprocess/mapped_region.hpp>
-      <boost/interprocess/exceptions.hpp>
-
-      # --- Boost: beast (used by random_access_file.hpp) ---
-      <boost/beast.hpp>
-
-      # --- Boost: preprocessor (used by fc::reflect macros) ---
-      <boost/preprocessor/seq/for_each.hpp>
-      <boost/preprocessor/seq/enum.hpp>
-      <boost/preprocessor/seq/size.hpp>
-      <boost/preprocessor/seq/seq.hpp>
-      <boost/preprocessor/stringize.hpp>
-
-      # --- Boost: misc utilities ---
-      <boost/lexical_cast.hpp>
-      <boost/core/typeinfo.hpp>
-      <boost/core/demangle.hpp>
-      <boost/exception/diagnostic_information.hpp>
-      <boost/scoped_array.hpp>
-      <boost/dll/runtime_symbol_info.hpp>
-      <boost/crc.hpp>
-      <boost/pool/singleton_pool.hpp>
-
-      # --- fc project headers (stable foundation, included in 15-35 of ~70 TUs) ---
-      <fc/exception/exception.hpp>
-      <fc/log/logger.hpp>
-      <fc/variant.hpp>
-      <fc/variant_object.hpp>
-      <fc/reflect/reflect.hpp>
-      <fc/crypto/hex.hpp>
-      <fc/io/json.hpp>
-      <fc/io/raw.hpp>
-      <fc/io/datastream.hpp>
-      <fc/string.hpp>
-      <fc/fwd_impl.hpp>
-   )
+   target_precompile_headers(${target} PRIVATE ${SYSIO_PCH_HEADER})
 endfunction()
 
 # ---------------------------------------------------------------------------
@@ -132,83 +41,5 @@ function(configure_chain_pch target)
       PROPERTIES SKIP_PRECOMPILE_HEADERS ON
    )
 
-   target_precompile_headers(${target} PRIVATE
-      # --- C++ standard library ---
-      <algorithm>
-      <memory>
-      <mutex>
-      <ranges>
-      <string>
-      <vector>
-
-      # --- Boost: multiprecision ---
-      <boost/multiprecision/cpp_int.hpp>
-
-      # --- Boost: multi_index (used by fork_database, vote_processor, subjective_billing, snapshot_scheduler) ---
-      <boost/multi_index_container.hpp>
-      <boost/multi_index/ordered_index.hpp>
-      <boost/multi_index/hashed_index.hpp>
-      <boost/multi_index/member.hpp>
-      <boost/multi_index/mem_fun.hpp>
-      <boost/multi_index/composite_key.hpp>
-      <boost/multi_index/global_fun.hpp>
-      <boost/multi_index/random_access_index.hpp>
-
-      # --- Boost: asio (used by thread_utils, transaction_metadata, wasm_interface, platform_timer) ---
-      <boost/asio.hpp>
-      <boost/asio/io_context.hpp>
-      <boost/asio/thread_pool.hpp>
-      <boost/asio/post.hpp>
-      <boost/asio/use_future.hpp>
-      <boost/asio/local/datagram_protocol.hpp>
-
-      # --- Boost: iostreams (used by transaction.cpp, zlib compression) ---
-      <boost/iostreams/filtering_stream.hpp>
-      <boost/iostreams/device/back_inserter.hpp>
-      <boost/iostreams/filter/zlib.hpp>
-
-      # --- Boost: signals2 (used by controller.hpp) ---
-      <boost/signals2/signal.hpp>
-
-      # --- Boost: misc utilities ---
-      <boost/container/flat_set.hpp>
-      <boost/unordered/unordered_flat_map.hpp>
-      <boost/core/demangle.hpp>
-      <boost/core/typeinfo.hpp>
-      <boost/core/ignore_unused.hpp>
-      <boost/algorithm/string.hpp>
-      # NOTE: boost/range intentionally excluded — conflicts with <ranges>
-      # (ADL ambiguity: boost::range::find vs std::ranges::find).
-      # Use std::find / std::ranges in new code instead.
-      <boost/hana/string.hpp>
-      <boost/hana/equal.hpp>
-      <boost/rational.hpp>
-      <boost/tuple/tuple_io.hpp>
-      <boost/property_tree/ptree.hpp>
-      <boost/property_tree/json_parser.hpp>
-      <boost/date_time/posix_time/posix_time.hpp>
-      <boost/accumulators/accumulators.hpp>
-      <boost/accumulators/statistics/stats.hpp>
-      <boost/assign/list_of.hpp>
-
-      # --- fc project headers (stable, used across most chain TUs) ---
-      <fc/exception/exception.hpp>
-      <fc/io/json.hpp>
-      <fc/io/raw.hpp>
-      <fc/variant.hpp>
-      <fc/time.hpp>
-      <fc/bitutil.hpp>
-      <fc/reflect/reflect.hpp>
-
-      # --- chain project headers (stable, used in 8-28 of ~50 TUs) ---
-      <sysio/chain/exceptions.hpp>
-      <sysio/chain/apply_context.hpp>
-      <sysio/chain/controller.hpp>
-      <sysio/chain/account_object.hpp>
-      <sysio/chain/global_property_object.hpp>
-      <sysio/chain/transaction_context.hpp>
-      <sysio/chain/authorization_manager.hpp>
-      <sysio/chain/deep_mind.hpp>
-      <sysio/chain/resource_limits.hpp>
-   )
+   target_precompile_headers(${target} PRIVATE ${SYSIO_PCH_HEADER})
 endfunction()

--- a/cmake/precompiled-headers.cmake
+++ b/cmake/precompiled-headers.cmake
@@ -1,0 +1,214 @@
+# precompiled-headers.cmake
+#
+# Precompiled header (PCH) support for fc and sysio_chain targets.
+# Toggle with -DENABLE_PCH=ON|OFF (default ON).
+#
+# Benchmarked on fc + sysio_chain clean build (12-core, clang-18, Debug):
+#   Without PCH: 2m 55s wall / 3014s CPU
+#   With PCH:    1m 36s wall / 1129s CPU  (45% wall-time reduction)
+#
+# Header selection criteria:
+#   - Frequently included across many TUs in the target
+#   - Rarely or never modified (Boost/STL are ideal — zero local edits)
+#   - Heavy parse cost (boost/multiprecision, boost/asio, boost/beast)
+#   - Project headers only when stable and included in >25% of TUs
+#
+# Maintenance notes:
+#   - boost/range headers are intentionally excluded from the chain PCH
+#     because they conflict with <ranges> (ADL ambiguity between
+#     boost::range::find and std::ranges::find). Prefer std::ranges in
+#     new code; see authority_checker.hpp and parallel_markers.hpp.
+#   - The chain target mixes C and C++ sources. The C file
+#     (gs_seg_helpers.c) must be excluded via SKIP_PRECOMPILE_HEADERS
+#     since this PCH is C++ only.
+#   - Adding a header here that changes frequently will hurt incremental
+#     builds — any PCH header change forces recompilation of every TU
+#     in the target.
+
+option(ENABLE_PCH "Enable precompiled headers for faster builds" ON)
+
+# ---------------------------------------------------------------------------
+# fc (foundation library, ~70 TUs)
+# ---------------------------------------------------------------------------
+function(configure_fc_pch target)
+   if(NOT ENABLE_PCH)
+      return()
+   endif()
+
+   target_precompile_headers(${target} PRIVATE
+      # --- C++ standard library ---
+      <algorithm>
+      <fstream>
+      <iostream>
+      <limits>
+      <memory>
+      <ranges>
+      <sstream>
+      <string>
+      <string_view>
+      <vector>
+
+      # --- Boost: multiprecision (single heaviest header; used by variant, datastream, raw, int256) ---
+      <boost/multiprecision/cpp_int.hpp>
+
+      # --- Boost: multi_index (used by tracked_storage, various indices) ---
+      <boost/multi_index_container.hpp>
+      <boost/multi_index_container_fwd.hpp>
+      <boost/multi_index/ordered_index.hpp>
+      <boost/multi_index/hashed_index.hpp>
+      <boost/multi_index/member.hpp>
+      <boost/multi_index/mem_fun.hpp>
+      <boost/multi_index/composite_key.hpp>
+      <boost/multi_index/global_fun.hpp>
+
+      # --- Boost: iostreams (used by json.cpp, zlib.cpp, random_access_file) ---
+      <boost/iostreams/filtering_stream.hpp>
+      <boost/iostreams/device/back_inserter.hpp>
+      <boost/iostreams/device/array.hpp>
+      <boost/iostreams/device/mapped_file.hpp>
+      <boost/iostreams/stream.hpp>
+      <boost/iostreams/filter/zlib.hpp>
+      <boost/iostreams/categories.hpp>
+      <boost/iostreams/pipeline.hpp>
+      <boost/iostreams/positioning.hpp>
+
+      # --- Boost: asio (used by listener, message_buffer, mock_time) ---
+      <boost/asio/ip/tcp.hpp>
+      <boost/asio/deadline_timer.hpp>
+      <boost/asio/random_access_file.hpp>
+
+      # --- Boost: interprocess (used by exception.hpp, cfile.hpp, random_access_file) ---
+      <boost/interprocess/file_mapping.hpp>
+      <boost/interprocess/mapped_region.hpp>
+      <boost/interprocess/exceptions.hpp>
+
+      # --- Boost: beast (used by random_access_file.hpp) ---
+      <boost/beast.hpp>
+
+      # --- Boost: preprocessor (used by fc::reflect macros) ---
+      <boost/preprocessor/seq/for_each.hpp>
+      <boost/preprocessor/seq/enum.hpp>
+      <boost/preprocessor/seq/size.hpp>
+      <boost/preprocessor/seq/seq.hpp>
+      <boost/preprocessor/stringize.hpp>
+
+      # --- Boost: misc utilities ---
+      <boost/lexical_cast.hpp>
+      <boost/core/typeinfo.hpp>
+      <boost/core/demangle.hpp>
+      <boost/exception/diagnostic_information.hpp>
+      <boost/scoped_array.hpp>
+      <boost/dll/runtime_symbol_info.hpp>
+      <boost/crc.hpp>
+      <boost/pool/singleton_pool.hpp>
+
+      # --- fc project headers (stable foundation, included in 15-35 of ~70 TUs) ---
+      <fc/exception/exception.hpp>
+      <fc/log/logger.hpp>
+      <fc/variant.hpp>
+      <fc/variant_object.hpp>
+      <fc/reflect/reflect.hpp>
+      <fc/crypto/hex.hpp>
+      <fc/io/json.hpp>
+      <fc/io/raw.hpp>
+      <fc/io/datastream.hpp>
+      <fc/string.hpp>
+      <fc/fwd_impl.hpp>
+   )
+endfunction()
+
+# ---------------------------------------------------------------------------
+# sysio_chain (blockchain core, ~50 C++ TUs + 1 C file + 1 .s file)
+# ---------------------------------------------------------------------------
+function(configure_chain_pch target)
+   if(NOT ENABLE_PCH)
+      return()
+   endif()
+
+   # Exclude C source from C++ PCH (would fail on #include <algorithm> etc.)
+   set_source_files_properties(
+      webassembly/runtimes/sys-vm-oc/gs_seg_helpers.c
+      DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      PROPERTIES SKIP_PRECOMPILE_HEADERS ON
+   )
+
+   target_precompile_headers(${target} PRIVATE
+      # --- C++ standard library ---
+      <algorithm>
+      <memory>
+      <mutex>
+      <ranges>
+      <string>
+      <vector>
+
+      # --- Boost: multiprecision ---
+      <boost/multiprecision/cpp_int.hpp>
+
+      # --- Boost: multi_index (used by fork_database, vote_processor, subjective_billing, snapshot_scheduler) ---
+      <boost/multi_index_container.hpp>
+      <boost/multi_index/ordered_index.hpp>
+      <boost/multi_index/hashed_index.hpp>
+      <boost/multi_index/member.hpp>
+      <boost/multi_index/mem_fun.hpp>
+      <boost/multi_index/composite_key.hpp>
+      <boost/multi_index/global_fun.hpp>
+      <boost/multi_index/random_access_index.hpp>
+
+      # --- Boost: asio (used by thread_utils, transaction_metadata, wasm_interface, platform_timer) ---
+      <boost/asio.hpp>
+      <boost/asio/io_context.hpp>
+      <boost/asio/thread_pool.hpp>
+      <boost/asio/post.hpp>
+      <boost/asio/use_future.hpp>
+      <boost/asio/local/datagram_protocol.hpp>
+
+      # --- Boost: iostreams (used by transaction.cpp, zlib compression) ---
+      <boost/iostreams/filtering_stream.hpp>
+      <boost/iostreams/device/back_inserter.hpp>
+      <boost/iostreams/filter/zlib.hpp>
+
+      # --- Boost: signals2 (used by controller.hpp) ---
+      <boost/signals2/signal.hpp>
+
+      # --- Boost: misc utilities ---
+      <boost/container/flat_set.hpp>
+      <boost/unordered/unordered_flat_map.hpp>
+      <boost/core/demangle.hpp>
+      <boost/core/typeinfo.hpp>
+      <boost/core/ignore_unused.hpp>
+      <boost/algorithm/string.hpp>
+      # NOTE: boost/range intentionally excluded — conflicts with <ranges>
+      # (ADL ambiguity: boost::range::find vs std::ranges::find).
+      # Use std::find / std::ranges in new code instead.
+      <boost/hana/string.hpp>
+      <boost/hana/equal.hpp>
+      <boost/rational.hpp>
+      <boost/tuple/tuple_io.hpp>
+      <boost/property_tree/ptree.hpp>
+      <boost/property_tree/json_parser.hpp>
+      <boost/date_time/posix_time/posix_time.hpp>
+      <boost/accumulators/accumulators.hpp>
+      <boost/accumulators/statistics/stats.hpp>
+      <boost/assign/list_of.hpp>
+
+      # --- fc project headers (stable, used across most chain TUs) ---
+      <fc/exception/exception.hpp>
+      <fc/io/json.hpp>
+      <fc/io/raw.hpp>
+      <fc/variant.hpp>
+      <fc/time.hpp>
+      <fc/bitutil.hpp>
+      <fc/reflect/reflect.hpp>
+
+      # --- chain project headers (stable, used in 8-28 of ~50 TUs) ---
+      <sysio/chain/exceptions.hpp>
+      <sysio/chain/apply_context.hpp>
+      <sysio/chain/controller.hpp>
+      <sysio/chain/account_object.hpp>
+      <sysio/chain/global_property_object.hpp>
+      <sysio/chain/transaction_context.hpp>
+      <sysio/chain/authorization_manager.hpp>
+      <sysio/chain/deep_mind.hpp>
+      <sysio/chain/resource_limits.hpp>
+   )
+endfunction()

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -171,6 +171,8 @@ target_include_directories( sysio_chain
                             )
 target_compile_definitions( sysio_chain PUBLIC ${CHAIN_NATIVE_MODULE_DEFINITIONS} )
 
+configure_chain_pch(sysio_chain)
+
 add_library(sysio_chain_wrap INTERFACE )
 target_link_libraries(sysio_chain_wrap INTERFACE sysio_chain)
 

--- a/libraries/chain/include/sysio/chain/authority_checker.hpp
+++ b/libraries/chain/include/sysio/chain/authority_checker.hpp
@@ -7,10 +7,9 @@
 
 #include <fc/scoped_exit.hpp>
 
-#include <boost/range/algorithm/find.hpp>
-#include <boost/algorithm/cxx11/all_of.hpp>
-
+#include <algorithm>
 #include <functional>
+#include <ranges>
 
 namespace sysio { namespace chain {
 
@@ -86,7 +85,7 @@ namespace detail {
             return satisfied( authority, *cached_perms, 0 );
          }
 
-         bool all_keys_used() const { return boost::algorithm::all_of_equal(_used_keys, true); }
+         bool all_keys_used() const { return std::ranges::all_of(_used_keys, std::identity{}); }
 
          flat_set<public_key_type> used_keys() const {
             auto range = filter_data_by_marker(provided_keys, _used_keys, true);
@@ -170,7 +169,7 @@ namespace detail {
 
             template<typename KeyWeight, typename = std::enable_if_t<detail::is_any_of_v<KeyWeight, shared_key_weight, key_weight>>>
             uint32_t operator()(const KeyWeight& permission) {
-               auto itr = boost::find( checker.provided_keys, permission.key );
+               auto itr = std::find( checker.provided_keys.begin(), checker.provided_keys.end(), permission.key );
                if( itr != checker.provided_keys.end() ) {
                   checker._used_keys[itr - checker.provided_keys.begin()] = true;
                   total_weight += permission.weight;

--- a/libraries/chain/include/sysio/chain/parallel_markers.hpp
+++ b/libraries/chain/include/sysio/chain/parallel_markers.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <boost/range/combine.hpp>
-#include <boost/range/adaptor/filtered.hpp>
-#include <boost/range/adaptor/transformed.hpp>
+#include <algorithm>
+#include <ranges>
 
 namespace sysio { namespace chain {
 
@@ -23,17 +22,14 @@ namespace sysio { namespace chain {
  */
 template<typename DataRange, typename MarkerRange, typename Marker>
 DataRange filter_data_by_marker(DataRange data, MarkerRange markers, const Marker& markerValue) {
-   auto remove_mismatched_markers = boost::adaptors::filtered([&markerValue](const auto& tuple) {
-      return boost::get<0>(tuple) == markerValue;
-   });
-   auto ToData = boost::adaptors::transformed([](const auto& tuple) {
-      return boost::get<1>(tuple);
-   });
-
-   // Zip the ranges together, filter out data with markers that don't match, and return the data without the markers
-   auto range = boost::combine(markers, data) | remove_mismatched_markers | ToData;
-   return {range.begin(), range.end()};
+   auto zipped = std::views::zip(markers, data)
+               | std::views::filter([&markerValue](const auto& tuple) {
+                    return std::get<0>(tuple) == markerValue;
+                 })
+               | std::views::transform([](const auto& tuple) {
+                    return std::get<1>(tuple);
+                 });
+   return {zipped.begin(), zipped.end()};
 }
 
 }} // namespace sysio::chain
-

--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -124,6 +124,8 @@ target_link_libraries(
 
 target_compile_definitions(fc PUBLIC -DFC_AVAILABLE=1)
 
+configure_fc_pch(fc)
+
 if (ENABLE_TESTS)
     add_subdirectory(test)
 endif ()


### PR DESCRIPTION
## Summary
- Adds precompiled header (PCH) support for the two heaviest build targets (`fc` and `sysio_chain`), controlled via `-DENABLE_PCH=ON` (default ON)
- Includes all frequently used Boost headers (multiprecision, multi_index, asio, beast, iostreams, signals2, etc.), stable STL headers, and widely included fc/chain project headers
- Replaces `boost::range` usage with `std::ranges`/`std::find` in `authority_checker.hpp` and `parallel_markers.hpp` to resolve ADL ambiguity between `boost::range::find` and `std::ranges::find`

## Benchmark (clean build of fc + sysio_chain, 12-core, clang-18, Debug)

| | Wall time | CPU time |
|---|---|---|
| Without PCH | 2:54.55 | 3013.60s |
| With PCH | 1:36.06 | 1128.80s |
| **Speedup** | **45%** | **63%** |