### PR TITLE
kv: split iterator slot into independent primary/secondary pools

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -725,8 +725,8 @@ int32_t apply_context::kv_contains(uint16_t table_id, name code, const char* key
 // --- Primary KV iterators ---
 
 uint32_t apply_context::kv_it_create(uint16_t table_id, name code, const char* prefix, uint32_t prefix_size) {
-   const uint32_t handle = kv_iterators.allocate_primary(table_id, code, prefix, prefix_size);
-   auto& slot = kv_iterators.get(handle);
+   const uint32_t handle = kv_primary_iterators.allocate(table_id, code, prefix, prefix_size);
+   auto& slot = kv_primary_iterators.get(handle);
 
    // Seek to first entry matching prefix
    const auto& idx = db.get_index<kv_index, by_code_key>();
@@ -744,16 +744,24 @@ uint32_t apply_context::kv_it_create(uint16_t table_id, name code, const char* p
 }
 
 void apply_context::kv_it_destroy(uint32_t handle) {
-   kv_iterators.release(handle);
+   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_it_destroy called with secondary iterator handle ({})", handle);
+   kv_primary_iterators.release(handle);
 }
 
 int32_t apply_context::kv_it_status(uint32_t handle) {
-   return static_cast<int32_t>(kv_iterators.get(handle).status);
+   // Accepts either handle kind; dispatch on the tag bit so generic wrappers
+   // (CDT iterator destructors / status checks) keep working for both.
+   if (kv_handle_is_secondary(handle)) {
+      return static_cast<int32_t>(kv_secondary_iterators.get(kv_handle_slot_index(handle)).status);
+   }
+   return static_cast<int32_t>(kv_primary_iterators.get(handle).status);
 }
 
 int32_t apply_context::kv_it_next(uint32_t handle) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(slot.is_primary, kv_invalid_iterator, "kv_it_next called on secondary iterator");
+   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_it_next called with secondary iterator handle ({})", handle);
+   auto& slot = kv_primary_iterators.get(handle);
 
    if (slot.status == kv_it_stat::iterator_end) return static_cast<int32_t>(kv_it_stat::iterator_end);
 
@@ -790,8 +798,9 @@ int32_t apply_context::kv_it_next(uint32_t handle) {
 }
 
 int32_t apply_context::kv_it_prev(uint32_t handle) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(slot.is_primary, kv_invalid_iterator, "kv_it_prev called on secondary iterator");
+   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_it_prev called with secondary iterator handle ({})", handle);
+   auto& slot = kv_primary_iterators.get(handle);
 
    const auto& idx = db.get_index<kv_index, by_code_key>();
 
@@ -858,8 +867,9 @@ int32_t apply_context::kv_it_prev(uint32_t handle) {
 }
 
 int32_t apply_context::kv_it_lower_bound(uint32_t handle, const char* key, uint32_t key_size) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(slot.is_primary, kv_invalid_iterator, "kv_it_lower_bound called on secondary iterator");
+   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_it_lower_bound called with secondary iterator handle ({})", handle);
+   auto& slot = kv_primary_iterators.get(handle);
 
    const auto& idx = db.get_index<kv_index, by_code_key>();
 
@@ -885,7 +895,7 @@ int32_t apply_context::kv_it_lower_bound(uint32_t handle, const char* key, uint3
 
 // Helper: find the current primary row by cached ID (fast) or key bytes (slow).
 // Updates cached_id on success. Returns nullptr if the row was erased.
-static const kv_object* find_current_primary(const chainbase::database& db, kv_iterator_slot& slot) {
+static const kv_object* find_current_primary(const chainbase::database& db, kv_primary_slot& slot) {
    // Fast path: by cached chainbase ID
    if (slot.cached_id >= 0) {
       const auto* obj = db.find<kv_object>(kv_object::id_type(slot.cached_id));
@@ -905,8 +915,9 @@ static const kv_object* find_current_primary(const chainbase::database& db, kv_i
 }
 
 int32_t apply_context::kv_it_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(slot.is_primary, kv_invalid_iterator, "kv_it_key called on secondary iterator");
+   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_it_key called with secondary iterator handle ({})", handle);
+   auto& slot = kv_primary_iterators.get(handle);
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -929,42 +940,56 @@ int32_t apply_context::kv_it_key(uint32_t handle, uint32_t offset, char* dest, u
    return static_cast<int32_t>(kv_it_stat::iterator_ok);
 }
 
+// Copy bytes from `src` to `dest` honoring the intrinsic's offset+truncation
+// contract.  Shared between the primary and secondary kv_it_value paths.
+static void copy_value_window(const char* src, size_t src_size, uint32_t offset,
+                              char* dest, uint32_t dest_size, uint32_t& actual_size) {
+   actual_size = static_cast<uint32_t>(src_size);
+   if (dest_size > 0 && offset < src_size) {
+      auto copy_size = std::min(static_cast<size_t>(dest_size), src_size - offset);
+      memcpy(dest, src + offset, copy_size);
+   }
+}
+
 // Read the value at a primary OR secondary iterator's current position.
 // For primary iters, the value comes from the kv_object the iter is positioned
 // on. For secondary iters, the value comes from the kv_object referenced by
 // the slot's cached primary_id — a by_id lookup that avoids kv_get's
 // by_code_key walk.
 int32_t apply_context::kv_it_value(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = kv_iterators.get(handle);
-
-   if (slot.status != kv_it_stat::iterator_ok) {
-      actual_size = 0;
-      return static_cast<int32_t>(slot.status);
-   }
-
-   const kv_object* obj;
-   if (slot.is_primary) {
-      obj = find_current_primary(db, slot);
-   } else {
+   if (kv_handle_is_secondary(handle)) {
+      auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
+      if (slot.status != kv_it_stat::iterator_ok) {
+         actual_size = 0;
+         return static_cast<int32_t>(slot.status);
+      }
       if (slot.primary_id < 0) {
          slot.status = kv_it_stat::iterator_erased;
          actual_size = 0;
          return static_cast<int32_t>(slot.status);
       }
-      obj = db.find<kv_object>(kv_object::id_type(slot.primary_id));
+      const kv_object* obj = db.find<kv_object>(kv_object::id_type(slot.primary_id));
+      if (!obj) {
+         slot.status = kv_it_stat::iterator_erased;
+         actual_size = 0;
+         return static_cast<int32_t>(slot.status);
+      }
+      copy_value_window(obj->value.data(), obj->value.size(), offset, dest, dest_size, actual_size);
+      return static_cast<int32_t>(kv_it_stat::iterator_ok);
    }
+
+   auto& slot = kv_primary_iterators.get(handle);
+   if (slot.status != kv_it_stat::iterator_ok) {
+      actual_size = 0;
+      return static_cast<int32_t>(slot.status);
+   }
+   const kv_object* obj = find_current_primary(db, slot);
    if (!obj) {
       slot.status = kv_it_stat::iterator_erased;
       actual_size = 0;
       return static_cast<int32_t>(slot.status);
    }
-
-   actual_size = static_cast<uint32_t>(obj->value.size());
-   if (dest_size > 0 && offset < obj->value.size()) {
-      auto copy_size = std::min(static_cast<size_t>(dest_size), obj->value.size() - offset);
-      memcpy(dest, obj->value.data() + offset, copy_size);
-   }
-
+   copy_value_window(obj->value.data(), obj->value.size(), offset, dest, dest_size, actual_size);
    return static_cast<int32_t>(kv_it_stat::iterator_ok);
 }
 
@@ -1077,13 +1102,13 @@ int32_t apply_context::kv_idx_find_secondary(name code, uint16_t table_id,
       return -1; // not found — no iterator slot allocated
    }
 
-   const uint32_t handle = kv_iterators.allocate_secondary(code, table_id);
-   auto& slot = kv_iterators.get(handle);
+   const uint32_t slot_idx = kv_secondary_iterators.allocate(code, table_id);
+   auto& slot = kv_secondary_iterators.get(slot_idx);
    slot.status = kv_it_stat::iterator_ok;
    slot.current_sec_key.assign(itr->sec_key.data(), itr->sec_key.data() + itr->sec_key.size());
    slot.cached_id = itr->id._id;
    slot.primary_id = itr->primary_id._id;
-   return static_cast<int32_t>(handle);
+   return static_cast<int32_t>(kv_make_secondary_handle(slot_idx));
 }
 
 int32_t apply_context::kv_idx_lower_bound(name code, uint16_t table_id,
@@ -1104,26 +1129,27 @@ int32_t apply_context::kv_idx_lower_bound(name code, uint16_t table_id,
          table_has_rows = (prev->code == code && prev->table_id == table_id);
       }
       if (table_has_rows) {
-         const uint32_t handle = kv_iterators.allocate_secondary(code, table_id);
-         auto& slot = kv_iterators.get(handle);
+         const uint32_t slot_idx = kv_secondary_iterators.allocate(code, table_id);
+         auto& slot = kv_secondary_iterators.get(slot_idx);
          slot.status = kv_it_stat::iterator_end;
-         return static_cast<int32_t>(handle);
+         return static_cast<int32_t>(kv_make_secondary_handle(slot_idx));
       }
       return -1;
    }
 
-   const uint32_t handle = kv_iterators.allocate_secondary(code, table_id);
-   auto& slot = kv_iterators.get(handle);
+   const uint32_t slot_idx = kv_secondary_iterators.allocate(code, table_id);
+   auto& slot = kv_secondary_iterators.get(slot_idx);
    slot.status = kv_it_stat::iterator_ok;
    slot.current_sec_key.assign(itr->sec_key.data(), itr->sec_key.data() + itr->sec_key.size());
    slot.cached_id = itr->id._id;
    slot.primary_id = itr->primary_id._id;
-   return static_cast<int32_t>(handle);
+   return static_cast<int32_t>(kv_make_secondary_handle(slot_idx));
 }
 
 int32_t apply_context::kv_idx_next(uint32_t handle) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(!slot.is_primary, kv_invalid_iterator, "kv_idx_next called on primary iterator");
+   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_idx_next called with primary iterator handle ({})", handle);
+   auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
 
    if (slot.status == kv_it_stat::iterator_end) return static_cast<int32_t>(kv_it_stat::iterator_end);
 
@@ -1171,8 +1197,9 @@ int32_t apply_context::kv_idx_next(uint32_t handle) {
 }
 
 int32_t apply_context::kv_idx_prev(uint32_t handle) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(!slot.is_primary, kv_invalid_iterator, "kv_idx_prev called on primary iterator");
+   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_idx_prev called with primary iterator handle ({})", handle);
+   auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
 
    const auto& idx = db.get_index<kv_index_index, by_code_table_id_seckey>();
 
@@ -1248,7 +1275,7 @@ int32_t apply_context::kv_idx_prev(uint32_t handle) {
 // Helper: find the current secondary entry by cached ID (fast) or composite key (slow).
 // The composite key uses (code, table_id, sec_key, primary_id); re-seeking is only
 // possible when primary_id is still known from the slot.
-static const kv_index_object* find_current_secondary(const chainbase::database& db, kv_iterator_slot& slot) {
+static const kv_index_object* find_current_secondary(const chainbase::database& db, kv_secondary_slot& slot) {
    if (slot.cached_id >= 0) {
       const auto* obj = db.find<kv_index_object>(kv_index_object::id_type(slot.cached_id));
       if (obj && obj->code == slot.code && obj->table_id == slot.table_id)
@@ -1271,8 +1298,9 @@ static const kv_index_object* find_current_secondary(const chainbase::database& 
 }
 
 int32_t apply_context::kv_idx_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(!slot.is_primary, kv_invalid_iterator, "kv_idx_key called on primary iterator");
+   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_idx_key called with primary iterator handle ({})", handle);
+   auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -1296,8 +1324,9 @@ int32_t apply_context::kv_idx_key(uint32_t handle, uint32_t offset, char* dest, 
 }
 
 int32_t apply_context::kv_idx_primary_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(!slot.is_primary, kv_invalid_iterator, "kv_idx_primary_key called on primary iterator");
+   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_idx_primary_key called with primary iterator handle ({})", handle);
+   auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -1332,7 +1361,9 @@ int32_t apply_context::kv_idx_primary_key(uint32_t handle, uint32_t offset, char
 }
 
 void apply_context::kv_idx_destroy(uint32_t handle) {
-   kv_iterators.release(handle);
+   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_idx_destroy called with primary iterator handle ({})", handle);
+   kv_secondary_iterators.release(kv_handle_slot_index(handle));
 }
 
 } /// sysio::chain

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -725,6 +725,14 @@ int32_t apply_context::kv_contains(uint16_t table_id, name code, const char* key
 // --- Primary KV iterators ---
 
 uint32_t apply_context::kv_it_create(uint16_t table_id, name code, const char* prefix, uint32_t prefix_size) {
+   // Cap prefix at the constexpr absolute ceiling (max_kv_key_size_limit, 1024 B).  The prefix bytes are copied into
+   // the iterator slot's std::vector<char>, so an unbounded prefix_size would let a contract allocate arbitrary
+   // host-side storage per iterator (up to max_kv_iterators slots per action).  The absolute ceiling is used
+   // instead of the dynamic max_kv_key_size because the prefix bound is about capping host-side slot memory, not
+   // matching the current on-chain stored-key limit, and the constexpr check has zero runtime cost — matching
+   // the rationale that leaves read-path query keys bounded only by WASM linear memory.
+   SYS_ASSERT( prefix_size <= config::max_kv_key_size_limit, kv_key_too_large,
+               "KV iterator prefix size {} exceeds absolute maximum {}", prefix_size, config::max_kv_key_size_limit );
    const uint32_t handle = kv_primary_iterators.allocate(table_id, code, prefix, prefix_size);
    auto& slot = kv_primary_iterators.get(handle);
 
@@ -744,12 +752,14 @@ uint32_t apply_context::kv_it_create(uint16_t table_id, name code, const char* p
 }
 
 void apply_context::kv_it_destroy(uint32_t handle) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_it_destroy called with secondary iterator handle ({})", handle);
    kv_primary_iterators.release(handle);
 }
 
 int32_t apply_context::kv_it_status(uint32_t handle) {
+   kv_handle_check_reserved_zero(handle);
    // Accepts either handle kind; dispatch on the tag bit so generic wrappers
    // (CDT iterator destructors / status checks) keep working for both.
    if (kv_handle_is_secondary(handle)) {
@@ -759,6 +769,7 @@ int32_t apply_context::kv_it_status(uint32_t handle) {
 }
 
 int32_t apply_context::kv_it_next(uint32_t handle) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_it_next called with secondary iterator handle ({})", handle);
    auto& slot = kv_primary_iterators.get(handle);
@@ -798,6 +809,7 @@ int32_t apply_context::kv_it_next(uint32_t handle) {
 }
 
 int32_t apply_context::kv_it_prev(uint32_t handle) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_it_prev called with secondary iterator handle ({})", handle);
    auto& slot = kv_primary_iterators.get(handle);
@@ -867,6 +879,7 @@ int32_t apply_context::kv_it_prev(uint32_t handle) {
 }
 
 int32_t apply_context::kv_it_lower_bound(uint32_t handle, const char* key, uint32_t key_size) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_it_lower_bound called with secondary iterator handle ({})", handle);
    auto& slot = kv_primary_iterators.get(handle);
@@ -915,6 +928,7 @@ static const kv_object* find_current_primary(const chainbase::database& db, kv_p
 }
 
 int32_t apply_context::kv_it_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_it_key called with secondary iterator handle ({})", handle);
    auto& slot = kv_primary_iterators.get(handle);
@@ -940,8 +954,8 @@ int32_t apply_context::kv_it_key(uint32_t handle, uint32_t offset, char* dest, u
    return static_cast<int32_t>(kv_it_stat::iterator_ok);
 }
 
-// Copy bytes from `src` to `dest` honoring the intrinsic's offset+truncation
-// contract.  Shared between the primary and secondary kv_it_value paths.
+// Copy bytes from `src` to `dest` honoring the intrinsic's offset+truncation contract.  Shared between the
+// primary and secondary kv_it_value paths.
 static void copy_value_window(const char* src, size_t src_size, uint32_t offset,
                               char* dest, uint32_t dest_size, uint32_t& actual_size) {
    actual_size = static_cast<uint32_t>(src_size);
@@ -951,12 +965,11 @@ static void copy_value_window(const char* src, size_t src_size, uint32_t offset,
    }
 }
 
-// Read the value at a primary OR secondary iterator's current position.
-// For primary iters, the value comes from the kv_object the iter is positioned
-// on. For secondary iters, the value comes from the kv_object referenced by
-// the slot's cached primary_id — a by_id lookup that avoids kv_get's
-// by_code_key walk.
+// Read the value at a primary OR secondary iterator's current position.  For primary iters, the value comes
+// from the kv_object the iter is positioned on.  For secondary iters, the value comes from the kv_object
+// referenced by the slot's cached primary_id — a by_id lookup that avoids kv_get's by_code_key walk.
 int32_t apply_context::kv_it_value(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
+   kv_handle_check_reserved_zero(handle);
    if (kv_handle_is_secondary(handle)) {
       auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
       if (slot.status != kv_it_stat::iterator_ok) {
@@ -1147,6 +1160,7 @@ int32_t apply_context::kv_idx_lower_bound(name code, uint16_t table_id,
 }
 
 int32_t apply_context::kv_idx_next(uint32_t handle) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_idx_next called with primary iterator handle ({})", handle);
    auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
@@ -1197,6 +1211,7 @@ int32_t apply_context::kv_idx_next(uint32_t handle) {
 }
 
 int32_t apply_context::kv_idx_prev(uint32_t handle) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_idx_prev called with primary iterator handle ({})", handle);
    auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
@@ -1298,6 +1313,7 @@ static const kv_index_object* find_current_secondary(const chainbase::database& 
 }
 
 int32_t apply_context::kv_idx_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_idx_key called with primary iterator handle ({})", handle);
    auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
@@ -1324,6 +1340,7 @@ int32_t apply_context::kv_idx_key(uint32_t handle, uint32_t offset, char* dest, 
 }
 
 int32_t apply_context::kv_idx_primary_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_idx_primary_key called with primary iterator handle ({})", handle);
    auto& slot = kv_secondary_iterators.get(kv_handle_slot_index(handle));
@@ -1361,6 +1378,7 @@ int32_t apply_context::kv_idx_primary_key(uint32_t handle, uint32_t offset, char
 }
 
 void apply_context::kv_idx_destroy(uint32_t handle) {
+   kv_handle_check_reserved_zero(handle);
    SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
               "kv_idx_destroy called with primary iterator handle ({})", handle);
    kv_secondary_iterators.release(kv_handle_slot_index(handle));

--- a/libraries/chain/include/sysio/chain/apply_context.hpp
+++ b/libraries/chain/include/sysio/chain/apply_context.hpp
@@ -176,7 +176,8 @@ class apply_context {
 
    private:
 
-      kv_iterator_pool                    kv_iterators;
+      kv_primary_iterator_pool            kv_primary_iterators;
+      kv_secondary_iterator_pool          kv_secondary_iterators;
       std::optional<const account_metadata_object*> _first_receiver_metadata; ///< cached across notification dispatch
       vector< std::pair<account_name, uint32_t> > _notified; ///< keeps track of new accounts to be notifed of current message
       vector<uint32_t>                    _inline_actions; ///< action_ordinals of queued inline actions

--- a/libraries/chain/include/sysio/chain/kv_context.hpp
+++ b/libraries/chain/include/sysio/chain/kv_context.hpp
@@ -14,76 +14,103 @@ enum class kv_it_stat : int32_t {
    iterator_erased = 2
 };
 
-struct kv_iterator_slot {
+// ---------------------------------------------------------------------------
+// Handle encoding
+//
+// Primary and secondary iterators live in separate pools with their own slot
+// arrays.  A single handle space must still fit in int32_t because the host
+// intrinsics expose handles through that type (with negative values reserved
+// for "not found" returns).  Bit 30 tags secondary handles; bit 31 stays
+// clear so every encoded handle is positive when observed as int32_t.
+//
+// config::max_kv_iterators is 1024 (well under 2^30), so the raw slot index
+// always fits in the lower 30 bits.
+// ---------------------------------------------------------------------------
+constexpr uint32_t kv_secondary_handle_tag = 0x40000000u;
+
+inline bool kv_handle_is_secondary(uint32_t handle) {
+   return (handle & kv_secondary_handle_tag) != 0;
+}
+
+inline uint32_t kv_handle_slot_index(uint32_t handle) {
+   return handle & ~kv_secondary_handle_tag;
+}
+
+inline uint32_t kv_make_secondary_handle(uint32_t slot_index) {
+   return slot_index | kv_secondary_handle_tag;
+}
+
+// Fields every slot carries regardless of direction.
+struct kv_iterator_slot_common {
    bool              in_use = false;
-   bool              is_primary = true;
    kv_it_stat        status = kv_it_stat::iterator_end;
    account_name      code;
    uint16_t          table_id = 0;  ///< table namespace (primary or secondary index)
-
-   // Primary iterator: prefix for bounded iteration
-   std::vector<char>  prefix;
-
-   // Current position key bytes (for re-seeking after invalidation)
-   std::vector<char>  current_key;
-   // For secondary iterators: current secondary key
-   std::vector<char>  current_sec_key;
-   // For secondary iterators: lazy cache of primary-key bytes, populated only
-   // when kv_idx_primary_key materializes them from the referenced kv_object.
-   // Empty otherwise so iteration does not pay the by_id materialization cost.
-   std::vector<char>  current_pri_key;
 
    // Cached chainbase ID for O(1) iterator_to fast path.
    // -1 means no cached ID; falls back to lower_bound re-seek.
    //   - primary iterator: kv_object id
    //   - secondary iterator: kv_index_object id
    int64_t           cached_id = -1;
-
-   // Secondary iterator only: id of the kv_object referenced by the current
-   // secondary row, used for pri_key/value materialization and as the
-   // composite-key tiebreaker for re-seeking after invalidation.
-   // -1 when not at a valid secondary position.
-   // Invariant: when status == iterator_ok, primary_id >= 0. The slow-path
-   // re-seek in kv_idx_next/kv_idx_prev asserts this to catch an
-   // internally-inconsistent slot rather than synthesize garbage.
-   int64_t           primary_id = -1;
 };
 
-class kv_iterator_pool {
-public:
-   kv_iterator_pool() : _slots(config::max_kv_iterators) {}
+struct kv_primary_slot : kv_iterator_slot_common {
+   std::vector<char>  prefix;       ///< prefix for bounded iteration
+   std::vector<char>  current_key;  ///< current position key bytes (for re-seek after invalidation)
 
-   uint32_t allocate_primary(uint16_t table_id, account_name code, const char* prefix, uint32_t prefix_size) {
+   void reset() {
+      status = kv_it_stat::iterator_end;
+      cached_id = -1;
+      prefix.clear();
+      current_key.clear();
+   }
+};
+
+struct kv_secondary_slot : kv_iterator_slot_common {
+   std::vector<char>  current_sec_key;  ///< current secondary key bytes (for re-seek)
+   // Lazy cache of primary-key bytes, populated only when kv_idx_primary_key
+   // materializes them from the referenced kv_object.  Empty otherwise so
+   // iteration does not pay the by_id materialization cost.
+   std::vector<char>  current_pri_key;
+
+   // id of the kv_object referenced by the current secondary row, used for
+   // pri_key/value materialization and as the composite-key tiebreaker for
+   // re-seeking after invalidation.  -1 when not at a valid secondary
+   // position.
+   // Invariant: when status == iterator_ok, primary_id >= 0.  The slow-path
+   // re-seek in kv_idx_next/kv_idx_prev asserts this to catch an
+   // internally-inconsistent slot rather than synthesize garbage.
+   int64_t            primary_id = -1;
+
+   void reset() {
+      status = kv_it_stat::iterator_end;
+      cached_id = -1;
+      current_sec_key.clear();
+      current_pri_key.clear();
+      primary_id = -1;
+   }
+};
+
+// Pool for primary (kv_it_*) iterators.  Slot type is tight (~72B): no
+// secondary-only fields, so cache locality on hot iteration paths improves
+// over the pre-split union slot.
+//
+// The slot array is lazily sized on first allocate() so actions that touch
+// no KV iterators pay zero heap for this pool.  Once sized, the pool
+// behaves identically to an eagerly-allocated one.
+class kv_primary_iterator_pool {
+public:
+   kv_primary_iterator_pool() = default;
+
+   uint32_t allocate(uint16_t table_id, account_name code, const char* prefix, uint32_t prefix_size) {
+      if (_slots.empty()) _slots.resize(config::max_kv_iterators);
       uint32_t idx = find_free();
       auto& s = _slots[idx];
-      s.in_use = true;
-      s.is_primary = true;
-      s.status = kv_it_stat::iterator_end;
-      s.code = code;
+      s.reset();
+      s.in_use   = true;
+      s.code     = code;
       s.table_id = table_id;
       s.prefix.assign(prefix, prefix + prefix_size);
-      s.current_key.clear();
-      s.current_sec_key.clear();
-      s.current_pri_key.clear();
-      s.cached_id = -1;
-      s.primary_id = -1;
-      return idx;
-   }
-
-   uint32_t allocate_secondary(account_name code, uint16_t table_id) {
-      uint32_t idx = find_free();
-      auto& s = _slots[idx];
-      s.in_use = true;
-      s.is_primary = false;
-      s.status = kv_it_stat::iterator_end;
-      s.code = code;
-      s.table_id = table_id;
-      s.prefix.clear();
-      s.current_key.clear();
-      s.current_sec_key.clear();
-      s.current_pri_key.clear();
-      s.cached_id = -1;
-      s.primary_id = -1;
       return idx;
    }
 
@@ -91,23 +118,18 @@ public:
       SYS_ASSERT(handle < _slots.size() && _slots[handle].in_use,
          kv_invalid_iterator, "invalid KV iterator handle {}", handle);
       auto& s = _slots[handle];
+      s.reset();
       s.in_use = false;
-      s.prefix.clear();
-      s.current_key.clear();
-      s.current_sec_key.clear();
-      s.current_pri_key.clear();
-      s.cached_id = -1;
-      s.primary_id = -1;
       if (handle < _next_free) _next_free = handle;
    }
 
-   kv_iterator_slot& get(uint32_t handle) {
+   kv_primary_slot& get(uint32_t handle) {
       SYS_ASSERT(handle < _slots.size() && _slots[handle].in_use,
          kv_invalid_iterator, "invalid KV iterator handle {}", handle);
       return _slots[handle];
    }
 
-   const kv_iterator_slot& get(uint32_t handle) const {
+   const kv_primary_slot& get(uint32_t handle) const {
       SYS_ASSERT(handle < _slots.size() && _slots[handle].in_use,
          kv_invalid_iterator, "invalid KV iterator handle {}", handle);
       return _slots[handle];
@@ -122,10 +144,66 @@ private:
          }
       }
       SYS_THROW(kv_iterator_limit_exceeded,
-         "exceeded maximum number of KV iterators ({})", config::max_kv_iterators);
+         "exceeded maximum number of KV primary iterators ({})", config::max_kv_iterators);
    }
 
-   std::vector<kv_iterator_slot> _slots;
+   std::vector<kv_primary_slot> _slots;
+   uint32_t _next_free = 0;
+};
+
+// Pool for secondary (kv_idx_*) iterators.  Independent free-list from the
+// primary pool so a contract may hold up to max_kv_iterators of each type
+// simultaneously.  Lazily sized on first allocate(), same as the primary
+// pool.
+class kv_secondary_iterator_pool {
+public:
+   kv_secondary_iterator_pool() = default;
+
+   uint32_t allocate(account_name code, uint16_t table_id) {
+      if (_slots.empty()) _slots.resize(config::max_kv_iterators);
+      uint32_t idx = find_free();
+      auto& s = _slots[idx];
+      s.reset();
+      s.in_use   = true;
+      s.code     = code;
+      s.table_id = table_id;
+      return idx;
+   }
+
+   void release(uint32_t handle) {
+      SYS_ASSERT(handle < _slots.size() && _slots[handle].in_use,
+         kv_invalid_iterator, "invalid KV iterator handle {}", handle);
+      auto& s = _slots[handle];
+      s.reset();
+      s.in_use = false;
+      if (handle < _next_free) _next_free = handle;
+   }
+
+   kv_secondary_slot& get(uint32_t handle) {
+      SYS_ASSERT(handle < _slots.size() && _slots[handle].in_use,
+         kv_invalid_iterator, "invalid KV iterator handle {}", handle);
+      return _slots[handle];
+   }
+
+   const kv_secondary_slot& get(uint32_t handle) const {
+      SYS_ASSERT(handle < _slots.size() && _slots[handle].in_use,
+         kv_invalid_iterator, "invalid KV iterator handle {}", handle);
+      return _slots[handle];
+   }
+
+private:
+   uint32_t find_free() {
+      for (uint32_t i = _next_free; i < _slots.size(); ++i) {
+         if (!_slots[i].in_use) {
+            _next_free = i + 1;
+            return i;
+         }
+      }
+      SYS_THROW(kv_iterator_limit_exceeded,
+         "exceeded maximum number of KV secondary iterators ({})", config::max_kv_iterators);
+   }
+
+   std::vector<kv_secondary_slot> _slots;
    uint32_t _next_free = 0;
 };
 

--- a/libraries/chain/include/sysio/chain/kv_context.hpp
+++ b/libraries/chain/include/sysio/chain/kv_context.hpp
@@ -14,30 +14,68 @@ enum class kv_it_stat : int32_t {
    iterator_erased = 2
 };
 
-// ---------------------------------------------------------------------------
-// Handle encoding
+// ------------------------------------------------------------------------------------------------------------
+// Handle encoding (CONSENSUS-OBSERVABLE)
 //
-// Primary and secondary iterators live in separate pools with their own slot
-// arrays.  A single handle space must still fit in int32_t because the host
-// intrinsics expose handles through that type (with negative values reserved
-// for "not found" returns).  Bit 30 tags secondary handles; bit 31 stays
-// clear so every encoded handle is positive when observed as int32_t.
+// Handle values returned from the KV iterator intrinsics are visible to contracts as the intrinsic's return
+// value.  Contracts may read, store, and branch on those values, so the encoding below is part of the consensus
+// surface: every bit that is set today and every bit we promise to leave zero today must remain that way unless
+// a future protocol feature deliberately redefines them.
 //
-// config::max_kv_iterators is 1024 (well under 2^30), so the raw slot index
-// always fits in the lower 30 bits.
-// ---------------------------------------------------------------------------
-constexpr uint32_t kv_secondary_handle_tag = 0x40000000u;
+// Layout (bits numbered from LSB):
+//
+//   [ 0.. 9]  slot index (10 bits, covers max_kv_iterators = 1024)
+//   [10..15]  RESERVED — must be zero
+//   [16    ]  secondary-pool tag (1 = secondary, 0 = primary)
+//   [17..30]  RESERVED — must be zero
+//   [31    ]  MUST be zero — keeps the handle positive when read as int32_t (intrinsics return int32_t;
+//             negative means "not found").
+//
+// Bit 16 was chosen over a high bit to keep handle values small and human-readable in logs and error messages.
+// The reserved bits give future protocol features room to encode things like iterator generation counters (to
+// catch stale-handle reuse across destroy/re-allocate) or additional pool discriminators, without disturbing
+// already-deployed contract code.
+//
+// Any change to this encoding — including the tag bit position, the slot mask width, or the interpretation of
+// any reserved bit — is a protocol change.  Contracts MUST NOT rely on reserved bits being anything other than
+// zero; kv_handle_check_reserved_zero enforces the invariant at the host-intrinsic boundary so any accidental
+// non-zero reserved bit is caught before it becomes load-bearing.
+// ------------------------------------------------------------------------------------------------------------
+
+// Primary pool capacity. Matches config::max_kv_iterators.
+constexpr uint32_t kv_handle_slot_mask     = 0x000003FFu;  // bits  0.. 9: slot index in [0, 1024)
+constexpr uint32_t kv_secondary_handle_tag = 0x00010000u;  // bit  16    : secondary-pool tag
+
+// Everything that is neither slot index nor tag must be zero.  Negation is cast to uint32_t so the reserved
+// mask stays exactly 32 bits regardless of integral promotion to int on the host.
+constexpr uint32_t kv_handle_reserved_mask =
+   static_cast<uint32_t>(~(kv_handle_slot_mask | kv_secondary_handle_tag));
+
+static_assert(config::max_kv_iterators <= kv_handle_slot_mask + 1,
+              "kv_handle_slot_mask is too narrow for config::max_kv_iterators");
+static_assert((kv_handle_slot_mask & kv_secondary_handle_tag) == 0,
+              "kv_handle_slot_mask and kv_secondary_handle_tag must not overlap");
 
 inline bool kv_handle_is_secondary(uint32_t handle) {
    return (handle & kv_secondary_handle_tag) != 0;
 }
 
 inline uint32_t kv_handle_slot_index(uint32_t handle) {
-   return handle & ~kv_secondary_handle_tag;
+   return handle & kv_handle_slot_mask;
 }
 
 inline uint32_t kv_make_secondary_handle(uint32_t slot_index) {
    return slot_index | kv_secondary_handle_tag;
+}
+
+// Enforce the reserved-bits-zero invariant at the host-intrinsic boundary.  Any non-zero bit in
+// kv_handle_reserved_mask means the contract has been fabricating handle values rather than using one returned
+// from the host, or has relied on an undocumented bit pattern.  Rejecting these early keeps the reserved bits
+// genuinely reserved — available for future protocol features.
+inline void kv_handle_check_reserved_zero(uint32_t handle) {
+   SYS_ASSERT((handle & kv_handle_reserved_mask) == 0, kv_invalid_iterator,
+              "KV iterator handle has non-zero reserved bits (handle={:#x})",
+              handle);
 }
 
 // Fields every slot carries regardless of direction.
@@ -68,18 +106,15 @@ struct kv_primary_slot : kv_iterator_slot_common {
 
 struct kv_secondary_slot : kv_iterator_slot_common {
    std::vector<char>  current_sec_key;  ///< current secondary key bytes (for re-seek)
-   // Lazy cache of primary-key bytes, populated only when kv_idx_primary_key
-   // materializes them from the referenced kv_object.  Empty otherwise so
-   // iteration does not pay the by_id materialization cost.
+   // Lazy cache of primary-key bytes, populated only when kv_idx_primary_key materializes them from the
+   // referenced kv_object.  Empty otherwise so iteration does not pay the by_id materialization cost.
    std::vector<char>  current_pri_key;
 
-   // id of the kv_object referenced by the current secondary row, used for
-   // pri_key/value materialization and as the composite-key tiebreaker for
-   // re-seeking after invalidation.  -1 when not at a valid secondary
+   // id of the kv_object referenced by the current secondary row, used for pri_key/value materialization and
+   // as the composite-key tiebreaker for re-seeking after invalidation.  -1 when not at a valid secondary
    // position.
-   // Invariant: when status == iterator_ok, primary_id >= 0.  The slow-path
-   // re-seek in kv_idx_next/kv_idx_prev asserts this to catch an
-   // internally-inconsistent slot rather than synthesize garbage.
+   // Invariant: when status == iterator_ok, primary_id >= 0.  The slow-path re-seek in kv_idx_next/kv_idx_prev
+   // asserts this to catch an internally-inconsistent slot rather than synthesize garbage.
    int64_t            primary_id = -1;
 
    void reset() {
@@ -91,13 +126,11 @@ struct kv_secondary_slot : kv_iterator_slot_common {
    }
 };
 
-// Pool for primary (kv_it_*) iterators.  Slot type is tight (~72B): no
-// secondary-only fields, so cache locality on hot iteration paths improves
-// over the pre-split union slot.
+// Pool for primary (kv_it_*) iterators.  Slot type is tight (~72B): no secondary-only fields, so cache
+// locality on hot iteration paths improves over the pre-split union slot.
 //
-// The slot array is lazily sized on first allocate() so actions that touch
-// no KV iterators pay zero heap for this pool.  Once sized, the pool
-// behaves identically to an eagerly-allocated one.
+// The slot array is lazily sized on first allocate() so actions that touch no KV iterators pay zero heap for
+// this pool.  Once sized, the pool behaves identically to an eagerly-allocated one.
 class kv_primary_iterator_pool {
 public:
    kv_primary_iterator_pool() = default;
@@ -151,10 +184,9 @@ private:
    uint32_t _next_free = 0;
 };
 
-// Pool for secondary (kv_idx_*) iterators.  Independent free-list from the
-// primary pool so a contract may hold up to max_kv_iterators of each type
-// simultaneously.  Lazily sized on first allocate(), same as the primary
-// pool.
+// Pool for secondary (kv_idx_*) iterators.  Independent free-list from the primary pool so a contract may
+// hold up to max_kv_iterators of each type simultaneously.  Lazily sized on first allocate(), same as the
+// primary pool.
 class kv_secondary_iterator_pool {
 public:
    kv_secondary_iterator_pool() = default;

--- a/unittests/kv_tests.cpp
+++ b/unittests/kv_tests.cpp
@@ -253,48 +253,70 @@ BOOST_AUTO_TEST_CASE(kv_index_object_crud) {
 }
 
 BOOST_AUTO_TEST_CASE(kv_iterator_pool_basic) {
-   kv_iterator_pool pool;
+   // Primary and secondary iterators now live in independent pools.  Both pools
+   // start at slot index 0 and do not share the free-list; a handle namespace
+   // on top (see kv_make_secondary_handle) distinguishes them externally.
+   kv_primary_iterator_pool primary;
+   kv_secondary_iterator_pool secondary;
 
-   // Allocate primary
-   uint32_t h1 = pool.allocate_primary(uint16_t(0), "test"_n, "prefix", 6);
+   // Allocate primary — returns raw slot index (no tag bit).
+   uint32_t h1 = primary.allocate(uint16_t(0), "test"_n, "prefix", 6);
    BOOST_CHECK_EQUAL(h1, 0u);
-   auto& slot1 = pool.get(h1);
-   BOOST_CHECK(slot1.is_primary);
+   BOOST_CHECK(!kv_handle_is_secondary(h1));
+   auto& slot1 = primary.get(h1);
    BOOST_CHECK_EQUAL(slot1.code, "test"_n);
 
-   // Allocate secondary
-   uint32_t h2 = pool.allocate_secondary("test"_n, uint16_t(100));
-   BOOST_CHECK_EQUAL(h2, 1u);
-   auto& slot2 = pool.get(h2);
-   BOOST_CHECK(!slot2.is_primary);
+   // Allocate secondary — pool returns a raw index; apply_context tags it
+   // with the secondary handle bit before handing back to the contract.
+   uint32_t s_idx = secondary.allocate("test"_n, uint16_t(100));
+   BOOST_CHECK_EQUAL(s_idx, 0u);
+   uint32_t h2 = kv_make_secondary_handle(s_idx);
+   BOOST_CHECK(kv_handle_is_secondary(h2));
+   BOOST_CHECK_EQUAL(kv_handle_slot_index(h2), 0u);
+   auto& slot2 = secondary.get(s_idx);
+   BOOST_CHECK_EQUAL(slot2.code, "test"_n);
 
-   // Release and reuse
-   pool.release(h1);
-   uint32_t h3 = pool.allocate_primary(uint16_t(0), "other"_n, "", 0);
-   BOOST_CHECK_EQUAL(h3, 0u); // reuses slot 0
+   // Release and reuse within each pool independently.
+   primary.release(h1);
+   uint32_t h3 = primary.allocate(uint16_t(0), "other"_n, "", 0);
+   BOOST_CHECK_EQUAL(h3, 0u); // reuses slot 0 of the primary pool
 
-   pool.release(h2);
-   pool.release(h3);
+   secondary.release(s_idx);
+   primary.release(h3);
 }
 
 BOOST_AUTO_TEST_CASE(kv_iterator_pool_exhaustion) {
-   kv_iterator_pool pool;
+   kv_primary_iterator_pool primary;
+   kv_secondary_iterator_pool secondary;
 
-   // Allocate all 16 slots
+   // Fill both pools — each independently sized to max_kv_iterators.
    for (uint32_t i = 0; i < config::max_kv_iterators; ++i) {
-      pool.allocate_primary(uint16_t(0), "test"_n, "", 0);
+      primary.allocate(uint16_t(0), "test"_n, "", 0);
+      secondary.allocate("test"_n, uint16_t(100));
    }
 
-   // 17th should throw
+   // One more primary allocation throws — tests that the primary pool
+   // caps independently of the secondary pool.
    BOOST_CHECK_THROW(
-      pool.allocate_primary(uint16_t(0), "test"_n, "", 0),
+      primary.allocate(uint16_t(0), "test"_n, "", 0),
       kv_iterator_limit_exceeded
    );
 
-   // Release one and try again
-   pool.release(5);
-   uint32_t h = pool.allocate_primary(uint16_t(0), "test"_n, "", 0);
+   // Same for secondary.
+   BOOST_CHECK_THROW(
+      secondary.allocate("test"_n, uint16_t(100)),
+      kv_iterator_limit_exceeded
+   );
+
+   // Releasing a primary slot frees a primary handle only; secondary is
+   // still saturated.
+   primary.release(5);
+   uint32_t h = primary.allocate(uint16_t(0), "test"_n, "", 0);
    BOOST_CHECK_EQUAL(h, 5u);
+   BOOST_CHECK_THROW(
+      secondary.allocate("test"_n, uint16_t(100)),
+      kv_iterator_limit_exceeded
+   );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/kv_tests.cpp
+++ b/unittests/kv_tests.cpp
@@ -319,4 +319,43 @@ BOOST_AUTO_TEST_CASE(kv_iterator_pool_exhaustion) {
    );
 }
 
+BOOST_AUTO_TEST_CASE(kv_handle_encoding_layout) {
+   // Pin the consensus-observable handle encoding.  Any change to this
+   // layout is a protocol change and should fail this test loudly.
+   BOOST_CHECK_EQUAL(kv_handle_slot_mask,     0x000003FFu);
+   BOOST_CHECK_EQUAL(kv_secondary_handle_tag, 0x00010000u);
+
+   // Reserved mask is every bit outside of slot+tag (within 32 bits).
+   BOOST_CHECK_EQUAL(kv_handle_reserved_mask,
+                     static_cast<uint32_t>(~(kv_handle_slot_mask | kv_secondary_handle_tag)));
+
+   // Well-formed primary handle: only slot bits may be set.
+   uint32_t primary_handle = 5u;
+   BOOST_CHECK((primary_handle & kv_handle_reserved_mask) == 0);
+   BOOST_CHECK(!kv_handle_is_secondary(primary_handle));
+   BOOST_CHECK_NO_THROW(kv_handle_check_reserved_zero(primary_handle));
+
+   // Well-formed secondary handle: slot bits + tag bit.
+   uint32_t secondary_handle = kv_make_secondary_handle(5u);
+   BOOST_CHECK_EQUAL(secondary_handle, 0x00010005u);
+   BOOST_CHECK((secondary_handle & kv_handle_reserved_mask) == 0);
+   BOOST_CHECK(kv_handle_is_secondary(secondary_handle));
+   BOOST_CHECK_EQUAL(kv_handle_slot_index(secondary_handle), 5u);
+   BOOST_CHECK_NO_THROW(kv_handle_check_reserved_zero(secondary_handle));
+
+   // Any bit inside the reserved mask must be rejected.  Walk each reserved
+   // bit individually to catch a future layout change that accidentally
+   // shrinks the reserved set.
+   for (uint32_t bit = 0; bit < 32; ++bit) {
+      uint32_t probe = 1u << bit;
+      if ((probe & kv_handle_reserved_mask) == 0) continue;
+      BOOST_CHECK_THROW(kv_handle_check_reserved_zero(probe), kv_invalid_iterator);
+   }
+
+   // Handle values in int32_t form must remain non-negative; bit 31 is
+   // reserved (and catches the "negative means not found" intrinsic
+   // contract at the encoding layer).
+   BOOST_CHECK((kv_handle_reserved_mask & 0x80000000u) != 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Follow-on to #304 (kv secondary rows reference primary by chainbase id).  Splits the single 1024-slot `kv_iterator_pool` into two independent pools with type-specific slot layouts so primary and secondary iterators no longer share a free-list or fall-through cache lines of data neither uses, and hardens the contract-visible iterator handle ABI.

## Motivation

Pre-split, every slot in `apply_context::kv_iterators` was a union of every field used by either a primary or a secondary iterator — four `std::vector<char>` buffers plus a `primary_id` plus an `is_primary` flag.  Hot paths (`kv_it_next`, `kv_idx_next`, `kv_it_value`) loaded cache lines holding fields the operation never touched, and a contract that iterated both kinds concurrently competed for the same 1024-slot budget.

## Pool split

* `kv_iterator_slot_common` holds the fields every iterator needs (status, code, table_id, cached_id).
* `kv_primary_slot` adds primary-only byte buffers (`prefix`, `current_key`).  ~72 B / one cache line.
* `kv_secondary_slot` adds secondary-only fields (`current_sec_key`, `current_pri_key` lazy cache, `primary_id`).  ~80 B.
* `kv_primary_iterator_pool` and `kv_secondary_iterator_pool` each expose `max_kv_iterators` (1024) slots, independently.  A contract may now hold up to 1024 primary **and** 1024 secondary iterators at once.
* Both pools lazily `resize` on first `allocate()` — actions that never touch KV iterators (e.g. `sysio.token::transfer`, which routes through `kv_get`/`kv_set` only) pay zero heap.  First `allocate` pays the same ~82 KB this code paid up front before; no realloc, no reference invalidation, identical `get()` path.

## Handle encoding (CONSENSUS-OBSERVABLE)

Handle values are contract-visible — they're the return value of `kv_it_create` / `kv_idx_find_secondary` / `kv_idx_lower_bound`, and contracts may read, store, and branch on them.  The encoding is therefore part of the consensus surface.  Fixed now:

```
[ 0.. 9]  slot index (10 bits, covers max_kv_iterators = 1024)
[10..15]  RESERVED — must be zero
[16    ]  secondary-pool tag (1 = secondary, 0 = primary)
[17..30]  RESERVED — must be zero
[31    ]  MUST be zero — keeps handle positive when read as int32_t
```

Bit 16 (`0x00010000`) was chosen over a high bit so handle values stay small and readable in logs/error messages (secondary handle 0x00010005 vs 0x40000005).  Reserved bits give future protocol features room to encode e.g. iterator generation counters (to catch stale-handle reuse across destroy/re-allocate) or additional pool discriminators without disturbing deployed contract code.  Any change to this layout is a protocol change.

## Reserved-bit invariant

`kv_handle_check_reserved_zero()` is called at every host-intrinsic entry point that consumes a handle (`kv_it_destroy`, `kv_it_status`, `kv_it_next`, `kv_it_prev`, `kv_it_lower_bound`, `kv_it_key`, `kv_it_value`, `kv_idx_next`, `kv_idx_prev`, `kv_idx_key`, `kv_idx_primary_key`, `kv_idx_destroy`).  A contract that fabricates handle values rather than passing back one returned from the host fails with a clean `kv_invalid_iterator` exception instead of silently aliasing a real slot through the truncated slot-index mask.

## Prefix-size bound on kv_it_create

Cap `prefix_size` at `config::max_kv_key_size_limit` (constexpr absolute ceiling, 1024 B).  The prefix bytes are `memcpy`'d into the iterator slot's `std::vector<char>`, so an unbounded `prefix_size` would let a contract allocate arbitrary host-side storage per iterator (up to `max_kv_iterators` slots per action).  The absolute ceiling is used instead of the dynamic `max_kv_key_size` because the cap exists to limit host-side slot memory, not to match the current on-chain stored-key limit, and the `constexpr` compile-time compare has zero runtime cost.  Legitimate CDT usage passes 0 or `kv_scope_size` (8 bytes), far below the cap.

## Read-path inputs intentionally left unbounded beyond legacy_span

`kv_get`, `kv_contains`, `kv_erase` lookup key, `kv_it_lower_bound` seek key, `kv_idx_find_secondary` and `kv_idx_lower_bound` query keys, `kv_idx_remove` and `kv_idx_update` old sec_key — all pass their `(ptr, size)` pair through `legacy_span` (WASM memory bounds check) and then into a `string_view` used only for a chainbase index lookup.  There is no host-side copy, so no allocation griefing vector.  Comparator cost is capped at `min(query_size, stored_size)`; stored sizes are already bounded by the write-path checks on `kv_set` / `kv_idx_store`.  Adding an additional runtime bound here would break legitimate CDT idioms — notably the `operator--` seek-past-end trick in `kv::table` iterators which memsets a 1024-byte buffer to 0xFF and calls `kv_it_lower_bound` / `kv_idx_lower_bound` to position past the last row in a scope.

## Capacity change

No contract that worked pre-split gets a new error.  Some that exhausted the shared 1024-slot pool mid-mixed use now succeed (primary+secondary sum up to 2048).

## Host ABI / chainbase

No change.  Host intrinsic signatures, `kv_object` / `kv_index_object` layout, and serialization are all untouched.