### PR TITLE
Fix incorrect help text for read-mode irreversible

### DIFF
--- a/plugins/chain_plugin/src/chain_plugin.cpp
+++ b/plugins/chain_plugin/src/chain_plugin.cpp
@@ -344,7 +344,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Database read mode (\"head\", \"irreversible\", \"speculative\").\n"
           "In \"head\" mode: database contains state changes up to the head block; transactions received by the node are relayed if valid.\n"
           "In \"irreversible\" mode: database contains state changes up to the last irreversible block; "
-          "transactions received via the P2P network are not relayed and transactions cannot be pushed via the chain API.\n"
+          "transactions received by the node are speculatively executed and relayed if valid.\n"
           "In \"speculative\" mode: database contains state changes by transactions in the blockchain "
           "up to the head block as well as some transactions not yet included in the blockchain; transactions received by the node are relayed if valid.\n"
           )


### PR DESCRIPTION
## Summary
- The `--read-mode irreversible` help text incorrectly stated that transactions are not relayed and cannot be pushed via the chain API.
- Speculative execution of transactions was added to irreversible mode in https://github.com/AntelopeIO/spring/pull/1036, but the help text was not updated.
- Irreversible mode speculatively executes transactions on top of LIB state and relays them if valid — the help text now reflects this.