### PR TITLE
Add clio convert name subcommand for sysio::name <-> uint64_t

### DIFF
--- a/programs/clio/main.cpp
+++ b/programs/clio/main.cpp
@@ -2095,7 +2095,7 @@ int main( int argc, char** argv ) {
          std::cout << localized("As sysio::name : \"${name}\" -> uint64_t: ${value}",
                                 ("name", n.to_string())("value", n.to_uint64_t())) << std::endl;
          any_success = true;
-      } catch (const std::exception&) {}
+      } catch (const fc::exception&) {}
       try {
          size_t pos = 0;
          uint64_t v = std::stoull(name_input, &pos, 0);
@@ -2105,9 +2105,11 @@ int main( int argc, char** argv ) {
          std::cout << localized("As uint64_t    : ${value} -> sysio::name: \"${name}\"",
                                 ("value", v)("name", n.to_string())) << std::endl;
          any_success = true;
-      } catch (const std::exception&) {}
+      } catch (const std::invalid_argument&) {
+      } catch (const std::out_of_range&) {}
       if (!any_success) {
-         std::cerr << "ERROR: Input is neither a valid sysio::name nor a uint64_t" << std::endl;
+         std::cerr << localized("ERROR: Input is neither a valid sysio::name nor a uint64_t") << std::endl;
+         FC_THROW_EXCEPTION(explained_exception, "invalid name input");
       }
    });
 

--- a/programs/clio/main.cpp
+++ b/programs/clio/main.cpp
@@ -2085,6 +2085,32 @@ int main( int argc, char** argv ) {
       std::cout << localized("Public key: ${key}", ("key", pubk.to_string({}, true) ) ) << std::endl;
    });
 
+   string name_input;
+   auto name_cmd = convert_cmd->add_subcommand("name", localized("Convert between sysio::name and uint64_t, printing both interpretations"));
+   name_cmd->add_option("input", name_input, localized("A sysio name or uint64_t value (decimal, or 0x-prefixed hex)"))->required();
+   name_cmd->callback([&name_input] {
+      bool any_success = false;
+      try {
+         name n{name_input};
+         std::cout << localized("As sysio::name : \"${name}\" -> uint64_t: ${value}",
+                                ("name", n.to_string())("value", n.to_uint64_t())) << std::endl;
+         any_success = true;
+      } catch (const std::exception&) {}
+      try {
+         size_t pos = 0;
+         uint64_t v = std::stoull(name_input, &pos, 0);
+         if (pos != name_input.size())
+            throw std::invalid_argument("trailing characters after number");
+         name n{v};
+         std::cout << localized("As uint64_t    : ${value} -> sysio::name: \"${name}\"",
+                                ("value", v)("name", n.to_string())) << std::endl;
+         any_success = true;
+      } catch (const std::exception&) {}
+      if (!any_success) {
+         std::cerr << "ERROR: Input is neither a valid sysio::name nor a uint64_t" << std::endl;
+      }
+   });
+
    // pack hex
    using try_types = std::tuple<signed_block, transaction_trace, action_trace, transaction_receipt,
                                 packed_transaction, signed_transaction, transaction, abi_def, action>;

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -471,6 +471,42 @@ def clio_protobuf_abi_test():
     assert b'"note": "test"' in outs, "unpack missing note=test"
     Utils.Print("protobuf pbaction round-trip OK")
 
