### PR TITLE
Fix SHiP log corruption from pwritev2 RWF_APPEND on container filesystems

### DIFF
--- a/libraries/libfc/include/fc/io/random_access_file.hpp
+++ b/libraries/libfc/include/fc/io/random_access_file.hpp
@@ -126,9 +126,12 @@ struct random_access_file_context {
          do {
             if(offs == append_t) {
 #ifdef __linux__
-               wrote = pwritev2(fd, iov, i, 0, RWF_APPEND);   //linux *not* opened with O_APPEND, appending requires special flag
-               if(wrote == -1 && errno == EOPNOTSUPP)         //fallback for kernels before 4.16
-                  wrote = pwritev(fd, iov, i, size());
+               // linux is *not* opened with O_APPEND (O_APPEND breaks pwrite/pwritev on linux,
+               // see pwrite(2) BUGS). pwritev2 RWF_APPEND is unreliable on some container
+               // filesystems (e.g. overlayfs) where the flag is silently ignored and the write
+               // goes to offset 0 instead of EOF. Use pwritev at current file size which is
+               // safe for the documented single-threaded append usage.
+               wrote = pwritev(fd, iov, i, size());
 #else
                wrote = writev(fd, iov, i);                    //opened with O_APPEND, just write
 #endif


### PR DESCRIPTION
## Summary
- **Root cause:** `pwritev2` with `RWF_APPEND` is silently ignored on some container filesystems (e.g. overlayfs used by Blacksmith CI runners). The write goes to offset 0 instead of EOF, overwriting the ship magic header of the first log entry with the position of the last entry.
- **Impact:** On node restart, state_history_plugin fails to initialize because `trace_history.log` (and other SHiP logs) have corrupted magic headers. Affects `ship_restart_test`, `ship_streamer_test`, and `ship_streamer_if_fetch_finality_data_test`.
- **Fix:** Replace `pwritev2`+`RWF_APPEND` with `pwritev` at `fstat`'d file size. This is safe for the documented single-threaded append usage and adds only ~200ns of `fstat` overhead per append call.