### PR TITLE
boringssl-custom: bump to 1.0.2 (upstream 0.20260413.0)

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,8 +9,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
-      "reference": "feature/boringssl-upstream-bump",
-      "baseline": "810862bde15169d886adc9c1e72268b54301cd94",
+      "baseline": "54d969e98171c7447dc07b57b3420df4ae246eb0",
       "packages": [
         "boost",
         "softfloat",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
-      "baseline": "f941f19ffa37df111e97cb32652d6d30aeaa16f3",
+      "baseline": "810862bde15169d886adc9c1e72268b54301cd94",
       "packages": [
         "boost",
         "softfloat",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,6 +9,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
+      "reference": "feature/boringssl-upstream-bump",
       "baseline": "810862bde15169d886adc9c1e72268b54301cd94",
       "packages": [
         "boost",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -96,7 +96,7 @@
     },
     {
       "name": "boringssl-custom",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "catch2",


### PR DESCRIPTION
Bumps the `boringssl-custom` vcpkg override from 1.0.1 to 1.0.2 and the wire-vcpkg-registry baseline to the merge commit that publishes 1.0.2. No wire-sysio source changes -- cmake target names, header paths, and link surfaces are unchanged.

## What the registry bump gives us

Registry PR: Wire-Network/wire-vcpkg-registry#10 (merged, `54d969e9…` on master)

- BoringSSL source moves from `Wire-Network/boringssl-custom @ 15500a39d8` (fork of AntelopeIO/boringssl pinned 2023-09-04) to `google/boringssl @ 0.20260413.0` (upstream release, 2026-04-14). ~19 months of upstream crypto/decrepit bug fixes.
- Port build no longer requires Go or Python on the build host; upstream's own cmake handles all codegen for non-FIPS / non-prefix builds.
- Upstream's `target_link_libraries(decrepit ssl crypto)` relationship now propagates through `INTERFACE_LINK_LIBRARIES` in `boringssl-customConfig.cmake`, so `libdecrepit → libbscrypto` link order is correct for static archive resolution without any consumer-side change.
- The `Wire-Network/boringssl-custom` fork can be archived -- its only delta (patching `generate_build_files.py` to emit a `libdecrepit` target) is obsolete now that we install `decrepit` via the port's cmake append.

## Stale tree removal

`libraries/libfc/libraries/boringssl/` was an untracked leftover from the pre-vcpkg submodule layout; `.gitmodules` already doesn't reference it. Removed.

## Consensus surfaces touched

Host crypto intrinsics routed through BoringSSL's `crypto` (sha1/sha256/sha512) and `decrepit` (ripemd160). These are math-defined algorithms, so upstream behavior is byte-identical. Local crypto-focused suites (`crypto_golden_tests`, `crypto_primitives_tests`, `signature_recovery_tests`, `ed25519_tests`, `bls_primitives_tests`: 54 cases) pass after the bump; full CI ctest matrix validates the rest.