+def clio_convert_name_test():
+    """Test 'clio convert name' prints both interpretations and exits non-zero on bad input"""
+    # Valid sysio::name only ("sysio" is 5 lowercase chars; decimal value is 20 digits, > uint64_t max)
+    completed = subprocess.run(['./programs/clio/clio', '--no-auto-kiod', 'convert', 'name', 'sysio'],
+                               check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert completed.returncode == 0, f"stderr={completed.stderr!r}"
+    assert b'As sysio::name : "sysio" -> uint64_t: 14389258095169634304' in completed.stdout
+    assert b'As uint64_t' not in completed.stdout
+
+    # Valid uint64_t only (16 digits, too long to parse as a sysio::name)
+    completed = subprocess.run(['./programs/clio/clio', '--no-auto-kiod', 'convert', 'name', '14389258095169634304'],
+                               check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert completed.returncode == 0, f"stderr={completed.stderr!r}"
+    assert b'As uint64_t    : 14389258095169634304 -> sysio::name: "sysio"' in completed.stdout
+    assert b'As sysio::name' not in completed.stdout
+
+    # Valid under both interpretations: "12345" is a valid sysio::name and a valid uint64_t
+    completed = subprocess.run(['./programs/clio/clio', '--no-auto-kiod', 'convert', 'name', '12345'],
+                               check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert completed.returncode == 0, f"stderr={completed.stderr!r}"
+    assert b'As sysio::name : "12345" -> uint64_t: 614251516705898496' in completed.stdout
+    assert b'As uint64_t    : 12345 -> sysio::name: "..........s3d"' in completed.stdout
+
+    # 0x-prefixed hex parses as uint64_t; not a valid name
+    completed = subprocess.run(['./programs/clio/clio', '--no-auto-kiod', 'convert', 'name', '0xdeadbeef'],
+                               check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert completed.returncode == 0, f"stderr={completed.stderr!r}"
+    assert b'As uint64_t    : 3735928559 -> sysio::name: "......aypqzij"' in completed.stdout
+    assert b'As sysio::name' not in completed.stdout
+
+    # Neither interpretation valid: uppercase letters are not legal in names, and not a number
+    completed = subprocess.run(['./programs/clio/clio', '--no-auto-kiod', 'convert', 'name', 'INVALID'],
+                               check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert completed.returncode != 0, "expected non-zero exit for invalid input"
+    assert b'ERROR: Input is neither a valid sysio::name nor a uint64_t' in completed.stderr
+
 nodeop_help_test()
 
 clio_help_test(['--help'])
@@ -482,6 +518,8 @@ cli11_bugfix_test()
 
 cli11_optional_option_arg_test()
 clio_sign_test()
+
+clio_convert_name_test()
 
 clio_abi_file_test()
 clio_protobuf_abi_test()

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -473,14 +473,14 @@ def clio_protobuf_abi_test():
 
 def clio_convert_name_test():
     """Test 'clio convert name' prints both interpretations and exits non-zero on bad input"""
-    # Valid sysio::name only ("sysio" is 5 lowercase chars; decimal value is 20 digits, > uint64_t max)
+    # Valid sysio::name only ("sysio" contains letters, so stoull throws std::invalid_argument)
     completed = subprocess.run(['./programs/clio/clio', '--no-auto-kiod', 'convert', 'name', 'sysio'],
                                check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert completed.returncode == 0, f"stderr={completed.stderr!r}"
     assert b'As sysio::name : "sysio" -> uint64_t: 14389258095169634304' in completed.stdout
     assert b'As uint64_t' not in completed.stdout
 
-    # Valid uint64_t only (16 digits, too long to parse as a sysio::name)
+    # Valid uint64_t only (20 digits, exceeds sysio::name's 13-char limit)
     completed = subprocess.run(['./programs/clio/clio', '--no-auto-kiod', 'convert', 'name', '14389258095169634304'],
                                check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert completed.returncode == 0, f"stderr={completed.stderr!r}"


### PR DESCRIPTION
## Summary
Adds `clio convert name <input>` which prints both interpretations of
the input: as a `sysio::name` (showing the uint64_t value) and as a
uint64_t (showing the decoded `sysio::name`). Inputs valid under both
forms show both; invalid interpretations are silently skipped.

## Examples

String input (valid name, not a uint64_t):
```
$ clio convert name sysio
As sysio::name : "sysio" -> uint64_t: 14389258095169634304
```

Numeric uint64_t (too long to parse as a sysio::name):
```
$ clio convert name 14389258095169634304
As uint64_t    : 14389258095169634304 -> sysio::name: "sysio"
```

Input valid under both interpretations:
```
$ clio convert name 12345
As sysio::name : "12345" -> uint64_t: 614251516705898496
As uint64_t    : 12345 -> sysio::name: "..........s3d"
```

Hex uint64_t (not a valid name):
```
$ clio convert name 0xdeadbeef
As uint64_t    : 3735928559 -> sysio::name: "......aypqzij"
```

Neither interpretation valid:
```
$ clio convert name INVALID
ERROR: Input is neither a valid sysio::name nor a uint64_t
```