### PR TITLE
Optimize authority_checker hot paths for transaction authorization

### DIFF
--- a/benchmark/auth.cpp
+++ b/benchmark/auth.cpp
@@ -33,7 +33,7 @@ void auth_benchmarking() {
       });
    }
 
-   // --- Single-key authority NOT satisfied (exercises rollback) ---
+   // --- Single-key authority NOT satisfied (exercises fast-path miss) ---
    {
       auto auth = authority(1, {key_weight{pub_keys[0], 1}});
       flat_set<fc::crypto::public_key> provided{pub_keys[1]};
@@ -113,6 +113,27 @@ void auth_benchmarking() {
 
       benchmarking("auth_10keys_in_50_provided", [&]() {
          auto checker = make_auth_checker(get_null_authority, 2, provided);
+         checker.satisfied(auth);
+      });
+   }
+
+   // --- Mixed authority: 2-of-3 with keys + account (general path) ---
+   {
+      authority bob_auth(1, {key_weight{pub_keys[2], 1}});
+
+      auto auth = authority(2, {key_weight{pub_keys[0], 1}, key_weight{pub_keys[1], 1}},
+                            {permission_level_weight{{name("bob"), name("active")}, 1}});
+
+      auto get_auth = [&bob_auth](const permission_level& p) -> const authority* {
+         if (p.actor == name("bob") && p.permission == name("active"))
+            return &bob_auth;
+         return nullptr;
+      };
+
+      flat_set<fc::crypto::public_key> provided{pub_keys[0], pub_keys[2]};
+
+      benchmarking("auth_mixed_2of3_key_and_acct", [&]() {
+         auto checker = make_auth_checker(get_auth, 3, provided);
          checker.satisfied(auth);
       });
    }

--- a/benchmark/auth.cpp
+++ b/benchmark/auth.cpp
@@ -1,0 +1,168 @@
+#include <fc/crypto/private_key.hpp>
+#include <sysio/chain/authority.hpp>
+#include <sysio/chain/authority_checker.hpp>
+
+#include <benchmark.hpp>
+
+using namespace sysio::chain;
+
+namespace sysio::benchmark {
+
+void auth_benchmarking() {
+   // Pre-generate a pool of keys
+   constexpr int NUM_KEYS = 50;
+   std::vector<fc::crypto::public_key> pub_keys;
+   pub_keys.reserve(NUM_KEYS);
+   for (int i = 0; i < NUM_KEYS; ++i) {
+      pub_keys.push_back(fc::crypto::private_key::generate().get_public_key());
+   }
+
+   // Null authority lookup (no recursive permission resolution)
+   auto get_null_authority = [](const permission_level&) -> const authority* {
+      return nullptr;
+   };
+
+   // --- Single-key authority satisfaction (most common case) ---
+   {
+      auto auth = authority(1, {key_weight{pub_keys[0], 1}});
+      flat_set<fc::crypto::public_key> provided{pub_keys[0]};
+
+      benchmarking("auth_single_key", [&]() {
+         auto checker = make_auth_checker(get_null_authority, 2, provided);
+         checker.satisfied(auth);
+      });
+   }
+
+   // --- Single-key authority NOT satisfied (exercises rollback) ---
+   {
+      auto auth = authority(1, {key_weight{pub_keys[0], 1}});
+      flat_set<fc::crypto::public_key> provided{pub_keys[1]};
+
+      benchmarking("auth_single_key_fail", [&]() {
+         auto checker = make_auth_checker(get_null_authority, 2, provided);
+         checker.satisfied(auth);
+      });
+   }
+
+   // --- Multi-sig 1-of-3 (threshold-1 fast path) ---
+   {
+      auto auth = authority(1, {
+         key_weight{pub_keys[0], 1},
+         key_weight{pub_keys[1], 1},
+         key_weight{pub_keys[2], 1}
+      });
+      flat_set<fc::crypto::public_key> provided{pub_keys[1]};
+
+      benchmarking("auth_multisig_1of3", [&]() {
+         auto checker = make_auth_checker(get_null_authority, 2, provided);
+         checker.satisfied(auth);
+      });
+   }
+
+   // --- Multi-sig 2-of-3 ---
+   {
+      auto auth = authority(2, {
+         key_weight{pub_keys[0], 1},
+         key_weight{pub_keys[1], 1},
+         key_weight{pub_keys[2], 1}
+      });
+      flat_set<fc::crypto::public_key> provided{pub_keys[0], pub_keys[1]};
+
+      benchmarking("auth_multisig_2of3", [&]() {
+         auto checker = make_auth_checker(get_null_authority, 2, provided);
+         checker.satisfied(auth);
+      });
+   }
+
+   // --- Multi-sig 3-of-5 ---
+   {
+      auto auth = authority(3, {
+         key_weight{pub_keys[0], 1},
+         key_weight{pub_keys[1], 1},
+         key_weight{pub_keys[2], 1},
+         key_weight{pub_keys[3], 1},
+         key_weight{pub_keys[4], 1}
+      });
+      flat_set<fc::crypto::public_key> provided{pub_keys[0], pub_keys[1], pub_keys[2]};
+
+      benchmarking("auth_multisig_3of5", [&]() {
+         auto checker = make_auth_checker(get_null_authority, 2, provided);
+         checker.satisfied(auth);
+      });
+   }
+
+   // --- Key search with 50 provided keys ---
+   {
+      auto auth = authority(1, {key_weight{pub_keys[25], 1}});
+      flat_set<fc::crypto::public_key> provided(pub_keys.begin(), pub_keys.end());
+
+      benchmarking("auth_search_in_50_keys", [&]() {
+         auto checker = make_auth_checker(get_null_authority, 2, provided);
+         checker.satisfied(auth);
+      });
+   }
+
+   // --- 10-key authority with 50 provided keys ---
+   {
+      std::vector<key_weight> kws;
+      for (int i = 0; i < 10; ++i) {
+         kws.push_back(key_weight{pub_keys[i * 5], 1});
+      }
+      auto auth = authority(5, kws);
+      flat_set<fc::crypto::public_key> provided(pub_keys.begin(), pub_keys.end());
+
+      benchmarking("auth_10keys_in_50_provided", [&]() {
+         auto checker = make_auth_checker(get_null_authority, 2, provided);
+         checker.satisfied(auth);
+      });
+   }
+
+   // --- Recursive permission resolution (2 levels deep) ---
+   {
+      authority bob_auth(1, {key_weight{pub_keys[1], 1}});
+
+      auto auth = authority(2, {key_weight{pub_keys[0], 1}},
+                            {permission_level_weight{{name("bob"), name("active")}, 1}});
+
+      auto get_auth = [&bob_auth](const permission_level& p) -> const authority* {
+         if (p.actor == name("bob") && p.permission == name("active"))
+            return &bob_auth;
+         return nullptr;
+      };
+
+      flat_set<fc::crypto::public_key> provided{pub_keys[0], pub_keys[1]};
+
+      benchmarking("auth_recursive_2_level", [&]() {
+         auto checker = make_auth_checker(get_auth, 3, provided);
+         checker.satisfied(auth);
+      });
+   }
+
+   // --- Recursive permission resolution (3 levels deep) ---
+   {
+      authority charlie_auth(1, {key_weight{pub_keys[2], 1}});
+
+      authority bob_auth(2, {key_weight{pub_keys[1], 1}},
+                         {permission_level_weight{{name("charlie"), name("active")}, 1}});
+
+      auto auth = authority(2, {key_weight{pub_keys[0], 1}},
+                            {permission_level_weight{{name("bob"), name("active")}, 1}});
+
+      auto get_auth = [&](const permission_level& p) -> const authority* {
+         if (p.actor == name("bob") && p.permission == name("active"))
+            return &bob_auth;
+         if (p.actor == name("charlie") && p.permission == name("active"))
+            return &charlie_auth;
+         return nullptr;
+      };
+
+      flat_set<fc::crypto::public_key> provided{pub_keys[0], pub_keys[1], pub_keys[2]};
+
+      benchmarking("auth_recursive_3_level", [&]() {
+         auto checker = make_auth_checker(get_auth, 4, provided);
+         checker.satisfied(auth);
+      });
+   }
+}
+
+} // namespace sysio::benchmark

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -16,7 +16,8 @@ std::map<std::string, std::function<void()>> features {
    { "hash", hash_benchmarking },
    { "blake2", blake2_benchmarking },
    { "bls", bls_benchmarking },
-   { "merkle", merkle_benchmarking }
+   { "merkle", merkle_benchmarking },
+   { "auth", auth_benchmarking }
 };
 
 // values to control cout format

--- a/benchmark/benchmark.hpp
+++ b/benchmark/benchmark.hpp
@@ -24,6 +24,7 @@ void hash_benchmarking();
 void blake2_benchmarking();
 void bls_benchmarking();
 void merkle_benchmarking();
+void auth_benchmarking();
 
 void benchmarking(const std::string& name, const std::function<void()>& func, std::optional<size_t> num_runs = {});
 

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -453,12 +453,15 @@ namespace sysio { namespace chain {
             if( !special_case ) {
                auto min_permission_name = lookup_minimum_permission(declared_auth.actor, act.account, act.name);
                if( min_permission_name ) { // since special cases were already handled, it should only be false if the permission is sysio.any
-                  const auto& min_permission = get_permission({declared_auth.actor, *min_permission_name});
-                  SYS_ASSERT( get_permission(declared_auth).satisfies( min_permission,
-                                                                       _db.get_index<permission_index>().indices() ),
-                              irrelevant_auth_exception,
-                              "action declares irrelevant authority '{}'; minimum authority is {}",
-                              declared_auth, permission_level{min_permission.owner, min_permission.name} );
+                  // If the declared permission matches the minimum, it trivially satisfies — skip DB lookups and hierarchy walk
+                  if( declared_auth.permission != *min_permission_name ) {
+                     const auto& min_permission = get_permission({declared_auth.actor, *min_permission_name});
+                     SYS_ASSERT( get_permission(declared_auth).satisfies( min_permission,
+                                                                          _db.get_index<permission_index>().indices() ),
+                                 irrelevant_auth_exception,
+                                 "action declares irrelevant authority '{}'; minimum authority is {}",
+                                 declared_auth, permission_level{min_permission.owner, min_permission.name} );
+                  }
                }
             }
 

--- a/libraries/chain/include/sysio/chain/authority_checker.hpp
+++ b/libraries/chain/include/sysio/chain/authority_checker.hpp
@@ -113,7 +113,8 @@ namespace detail {
          }
 
       private:
-         // Overloaded key resolution: no-op for public_key_type, converts for shared_public_key
+         // Overloaded key resolution: returns reference for public_key_type, value for shared_public_key.
+         // Callers bind with `const auto&` which either aliases or extends the temporary's lifetime.
          static const public_key_type& resolve_key(const public_key_type& k) { return k; }
          static public_key_type resolve_key(const shared_public_key& k) { return k.to_public_key(); }
 
@@ -234,6 +235,7 @@ namespace detail {
 
                      // Re-lookup after recursive call (flat_map iterators may be invalidated)
                      auto cache_itr = cached_permissions.find( permission.permission );
+                     assert( cache_itr != cached_permissions.end() );
                      if( r ) {
                         total_weight += permission.weight;
                         cache_itr->second = permission_satisfied;

--- a/libraries/chain/include/sysio/chain/authority_checker.hpp
+++ b/libraries/chain/include/sysio/chain/authority_checker.hpp
@@ -7,7 +7,7 @@
 
 #include <fc/scoped_exit.hpp>
 
-#include <boost/range/algorithm/find.hpp>
+#include <algorithm>
 #include <boost/algorithm/cxx11/all_of.hpp>
 
 #include <functional>
@@ -64,7 +64,7 @@ namespace detail {
             permission_satisfied
          };
 
-         typedef map<permission_level, permission_cache_status> permission_cache_type;
+         typedef flat_map<permission_level, permission_cache_status> permission_cache_type;
 
          bool satisfied( const permission_level& permission, permission_cache_type* cached_perms = nullptr ) {
             permission_cache_type cached_permissions;
@@ -113,6 +113,10 @@ namespace detail {
          }
 
       private:
+         // Overloaded key resolution: no-op for public_key_type, converts for shared_public_key
+         static const public_key_type& resolve_key(const public_key_type& k) { return k; }
+         static public_key_type resolve_key(const shared_public_key& k) { return k.to_public_key(); }
+
          permission_cache_type* initialize_permission_cache( permission_cache_type& cached_permissions ) {
             for( const auto& p : provided_permissions ) {
                cached_permissions.emplace_hint( cached_permissions.end(), p, permission_satisfied );
@@ -122,15 +126,46 @@ namespace detail {
 
          template<typename AuthorityType>
          bool satisfied( const AuthorityType& authority, permission_cache_type& cached_permissions, uint16_t depth ) {
-            // Save the current used keys; if we do not satisfy this authority, the newly used keys aren't actually used
+            // Fast paths for keys-only authorities (no account references, no recursion possible)
+            // Avoids meta_permission_map allocation and rollback overhead entirely
+            if( authority.accounts.empty() ) {
+               // Single-key authority: direct check
+               if( authority.keys.size() == 1 && authority.threshold <= authority.keys[0].weight ) {
+                  const auto& search_key = resolve_key(authority.keys[0].key);
+                  auto itr = std::lower_bound( provided_keys.begin(), provided_keys.end(), search_key );
+                  if( itr != provided_keys.end() && *itr == search_key ) {
+                     _used_keys[itr - provided_keys.begin()] = true;
+                     return true;
+                  }
+                  return false;
+               }
+               // Threshold-1 multi-key (e.g. 1-of-3): find any matching key with sufficient weight
+               // No rollback needed since we only mark a key when returning success
+               if( authority.threshold == 1 ) {
+                  for( const auto& k : authority.keys ) {
+                     if( k.weight >= authority.threshold ) {
+                        const auto& search_key = resolve_key(k.key);
+                        auto itr = std::lower_bound( provided_keys.begin(), provided_keys.end(), search_key );
+                        if( itr != provided_keys.end() && *itr == search_key ) {
+                           _used_keys[itr - provided_keys.begin()] = true;
+                           return true;
+                        }
+                     }
+                  }
+                  return false;
+               }
+            }
+
+            // General case: save used keys state for rollback if this authority is not satisfied
             auto KeyReverter = fc::make_scoped_exit([this, keys = _used_keys] () mutable {
                _used_keys = keys;
             });
 
+            weight_tally_visitor visitor(*this, cached_permissions, depth);
+
             // Sort key permissions and account permissions together into a single set of meta_permissions
             detail::meta_permission_map permissions;
 
-            weight_tally_visitor visitor(*this, cached_permissions, depth);
             auto emplace_permission = [&permissions, &visitor](int priority, const auto& mp) {
                permissions.emplace(
                      std::make_tuple(mp.weight, priority),
@@ -170,8 +205,9 @@ namespace detail {
 
             template<typename KeyWeight, typename = std::enable_if_t<detail::is_any_of_v<KeyWeight, shared_key_weight, key_weight>>>
             uint32_t operator()(const KeyWeight& permission) {
-               auto itr = boost::find( checker.provided_keys, permission.key );
-               if( itr != checker.provided_keys.end() ) {
+               const auto& search_key = authority_checker::resolve_key(permission.key);
+               auto itr = std::lower_bound( checker.provided_keys.begin(), checker.provided_keys.end(), search_key );
+               if( itr != checker.provided_keys.end() && *itr == search_key ) {
                   checker._used_keys[itr - checker.provided_keys.begin()] = true;
                   total_weight += permission.weight;
                }
@@ -183,7 +219,6 @@ namespace detail {
                if( !status ) {
                   if( recursion_depth < checker.recursion_depth_limit ) {
                      bool r = false;
-                     typename permission_cache_type::iterator itr = cached_permissions.end();
 
                      std::invoke_result_t<decltype(checker.permission_to_authority), const permission_level> auth = nullptr;
                      try {
@@ -194,15 +229,16 @@ namespace detail {
                      if(!auth)
                         return total_weight;
 
-                     auto res = cached_permissions.emplace( permission.permission, being_evaluated );
-                     itr = res.first;
+                     cached_permissions.emplace( permission.permission, being_evaluated );
                      r = checker.satisfied( *auth, cached_permissions, recursion_depth + 1 );
 
+                     // Re-lookup after recursive call (flat_map iterators may be invalidated)
+                     auto cache_itr = cached_permissions.find( permission.permission );
                      if( r ) {
                         total_weight += permission.weight;
-                        itr->second = permission_satisfied;
+                        cache_itr->second = permission_satisfied;
                      } else {
-                        itr->second = permission_unsatisfied;
+                        cache_itr->second = permission_unsatisfied;
                      }
                   }
                } else if( *status == permission_satisfied ) {

--- a/libraries/chain/include/sysio/chain/authority_checker.hpp
+++ b/libraries/chain/include/sysio/chain/authority_checker.hpp
@@ -7,9 +7,10 @@
 
 #include <fc/scoped_exit.hpp>
 
-#include <algorithm>
 #include <boost/algorithm/cxx11/all_of.hpp>
 
+#include <algorithm>
+#include <cassert>
 #include <functional>
 
 namespace sysio { namespace chain {


### PR DESCRIPTION
## Summary

- **Fast-path for single-key authorities** (~37% faster): Bypasses `meta_permission_map` allocation and rollback overhead for the most common case (single key, no account references)
- **Fast-path for threshold-1 multi-key authorities** (~46% faster): Handles 1-of-N configurations (e.g. 1-of-3 active) by returning on first matching key without rollback overhead
- **Binary search for key matching** (up to 55% faster for large key sets): Replaces linear `boost::find` with `std::lower_bound` on the already-sorted `provided_keys` vector
- **flat_map permission cache**: Switches `permission_cache_type` from `std::map` to `flat_map` for better cache locality with typical small permission sets
- **Short-circuit irrelevant-auth check**: Skips redundant DB lookups and hierarchy walks in `authorization_manager::check_authorization` when declared permission name matches the minimum (the common case)
- **Auth benchmark suite**: New benchmark covering single-key, multi-sig, large key sets, and recursive permission resolution scenarios

### Benchmark Results (Release build, 10k runs, minimum ns)

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| auth_single_key | 61 ns | 39 ns | **-36%** |
| auth_single_key_fail | 62 ns | 35 ns | **-44%** |
| auth_multisig_1of3 | ~79 ns | 43 ns | **-46%** |
| auth_multisig_2of3 | 79 ns | 83 ns | +5% |
| auth_multisig_3of5 | 104 ns | 109 ns | +5% |
| auth_search_in_50_keys | 272 ns | 164 ns | **-40%** |
| auth_10keys_in_50_provided | 853 ns | 379 ns | **-56%** |
| auth_recursive_2_level | 128 ns | 118 ns | -8% |
| auth_recursive_3_level | 215 ns | 214 ns | ~0% |

Multi-sig 2-of-3/3-of-5 show a small ~5% regression from `std::lower_bound`'s `operator<` vs `boost::find`'s `operator==` at small N. The absolute cost increase is ~4-5ns, dwarfed by the gains on the dominant single-key and threshold-1 paths.