### PR TITLE
Fix OPP bundle tool detection: per-tool find_program cache variables

### DIFF
--- a/libraries/opp/CMakeLists.txt
+++ b/libraries/opp/CMakeLists.txt
@@ -71,8 +71,13 @@ target_link_libraries(
 set(_required_progs fish npm pnpm node wire-protobuf-bundler protoc-gen-solidity protoc-gen-solana)
 set(_missing_progs)
 foreach(_prog ${_required_progs})
-    find_program(_found_prog ${_prog})
-    if (NOT _found_prog)
+    # Use a distinct cache variable per tool: find_program short-circuits when
+    # its output variable is already set in the cache, so reusing one variable
+    # across iterations would return the first tool's path for every subsequent
+    # lookup and silently mark all tools as "found".
+    string(MAKE_C_IDENTIFIER "${_prog}" _prog_var)
+    find_program(_found_prog_${_prog_var} ${_prog})
+    if (NOT _found_prog_${_prog_var})
         list(APPEND _missing_progs ${_prog})
     endif()
 endforeach()


### PR DESCRIPTION
## Summary

- `libraries/opp/CMakeLists.txt` reused a single `_found_prog` cache variable across all seven required bundle tools. `find_program` is a no-op when its output variable is already set in the cache, so after iteration 1 cached `fish`'s path, every subsequent lookup returned that same path and no tool was ever marked missing.
- CMake unconditionally added the POST_BUILD bundle step; the fish script itself later detected the real missing tools and failed the `libopp.a` link with errors like:

```
Error: The following required tools are not found on PATH:
  - wire-protobuf-bundler
  - protoc-gen-solidity
  - protoc-gen-solana
```

- CI hid this because those tools happen to be installed there.
- Fix: use a per-tool cache variable (`_found_prog_<sanitized_name>`) so each `find_program` actually searches. CMake now correctly warns and skips the POST_BUILD step when any bundle tool is absent, matching the original intent of the graceful-degradation block.