### PR TITLE
Preserve y-parity when parsing compressed EM public keys

### DIFF
--- a/libraries/libfc/include/fc/crypto/ethereum/ethereum_utils.hpp
+++ b/libraries/libfc/include/fc/crypto/ethereum/ethereum_utils.hpp
@@ -19,9 +19,15 @@ namespace fc::em {
 namespace fc::crypto::ethereum {
 
 /**
- * Public key lengths
+ * Accepted hex-string lengths for an EM public key. Bare 32-byte x-only (64
+ * hex chars) is intentionally excluded: y-parity cannot be recovered from x
+ * alone, so the parser has no way to select the correct curve point and
+ * previously defaulted to even y — silently producing the wrong key whenever
+ * the caller's real key had odd parity. Callers should supply 66-char
+ * compressed (0x02/0x03 + x), 128-char uncompressed (x||y), or 130-char
+ * uncompressed with 0x04 prefix.
  */
-constexpr std::array public_key_string_lengths = {64,66,128,130};
+constexpr std::array public_key_string_lengths = {66,128,130};
 
 /**
  * Standard Ethereum message prefix used for signing according to EIP-155

--- a/libraries/libfc/src/crypto/ethereum/ethereum_utils.cpp
+++ b/libraries/libfc/src/crypto/ethereum/ethereum_utils.cpp
@@ -26,9 +26,12 @@ std::string trim_public_key(const std::string& hex) {
 
    FC_ASSERT(std::ranges::contains(public_key_string_lengths, len), "Invalid public key length({}): {}", len, hex);
 
-   // If len mod 64 remainder is > 0, that means that the
-   // first two bytes denote the type and will be truncated
-   if (len % 64 > 0)
+   // For uncompressed keys (130 chars = 0x04 + 64 bytes x||y) strip the fixed
+   // 0x04 prefix — it's reapplied unconditionally below. For compressed keys
+   // (66 chars = 0x02/0x03 + 32 bytes x) the prefix encodes y-parity and MUST
+   // be preserved; stripping it forced every caller through the bare-x path
+   // which defaulted to 0x02 and silently corrupted odd-parity (0x03) keys.
+   if (len == 130)
       clean_hex = clean_hex.substr(2);
 
    return clean_hex;
@@ -87,7 +90,7 @@ fc::em::public_key to_em_public_key(const std::string& pubkey_hex) {
    if (pubkey_byte_count == 33) {
       FC_ASSERT(pubkey_bytes[0] == 0x02 || pubkey_bytes[0] == 0x03);
    }
-   switch (pubkey_bytes.size()) {
+   switch (pubkey_byte_count) {
    case 64:
       copy_to_offset = 1;
    case 65: {
@@ -98,21 +101,15 @@ fc::em::public_key to_em_public_key(const std::string& pubkey_hex) {
       }
       return fc::em::public_key(pubkey_data);
    }
-   case 32:
-      copy_to_offset = 1;
    case 33: {
       em::public_key_data pubkey_data{};
-      std::copy_n(pubkey_bytes.data(), pubkey_bytes.size(), pubkey_data.data() + copy_to_offset);
-      if (copy_to_offset) {
-         pubkey_data[0] = 0x02;
-      }
+      std::copy_n(pubkey_bytes.data(), pubkey_bytes.size(), pubkey_data.data());
       return fc::em::public_key(pubkey_data);
    }
    default:
-      FC_ASSERT(
-         false,
-         "Invalid public key size, expected 64/65 character hex string for compressed key OR 128/130 character hex string for public key")
-      ;
+      FC_ASSERT(false,
+                "Invalid EM public key byte count ({}). Expected 33 (compressed), 64 or 65 (uncompressed).",
+                pubkey_byte_count);
    }
 }
 

--- a/libraries/libfc/test/crypto/test_cypher_suites.cpp
+++ b/libraries/libfc/test/crypto/test_cypher_suites.cpp
@@ -192,6 +192,52 @@ BOOST_AUTO_TEST_CASE(test_em_alt) try {
    BOOST_CHECK_EQUAL(key.to_string({}, true), test_private_key2.to_string({}, true));
 } FC_LOG_AND_RETHROW();
 
+BOOST_AUTO_TEST_CASE(test_em_compressed_prefix_roundtrip) try {
+   // Parsing a compressed (33-byte) secp256k1 public key from hex must preserve
+   // the SEC1 prefix byte (0x02 = even y, 0x03 = odd y). Normalizing 0x03 to
+   // 0x02 silently flips to the wrong curve point and breaks Ethereum address
+   // derivation / signature verification for roughly half of all keys.
+   bool saw_02 = false;
+   bool saw_03 = false;
+   for (int i = 0; i < 80 && (!saw_02 || !saw_03); ++i) {
+      auto priv = private_key::generate(private_key::key_type::em);
+      auto pub  = priv.get_public_key();
+      const auto& compressed = pub.get<em::public_key_shim>()._data;
+      const uint8_t prefix = static_cast<uint8_t>(compressed[0]);
+      BOOST_TEST((prefix == 0x02 || prefix == 0x03));
+
+      const std::string compressed_hex = fc::to_hex(compressed, true); // "0x" + 66 hex chars
+      BOOST_CHECK_EQUAL(compressed_hex.size(), 68u);
+
+      auto parsed = public_key::from_string(compressed_hex, public_key::key_type::em);
+      const auto& parsed_bytes = parsed.get<em::public_key_shim>()._data;
+
+      BOOST_CHECK_EQUAL(static_cast<unsigned>(static_cast<uint8_t>(parsed_bytes[0])),
+                        static_cast<unsigned>(prefix));
+      BOOST_CHECK(std::equal(compressed.begin(), compressed.end(), parsed_bytes.begin()));
+
+      if (prefix == 0x02) saw_02 = true;
+      if (prefix == 0x03) saw_03 = true;
+   }
+   BOOST_CHECK_MESSAGE(saw_02, "did not sample any 0x02-prefix EM key in 80 iterations");
+   BOOST_CHECK_MESSAGE(saw_03, "did not sample any 0x03-prefix EM key in 80 iterations");
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(test_em_rejects_bare_x_hex) try {
+   // Bare 32-byte x-coordinate (64 hex chars) does not carry y-parity and
+   // cannot identify a unique curve point, so it must be rejected rather
+   // than silently defaulted to even y.
+   auto priv = private_key::generate(private_key::key_type::em);
+   auto pub  = priv.get_public_key();
+   const auto& compressed = pub.get<em::public_key_shim>()._data;
+   const std::string bare_x_hex =
+      std::string("0x") + fc::to_hex(compressed.data() + 1, compressed.size() - 1);
+   BOOST_CHECK_EQUAL(bare_x_hex.size(), 66u); // "0x" + 64 hex chars
+
+   BOOST_CHECK_THROW(public_key::from_string(bare_x_hex, public_key::key_type::em),
+                     fc::exception);
+} FC_LOG_AND_RETHROW();
+
 BOOST_AUTO_TEST_CASE(test_em_recovery_of_trx) try {
    auto        payload    = "Test Cases";
    auto        digest_raw = fc::sha256::hash(payload); // pretend payload is a transaction


### PR DESCRIPTION
## Summary
- `libfc`'s `to_em_public_key`/`trim_public_key` was silently normalizing compressed EM public keys with a `0x03` (odd y) prefix to `0x02` (even y) during hex parsing, flipping the key to a different curve point. Any address derived from the corrupted key no longer matched the real signer, breaking authex `createlink`, OPERATORS attestations, and any downstream address check for roughly half of all randomly-generated keys.
- Fix: preserve the SEC1 prefix byte for 33-byte compressed input; only strip the fixed `0x04` from 130-char uncompressed input.
- Also rejects bare 32-byte x-coordinate hex (64 chars): y-parity is not recoverable from x alone, and the previous "default to 0x02" behavior was a silent footgun. Callers must now supply 66-char compressed, 128-char x||y, or 130-char SEC1 uncompressed.