### PR TITLE
chain_plugin: get_table_rows pagination + fix reverse off-by-one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,40 @@ Any value drawn from a closed set — chain kind, envelope status, operator type
 
 - Prefer `FC_REFLECT_ENUM`-reflected protobuf enums (`sysio::opp::types::ChainKind`, `sysio::opp::types::EnvelopeStatus`) over hand-rolled sentinels.
 - Decode variants as the enum type: `obj["status"].as<EnvelopeStatus>()`, never `static_cast<EnvelopeStatus>(obj["status"].as_uint64())`.
-- Enum-to-string: `sysio::opp::types::ChainKind_Name(kind)`. Don't hand-roll switches for human-readable names.
+- Don't hand-roll switches for human-readable names.
 
 A rename of `CHAIN_KIND_ETHEREUM` propagates through the compiler automatically when the code holds the enum. It doesn't when the code holds the bare string `"CHAIN_KIND_ETHEREUM"` or the integer `2`.
+
+#### Enum conversions — use `magic_enum`, never `static_cast`
+
+Every enum ↔ raw value conversion goes through `magic_enum` (`#include <magic_enum/magic_enum.hpp>`). `static_cast` and hand-rolled switches survive rename refactors silently; `magic_enum` does not.
+
+| Need | Use |
+|---|---|
+| Enum → underlying integer | `magic_enum::enum_integer(v)` |
+| Enum → string name (runtime) | `magic_enum::enum_name(v)` |
+| Integer → enum (checked `std::optional<E>`) | `magic_enum::enum_cast<E>(n)` |
+| String name → enum (checked `std::optional<E>`) | `magic_enum::enum_cast<E>(name)` |
+| N-th member by declaration order | `magic_enum::enum_value<E>(i)` |
+
+Forbidden once a `magic_enum` form exists:
+
+- `static_cast<uint64_t>(SomeEnum::X)` — use `magic_enum::enum_integer(SomeEnum::X)`.
+- `static_cast<SomeEnum>(int_var)` at a trust boundary — use `magic_enum::enum_cast<SomeEnum>(int_var).value_or(SomeEnum::DEFAULT)`; static_cast past the enum's declared range is UB and it hides bad input.
+- Hand-rolled `if/switch` tables that map an enum to its spelling — use `magic_enum::enum_name`.
+
+**Sole exception — protobuf-generated enums.** `protoc` emits a `<EnumName>_Name(int value)` free function (and `<EnumName>_Parse`) for every proto enum. Use those instead of `magic_enum` for the generated types under `sysio::opp::types::` and any other `.pb.h` enums:
+
+```cpp
+// Protobuf-generated enum — prefer the generated helper.
+auto s = sysio::opp::types::ChainKind_Name(kind);        // ✓
+auto n = magic_enum::enum_name(kind);                    // ✗ works, but skip for proto enums
+
+// Non-proto enum — magic_enum.
+auto s = magic_enum::enum_name(EnvelopeStatus::PENDING); // ✓
+```
+
+Rationale: the generated `_Name` encodes the exact wire-format spelling (e.g. `"CHAIN_KIND_ETHEREUM"`), stays in lock-step with the `.proto` on every regeneration, and does not depend on the compile-time name-discovery tricks `magic_enum` uses. For every other enum in the tree, `magic_enum` is the standard.
 
 ## Project Overview
 

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -224,23 +224,53 @@ struct batch_operator_plugin::impl {
    //  Table read helper
    // -----------------------------------------------------------------------
 
-   /// Thin plumbing around `chain_apis::read_only::get_table_rows`: binds this
-   /// plugin's `chain_plug` and the configured `delivery_timeout_ms`,
-   /// unwraps the deferred callable, and turns RPC errors into an empty
-   /// result with an error log. All query shape — pagination, filter,
-   /// unwrap, reverse, find+index — lives on `get_table_rows_params`.
+   /// Posts a `get_table_rows` scan onto the app's read_only queue and blocks this (cron-worker) thread on the
+   /// result. Running the scan during the controller's read window is what makes the chainbase iteration safe:
+   /// the main chain thread isn't writing blocks while read-only-queue items execute. Calling
+   /// `chain_plug->get_read_only_api(...)` and iterating directly from the cron thread would race with block
+   /// apply. All query shape (`find`, `index_name`, `all_rows`, `filter`, `values_only`) lives on
+   /// `get_table_rows_params`.
    sysio::chain_apis::read_only::get_table_rows_result
    read_table(sysio::chain_apis::read_only::get_table_rows_params p) {
-      auto timeout  = fc::milliseconds(delivery_timeout_ms);
-      auto ro       = chain_plug->get_read_only_api(timeout);
-      auto deadline = fc::time_point::now() + timeout;
-      auto result   = ro.get_table_rows(p, deadline)();
-      if (auto* err = std::get_if<fc::exception_ptr>(&result)) {
-         elog("batch_operator: table read failed {}::{} — {}",
-              p.code.to_string(), p.table, (*err)->to_string());
+      using result_t  = sysio::chain_apis::read_only::get_table_rows_result;
+      const auto timeout  = fc::milliseconds(delivery_timeout_ms);
+      const auto deadline = fc::time_point::now() + timeout;
+
+      // shared_ptr so the posted lambda and this stack frame each own a reference; if `wait_for` times out and
+      // returns, the lambda can still safely write into the promise when the read_only queue eventually drains.
+      auto prom = std::make_shared<std::promise<result_t>>();
+      auto fut  = prom->get_future();
+
+      app().executor().post(appbase::priority::medium, appbase::exec_queue::read_only,
+         [this, p = std::move(p), deadline, prom]() mutable {
+            try {
+               auto ro       = chain_plug->get_read_only_api(fc::microseconds(delivery_timeout_ms * 1000ll));
+               auto variant  = ro.get_table_rows(p, deadline)();
+               if (auto* err = std::get_if<fc::exception_ptr>(&variant)) {
+                  elog("batch_operator: table read failed {}::{} -- {}",
+                       p.code.to_string(), p.table, (*err)->to_string());
+                  prom->set_value({});
+               } else {
+                  prom->set_value(std::get<result_t>(std::move(variant)));
+               }
+            } catch (const fc::exception& e) {
+               elog("batch_operator: table read threw {}::{} -- {}", p.code.to_string(), p.table, e.to_string());
+               prom->set_value({});
+            } catch (const std::exception& e) {
+               elog("batch_operator: table read threw {}::{} -- {}", p.code.to_string(), p.table, e.what());
+               prom->set_value({});
+            } catch (...) {
+               elog("batch_operator: table read threw unknown exception {}::{}", p.code.to_string(), p.table);
+               prom->set_value({});
+            }
+         });
+
+      if (fut.wait_for(std::chrono::milliseconds(delivery_timeout_ms)) != std::future_status::ready) {
+         elog("batch_operator: table read queue-wait exceeded {}ms ({}::{})",
+              delivery_timeout_ms, p.code.to_string(), p.table);
          return {};
       }
-      return std::get<sysio::chain_apis::read_only::get_table_rows_result>(std::move(result));
+      return fut.get();
    }
 
    /// Check if this operator already delivered an envelope for the

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -11,6 +11,7 @@
 #include <sysio/batch_operator_plugin/outpost_opp_job.hpp>
 #include <sysio/chain/abi_serializer.hpp>
 #include <sysio/chain/transaction.hpp>
+#include <sysio/chain_plugin/chain_plugin.hpp>
 #include <sysio/opp/opp.hpp>
 #include <sysio/opp/attestations/attestations.pb.h>
 #include <sysio/outpost_ethereum_client_plugin/outpost_ethereum_client.hpp>
@@ -33,12 +34,14 @@ namespace {
    /// that finds outposts later still responds.
    constexpr std::size_t MIN_CRON_THREADS = 5;
 
-   /// `chain_plug->get_read_only_api(...)` timeout. Covers ABI loading plus
-   /// the table scan; should not dominate the tick.
-   constexpr auto READ_ONLY_API_TIMEOUT_US = 200000;
-
    /// my_group sentinel meaning "we are not in any batch-op group".
    constexpr uint8_t GROUP_NONE = 255;
+
+   /// Rolling window size for the outbound-envelope lookup. Covers ~4 epochs
+   /// across up to 2 outposts (`DEPOT → OUTPOST` pair each epoch) plus a
+   /// slack row, so `read_pending_outbound` always sees the current epoch
+   /// without paying for a full-table scan as `outenvelopes` grows.
+   constexpr uint32_t OUTBOUND_LOOKUP_WINDOW = 8;
 
    // ── WIRE contract identifiers (actions, tables, indexes, field names) ──
    // Centralised so a contract rename/refactor shows up as one search hit,
@@ -153,7 +156,19 @@ struct batch_operator_plugin::impl {
 
       std::optional<sysio::outbound_envelope_record>
       read_pending_outbound(uint64_t outpost_id, uint32_t epoch_index) override {
-         auto rows = _impl.read_table(msgch::account, msgch::account, msgch::table_outenvelopes, 50);
+         // Reverse-iterate the latest `OUTBOUND_LOOKUP_WINDOW` rows. The primary
+         // key is auto-incrementing `id`, so reverse + small window gives the
+         // most recent epochs' envelopes without scanning the whole table (which
+         // grows unbounded until cleanup). Filtering by (outpost_id, epoch_index)
+         // after the fact is O(window), not O(rows).
+         sysio::chain_apis::read_only::get_table_rows_params p;
+         p.code        = chain::name(msgch::account);
+         p.scope       = msgch::account;
+         p.table       = msgch::table_outenvelopes;
+         p.reverse     = true;
+         p.limit       = OUTBOUND_LOOKUP_WINDOW;
+         p.unwrap_rows = true;
+         auto rows = _impl.read_table(std::move(p));
          for (auto& row : rows.rows) {
             auto     obj         = row.get_object();
             uint64_t row_outpost = obj[msgch::field::outpost_id].as_uint64();
@@ -209,84 +224,23 @@ struct batch_operator_plugin::impl {
    //  Table read helper
    // -----------------------------------------------------------------------
 
-   struct read_table_options {
-      std::optional<std::string>                              lower_bound;
-      std::optional<std::string>                              upper_bound;
-      /// Exact-match key lookup. When set, the chain plugin treats the value as
-      /// both lower and upper bound AND appends a null byte to the upper bound
-      /// so the iterator includes the target row. Use this (not `lower_bound ==
-      /// upper_bound`) for secondary-index lookups on `multi_index` tables —
-      /// those store the secondary key bytes alone and compare with `sk >=
-      /// ub_sv`, so an identical upper-bound breaks out of the loop before the
-      /// match is emitted.
-      std::optional<std::string>                              find;
-      std::optional<std::string>                              index_name;
-      std::optional<std::function<bool(const fc::variant&)>>  filter;
-      bool                                                    get_all = false;
-   };
-
-   read_only::get_table_rows_result read_table(const std::string& code,
-                                                const std::string& scope,
-                                                const std::string& table,
-                                                uint32_t limit = 100,
-                                                std::optional<read_table_options> opts = std::nullopt) {
-      auto ro = chain_plug->get_read_only_api(fc::microseconds(READ_ONLY_API_TIMEOUT_US));
-      read_only::get_table_rows_params p;
-      p.json  = true;
-      p.code  = chain::name(code);
-      p.scope = scope;
-      p.table = table;
-      p.limit = limit;
-
-      if (opts) {
-         if (opts->lower_bound)    p.lower_bound    = *opts->lower_bound;
-         if (opts->upper_bound)    p.upper_bound    = *opts->upper_bound;
-         if (opts->find)           p.find           = *opts->find;
-         if (opts->index_name)     p.index_name     = *opts->index_name;
+   /// Thin plumbing around `chain_apis::read_only::get_table_rows`: binds this
+   /// plugin's `chain_plug` and the configured `delivery_timeout_ms`,
+   /// unwraps the deferred callable, and turns RPC errors into an empty
+   /// result with an error log. All query shape — pagination, filter,
+   /// unwrap, reverse, find+index — lives on `get_table_rows_params`.
+   sysio::chain_apis::read_only::get_table_rows_result
+   read_table(sysio::chain_apis::read_only::get_table_rows_params p) {
+      auto timeout  = fc::milliseconds(delivery_timeout_ms);
+      auto ro       = chain_plug->get_read_only_api(timeout);
+      auto deadline = fc::time_point::now() + timeout;
+      auto result   = ro.get_table_rows(p, deadline)();
+      if (auto* err = std::get_if<fc::exception_ptr>(&result)) {
+         elog("batch_operator: table read failed {}::{} — {}",
+              p.code.to_string(), p.table, (*err)->to_string());
+         return {};
       }
-
-      auto deadline = fc::time_point::now() + fc::milliseconds(delivery_timeout_ms);
-
-      read_only::get_table_rows_result combined;
-      while (true) {
-         auto result_fn = ro.get_table_rows(p, deadline);
-         auto result = result_fn();
-         if (auto* err = std::get_if<fc::exception_ptr>(&result)) {
-            elog("batch_operator: table read failed {}::{} — {}", code, table, (*err)->to_string());
-            return combined;
-         }
-         auto page = std::get<read_only::get_table_rows_result>(result);
-         combined.rows.insert(combined.rows.end(),
-            std::make_move_iterator(page.rows.begin()),
-            std::make_move_iterator(page.rows.end()));
-
-         if (!opts || !opts->get_all || !page.more || page.next_key.empty()) {
-            combined.more = page.more;
-            combined.next_key = page.next_key;
-            break;
-         }
-         p.lower_bound = page.next_key;
-      }
-
-      // chain_plugin::get_table_rows wraps every row as {"key", "value", [payer]}.
-      // Callers of this helper read contract fields directly, so unwrap to value.
-      // variant::operator=(const variant&) calls clear() before reading the source,
-      // so a direct `row = row.get_object()["value"]` would destroy the source ref
-      // mid-assignment. Copy into an independent variant first, then move-assign.
-      for (auto& row : combined.rows) {
-         if (!row.is_object()) continue;
-         const auto& row_obj = row.get_object();
-         if (!row_obj.contains("value")) continue;
-         fc::variant value{row_obj["value"]};
-         row = std::move(value);
-      }
-
-      if (opts && opts->filter) {
-         std::erase_if(combined.rows, [&](const fc::variant& row) {
-            return !(*opts->filter)(row);
-         });
-      }
-      return combined;
+      return std::get<sysio::chain_apis::read_only::get_table_rows_result>(std::move(result));
    }
 
    /// Check if this operator already delivered an envelope for the
@@ -303,15 +257,17 @@ struct batch_operator_plugin::impl {
       // because chain_plugin's secondary-index iteration breaks on
       // `sk >= ub_sv` — `find` mode appends a null byte to the upper bound
       // so the secondary key compares strictly less than it.
-      std::string key_json = std::format("{{\"{}\":{}}}", msgch::index_byoutepoch, key);
-      auto rows = read_table(msgch::account, msgch::account, msgch::table_envelopes, 50,
-         read_table_options{
-            .find           = key_json,
-            .index_name     = msgch::index_byoutepoch,
-            .filter         = [op_account](const fc::variant& row) {
-               return chain::name(row[msgch::field::batch_op_name].as_string()) == op_account;
-            }
-         });
+      sysio::chain_apis::read_only::get_table_rows_params p;
+      p.code        = chain::name(msgch::account);
+      p.scope       = msgch::account;
+      p.table       = msgch::table_envelopes;
+      p.find        = std::format("{{\"{}\":{}}}", msgch::index_byoutepoch, key);
+      p.index_name  = msgch::index_byoutepoch;
+      p.unwrap_rows = true;
+      p.filter      = [op_account](const fc::variant& row) {
+         return chain::name(row[msgch::field::batch_op_name].as_string()) == op_account;
+      };
+      auto rows = read_table(std::move(p));
       return !rows.rows.empty();
    }
 
@@ -342,7 +298,13 @@ struct batch_operator_plugin::impl {
     * Returns {true, epoch_index} on success, {false, 0} if state is unavailable.
     */
    std::pair<bool, uint32_t> parse_epoch_state() {
-      auto state_rows = read_table(epoch::account, epoch::account, epoch::table_epochstate, 1);
+      sysio::chain_apis::read_only::get_table_rows_params p;
+      p.code        = chain::name(epoch::account);
+      p.scope       = epoch::account;
+      p.table       = epoch::table_epochstate;
+      p.limit       = 1;
+      p.unwrap_rows = true;
+      auto state_rows = read_table(std::move(p));
       if (state_rows.rows.empty()) return {false, 0};
 
       auto obj = state_rows.rows[0].get_object();
@@ -436,7 +398,17 @@ struct batch_operator_plugin::impl {
 
    void refresh_outposts() {
       outposts.clear();
-      auto rows = read_table(epoch::account, epoch::account, epoch::table_outposts, 50);
+      // `limit = 0` → paginate through every row. The outpost count should
+      // stay tiny (one per external chain), but don't bake in a scan cap
+      // that would stall the batch operator if governance adds more than a
+      // default single-page bound.
+      sysio::chain_apis::read_only::get_table_rows_params p;
+      p.code        = chain::name(epoch::account);
+      p.scope       = epoch::account;
+      p.table       = epoch::table_outposts;
+      p.limit       = 0;
+      p.unwrap_rows = true;
+      auto rows = read_table(std::move(p));
       for (auto& row : rows.rows) {
          auto obj = row.get_object();
          outpost_descriptor od;

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -139,7 +139,7 @@ struct batch_operator_plugin::impl {
    /// plugin's startup/shutdown.
    sysio::services::cron_service_ptr cron_svc;
    std::vector<cron_service::job_id_t> cron_job_ids;
-   bool                              shutting_down = false;
+   std::atomic<bool>                 shutting_down{false};
 
    // -----------------------------------------------------------------------
    //  Chain-agnostic orchestration layer
@@ -224,53 +224,12 @@ struct batch_operator_plugin::impl {
    //  Table read helper
    // -----------------------------------------------------------------------
 
-   /// Posts a `get_table_rows` scan onto the app's read_only queue and blocks this (cron-worker) thread on the
-   /// result. Running the scan during the controller's read window is what makes the chainbase iteration safe:
-   /// the main chain thread isn't writing blocks while read-only-queue items execute. Calling
-   /// `chain_plug->get_read_only_api(...)` and iterating directly from the cron thread would race with block
-   /// apply. All query shape (`find`, `index_name`, `all_rows`, `filter`, `values_only`) lives on
-   /// `get_table_rows_params`.
+   /// Thin delegate to `chain_plugin::read_table_rows`, which posts the scan onto the app executor's read_only queue
+   /// so chainbase iteration runs during the controller's read window instead of racing with block apply.
    sysio::chain_apis::read_only::get_table_rows_result
    read_table(sysio::chain_apis::read_only::get_table_rows_params p) {
-      using result_t  = sysio::chain_apis::read_only::get_table_rows_result;
-      const auto timeout  = fc::milliseconds(delivery_timeout_ms);
-      const auto deadline = fc::time_point::now() + timeout;
-
-      // shared_ptr so the posted lambda and this stack frame each own a reference; if `wait_for` times out and
-      // returns, the lambda can still safely write into the promise when the read_only queue eventually drains.
-      auto prom = std::make_shared<std::promise<result_t>>();
-      auto fut  = prom->get_future();
-
-      app().executor().post(appbase::priority::medium, appbase::exec_queue::read_only,
-         [this, p = std::move(p), deadline, prom]() mutable {
-            try {
-               auto ro       = chain_plug->get_read_only_api(fc::microseconds(delivery_timeout_ms * 1000ll));
-               auto variant  = ro.get_table_rows(p, deadline)();
-               if (auto* err = std::get_if<fc::exception_ptr>(&variant)) {
-                  elog("batch_operator: table read failed {}::{} -- {}",
-                       p.code.to_string(), p.table, (*err)->to_string());
-                  prom->set_value({});
-               } else {
-                  prom->set_value(std::get<result_t>(std::move(variant)));
-               }
-            } catch (const fc::exception& e) {
-               elog("batch_operator: table read threw {}::{} -- {}", p.code.to_string(), p.table, e.to_string());
-               prom->set_value({});
-            } catch (const std::exception& e) {
-               elog("batch_operator: table read threw {}::{} -- {}", p.code.to_string(), p.table, e.what());
-               prom->set_value({});
-            } catch (...) {
-               elog("batch_operator: table read threw unknown exception {}::{}", p.code.to_string(), p.table);
-               prom->set_value({});
-            }
-         });
-
-      if (fut.wait_for(std::chrono::milliseconds(delivery_timeout_ms)) != std::future_status::ready) {
-         elog("batch_operator: table read queue-wait exceeded {}ms ({}::{})",
-              delivery_timeout_ms, p.code.to_string(), p.table);
-         return {};
-      }
-      return fut.get();
+      return chain_plug->read_table_rows(std::move(p), fc::milliseconds(delivery_timeout_ms),
+                                         "batch_operator", shutting_down);
    }
 
    /// Check if this operator already delivered an envelope for the

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -167,7 +167,7 @@ struct batch_operator_plugin::impl {
          p.table       = msgch::table_outenvelopes;
          p.reverse     = true;
          p.limit       = OUTBOUND_LOOKUP_WINDOW;
-         p.unwrap_rows = true;
+         p.values_only = true;
          auto rows = _impl.read_table(std::move(p));
          for (auto& row : rows.rows) {
             auto     obj         = row.get_object();
@@ -263,7 +263,7 @@ struct batch_operator_plugin::impl {
       p.table       = msgch::table_envelopes;
       p.find        = std::format("{{\"{}\":{}}}", msgch::index_byoutepoch, key);
       p.index_name  = msgch::index_byoutepoch;
-      p.unwrap_rows = true;
+      p.values_only = true;
       p.filter      = [op_account](const fc::variant& row) {
          return chain::name(row[msgch::field::batch_op_name].as_string()) == op_account;
       };
@@ -303,7 +303,7 @@ struct batch_operator_plugin::impl {
       p.scope       = epoch::account;
       p.table       = epoch::table_epochstate;
       p.limit       = 1;
-      p.unwrap_rows = true;
+      p.values_only = true;
       auto state_rows = read_table(std::move(p));
       if (state_rows.rows.empty()) return {false, 0};
 
@@ -398,16 +398,14 @@ struct batch_operator_plugin::impl {
 
    void refresh_outposts() {
       outposts.clear();
-      // `limit = 0` → paginate through every row. The outpost count should
-      // stay tiny (one per external chain), but don't bake in a scan cap
-      // that would stall the batch operator if governance adds more than a
-      // default single-page bound.
+      // `all_rows` walks every row in one call. The outpost count should stay tiny (one per external chain), but
+      // don't bake in a scan cap that would stall the batch operator if governance adds more than the default bound.
       sysio::chain_apis::read_only::get_table_rows_params p;
       p.code        = chain::name(epoch::account);
       p.scope       = epoch::account;
       p.table       = epoch::table_outposts;
-      p.limit       = 0;
-      p.unwrap_rows = true;
+      p.all_rows    = true;
+      p.values_only = true;
       auto rows = read_table(std::move(p));
       for (auto& row : rows.rows) {
          auto obj = row.get_object();

--- a/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
@@ -408,7 +408,7 @@ public:
       std::optional<bool>  reverse;                   ///< iterate in reverse; pairs with `limit` to return the most recent N rows
       std::optional<bool>  show_payer;                ///< include RAM payer in each row
       std::optional<uint32_t> time_limit_ms;          ///< defaults to http-max-response-time-ms
-      std::optional<bool>  values_only;               ///< return each row as just its `value` instead of `{key, value, payer?}`.
+      std::optional<bool>  values_only;               ///< return each row as just its `value` instead of `{key, value, payer?}`. With `json=false` each row is therefore a bare hex string, not an object.
 
       // ---- C++-only fields below. Not FC_REFLECT'd, so HTTP callers cannot set them. ----
 
@@ -430,15 +430,11 @@ public:
 
    using get_table_rows_return_t = std::function<chain::t_or_exception<get_table_rows_result>()>;
 
-   /// Public table-rows query. Wraps {@link get_table_rows_page} and layers the C++-only behaviours from
-   /// `get_table_rows_params`: `all_rows` (walk the entire scan, ignoring limit/deadline), `filter` (post-fetch
-   /// predicate), and `values_only` (strip the `{key, value, payer?}` wrapper). HTTP callers that don't set any of
-   /// those land directly on the page impl and pay zero extra indirection.
+   /// Public table-rows query. Honors the per-caller scan bounds on `get_table_rows_params` (`limit`,
+   /// `time_limit_ms`, `lower/upper_bound`, `find`, `index_name`, `reverse`) plus the C++-only behaviours
+   /// `all_rows` (walk the entire scan, ignoring limit/deadline), `filter` (post-fetch predicate), and
+   /// `values_only` (strip the `{key, value, payer?}` wrapper).
    get_table_rows_return_t get_table_rows( const get_table_rows_params& params, const fc::time_point& deadline )const;
-
-   /// Single-page implementation of the table scan. Honors `limit` as the per-page row cap; does NOT walk the
-   /// whole table, filter, or strip the wrapper -- those are applied by the public {@link get_table_rows}.
-   get_table_rows_return_t get_table_rows_page( const get_table_rows_params& params, const fc::time_point& deadline )const;
 
    struct get_table_by_scope_params {
       name                 code; // mandatory

--- a/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
@@ -27,6 +27,9 @@
 
 #include <sysio/signature_provider_manager_plugin/signature_provider_manager_plugin.hpp>
 
+#include <atomic>
+#include <string_view>
+
 namespace fc { class variant; }
 
 namespace sysio {
@@ -668,6 +671,17 @@ public:
 
    chain_apis::read_write get_read_write_api(const fc::microseconds& http_max_response_time);
    chain_apis::read_only get_read_only_api(const fc::microseconds& http_max_response_time) const;
+
+   /// Runs a `get_table_rows` scan on the app executor's read_only queue and blocks the caller on the result. The
+   /// scan runs during the controller's read window, avoiding races with block apply that would occur if the caller
+   /// iterated chainbase directly from its own thread. `shutdown_flag` is polled every 200ms so the caller returns
+   /// early on plugin shutdown instead of stalling up to `timeout` for the executor to drain. `log_prefix` is a
+   /// short tag (plugin name) used in error log lines.
+   chain_apis::read_only::get_table_rows_result
+   read_table_rows(chain_apis::read_only::get_table_rows_params params,
+                   fc::microseconds timeout,
+                   std::string_view log_prefix,
+                   const std::atomic<bool>& shutdown_flag);
 
    void accept_transaction(const chain::packed_transaction_ptr& trx, chain::plugin_interface::next_function<chain::transaction_trace_ptr> next);
 

--- a/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
@@ -401,32 +401,40 @@ public:
       string               index_name;                ///< secondary index name (e.g. "byowner") or numeric position (e.g. "2")
       string               lower_bound;               ///< inclusive lower key (JSON obj when json=true, hex when json=false)
       string               upper_bound;               ///< exclusive upper key
-      uint32_t             limit = 50;                ///< max rows to return. `0` = paginate until the scan is exhausted (aggregating all pages into a single result). A non-zero value returns at most that many rows in a single page with `more`/`next_key` set for caller-driven pagination.
+      uint32_t             limit = 50;                ///< max rows to return in a single page; the caller paginates by re-issuing with `lower_bound`/`upper_bound = next_key`. Capped per page by the deadline.
       std::optional<bool>  reverse;                   ///< iterate in reverse; pairs with `limit` to return the most recent N rows
       std::optional<bool>  show_payer;                ///< include RAM payer in each row
       std::optional<uint32_t> time_limit_ms;          ///< defaults to http-max-response-time-ms
-      std::optional<bool>  unwrap_rows;               ///< strip the `{key, value, payer?}` wrapper, returning only the `value` side of each row. C++-only (not serialized over the HTTP surface).
-      std::optional<std::function<bool(const fc::variant&)>> filter; ///< post-pagination predicate — rows returning `false` are dropped. Runs AFTER `unwrap_rows` so it sees the same shape callers do. C++-only (not serialized).
+      std::optional<bool>  values_only;               ///< return each row as just its `value` instead of `{key, value, payer?}`.
+
+      // ---- C++-only fields below. Not FC_REFLECT'd, so HTTP callers cannot set them. ----
+
+      /// Walk the entire scan in a single call, ignoring `limit`, `time_limit_ms`, and the caller's deadline.
+      /// On return, `more` is always `false` and `next_key` is empty. Only in-process callers (e.g. the OPP
+      /// cron plugins) should set this; gating it off the HTTP surface prevents unbounded server work.
+      bool                 all_rows = false;
+
+      /// Post-pagination predicate -- rows returning `false` are dropped. Runs AFTER `values_only` so it sees the
+      /// same shape the caller will consume.
+      std::optional<std::function<bool(const fc::variant&)>> filter;
    };
 
    struct get_table_rows_result {
-      fc::variants         rows;                      ///< array of {key: {...}, value: {...}, payer?: "..."} objects (or bare values when `unwrap_rows` is set)
+      fc::variants         rows;                      ///< array of {key: {...}, value: {...}, payer?: "..."} objects (or bare values when `values_only` is set)
       bool                 more = false;
       string               next_key;                  ///< scope-stripped key for pagination
    };
 
    using get_table_rows_return_t = std::function<chain::t_or_exception<get_table_rows_result>()>;
 
-   /// Public table-rows query. Wraps {@link get_table_rows_page} with the
-   /// opt-in behaviors layered on `get_table_rows_params` — internal pagination
-   /// when `limit == 0`, post-fetch filter, row unwrapping. HTTP callers using
-   /// defaults (`limit=50`, no filter, no `unwrap_rows`) land on the same
-   /// single-page path as before.
+   /// Public table-rows query. Wraps {@link get_table_rows_page} and layers the C++-only behaviours from
+   /// `get_table_rows_params`: `all_rows` (walk the entire scan, ignoring limit/deadline), `filter` (post-fetch
+   /// predicate), and `values_only` (strip the `{key, value, payer?}` wrapper). HTTP callers that don't set any of
+   /// those land directly on the page impl and pay zero extra indirection.
    get_table_rows_return_t get_table_rows( const get_table_rows_params& params, const fc::time_point& deadline )const;
 
-   /// Single-page implementation of the table scan. Honors `limit` as the
-   /// per-page row cap; does NOT paginate, filter, or unwrap — those are
-   /// applied by the public {@link get_table_rows}.
+   /// Single-page implementation of the table scan. Honors `limit` as the per-page row cap; does NOT walk the
+   /// whole table, filter, or strip the wrapper -- those are applied by the public {@link get_table_rows}.
    get_table_rows_return_t get_table_rows_page( const get_table_rows_params& params, const fc::time_point& deadline )const;
 
    struct get_table_by_scope_params {
@@ -713,8 +721,9 @@ FC_REFLECT(sysio::chain_apis::read_only::get_block_header_result, (id)(signed_bl
 FC_REFLECT( sysio::chain_apis::read_write::push_transaction_results, (transaction_id)(processed) )
 FC_REFLECT( sysio::chain_apis::read_write::send_transaction2_params, (return_failure_trace)(retry_trx)(retry_trx_num_blocks)(transaction) )
 
-// `filter` deliberately excluded — `std::function` is not serialisable so it's C++-only.
-FC_REFLECT( sysio::chain_apis::read_only::get_table_rows_params, (json)(code)(table)(scope)(find)(index_name)(lower_bound)(upper_bound)(limit)(reverse)(show_payer)(time_limit_ms)(unwrap_rows) )
+// `all_rows` and `filter` deliberately excluded -- gated to in-process callers so HTTP cannot trigger a full-table walk
+// or inject a predicate via the wire format.
+FC_REFLECT( sysio::chain_apis::read_only::get_table_rows_params, (json)(code)(table)(scope)(find)(index_name)(lower_bound)(upper_bound)(limit)(reverse)(show_payer)(time_limit_ms)(values_only) )
 FC_REFLECT( sysio::chain_apis::read_only::get_table_rows_result, (rows)(more)(next_key) );
 
 FC_REFLECT( sysio::chain_apis::read_only::get_table_by_scope_params, (code)(table)(lower_bound)(upper_bound)(limit)(reverse)(time_limit_ms) )

--- a/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
@@ -401,21 +401,33 @@ public:
       string               index_name;                ///< secondary index name (e.g. "byowner") or numeric position (e.g. "2")
       string               lower_bound;               ///< inclusive lower key (JSON obj when json=true, hex when json=false)
       string               upper_bound;               ///< exclusive upper key
-      uint32_t             limit = 50;                ///< max rows to return
-      std::optional<bool>  reverse;                   ///< iterate in reverse
+      uint32_t             limit = 50;                ///< max rows to return. `0` = paginate until the scan is exhausted (aggregating all pages into a single result). A non-zero value returns at most that many rows in a single page with `more`/`next_key` set for caller-driven pagination.
+      std::optional<bool>  reverse;                   ///< iterate in reverse; pairs with `limit` to return the most recent N rows
       std::optional<bool>  show_payer;                ///< include RAM payer in each row
       std::optional<uint32_t> time_limit_ms;          ///< defaults to http-max-response-time-ms
+      std::optional<bool>  unwrap_rows;               ///< strip the `{key, value, payer?}` wrapper, returning only the `value` side of each row. C++-only (not serialized over the HTTP surface).
+      std::optional<std::function<bool(const fc::variant&)>> filter; ///< post-pagination predicate — rows returning `false` are dropped. Runs AFTER `unwrap_rows` so it sees the same shape callers do. C++-only (not serialized).
    };
 
    struct get_table_rows_result {
-      fc::variants         rows;                      ///< array of {key: {...}, value: {...}, payer?: "..."} objects
+      fc::variants         rows;                      ///< array of {key: {...}, value: {...}, payer?: "..."} objects (or bare values when `unwrap_rows` is set)
       bool                 more = false;
       string               next_key;                  ///< scope-stripped key for pagination
    };
 
    using get_table_rows_return_t = std::function<chain::t_or_exception<get_table_rows_result>()>;
 
+   /// Public table-rows query. Wraps {@link get_table_rows_page} with the
+   /// opt-in behaviors layered on `get_table_rows_params` — internal pagination
+   /// when `limit == 0`, post-fetch filter, row unwrapping. HTTP callers using
+   /// defaults (`limit=50`, no filter, no `unwrap_rows`) land on the same
+   /// single-page path as before.
    get_table_rows_return_t get_table_rows( const get_table_rows_params& params, const fc::time_point& deadline )const;
+
+   /// Single-page implementation of the table scan. Honors `limit` as the
+   /// per-page row cap; does NOT paginate, filter, or unwrap — those are
+   /// applied by the public {@link get_table_rows}.
+   get_table_rows_return_t get_table_rows_page( const get_table_rows_params& params, const fc::time_point& deadline )const;
 
    struct get_table_by_scope_params {
       name                 code; // mandatory
@@ -701,7 +713,8 @@ FC_REFLECT(sysio::chain_apis::read_only::get_block_header_result, (id)(signed_bl
 FC_REFLECT( sysio::chain_apis::read_write::push_transaction_results, (transaction_id)(processed) )
 FC_REFLECT( sysio::chain_apis::read_write::send_transaction2_params, (return_failure_trace)(retry_trx)(retry_trx_num_blocks)(transaction) )
 
-FC_REFLECT( sysio::chain_apis::read_only::get_table_rows_params, (json)(code)(table)(scope)(find)(index_name)(lower_bound)(upper_bound)(limit)(reverse)(show_payer)(time_limit_ms) )
+// `filter` deliberately excluded — `std::function` is not serialisable so it's C++-only.
+FC_REFLECT( sysio::chain_apis::read_only::get_table_rows_params, (json)(code)(table)(scope)(find)(index_name)(lower_bound)(upper_bound)(limit)(reverse)(show_payer)(time_limit_ms)(unwrap_rows) )
 FC_REFLECT( sysio::chain_apis::read_only::get_table_rows_result, (rows)(more)(next_key) );
 
 FC_REFLECT( sysio::chain_apis::read_only::get_table_by_scope_params, (code)(table)(lower_bound)(upper_bound)(limit)(reverse)(time_limit_ms) )

--- a/plugins/chain_plugin/src/chain_plugin.cpp
+++ b/plugins/chain_plugin/src/chain_plugin.cpp
@@ -1347,6 +1347,70 @@ chain_apis::read_only chain_plugin::get_read_only_api(const fc::microseconds& ht
    return chain_apis::read_only(chain(), my->_get_info_db, my->_account_query_db, my->_last_tracked_votes, get_abi_serializer_max_time(), http_max_response_time, my->_trx_finality_status_processing.get());
 }
 
+chain_apis::read_only::get_table_rows_result
+chain_plugin::read_table_rows(chain_apis::read_only::get_table_rows_params params,
+                              fc::microseconds timeout,
+                              std::string_view log_prefix,
+                              const std::atomic<bool>& shutdown_flag) {
+   using result_t = chain_apis::read_only::get_table_rows_result;
+   const auto deadline = fc::time_point::now() + timeout;
+
+   // Pre-capture log fields; `params` is moved into the posted lambda below, so the outer error paths cannot read
+   // from it.
+   const std::string log_code  = params.code.to_string();
+   const std::string log_table = params.table;
+
+   // shared_ptr so the posted lambda and this stack frame each own a reference; if the waiter bails (shutdown or
+   // deadline) the lambda can still safely write into the promise when the read_only queue eventually drains.
+   auto prom = std::make_shared<std::promise<result_t>>();
+   auto fut  = prom->get_future();
+
+   // Capturing `this` by raw pointer is safe: appbase drains the io_context and calls `exec.clear()` between
+   // `shutdown_plugins()` and `destroy_plugins()` (see `libraries/appbase/include/appbase/application_base.hpp`),
+   // so any lambda still queued when the plugin impl is about to be destroyed is destructed first.
+   app().executor().post(appbase::priority::medium, appbase::exec_queue::read_only,
+      [this, params = std::move(params), deadline, timeout, prom, log_prefix]() mutable {
+         try {
+            auto ro      = get_read_only_api(timeout);
+            auto variant = ro.get_table_rows(params, deadline)();
+            if (auto* err = std::get_if<fc::exception_ptr>(&variant)) {
+               elog("{}: table read failed {}::{} -- {}",
+                    log_prefix, params.code.to_string(), params.table, (*err)->to_string());
+               prom->set_value({});
+            } else {
+               prom->set_value(std::get<result_t>(std::move(variant)));
+            }
+         } catch (const fc::exception& e) {
+            elog("{}: table read threw {}::{} -- {}",
+                 log_prefix, params.code.to_string(), params.table, e.to_string());
+            prom->set_value({});
+         } catch (const std::exception& e) {
+            elog("{}: table read threw {}::{} -- {}",
+                 log_prefix, params.code.to_string(), params.table, e.what());
+            prom->set_value({});
+         } catch (...) {
+            elog("{}: table read threw unknown exception {}::{}",
+                 log_prefix, params.code.to_string(), params.table);
+            prom->set_value({});
+         }
+      });
+
+   // Poll every 200ms so we can abandon the wait if the caller is shutting down or if the deadline expires before
+   // the executor drains our lambda.
+   while (fut.wait_for(std::chrono::milliseconds(200)) == std::future_status::timeout) {
+      if (shutdown_flag.load(std::memory_order_relaxed)) {
+         wlog("{}: abandoning table read on shutdown ({}::{})", log_prefix, log_code, log_table);
+         return {};
+      }
+      if (fc::time_point::now() >= deadline) {
+         elog("{}: table read queue-wait exceeded {}ms ({}::{})",
+              log_prefix, timeout.count() / 1000, log_code, log_table);
+         return {};
+      }
+   }
+   return fut.get();
+}
+
 void chain_plugin::accept_transaction(const chain::packed_transaction_ptr& trx, next_function<chain::transaction_trace_ptr> next) {
    my->incoming_transaction_async_method(trx, false, transaction_metadata::trx_type::input, false, std::move(next));
 }

--- a/plugins/chain_plugin/src/chain_plugin.cpp
+++ b/plugins/chain_plugin/src/chain_plugin.cpp
@@ -1613,7 +1613,7 @@ fc::variant strip_scope_fields(fc::variant&& full_key, size_t count) {
 }
 
 read_only::get_table_rows_return_t
-read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::time_point& deadline ) const {
+read_only::get_table_rows_page( const read_only::get_table_rows_params& p, const fc::time_point& deadline ) const {
    abi_def abi = sysio::chain_apis::get_abi( db, p.code );
    const auto& tbl = get_kv_table_def( abi, p.table );
 
@@ -2140,6 +2140,116 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
       result.more = hp.more;
       result.next_key = hp.next_key;
       return result;
+   };
+}
+
+read_only::get_table_rows_return_t
+read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::time_point& deadline ) const {
+   const bool paginate_all = (p.limit == 0);
+   const bool has_filter   = p.filter.has_value();
+   const bool do_unwrap    = p.unwrap_rows.value_or(false);
+
+   // Fast path: classic single-page semantics with a non-zero limit and no
+   // post-processing. Forward straight to the page implementation so HTTP
+   // callers pay zero extra indirection.
+   if (!paginate_all && !has_filter && !do_unwrap) {
+      return get_table_rows_page(p, deadline);
+   }
+
+   // Extended path: pagination + unwrap + filter, stitched around repeated
+   // page_impl invocations.
+   return [this, p, deadline, paginate_all, has_filter, do_unwrap]()
+      -> chain::t_or_exception<get_table_rows_result> {
+      get_table_rows_params pp = p;
+
+      // When `limit == 0` (paginate-all), the page impl needs a concrete cap.
+      // Use a page size that balances round-trips vs. RPC deadline budget.
+      constexpr uint32_t INTERNAL_PAGE_SIZE = 100;
+      if (paginate_all) {
+         pp.limit = INTERNAL_PAGE_SIZE;
+      }
+
+      // Clear extension fields from the per-page params — the page impl does
+      // not look at them, but keeping the API-level fields quiet avoids any
+      // confusion if its behavior ever grows to key off them.
+      pp.unwrap_rows.reset();
+      pp.filter.reset();
+
+      const bool reverse_scan = p.reverse.value_or(false);
+
+      get_table_rows_result combined;
+
+      while (true) {
+         auto page_fn    = get_table_rows_page(pp, deadline);
+         auto page_value = page_fn();
+         if (auto* err = std::get_if<fc::exception_ptr>(&page_value)) {
+            return *err;
+         }
+         auto page = std::get<get_table_rows_result>(std::move(page_value));
+
+         combined.rows.insert(combined.rows.end(),
+            std::make_move_iterator(page.rows.begin()),
+            std::make_move_iterator(page.rows.end()));
+         combined.more     = page.more;
+         combined.next_key = page.next_key;
+
+         if (!paginate_all) break;
+         if (!page.more || page.next_key.empty()) break;
+         if (!pp.find.empty()) break; // `find` is exact-match — no next page
+
+         // Advance the cursor for the next page.
+         //
+         // Forward: `next_key` is the first row not yet returned; setting it
+         // as `lower_bound` (inclusive) resumes at that row.
+         //
+         // Reverse: `next_key` is ALSO the first unseen row (below the last
+         // returned one), but `upper_bound` is EXCLUSIVE. Setting
+         // `upper_bound = next_key` would skip that row entirely, causing a
+         // one-row gap per page boundary. Use the last RETURNED row's key
+         // instead — `upper_bound = last_key` (exclusive) yields rows
+         // strictly below it, which is exactly what we want.
+         if (reverse_scan) {
+            if (combined.rows.empty()) break;
+            const fc::variant& last_row = combined.rows.back();
+            if (!last_row.is_object()) break;
+            const auto& last_obj = last_row.get_object();
+            if (!last_obj.contains("key")) break;
+            pp.upper_bound = fc::json::to_string(last_obj["key"], fc::time_point::maximum());
+            pp.lower_bound.clear();
+         } else {
+            pp.lower_bound = page.next_key;
+            pp.upper_bound.clear();
+         }
+      }
+
+      if (paginate_all) {
+         // We walked the scan to completion; no resume cursor is meaningful.
+         combined.more = false;
+         combined.next_key.clear();
+      }
+
+      // Unwrap before filtering so the predicate sees the same shape the
+      // caller will eventually consume.
+      if (do_unwrap) {
+         for (auto& row : combined.rows) {
+            if (!row.is_object()) continue;
+            const auto& row_obj = row.get_object();
+            if (!row_obj.contains("value")) continue;
+            // variant::operator=(const variant&) clears before reading —
+            // copy into an independent variant first, then move-assign.
+            fc::variant value{row_obj["value"]};
+            row = std::move(value);
+         }
+      }
+
+      if (has_filter) {
+         const auto& predicate = *p.filter;
+         std::erase_if(combined.rows, [&](const fc::variant& row) {
+            return !predicate(row);
+         });
+      }
+
+      return combined;
    };
 }
 

--- a/plugins/chain_plugin/src/chain_plugin.cpp
+++ b/plugins/chain_plugin/src/chain_plugin.cpp
@@ -1677,7 +1677,7 @@ fc::variant strip_scope_fields(fc::variant&& full_key, size_t count) {
 }
 
 read_only::get_table_rows_return_t
-read_only::get_table_rows_page( const read_only::get_table_rows_params& p, const fc::time_point& deadline ) const {
+read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::time_point& deadline ) const {
    abi_def abi = sysio::chain_apis::get_abi( db, p.code );
    const auto& tbl = get_kv_table_def( abi, p.table );
 
@@ -1688,19 +1688,30 @@ read_only::get_table_rows_page( const read_only::get_table_rows_params& p, const
    // Use table_id from ABI (set by CDT's compute_table_id at compile time).
    const uint16_t table_id = tbl.table_id;
 
-   fc::time_point params_deadline = p.time_limit_ms
-      ? std::min(fc::time_point::now().safe_add(fc::milliseconds(*p.time_limit_ms)), deadline)
-      : deadline;
+   // `all_rows` is a C++-only escape hatch (not FC_REFLECT'd) that walks the entire scan in a single call,
+   // ignoring any caller-supplied `limit`, `time_limit_ms`, or `deadline`. In-tree callers that set it are driven
+   // by a tick, not an RPC deadline, and need the whole table every call. HTTP callers cannot reach this path.
+   fc::time_point params_deadline;
+   if (p.all_rows) {
+      params_deadline = fc::time_point::maximum();
+   } else if (p.time_limit_ms) {
+      params_deadline = std::min(fc::time_point::now().safe_add(fc::milliseconds(*p.time_limit_ms)), deadline);
+   } else {
+      params_deadline = deadline;
+   }
 
    // --- Validate find vs bounds ---
    SYS_ASSERT(p.find.empty() || (p.lower_bound.empty() && p.upper_bound.empty()),
               chain::contract_table_query_exception,
               "Cannot combine 'find' with 'lower_bound' or 'upper_bound'");
 
-   // Handle find: treat as exact key lookup by setting bounds to the same value
+   // Handle find: treat as exact key lookup by setting bounds to the same value.
+   // `all_rows` uncaps the per-scan limit so the single call walks every row; `find` stays limit=1 because it's an
+   // exact-match lookup.
    const string& effective_lower = p.find.empty() ? p.lower_bound : p.find;
    const string& effective_upper = p.find.empty() ? p.upper_bound : p.find;
-   uint32_t effective_limit = p.find.empty() ? p.limit : 1;
+   const uint32_t user_limit     = p.all_rows ? std::numeric_limits<uint32_t>::max() : p.limit;
+   uint32_t effective_limit      = p.find.empty() ? user_limit : 1;
 
    // --- Scope handling ---
    // If key_names[0] == "scope", this table uses scoped keys. The scope field must
@@ -2034,7 +2045,10 @@ read_only::get_table_rows_page( const read_only::get_table_rows_params& p, const
               key_names = std::move(key_names), key_types = std::move(key_types),
               scope_key_count,
               abi_serializer_max_time = abi_serializer_max_time,
-              shorten_abi_errors = shorten_abi_errors]() mutable ->
+              shorten_abi_errors = shorten_abi_errors,
+              all_rows    = p.all_rows,
+              values_only = p.values_only.value_or(false),
+              filter      = p.filter]() mutable ->
          chain::t_or_exception<read_only::get_table_rows_result> {
          get_table_rows_result result;
          result.more = p.more;
@@ -2073,6 +2087,22 @@ read_only::get_table_rows_page( const read_only::get_table_rows_params& p, const
             if (p.show_payer)
                obj["payer"] = row.payer.to_string();
             result.rows.push_back(std::move(obj));
+         }
+
+         // --- Post-pass: C++-only wrapper behaviors. Same shape as the primary-path Phase 2 below.
+         if (all_rows) { result.more = false; result.next_key.clear(); }
+         if (values_only) {
+            for (auto& row : result.rows) {
+               if (!row.is_object()) continue;
+               const auto& row_obj = row.get_object();
+               if (!row_obj.contains("value")) continue;
+               fc::variant value{row_obj["value"]};
+               row = std::move(value);
+            }
+         }
+         if (filter.has_value()) {
+            const auto& predicate = *filter;
+            std::erase_if(result.rows, [&](const fc::variant& row) { return !predicate(row); });
          }
          return result;
       };
@@ -2190,7 +2220,10 @@ read_only::get_table_rows_page( const read_only::get_table_rows_params& p, const
            key_names = std::move(key_names), key_types = std::move(key_types),
            scope_key_count,
            abi_serializer_max_time = abi_serializer_max_time,
-           shorten_abi_errors = shorten_abi_errors]() mutable
+           shorten_abi_errors = shorten_abi_errors,
+           all_rows    = p.all_rows,
+           values_only = p.values_only.value_or(false),
+           filter      = p.filter]() mutable
       -> chain::t_or_exception<read_only::get_table_rows_result> {
       read_only::get_table_rows_result result;
 
@@ -2235,54 +2268,18 @@ read_only::get_table_rows_page( const read_only::get_table_rows_params& p, const
 
       result.more = hp.more;
       result.next_key = hp.next_key;
-      return result;
-   };
-}
 
-read_only::get_table_rows_return_t
-read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::time_point& deadline ) const {
-   const bool all_rows    = p.all_rows;
-   const bool has_filter  = p.filter.has_value();
-   const bool values_only = p.values_only.value_or(false);
-
-   // Fast path: no wrapper-level behaviors. Forward to the page impl with the caller's params and deadline unchanged.
-   // HTTP callers with default params always land here.
-   if (!all_rows && !has_filter && !values_only) {
-      return get_table_rows_page(p, deadline);
-   }
-
-   return [this, p, deadline, all_rows, has_filter, values_only]()
-      -> chain::t_or_exception<get_table_rows_result> {
-      get_table_rows_params pp = p;
-      fc::time_point effective_deadline = deadline;
-
+      // --- Post-pass: C++-only wrapper behaviors ---
+      // `all_rows` walked the whole scan; a resume cursor is meaningless on the way out.
       if (all_rows) {
-         // C++-only escape hatch: walk the entire scan in a single page-impl call, ignoring any caller-supplied
-         // limit, `time_limit_ms`, or `deadline`. In-tree callers that set `all_rows` (the OPP cron plugins) are
-         // driven by a tick, not an RPC deadline, and need the whole table every call. `all_rows` is deliberately
-         // NOT FC_REFLECT'd so HTTP callers cannot trigger this path.
-         pp.limit = std::numeric_limits<uint32_t>::max();
-         pp.time_limit_ms.reset();
-         effective_deadline = fc::time_point::maximum();
+         result.more = false;
+         result.next_key.clear();
       }
 
-      auto page_fn    = get_table_rows_page(pp, effective_deadline);
-      auto page_value = page_fn();
-      if (auto* err = std::get_if<fc::exception_ptr>(&page_value)) {
-         return *err;
-      }
-      auto combined = std::get<get_table_rows_result>(std::move(page_value));
-
-      if (all_rows) {
-         // The whole scan is in `combined`; a resume cursor is meaningless.
-         combined.more = false;
-         combined.next_key.clear();
-      }
-
-      // Strip the {key, value, payer?} wrapper before filtering so the predicate sees the same shape the caller will
-      // consume.
+      // `values_only` strips the `{key, value, payer?}` wrapper before `filter` runs so the predicate sees the same
+      // shape the caller will consume.
       if (values_only) {
-         for (auto& row : combined.rows) {
+         for (auto& row : result.rows) {
             if (!row.is_object()) continue;
             const auto& row_obj = row.get_object();
             if (!row_obj.contains("value")) continue;
@@ -2293,14 +2290,14 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
          }
       }
 
-      if (has_filter) {
-         const auto& predicate = *p.filter;
-         std::erase_if(combined.rows, [&](const fc::variant& row) {
+      if (filter.has_value()) {
+         const auto& predicate = *filter;
+         std::erase_if(result.rows, [&](const fc::variant& row) {
             return !predicate(row);
          });
       }
 
-      return combined;
+      return result;
    };
 }
 

--- a/plugins/chain_plugin/src/chain_plugin.cpp
+++ b/plugins/chain_plugin/src/chain_plugin.cpp
@@ -1869,6 +1869,29 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
          return r;
       };
 
+      // Format a secondary-index `next_key` value. When `p.json` is set, emit
+      // a JSON object matching the bound syntax (e.g. `{"byowner":"u4"}`) so
+      // `upper_bound = next_key` round-trips through the bound parser, which
+      // expects JSON when `p.json` is set. Otherwise emit hex of the raw sk
+      // bytes. Falls back to hex on any decode failure.
+      auto emit_secondary_next_key = [&](std::string_view sk) {
+         if (p.json) {
+            try {
+               std::string_view sv = sk;
+               if (!scope_prefix_bytes.empty() && sv.size() >= scope_prefix_bytes.size()) {
+                  sv.remove_prefix(scope_prefix_bytes.size());
+               }
+               auto key_var = chain::be_key_codec::decode_key(sv.data(), sv.size(),
+                                                              bound_key_names, bound_key_types);
+               hp.next_key = fc::json::to_string(key_var, fc::time_point::maximum());
+               return;
+            } catch (...) {
+               // fall through to hex
+            }
+         }
+         hp.next_key = fc::to_hex(sk.data(), sk.size());
+      };
+
       if (!reverse) {
          auto itr = sec_idx.lower_bound(boost::make_tuple(p.code, sec_tid, lb_sv));
          uint32_t count = 0;
@@ -1877,7 +1900,7 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
             if (has_upper && sk >= ub_sv) break;
             if (count >= limit) {
                hp.more = true;
-               hp.next_key = fc::to_hex(sk.data(), sk.size());
+               emit_secondary_next_key(sk);
                break;
             }
             hp.rows.push_back(fetch_primary(*itr));
@@ -1886,14 +1909,21 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
             if (fc::time_point::now() >= params_deadline) {
                if (itr != sec_idx.end() && itr->code == p.code && itr->table_id == sec_tid) {
                   hp.more = true;
-                  auto next_sk = itr->sec_key_view();
-                  hp.next_key = fc::to_hex(next_sk.data(), next_sk.size());
+                  emit_secondary_next_key(itr->sec_key_view());
                }
                break;
             }
          }
       } else {
-         // Reverse iteration
+         // Reverse iteration.
+         //
+         // Resume cursor semantics: `next_key` is the LAST RETURNED row's sk,
+         // not the first unseen row's sk. Callers resume with
+         // `upper_bound = next_key`; since `upper_bound` is exclusive and the
+         // reverse loop starts at `lower_bound(upper_bound)` then `--itr`, the
+         // next page yields the first row strictly below the last returned
+         // one -- i.e. the first unseen row. Setting `next_key` to the first
+         // unseen row's sk instead would skip that row at every page boundary.
          decltype(sec_idx.end()) itr;
          if (has_upper) {
             itr = sec_idx.lower_bound(boost::make_tuple(p.code, sec_tid, ub_sv));
@@ -1902,6 +1932,12 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
          }
          auto begin = sec_idx.lower_bound(boost::make_tuple(p.code, sec_tid, lb_sv));
          uint32_t count = 0;
+         // Remember the last-returned row's sec_key bytes so the cutoff
+         // branches below can feed them to `emit_secondary_next_key`.
+         std::vector<char> last_added_sk_bytes;
+         auto last_added_sv = [&]() {
+            return std::string_view(last_added_sk_bytes.data(), last_added_sk_bytes.size());
+         };
          if (itr != begin) {
             do {
                --itr;
@@ -1909,20 +1945,19 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
                auto sk = itr->sec_key_view();
                if (!lb_bytes.empty() && sk < lb_sv) break;
                if (count >= limit) {
-                  hp.more = true;
-                  hp.next_key = fc::to_hex(sk.data(), sk.size());
+                  if (!last_added_sk_bytes.empty()) {
+                     hp.more = true;
+                     emit_secondary_next_key(last_added_sv());
+                  }
                   break;
                }
                hp.rows.push_back(fetch_primary(*itr));
+               last_added_sk_bytes.assign(sk.data(), sk.data() + sk.size());
                ++count;
                if (fc::time_point::now() >= params_deadline) {
                   if (itr != begin) {
-                     auto prev = itr; --prev;
-                     if (prev->code == p.code && prev->table_id == sec_tid) {
-                        hp.more = true;
-                        auto prev_sk = prev->sec_key_view();
-                        hp.next_key = fc::to_hex(prev_sk.data(), prev_sk.size());
-                     }
+                     hp.more = true;
+                     emit_secondary_next_key(last_added_sv());
                   }
                   break;
                }
@@ -2045,6 +2080,9 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
 
       if (itr != begin) {
          uint32_t count = 0;
+         // Resume cursor is the LAST RETURNED row, not the first unseen. See
+         // the secondary-index reverse branch above for the full rationale.
+         auto last_added_itr = kv_idx.end();
          do {
             --itr;
             if (itr->code != p.code || itr->table_id != table_id)
@@ -2055,8 +2093,10 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
                break;
 
             if (count >= limit) {
-               hp.more = true;
-               collect_next_key(*itr);
+               if (last_added_itr != kv_idx.end()) {
+                  hp.more = true;
+                  collect_next_key(*last_added_itr);
+               }
                break;
             }
 
@@ -2065,6 +2105,7 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
             row.value.assign(itr->value.data(), itr->value.data() + itr->value.size());
             row.payer = itr->payer;
             hp.rows.emplace_back(std::move(row));
+            last_added_itr = itr;
 
             ++count;
             if (itr == begin) {
@@ -2073,17 +2114,8 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
             }
 
             if (fc::time_point::now() >= params_deadline) {
-               if (itr != begin) {
-                  auto prev = itr;
-                  --prev;
-                  if (prev->code == p.code && prev->table_id == table_id) {
-                     auto prev_kv = prev->key_view();
-                     if (lb_bytes.empty() || prev_kv >= lb_sv) {
-                        hp.more = true;
-                        collect_next_key(*prev);
-                     }
-                  }
-               }
+               hp.more = true;
+               collect_next_key(*last_added_itr);
                break;
             }
          } while (true);

--- a/plugins/chain_plugin/src/chain_plugin.cpp
+++ b/plugins/chain_plugin/src/chain_plugin.cpp
@@ -2177,87 +2177,53 @@ read_only::get_table_rows_page( const read_only::get_table_rows_params& p, const
 
 read_only::get_table_rows_return_t
 read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::time_point& deadline ) const {
-   const bool paginate_all = (p.limit == 0);
-   const bool has_filter   = p.filter.has_value();
-   const bool do_unwrap    = p.unwrap_rows.value_or(false);
+   const bool all_rows    = p.all_rows;
+   const bool has_filter  = p.filter.has_value();
+   const bool values_only = p.values_only.value_or(false);
 
-   // Fast path: classic single-page semantics with a non-zero limit and no
-   // post-processing. Forward straight to the page implementation so HTTP
-   // callers pay zero extra indirection.
-   if (!paginate_all && !has_filter && !do_unwrap) {
+   // Fast path: no wrapper-level behaviors. Forward to the page impl with the caller's params and deadline unchanged.
+   // HTTP callers with default params always land here.
+   if (!all_rows && !has_filter && !values_only) {
       return get_table_rows_page(p, deadline);
    }
 
-   // Extended path: pagination + unwrap + filter, stitched around repeated
-   // page_impl invocations.
-   return [this, p, deadline, paginate_all, has_filter, do_unwrap]()
+   return [this, p, deadline, all_rows, has_filter, values_only]()
       -> chain::t_or_exception<get_table_rows_result> {
       get_table_rows_params pp = p;
+      fc::time_point effective_deadline = deadline;
 
-      // When `limit == 0` (paginate-all), the page impl needs a concrete cap.
-      // Use a page size that balances round-trips vs. RPC deadline budget.
-      constexpr uint32_t INTERNAL_PAGE_SIZE = 100;
-      if (paginate_all) {
-         pp.limit = INTERNAL_PAGE_SIZE;
+      if (all_rows) {
+         // C++-only escape hatch: walk the entire scan in a single page-impl call, ignoring any caller-supplied
+         // limit, `time_limit_ms`, or `deadline`. In-tree callers that set `all_rows` (the OPP cron plugins) are
+         // driven by a tick, not an RPC deadline, and need the whole table every call. `all_rows` is deliberately
+         // NOT FC_REFLECT'd so HTTP callers cannot trigger this path.
+         pp.limit = std::numeric_limits<uint32_t>::max();
+         pp.time_limit_ms.reset();
+         effective_deadline = fc::time_point::maximum();
       }
 
-      // Clear extension fields from the per-page params — the page impl does
-      // not look at them, but keeping the API-level fields quiet avoids any
-      // confusion if its behavior ever grows to key off them.
-      pp.unwrap_rows.reset();
-      pp.filter.reset();
-
-      const bool reverse_scan = p.reverse.value_or(false);
-
-      get_table_rows_result combined;
-
-      while (true) {
-         auto page_fn    = get_table_rows_page(pp, deadline);
-         auto page_value = page_fn();
-         if (auto* err = std::get_if<fc::exception_ptr>(&page_value)) {
-            return *err;
-         }
-         auto page = std::get<get_table_rows_result>(std::move(page_value));
-
-         combined.rows.insert(combined.rows.end(),
-            std::make_move_iterator(page.rows.begin()),
-            std::make_move_iterator(page.rows.end()));
-         combined.more     = page.more;
-         combined.next_key = page.next_key;
-
-         if (!paginate_all) break;
-         if (!page.more || page.next_key.empty()) break;
-         if (!pp.find.empty()) break; // `find` is exact-match — no next page
-
-         // Advance the cursor. `next_key` from the page impl is the correct
-         // resume key in both directions: the first unseen row for forward
-         // (inclusive `lower_bound`), and the last returned row for reverse
-         // (exclusive `upper_bound`). Forward it to the matching bound and
-         // clear the other.
-         if (reverse_scan) {
-            pp.upper_bound = page.next_key;
-            pp.lower_bound.clear();
-         } else {
-            pp.lower_bound = page.next_key;
-            pp.upper_bound.clear();
-         }
+      auto page_fn    = get_table_rows_page(pp, effective_deadline);
+      auto page_value = page_fn();
+      if (auto* err = std::get_if<fc::exception_ptr>(&page_value)) {
+         return *err;
       }
+      auto combined = std::get<get_table_rows_result>(std::move(page_value));
 
-      if (paginate_all) {
-         // We walked the scan to completion; no resume cursor is meaningful.
+      if (all_rows) {
+         // The whole scan is in `combined`; a resume cursor is meaningless.
          combined.more = false;
          combined.next_key.clear();
       }
 
-      // Unwrap before filtering so the predicate sees the same shape the
-      // caller will eventually consume.
-      if (do_unwrap) {
+      // Strip the {key, value, payer?} wrapper before filtering so the predicate sees the same shape the caller will
+      // consume.
+      if (values_only) {
          for (auto& row : combined.rows) {
             if (!row.is_object()) continue;
             const auto& row_obj = row.get_object();
             if (!row_obj.contains("value")) continue;
-            // variant::operator=(const variant&) clears before reading —
-            // copy into an independent variant first, then move-assign.
+            // variant::operator=(const variant&) clears before reading -- copy into an independent variant first,
+            // then move-assign.
             fc::variant value{row_obj["value"]};
             row = std::move(value);
          }

--- a/plugins/chain_plugin/src/chain_plugin.cpp
+++ b/plugins/chain_plugin/src/chain_plugin.cpp
@@ -2229,24 +2229,13 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
          if (!page.more || page.next_key.empty()) break;
          if (!pp.find.empty()) break; // `find` is exact-match — no next page
 
-         // Advance the cursor for the next page.
-         //
-         // Forward: `next_key` is the first row not yet returned; setting it
-         // as `lower_bound` (inclusive) resumes at that row.
-         //
-         // Reverse: `next_key` is ALSO the first unseen row (below the last
-         // returned one), but `upper_bound` is EXCLUSIVE. Setting
-         // `upper_bound = next_key` would skip that row entirely, causing a
-         // one-row gap per page boundary. Use the last RETURNED row's key
-         // instead — `upper_bound = last_key` (exclusive) yields rows
-         // strictly below it, which is exactly what we want.
+         // Advance the cursor. `next_key` from the page impl is the correct
+         // resume key in both directions: the first unseen row for forward
+         // (inclusive `lower_bound`), and the last returned row for reverse
+         // (exclusive `upper_bound`). Forward it to the matching bound and
+         // clear the other.
          if (reverse_scan) {
-            if (combined.rows.empty()) break;
-            const fc::variant& last_row = combined.rows.back();
-            if (!last_row.is_object()) break;
-            const auto& last_obj = last_row.get_object();
-            if (!last_obj.contains("key")) break;
-            pp.upper_bound = fc::json::to_string(last_obj["key"], fc::time_point::maximum());
+            pp.upper_bound = page.next_key;
             pp.lower_bound.clear();
          } else {
             pp.lower_bound = page.next_key;

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -2,7 +2,9 @@
 #include <fc/crypto/sha256.hpp>
 #include <fc/variant_object.hpp>
 #include <boost/endian/conversion.hpp>
+#include <magic_enum/magic_enum.hpp>
 
+#include <sysio/chain_plugin/chain_plugin.hpp>
 #include <sysio/underwriter_plugin/underwriter_plugin.hpp>
 #include <sysio/opp/opp.hpp>
 #include <sysio/opp/types/types.pb.h>
@@ -78,39 +80,36 @@ struct underwriter_plugin::impl {
    //  Table read helper
    // -----------------------------------------------------------------------
 
-   read_only::get_table_rows_result read_table(const std::string& code,
-                                                const std::string& scope,
-                                                const std::string& table,
-                                                uint32_t limit = 100) {
-      auto ro = chain_plug->get_read_only_api(fc::microseconds(action_timeout_ms * 1000));
-      read_only::get_table_rows_params p;
-      p.json  = true;
-      p.code  = chain::name(code);
-      p.scope = scope;
-      p.table = table;
-      p.limit = limit;
-      auto deadline = fc::time_point::now() + fc::milliseconds(action_timeout_ms);
-      auto result_fn = ro.get_table_rows(p, deadline);
-      auto result = result_fn();
+   /// Thin plumbing around `chain_apis::read_only::get_table_rows`: binds
+   /// this plugin's `chain_plug` and the configured `action_timeout_ms`,
+   /// unwraps the deferred callable, and turns RPC errors into an empty
+   /// result with an error log. All query shape — pagination, filter,
+   /// unwrap, reverse, find+index — lives on `get_table_rows_params`.
+   sysio::chain_apis::read_only::get_table_rows_result
+   read_table(sysio::chain_apis::read_only::get_table_rows_params p) {
+      auto timeout  = fc::milliseconds(action_timeout_ms);
+      auto ro       = chain_plug->get_read_only_api(timeout);
+      auto deadline = fc::time_point::now() + timeout;
+      auto result   = ro.get_table_rows(p, deadline)();
       if (auto* err = std::get_if<fc::exception_ptr>(&result)) {
-         elog("underwriter: table read failed {}::{} — {}", code, table, (*err)->to_string());
+         elog("underwriter: table read failed {}::{} — {}",
+              p.code.to_string(), p.table, (*err)->to_string());
          return {};
       }
-      auto res = std::get<read_only::get_table_rows_result>(result);
+      return std::get<sysio::chain_apis::read_only::get_table_rows_result>(std::move(result));
+   }
 
-      // chain_plugin::get_table_rows wraps every row as {"key", "value", [payer]}.
-      // Callers of this helper read contract fields directly, so unwrap to value.
-      // variant::operator=(const variant&) calls clear() before reading the source,
-      // so a direct `row = row.get_object()["value"]` would destroy the source ref
-      // mid-assignment. Copy into an independent variant first, then move-assign.
-      for (auto& row : res.rows) {
-         if (!row.is_object()) continue;
-         const auto& row_obj = row.get_object();
-         if (!row_obj.contains("value")) continue;
-         fc::variant value{row_obj["value"]};
-         row = std::move(value);
-      }
-      return res;
+   /// Shortcut for the common scan shape: paginate every row from a
+   /// code/scope/table, returning unwrapped values.
+   sysio::chain_apis::read_only::get_table_rows_result
+   read_all(std::string_view code, std::string_view scope, std::string_view table) {
+      sysio::chain_apis::read_only::get_table_rows_params p;
+      p.code        = chain::name(code);
+      p.scope       = scope;
+      p.table       = table;
+      p.limit       = 0; // paginate every row
+      p.unwrap_rows = true;
+      return read_table(std::move(p));
    }
 
    // -----------------------------------------------------------------------
@@ -163,7 +162,7 @@ struct underwriter_plugin::impl {
 
    void read_outpost_registry() {
       outpost_chain_kinds.clear();
-      auto rows = read_table("sysio.epoch", "sysio.epoch", "outposts", 100);
+      auto rows = read_all("sysio.epoch", "sysio.epoch", "outposts");
       for (auto& row : rows.rows) {
          auto obj = row.get_object();
          uint64_t id = obj["id"].as_uint64();
@@ -188,7 +187,7 @@ struct underwriter_plugin::impl {
    void read_credit_lines() {
       credit_lines.clear();
 
-      auto rows = read_table("sysio.opreg", "sysio.opreg", "operators", 100);
+      auto rows = read_all("sysio.opreg", "sysio.opreg", "operators");
       for (auto& row : rows.rows) {
          auto obj = row.get_object();
          auto acct = obj["account"].as_string();
@@ -266,20 +265,24 @@ struct underwriter_plugin::impl {
    std::vector<uw_request> scan_pending_requests() {
       std::vector<uw_request> requests;
 
-      auto rows = read_table("sysio.uwrit", "sysio.uwrit", "uwreqs", 100);
+      // `uwreqs.bystatus` is a uint64 secondary index on
+      // `static_cast<uint64_t>(status)`. Scan exactly the
+      // `UNDERWRITE_REQUEST_STATUS_PENDING (0)` slice — [0, 1) — instead of
+      // paging the whole table and filtering in C++.
+      sysio::chain_apis::read_only::get_table_rows_params p;
+      p.code        = chain::name("sysio.uwrit");
+      p.scope       = "sysio.uwrit";
+      p.table       = "uwreqs";
+      p.index_name  = "bystatus";
+      constexpr auto PENDING_STATUS = magic_enum::enum_integer(
+         UnderwriteRequestStatus::UNDERWRITE_REQUEST_STATUS_PENDING);
+      p.lower_bound = std::format("{{\"bystatus\":{}}}", PENDING_STATUS);
+      p.upper_bound = std::format("{{\"bystatus\":{}}}", PENDING_STATUS + 1);
+      p.limit       = 0; // paginate all pending rows
+      p.unwrap_rows = true;
+      auto rows = read_table(std::move(p));
       for (auto& row : rows.rows) {
          auto obj = row.get_object();
-
-         // Filter: PENDING status only (UnderwriteRequestStatus = 0)
-         int status = 0;
-         if (obj["status"].is_string()) {
-            auto s = obj["status"].as_string();
-            if (s == "UNDERWRITE_REQUEST_STATUS_PENDING") status = 0;
-            else continue; // Not PENDING
-         } else {
-            status = static_cast<int>(obj["status"].as_uint64());
-            if (status != 0) continue; // UNDERWRITE_REQUEST_STATUS_PENDING = 0
-         }
 
          // Skip if already assigned to another underwriter
          auto uw_name = obj["uw_name"].as_string();
@@ -290,7 +293,9 @@ struct underwriter_plugin::impl {
 
          uw_request req;
          req.id = obj["id"].as_uint64();
-         req.status = status;
+         // Pre-filtered to PENDING by the bystatus index range above.
+         req.status = magic_enum::enum_integer(
+            UnderwriteRequestStatus::UNDERWRITE_REQUEST_STATUS_PENDING);
          req.uw_name = uw_name;
 
          // Parse attestation type
@@ -317,12 +322,17 @@ struct underwriter_plugin::impl {
    }
 
    bool parse_swap_from_attestation(uw_request& req) {
-      // Read the attestation data from sysio.msgch::attestations by ID
-      auto rows = read_table("sysio.msgch", "sysio.msgch", "attestations", 100);
+      // Primary-key exact lookup on sysio.msgch::attestations (ABI key_names
+      // = ["id"]). One row or nothing — no full-table scan.
+      sysio::chain_apis::read_only::get_table_rows_params p;
+      p.code        = chain::name("sysio.msgch");
+      p.scope       = "sysio.msgch";
+      p.table       = "attestations";
+      p.find        = std::format("{{\"id\":{}}}", req.id);
+      p.unwrap_rows = true;
+      auto rows = read_table(std::move(p));
       for (auto& row : rows.rows) {
          auto obj = row.get_object();
-         uint64_t att_id = obj["id"].as_uint64();
-         if (att_id != req.id) continue;
 
          // Found the attestation — parse the raw data as a Swap protobuf
          auto data_hex = obj["data"].as_string();

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -80,23 +80,53 @@ struct underwriter_plugin::impl {
    //  Table read helper
    // -----------------------------------------------------------------------
 
-   /// Thin plumbing around `chain_apis::read_only::get_table_rows`: binds
-   /// this plugin's `chain_plug` and the configured `action_timeout_ms`,
-   /// unwraps the deferred callable, and turns RPC errors into an empty
-   /// result with an error log. All query shape — pagination, filter,
-   /// unwrap, reverse, find+index — lives on `get_table_rows_params`.
+   /// Posts a `get_table_rows` scan onto the app's read_only queue and blocks this (cron-worker) thread on the
+   /// result. Running the scan during the controller's read window is what makes the chainbase iteration safe:
+   /// the main chain thread isn't writing blocks while read-only-queue items execute. Calling
+   /// `chain_plug->get_read_only_api(...)` and iterating directly from the cron thread would race with block
+   /// apply. All query shape (`find`, `index_name`, `all_rows`, `filter`, `values_only`) lives on
+   /// `get_table_rows_params`.
    sysio::chain_apis::read_only::get_table_rows_result
    read_table(sysio::chain_apis::read_only::get_table_rows_params p) {
-      auto timeout  = fc::milliseconds(action_timeout_ms);
-      auto ro       = chain_plug->get_read_only_api(timeout);
-      auto deadline = fc::time_point::now() + timeout;
-      auto result   = ro.get_table_rows(p, deadline)();
-      if (auto* err = std::get_if<fc::exception_ptr>(&result)) {
-         elog("underwriter: table read failed {}::{} — {}",
-              p.code.to_string(), p.table, (*err)->to_string());
+      using result_t  = sysio::chain_apis::read_only::get_table_rows_result;
+      const auto timeout  = fc::milliseconds(action_timeout_ms);
+      const auto deadline = fc::time_point::now() + timeout;
+
+      // shared_ptr so the posted lambda and this stack frame each own a reference; if `wait_for` times out and
+      // returns, the lambda can still safely write into the promise when the read_only queue eventually drains.
+      auto prom = std::make_shared<std::promise<result_t>>();
+      auto fut  = prom->get_future();
+
+      app().executor().post(appbase::priority::medium, appbase::exec_queue::read_only,
+         [this, p = std::move(p), deadline, prom]() mutable {
+            try {
+               auto ro       = chain_plug->get_read_only_api(fc::microseconds(action_timeout_ms * 1000ll));
+               auto variant  = ro.get_table_rows(p, deadline)();
+               if (auto* err = std::get_if<fc::exception_ptr>(&variant)) {
+                  elog("underwriter: table read failed {}::{} -- {}",
+                       p.code.to_string(), p.table, (*err)->to_string());
+                  prom->set_value({});
+               } else {
+                  prom->set_value(std::get<result_t>(std::move(variant)));
+               }
+            } catch (const fc::exception& e) {
+               elog("underwriter: table read threw {}::{} -- {}", p.code.to_string(), p.table, e.to_string());
+               prom->set_value({});
+            } catch (const std::exception& e) {
+               elog("underwriter: table read threw {}::{} -- {}", p.code.to_string(), p.table, e.what());
+               prom->set_value({});
+            } catch (...) {
+               elog("underwriter: table read threw unknown exception {}::{}", p.code.to_string(), p.table);
+               prom->set_value({});
+            }
+         });
+
+      if (fut.wait_for(std::chrono::milliseconds(action_timeout_ms)) != std::future_status::ready) {
+         elog("underwriter: table read queue-wait exceeded {}ms ({}::{})",
+              action_timeout_ms, p.code.to_string(), p.table);
          return {};
       }
-      return std::get<sysio::chain_apis::read_only::get_table_rows_result>(std::move(result));
+      return fut.get();
    }
 
    /// Shortcut for the common scan shape: walk every row from a code/scope/table and return unwrapped values.

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -99,16 +99,15 @@ struct underwriter_plugin::impl {
       return std::get<sysio::chain_apis::read_only::get_table_rows_result>(std::move(result));
    }
 
-   /// Shortcut for the common scan shape: paginate every row from a
-   /// code/scope/table, returning unwrapped values.
+   /// Shortcut for the common scan shape: walk every row from a code/scope/table and return unwrapped values.
    sysio::chain_apis::read_only::get_table_rows_result
    read_all(std::string_view code, std::string_view scope, std::string_view table) {
       sysio::chain_apis::read_only::get_table_rows_params p;
       p.code        = chain::name(code);
       p.scope       = scope;
       p.table       = table;
-      p.limit       = 0; // paginate every row
-      p.unwrap_rows = true;
+      p.all_rows    = true;
+      p.values_only = true;
       return read_table(std::move(p));
    }
 
@@ -279,7 +278,7 @@ struct underwriter_plugin::impl {
       p.lower_bound = std::format("{{\"bystatus\":{}}}", PENDING_STATUS);
       p.upper_bound = std::format("{{\"bystatus\":{}}}", PENDING_STATUS + 1);
       p.limit       = 0; // paginate all pending rows
-      p.unwrap_rows = true;
+      p.values_only = true;
       auto rows = read_table(std::move(p));
       for (auto& row : rows.rows) {
          auto obj = row.get_object();
@@ -329,7 +328,7 @@ struct underwriter_plugin::impl {
       p.scope       = "sysio.msgch";
       p.table       = "attestations";
       p.find        = std::format("{{\"id\":{}}}", req.id);
-      p.unwrap_rows = true;
+      p.values_only = true;
       auto rows = read_table(std::move(p));
       for (auto& row : rows.rows) {
          auto obj = row.get_object();

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -71,7 +71,7 @@ struct underwriter_plugin::impl {
 
    // Cron job handle
    cron_service::job_id_t            scan_job_id = 0;
-   bool                              shutting_down = false;
+   std::atomic<bool>                 shutting_down{false};
 
    // Outpost chain_kind cache: outpost_id -> ChainKind
    std::map<uint64_t, ChainKind>     outpost_chain_kinds;
@@ -80,53 +80,12 @@ struct underwriter_plugin::impl {
    //  Table read helper
    // -----------------------------------------------------------------------
 
-   /// Posts a `get_table_rows` scan onto the app's read_only queue and blocks this (cron-worker) thread on the
-   /// result. Running the scan during the controller's read window is what makes the chainbase iteration safe:
-   /// the main chain thread isn't writing blocks while read-only-queue items execute. Calling
-   /// `chain_plug->get_read_only_api(...)` and iterating directly from the cron thread would race with block
-   /// apply. All query shape (`find`, `index_name`, `all_rows`, `filter`, `values_only`) lives on
-   /// `get_table_rows_params`.
+   /// Thin delegate to `chain_plugin::read_table_rows`, which posts the scan onto the app executor's read_only queue
+   /// so chainbase iteration runs during the controller's read window instead of racing with block apply.
    sysio::chain_apis::read_only::get_table_rows_result
    read_table(sysio::chain_apis::read_only::get_table_rows_params p) {
-      using result_t  = sysio::chain_apis::read_only::get_table_rows_result;
-      const auto timeout  = fc::milliseconds(action_timeout_ms);
-      const auto deadline = fc::time_point::now() + timeout;
-
-      // shared_ptr so the posted lambda and this stack frame each own a reference; if `wait_for` times out and
-      // returns, the lambda can still safely write into the promise when the read_only queue eventually drains.
-      auto prom = std::make_shared<std::promise<result_t>>();
-      auto fut  = prom->get_future();
-
-      app().executor().post(appbase::priority::medium, appbase::exec_queue::read_only,
-         [this, p = std::move(p), deadline, prom]() mutable {
-            try {
-               auto ro       = chain_plug->get_read_only_api(fc::microseconds(action_timeout_ms * 1000ll));
-               auto variant  = ro.get_table_rows(p, deadline)();
-               if (auto* err = std::get_if<fc::exception_ptr>(&variant)) {
-                  elog("underwriter: table read failed {}::{} -- {}",
-                       p.code.to_string(), p.table, (*err)->to_string());
-                  prom->set_value({});
-               } else {
-                  prom->set_value(std::get<result_t>(std::move(variant)));
-               }
-            } catch (const fc::exception& e) {
-               elog("underwriter: table read threw {}::{} -- {}", p.code.to_string(), p.table, e.to_string());
-               prom->set_value({});
-            } catch (const std::exception& e) {
-               elog("underwriter: table read threw {}::{} -- {}", p.code.to_string(), p.table, e.what());
-               prom->set_value({});
-            } catch (...) {
-               elog("underwriter: table read threw unknown exception {}::{}", p.code.to_string(), p.table);
-               prom->set_value({});
-            }
-         });
-
-      if (fut.wait_for(std::chrono::milliseconds(action_timeout_ms)) != std::future_status::ready) {
-         elog("underwriter: table read queue-wait exceeded {}ms ({}::{})",
-              action_timeout_ms, p.code.to_string(), p.table);
-         return {};
-      }
-      return fut.get();
+      return chain_plug->read_table_rows(std::move(p), fc::milliseconds(action_timeout_ms),
+                                         "underwriter", shutting_down);
    }
 
    /// Shortcut for the common scan shape: walk every row from a code/scope/table and return unwrapped values.

--- a/tests/get_kv_rows_test.py
+++ b/tests/get_kv_rows_test.py
@@ -191,21 +191,26 @@ try:
     # ---------------------------------------------------------------
     # Test 6: Reverse pagination
     # ---------------------------------------------------------------
+    # In reverse mode, next_key is the LAST RETURNED row's key. Callers
+    # resume with upper_bound = next_key (exclusive), which yields the
+    # first row strictly below -- i.e. the next previously unseen row.
+    # Four rows reverse with limit=2 yields two pages:
+    #   [us-west, us-east], [eu-west, ap-south].
     Print("Test 6: Reverse pagination with limit=2")
     page1 = get_table_rows({"code": "kvmap", "table": "geodata", "limit": 2, "reverse": True})
+    Print(f"  Page 1 (reverse): {[r['key']['region'] for r in page1['rows']]}, next_key={page1['next_key']}")
     assert len(page1["rows"]) == 2
     assert page1["more"] == True
-    Print(f"  Page 1 (reverse): {[r['key']['region'] for r in page1['rows']]}, next_key={page1['next_key']}")
+    assert [r["key"]["region"] for r in page1["rows"]] == ["us-west", "us-east"], \
+        f"Page 1 region mismatch: {[r['key']['region'] for r in page1['rows']]}"
 
-    # In reverse mode, next_key is the key we stopped at; use it as upper_bound for next page
     page2 = get_table_rows({"code": "kvmap", "table": "geodata", "limit": 2,
                           "reverse": True, "upper_bound": page1["next_key"]})
     Print(f"  Page 2 (reverse): {[r['key']['region'] for r in page2['rows']]}")
-    assert len(page2["rows"]) == 1, f"Page 2 expected 1 row, got {len(page2['rows'])}"
-    # us-west, us-east from page1; eu-west from page2; ap-south excluded by upper_bound
-    # Actually: reverse with upper_bound=eu-west means we iterate backward from before eu-west
-    # ap-south is the only entry < eu-west
-    assert page2["rows"][0]["key"]["region"] == "ap-south"
+    assert len(page2["rows"]) == 2, f"Page 2 expected 2 rows, got {len(page2['rows'])}"
+    assert [r["key"]["region"] for r in page2["rows"]] == ["eu-west", "ap-south"], \
+        f"Page 2 region mismatch: {[r['key']['region'] for r in page2['rows']]}"
+    assert page2["more"] == False
     Print("  PASSED")
 
     testSuccessful = True

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -643,18 +643,12 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
       BOOST_CHECK_EQUAL(page1.rows[0].get_object()["value"].get_object()["sec64"].as_uint64(), 2u);
       BOOST_CHECK_EQUAL(page1.rows[1].get_object()["value"].get_object()["sec64"].as_uint64(), 5u);
 
-      // next_key for secondary queries is the secondary key bytes (hex). Use
-      // it as lower_bound on a json=false call so the bytes are interpreted
-      // directly without re-encoding.
-      chain_apis::read_only::get_table_rows_params p2;
-      p2.json = false;
-      p2.code = "test"_n;
-      p2.scope = "test";
-      p2.table = "numobjs";
-      p2.index_name = "bysec1";
-      p2.lower_bound = page1.next_key;
-      p2.limit = 50;
-      auto page2 = get_table_rows_full(plugin, p2, fc::time_point::maximum());
+      // With `p.json = true`, `next_key` for secondary queries is a JSON
+      // object matching the bound syntax. Feed it back directly as
+      // `lower_bound` on another json=true call for seamless pagination.
+      p.lower_bound = page1.next_key;
+      p.limit       = 50;
+      auto page2 = get_table_rows_full(plugin, p, fc::time_point::maximum());
       BOOST_REQUIRE_EQUAL(page2.rows.size(), 1u);
       BOOST_REQUIRE_EQUAL(page2.more, false);
    }
@@ -1094,50 +1088,241 @@ BOOST_FIXTURE_TEST_CASE( get_kv_rows_basic_test, validating_tester ) try {
 
 } FC_LOG_AND_RETHROW()
 
+// Shared setup for the two primary-index reverse-pagination tests below.
+// `test_kv_sec_query` primary is a single-field uint64 `id`. Seeds ids 1..5.
+static void setup_kvrev_primary(validating_tester& t, account_name acct) {
+   t.produce_block();
+   t.create_accounts({acct});
+   t.produce_block();
+   t.set_code(acct, test_contracts::test_kv_sec_query_wasm());
+   t.set_abi(acct,  test_contracts::test_kv_sec_query_abi());
+   t.produce_block();
+   for (uint64_t id = 1; id <= 5; ++id) {
+      t.push_action(acct, "adduser"_n, acct,
+                    mutable_variant_object()("id", id)
+                                            ("owner", std::string("u") + std::to_string(id))
+                                            ("balance", id * 100));
+   }
+   t.produce_block();
+}
+
+// Reverse pagination over a primary key with `json=true`. Pins the
+// reverse-pagination resume contract: `upper_bound = prev.next_key` must
+// walk every row exactly once with no boundary drop. `next_key` in json
+// mode is a JSON object matching the bound syntax.
+//
+// Five rows with primary ids 1..5. With limit=2 reverse, a correct scan
+// returns three pages: [5,4], [3,2], [1].
 BOOST_FIXTURE_TEST_CASE( get_kv_rows_reverse_pagination_test, validating_tester ) try {
-   produce_block();
-   create_accounts({"kvrev"_n});
-   produce_block();
-
-   set_code("kvrev"_n, test_contracts::test_kv_map_wasm());
-   set_abi("kvrev"_n, test_contracts::test_kv_map_abi());
-   produce_block();
-
-   kv_put(*this, "kvrev"_n, "a", 1, "val1", 10);
-   kv_put(*this, "kvrev"_n, "b", 1, "val2", 20);
-   kv_put(*this, "kvrev"_n, "c", 1, "val3", 30);
-   kv_put(*this, "kvrev"_n, "d", 1, "val4", 40);
-   kv_put(*this, "kvrev"_n, "e", 1, "val5", 50);
-   produce_block();
+   setup_kvrev_primary(*this, "kvrev"_n);
 
    std::optional<sysio::chain_apis::tracked_votes> _tracked_votes;
    chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes,
                                 fc::microseconds::maximum(), fc::microseconds::maximum(), {});
 
-   // Reverse pagination with limit=2
    chain_apis::read_only::get_table_rows_params p;
-   p.json = true;
-   p.code = "kvrev"_n;
-   p.table = "geodata";
-   p.limit = 2;
+   p.json    = true;
+   p.code    = "kvrev"_n;
+   p.table   = "users";
+   p.limit   = 2;
    p.reverse = true;
 
-   // Page 1 (reverse): e/1, d/1
+   auto id_of = [](const fc::variant& row) {
+      return row.get_object()["key"].get_object()["id"].as_uint64();
+   };
+
+   // Page 1: id=5, id=4. next_key = JSON form of id=4 (last returned).
    auto page1 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
    BOOST_REQUIRE_EQUAL(2u, page1.rows.size());
    BOOST_REQUIRE_EQUAL(true, page1.more);
-   BOOST_REQUIRE(!page1.next_key.empty());
-   BOOST_REQUIRE_EQUAL("e", page1.rows[0]["key"].get_object()["region"].as_string());
-   BOOST_REQUIRE_EQUAL("d", page1.rows[1]["key"].get_object()["region"].as_string());
+   BOOST_CHECK_EQUAL(5u, id_of(page1.rows[0]));
+   BOOST_CHECK_EQUAL(4u, id_of(page1.rows[1]));
+   BOOST_CHECK_EQUAL(R"({"id":4})", page1.next_key);
 
-   // Page 2 (reverse): use next_key as upper_bound
-   // next_key from page1 points to "c" (exclusive), so page2 gets b, a
+   // Page 2: id=3, id=2. `upper_bound = {"id":4}` must NOT drop id=3.
    p.upper_bound = page1.next_key;
    auto page2 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
    BOOST_REQUIRE_EQUAL(2u, page2.rows.size());
-   BOOST_REQUIRE_EQUAL(false, page2.more); // only b, a remain
-   BOOST_REQUIRE_EQUAL("b", page2.rows[0]["key"].get_object()["region"].as_string());
-   BOOST_REQUIRE_EQUAL("a", page2.rows[1]["key"].get_object()["region"].as_string());
+   BOOST_REQUIRE_EQUAL(true, page2.more);
+   BOOST_CHECK_EQUAL(3u, id_of(page2.rows[0]));
+   BOOST_CHECK_EQUAL(2u, id_of(page2.rows[1]));
+   BOOST_CHECK_EQUAL(R"({"id":2})", page2.next_key);
+
+   // Page 3: id=1. Scan exhausted.
+   p.upper_bound = page2.next_key;
+   auto page3 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(1u, page3.rows.size());
+   BOOST_REQUIRE_EQUAL(false, page3.more);
+   BOOST_REQUIRE(page3.next_key.empty());
+   BOOST_CHECK_EQUAL(1u, id_of(page3.rows[0]));
+
+} FC_LOG_AND_RETHROW()
+
+// Same contract and data as the json=true test above, but `json=false`
+// end-to-end. Pins the hex `next_key` path.
+BOOST_FIXTURE_TEST_CASE( get_kv_rows_reverse_pagination_hex_test, validating_tester ) try {
+   setup_kvrev_primary(*this, "kvrevh"_n);
+
+   auto be8_hex = [](uint64_t v) {
+      char buf[8];
+      chain::kv_encode_be64(buf, v);
+      return fc::to_hex(buf, 8);
+   };
+
+   std::optional<sysio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes,
+                                fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+
+   chain_apis::read_only::get_table_rows_params p;
+   p.json    = false;
+   p.code    = "kvrevh"_n;
+   p.table   = "users";
+   p.limit   = 2;
+   p.reverse = true;
+
+   // Page 1: id=5, id=4. next_key = hex(be64(4)).
+   auto page1 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page1.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page1.more);
+   BOOST_CHECK_EQUAL(be8_hex(5), page1.rows[0].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(4), page1.rows[1].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(4), page1.next_key);
+
+   // Page 2: id=3, id=2. next_key = hex(be64(2)).
+   p.upper_bound = page1.next_key;
+   auto page2 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page2.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page2.more);
+   BOOST_CHECK_EQUAL(be8_hex(3), page2.rows[0].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(2), page2.rows[1].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(2), page2.next_key);
+
+   // Page 3: id=1. Scan exhausted.
+   p.upper_bound = page2.next_key;
+   auto page3 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(1u, page3.rows.size());
+   BOOST_REQUIRE_EQUAL(false, page3.more);
+   BOOST_REQUIRE(page3.next_key.empty());
+   BOOST_CHECK_EQUAL(be8_hex(1), page3.rows[0].get_object()["key"].as_string());
+
+} FC_LOG_AND_RETHROW()
+
+// Shared setup for the two secondary-index reverse-pagination tests below.
+// test_kv_sec_query has a single-field uint64 primary (`id`) and a `byowner`
+// name secondary. Five users u1-u5 with id=1..5 sort in byowner ascending as
+// u1, u2, u3, u4, u5; reverse walks them u5, u4, u3, u2, u1.
+static void setup_secrev(validating_tester& t, account_name acct) {
+   t.produce_block();
+   t.create_accounts({acct});
+   t.produce_block();
+   t.set_code(acct, test_contracts::test_kv_sec_query_wasm());
+   t.set_abi(acct,  test_contracts::test_kv_sec_query_abi());
+   t.produce_block();
+   for (uint64_t id = 1; id <= 5; ++id) {
+      t.push_action(acct, "adduser"_n, acct,
+                    mutable_variant_object()("id", id)
+                                            ("owner", std::string("u") + std::to_string(id))
+                                            ("balance", id * 100));
+   }
+   t.produce_block();
+}
+
+// Reverse pagination over a secondary index with `json=true`. Exercises the
+// secondary-index reverse branch AND the JSON next_key path: `upper_bound =
+// prev.next_key` must round-trip through the bound parser (which expects
+// JSON when `p.json` is set), and must not drop a row at each page boundary.
+BOOST_FIXTURE_TEST_CASE( get_kv_rows_reverse_pagination_secondary_test, validating_tester ) try {
+   setup_secrev(*this, "secrev"_n);
+
+   std::optional<sysio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes,
+                                fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+
+   chain_apis::read_only::get_table_rows_params p;
+   p.json       = true;
+   p.code       = "secrev"_n;
+   p.table      = "users";
+   p.index_name = "byowner";
+   p.limit      = 2;
+   p.reverse    = true;
+
+   auto owner_of = [](const fc::variant& row) {
+      return row.get_object()["value"].get_object()["owner"].as_string();
+   };
+
+   // Page 1: rows for u5, u4. next_key = JSON form of the byowner key for u4.
+   auto page1 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page1.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page1.more);
+   BOOST_CHECK_EQUAL("u5", owner_of(page1.rows[0]));
+   BOOST_CHECK_EQUAL("u4", owner_of(page1.rows[1]));
+   BOOST_CHECK_EQUAL(R"({"byowner":"u4"})", page1.next_key);
+
+   // Page 2: u3, u2. `upper_bound = {"byowner":"u4"}` must NOT drop u3.
+   p.upper_bound = page1.next_key;
+   auto page2 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page2.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page2.more);
+   BOOST_CHECK_EQUAL("u3", owner_of(page2.rows[0]));
+   BOOST_CHECK_EQUAL("u2", owner_of(page2.rows[1]));
+   BOOST_CHECK_EQUAL(R"({"byowner":"u2"})", page2.next_key);
+
+   // Page 3: u1. Scan exhausted.
+   p.upper_bound = page2.next_key;
+   auto page3 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(1u, page3.rows.size());
+   BOOST_REQUIRE_EQUAL(false, page3.more);
+   BOOST_REQUIRE(page3.next_key.empty());
+   BOOST_CHECK_EQUAL("u1", owner_of(page3.rows[0]));
+} FC_LOG_AND_RETHROW()
+
+// Same as above but with `json=false` end-to-end. Pins the hex next_key
+// path for secondary-index reverse pagination.
+BOOST_FIXTURE_TEST_CASE( get_kv_rows_reverse_pagination_secondary_hex_test, validating_tester ) try {
+   setup_secrev(*this, "secrevh"_n);
+
+   auto be8_hex = [](uint64_t v) {
+      char buf[8];
+      chain::kv_encode_be64(buf, v);
+      return fc::to_hex(buf, 8);
+   };
+   auto owner_sk_hex = [&](const char* owner) {
+      return be8_hex(chain::name(owner).to_uint64_t());
+   };
+
+   std::optional<sysio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes,
+                                fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+
+   chain_apis::read_only::get_table_rows_params p;
+   p.json       = false;
+   p.code       = "secrevh"_n;
+   p.table      = "users";
+   p.index_name = "byowner";
+   p.limit      = 2;
+   p.reverse    = true;
+
+   auto page1 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page1.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page1.more);
+   BOOST_CHECK_EQUAL(be8_hex(5),            page1.rows[0].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(4),            page1.rows[1].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(owner_sk_hex("u4"),    page1.next_key);
+
+   p.upper_bound = page1.next_key;
+   auto page2 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page2.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page2.more);
+   BOOST_CHECK_EQUAL(be8_hex(3),            page2.rows[0].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(2),            page2.rows[1].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(owner_sk_hex("u2"),    page2.next_key);
+
+   p.upper_bound = page2.next_key;
+   auto page3 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(1u, page3.rows.size());
+   BOOST_REQUIRE_EQUAL(false, page3.more);
+   BOOST_REQUIRE(page3.next_key.empty());
+   BOOST_CHECK_EQUAL(be8_hex(1),            page3.rows[0].get_object()["key"].as_string());
 
 } FC_LOG_AND_RETHROW()
 

--- a/tests/test_get_table_rows_page.cpp
+++ b/tests/test_get_table_rows_page.cpp
@@ -1,21 +1,17 @@
 /**
  * @file test_get_table_rows_page.cpp
- * @brief Unit tests for the extended `chain_apis::read_only::get_table_rows`.
+ * @brief Unit tests for `chain_apis::read_only::get_table_rows` behaviours layered over `get_table_rows_page`.
  *
- * These tests pin down the behaviours folded onto `get_table_rows_params`
- * when the stall-at-epoch-25 bug was fixed:
+ * These cases pin down the wrapper-level fields on `get_table_rows_params`:
  *
- * - `limit == 0` means "paginate through the entire scan" (a formerly-useless
- *   value; the fix repurposed it so the batch operator never re-creates a
- *   50-row clip bug).
- * - `unwrap_rows` strips the `{key, value, payer?}` wrapper.
- * - `filter` drops rows after unwrap.
- * - `reverse` + a small `limit` returns the latest N rows without skipping a
- *   row at every page boundary.
+ * - `all_rows` walks the entire scan in a single call, ignoring `limit`, `time_limit_ms`, and the caller deadline.
+ *   C++-only (not FC_REFLECT'd) so HTTP cannot trigger unbounded server work.
+ * - `values_only` strips the `{key, value, payer?}` wrapper, returning just the value side of each row.
+ * - `filter` drops rows post-`values_only`; the predicate sees the same shape the caller will consume.
+ * - `reverse` + a small `limit` returns the latest N rows without skipping a row at every page boundary (the
+ *   reverse-off-by-one fix in `get_table_rows_page`).
  *
- * Each case uses the `get_table_test` multi_index contract already wired up
- * for `get_table_tests.cpp`, so regressions surface as a failing assertion
- * rather than a live-cluster outage.
+ * Each case uses the `get_table_test` multi_index contract already wired up for `get_table_tests.cpp`.
  */
 
 #include <boost/test/unit_test.hpp>
@@ -34,12 +30,12 @@ using namespace sysio::chain_apis;
 using namespace sysio::testing;
 
 namespace {
-   /// Contract account that hosts the `numobjs` test table. Matches the
-   /// pattern used in `get_table_tests.cpp::get_table_next_key_test`.
+   /// Contract account that hosts the `numobjs` test table. Matches the pattern used in
+   /// `get_table_tests.cpp::get_table_next_key_test`.
    constexpr auto TEST_ACCOUNT = "test";
 
-   /// Build a read-only API instance against the tester's controller. Both
-   /// timeouts are `maximum()` so we never fail a test case on RPC deadline.
+   /// Build a read-only API instance against the tester's controller. Both timeouts are `maximum()` so we never
+   /// fail a test case on RPC deadline.
    read_only make_read_only(validating_tester& t) {
       std::optional<sysio::chain_apis::tracked_votes> tv;
       return read_only(*(t.control), {}, {}, tv,
@@ -56,11 +52,9 @@ namespace {
       t.produce_block();
    }
 
-   /// Populate the `numobjs` multi_index with `count` rows via the contract's
-   /// `addnumobj` action. Each row gets auto-incremented primary key `i` and
-   /// `sec64 == i` — matches what tests assert on. Produces a block every
-   /// `ROWS_PER_BLOCK` actions so large populations don't exceed the block
-   /// CPU budget.
+   /// Populate the `numobjs` multi_index with `count` rows via the contract's `addnumobj` action. Each row gets
+   /// auto-incremented primary key `i` and `sec64 == i` -- matches what tests assert on. Produces a block every
+   /// `ROWS_PER_BLOCK` actions so large populations don't exceed the block CPU budget.
    void populate_numobjs(validating_tester& t, uint32_t count) {
       constexpr uint32_t ROWS_PER_BLOCK = 50;
       for (uint32_t i = 0; i < count; ++i) {
@@ -73,8 +67,7 @@ namespace {
       t.produce_block();
    }
 
-   /// Build a starter params pointed at `test::numobjs`. Caller mutates the
-   /// fields they care about.
+   /// Build a starter params pointed at `test::numobjs`. Caller mutates the fields they care about.
    read_only::get_table_rows_params numobjs_params() {
       read_only::get_table_rows_params p;
       p.code  = "test"_n;
@@ -83,8 +76,8 @@ namespace {
       return p;
    }
 
-   /// Run a deferred get_table_rows to completion and return the decoded
-   /// result. Fails the test if the RPC produced an exception_ptr.
+   /// Run a deferred get_table_rows to completion and return the decoded result. Fails the test if the RPC
+   /// produced an exception_ptr.
    read_only::get_table_rows_result
    run(read_only& ro, const read_only::get_table_rows_params& p) {
       auto variant = ro.get_table_rows(p, fc::time_point::maximum())();
@@ -95,10 +88,8 @@ namespace {
 
 BOOST_AUTO_TEST_SUITE(table_reader_tests)
 
-// ---------------------------------------------------------------------------
-//  Baseline: the classic single-page path is unchanged. `limit=50` default
-//  returns up to 50 rows with the HTTP-friendly `{key, value, payer?}` wrap.
-// ---------------------------------------------------------------------------
+// Baseline: the classic single-page path is unchanged. `limit=50` default returns up to 50 rows with the
+// HTTP-friendly `{key, value, payer?}` wrap.
 BOOST_FIXTURE_TEST_CASE(default_limit_is_single_page_wrapped, validating_tester) try {
    deploy_contract(*this);
    populate_numobjs(*this, 7);
@@ -107,9 +98,7 @@ BOOST_FIXTURE_TEST_CASE(default_limit_is_single_page_wrapped, validating_tester)
    auto res = run(ro, numobjs_params());
 
    BOOST_REQUIRE_EQUAL(res.rows.size(), 7u);
-   // Rows are WRAPPED — each is a `{key, value, payer?}` object, callers read
-   // `row["value"]["sec64"]` etc. (This is the HTTP surface behaviour; the
-   // refactor must not accidentally break it.)
+   // Rows are WRAPPED -- each is a `{key, value, payer?}` object; callers read `row["value"]["sec64"]` etc.
    BOOST_REQUIRE(res.rows[0].is_object());
    BOOST_CHECK(res.rows[0].get_object().contains("value"));
    BOOST_CHECK(res.rows[0].get_object().contains("key"));
@@ -119,18 +108,14 @@ BOOST_FIXTURE_TEST_CASE(default_limit_is_single_page_wrapped, validating_tester)
    }
 } FC_LOG_AND_RETHROW()
 
-// ---------------------------------------------------------------------------
-//  `limit == 0` paginates through every row. Populate more rows than the
-//  internal 100-row page size and assert every row comes back in order.
-//  This is the behaviour whose absence caused the epoch-25 stall — a bare
-//  50-row read dropped everything past id 49.
-// ---------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(limit_zero_paginates_all_rows, validating_tester) try {
+// `all_rows = true` walks every row in one call regardless of `limit`. Populate a row count well over the default
+// `limit` of 50 to confirm the cap is ignored when `all_rows` is set.
+BOOST_FIXTURE_TEST_CASE(all_rows_walks_every_row, validating_tester) try {
    deploy_contract(*this);
-   populate_numobjs(*this, 205); // crosses 2 internal pages + spills into a 3rd
+   populate_numobjs(*this, 205);
 
    auto p = numobjs_params();
-   p.limit = 0;
+   p.all_rows = true;
 
    auto ro  = make_read_only(*this);
    auto res = run(ro, p);
@@ -144,17 +129,14 @@ BOOST_FIXTURE_TEST_CASE(limit_zero_paginates_all_rows, validating_tester) try {
    }
 } FC_LOG_AND_RETHROW()
 
-// ---------------------------------------------------------------------------
-//  `unwrap_rows` strips the `{key, value, payer}` wrapper, leaving just the
-//  contract-side value. Default stays wrapped (asserted above) so HTTP
-//  clients are unaffected.
-// ---------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(unwrap_rows_returns_bare_values, validating_tester) try {
+// `values_only` strips the `{key, value, payer}` wrapper, leaving just the contract-side value. Default stays
+// wrapped (asserted above) so HTTP clients are unaffected.
+BOOST_FIXTURE_TEST_CASE(values_only_strips_wrapper, validating_tester) try {
    deploy_contract(*this);
    populate_numobjs(*this, 3);
 
    auto p = numobjs_params();
-   p.unwrap_rows = true;
+   p.values_only = true;
 
    auto ro  = make_read_only(*this);
    auto res = run(ro, p);
@@ -169,16 +151,13 @@ BOOST_FIXTURE_TEST_CASE(unwrap_rows_returns_bare_values, validating_tester) try 
    }
 } FC_LOG_AND_RETHROW()
 
-// ---------------------------------------------------------------------------
-//  Filter drops rows post-unwrap. Predicate sees the same shape the caller
-//  will consume.
-// ---------------------------------------------------------------------------
+// Filter drops rows post-`values_only`. The predicate sees the same shape the caller will consume.
 BOOST_FIXTURE_TEST_CASE(filter_drops_unmatched_rows, validating_tester) try {
    deploy_contract(*this);
    populate_numobjs(*this, 10);
 
    auto p = numobjs_params();
-   p.unwrap_rows = true;
+   p.values_only = true;
    p.filter = [](const fc::variant& row) {
       return (row.get_object()["sec64"].as_uint64() % 2) == 0;
    };
@@ -192,11 +171,8 @@ BOOST_FIXTURE_TEST_CASE(filter_drops_unmatched_rows, validating_tester) try {
    }
 } FC_LOG_AND_RETHROW()
 
-// ---------------------------------------------------------------------------
-//  `reverse` + a small `limit` returns the LATEST N rows. This is the exact
-//  pattern used by `batch_operator_plugin::read_pending_outbound` after the
-//  epoch-stall fix; a regression here implies the stall has returned.
-// ---------------------------------------------------------------------------
+// `reverse` + a small `limit` returns the LATEST N rows. This is the exact pattern used by
+// `batch_operator_plugin::read_pending_outbound`; a regression implies the epoch stall has returned.
 BOOST_FIXTURE_TEST_CASE(reverse_with_limit_returns_latest, validating_tester) try {
    deploy_contract(*this);
    populate_numobjs(*this, 12);
@@ -204,7 +180,7 @@ BOOST_FIXTURE_TEST_CASE(reverse_with_limit_returns_latest, validating_tester) tr
    auto p = numobjs_params();
    p.reverse     = true;
    p.limit       = 3;
-   p.unwrap_rows = true;
+   p.values_only = true;
 
    auto ro  = make_read_only(*this);
    auto res = run(ro, p);
@@ -215,53 +191,43 @@ BOOST_FIXTURE_TEST_CASE(reverse_with_limit_returns_latest, validating_tester) tr
    BOOST_CHECK_EQUAL(res.rows[2].get_object()["key"].as_uint64(),  9u);
 } FC_LOG_AND_RETHROW()
 
-// ---------------------------------------------------------------------------
-//  `reverse` + `limit == 0` walks the table in reverse from end to start.
-//  The cursor advance has to use each page's LAST returned row as the next
-//  `upper_bound` (not `next_key`, which is the first UNSEEN row below it —
-//  setting `upper_bound = next_key` would skip a row per page boundary).
-// ---------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(reverse_limit_zero_spans_pages_without_skips, validating_tester) try {
+// `reverse` + `all_rows` walks the table from highest to lowest key with no skips. The page-impl's reverse branch
+// is what guarantees this -- a regression would show up as two consecutive rows differing by more than 1.
+BOOST_FIXTURE_TEST_CASE(reverse_all_rows_no_skips, validating_tester) try {
    deploy_contract(*this);
-   populate_numobjs(*this, 205); // forces multi-page reverse walk
+   populate_numobjs(*this, 205);
 
    auto p = numobjs_params();
    p.reverse     = true;
-   p.limit       = 0;
-   p.unwrap_rows = true;
+   p.all_rows    = true;
+   p.values_only = true;
 
    auto ro  = make_read_only(*this);
    auto res = run(ro, p);
 
    BOOST_REQUIRE_EQUAL(res.rows.size(), 205u);
-   // Strictly descending keys, no gaps. A page-boundary skip would show up
-   // as two consecutive rows that differ by 2 (or more) instead of 1.
    for (size_t i = 0; i < res.rows.size(); ++i) {
       BOOST_CHECK_EQUAL(res.rows[i].get_object()["key"].as_uint64(), 204u - i);
    }
 } FC_LOG_AND_RETHROW()
 
-// ---------------------------------------------------------------------------
-//  Empty table + `limit == 0` returns an empty result with no error.
-// ---------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(empty_table_paginate_all_is_empty, validating_tester) try {
+// Empty table + `all_rows` returns an empty result with no error.
+BOOST_FIXTURE_TEST_CASE(empty_table_all_rows_is_empty, validating_tester) try {
    deploy_contract(*this); // no populate_numobjs call
 
    auto p = numobjs_params();
-   p.limit = 0;
+   p.all_rows = true;
 
    auto ro  = make_read_only(*this);
    auto res = run(ro, p);
    BOOST_CHECK_EQUAL(res.rows.size(), 0u);
    BOOST_CHECK(!res.more);
+   BOOST_CHECK(res.next_key.empty());
 } FC_LOG_AND_RETHROW()
 
-// ---------------------------------------------------------------------------
-//  `find` + `index_name` is an exact-key lookup. With `limit == 0` the
-//  helper must still return only the matching row — pagination past a
-//  single-key match makes no sense.
-// ---------------------------------------------------------------------------
-BOOST_FIXTURE_TEST_CASE(find_with_index_returns_single_match_even_when_paginate_all,
+// `find` + `index_name` is an exact-key lookup. With `all_rows` set the result must still be a single row --
+// paginating past a single-key match makes no sense and the page-impl already returns `limit=1` worth naturally.
+BOOST_FIXTURE_TEST_CASE(find_with_index_returns_single_match_even_when_all_rows,
                         validating_tester) try {
    deploy_contract(*this);
    populate_numobjs(*this, 5); // keys/sec64 = 0..4
@@ -269,8 +235,8 @@ BOOST_FIXTURE_TEST_CASE(find_with_index_returns_single_match_even_when_paginate_
    auto p = numobjs_params();
    p.find        = R"({"bysec1":3})";
    p.index_name  = "bysec1";
-   p.limit       = 0; // should not loop past the single match
-   p.unwrap_rows = true;
+   p.all_rows    = true;
+   p.values_only = true;
 
    auto ro  = make_read_only(*this);
    auto res = run(ro, p);

--- a/tests/test_get_table_rows_page.cpp
+++ b/tests/test_get_table_rows_page.cpp
@@ -1,0 +1,282 @@
+/**
+ * @file test_get_table_rows_page.cpp
+ * @brief Unit tests for the extended `chain_apis::read_only::get_table_rows`.
+ *
+ * These tests pin down the behaviours folded onto `get_table_rows_params`
+ * when the stall-at-epoch-25 bug was fixed:
+ *
+ * - `limit == 0` means "paginate through the entire scan" (a formerly-useless
+ *   value; the fix repurposed it so the batch operator never re-creates a
+ *   50-row clip bug).
+ * - `unwrap_rows` strips the `{key, value, payer?}` wrapper.
+ * - `filter` drops rows after unwrap.
+ * - `reverse` + a small `limit` returns the latest N rows without skipping a
+ *   row at every page boundary.
+ *
+ * Each case uses the `get_table_test` multi_index contract already wired up
+ * for `get_table_tests.cpp`, so regressions surface as a failing assertion
+ * rather than a live-cluster outage.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <sysio/chain/abi_serializer.hpp>
+#include <sysio/chain_plugin/chain_plugin.hpp>
+#include <sysio/testing/tester.hpp>
+
+#include <test_contracts.hpp>
+
+#include <fc/variant_object.hpp>
+
+using namespace sysio;
+using namespace sysio::chain;
+using namespace sysio::chain_apis;
+using namespace sysio::testing;
+
+namespace {
+   /// Contract account that hosts the `numobjs` test table. Matches the
+   /// pattern used in `get_table_tests.cpp::get_table_next_key_test`.
+   constexpr auto TEST_ACCOUNT = "test";
+
+   /// Build a read-only API instance against the tester's controller. Both
+   /// timeouts are `maximum()` so we never fail a test case on RPC deadline.
+   read_only make_read_only(validating_tester& t) {
+      std::optional<sysio::chain_apis::tracked_votes> tv;
+      return read_only(*(t.control), {}, {}, tv,
+                       fc::microseconds::maximum(),
+                       fc::microseconds::maximum(),
+                       {});
+   }
+
+   /// Deploy the `get_table_test` contract to `test` and produce a block.
+   void deploy_contract(validating_tester& t) {
+      t.create_account("test"_n);
+      t.set_code("test"_n, test_contracts::get_table_test_wasm());
+      t.set_abi("test"_n,  test_contracts::get_table_test_abi());
+      t.produce_block();
+   }
+
+   /// Populate the `numobjs` multi_index with `count` rows via the contract's
+   /// `addnumobj` action. Each row gets auto-incremented primary key `i` and
+   /// `sec64 == i` — matches what tests assert on. Produces a block every
+   /// `ROWS_PER_BLOCK` actions so large populations don't exceed the block
+   /// CPU budget.
+   void populate_numobjs(validating_tester& t, uint32_t count) {
+      constexpr uint32_t ROWS_PER_BLOCK = 50;
+      for (uint32_t i = 0; i < count; ++i) {
+         t.push_action("test"_n, "addnumobj"_n, "test"_n,
+                       fc::mutable_variant_object()("input", i));
+         if (((i + 1) % ROWS_PER_BLOCK) == 0) {
+            t.produce_block();
+         }
+      }
+      t.produce_block();
+   }
+
+   /// Build a starter params pointed at `test::numobjs`. Caller mutates the
+   /// fields they care about.
+   read_only::get_table_rows_params numobjs_params() {
+      read_only::get_table_rows_params p;
+      p.code  = "test"_n;
+      p.scope = TEST_ACCOUNT;
+      p.table = "numobjs";
+      return p;
+   }
+
+   /// Run a deferred get_table_rows to completion and return the decoded
+   /// result. Fails the test if the RPC produced an exception_ptr.
+   read_only::get_table_rows_result
+   run(read_only& ro, const read_only::get_table_rows_params& p) {
+      auto variant = ro.get_table_rows(p, fc::time_point::maximum())();
+      BOOST_REQUIRE(!std::holds_alternative<fc::exception_ptr>(variant));
+      return std::get<read_only::get_table_rows_result>(std::move(variant));
+   }
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(table_reader_tests)
+
+// ---------------------------------------------------------------------------
+//  Baseline: the classic single-page path is unchanged. `limit=50` default
+//  returns up to 50 rows with the HTTP-friendly `{key, value, payer?}` wrap.
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(default_limit_is_single_page_wrapped, validating_tester) try {
+   deploy_contract(*this);
+   populate_numobjs(*this, 7);
+
+   auto ro  = make_read_only(*this);
+   auto res = run(ro, numobjs_params());
+
+   BOOST_REQUIRE_EQUAL(res.rows.size(), 7u);
+   // Rows are WRAPPED — each is a `{key, value, payer?}` object, callers read
+   // `row["value"]["sec64"]` etc. (This is the HTTP surface behaviour; the
+   // refactor must not accidentally break it.)
+   BOOST_REQUIRE(res.rows[0].is_object());
+   BOOST_CHECK(res.rows[0].get_object().contains("value"));
+   BOOST_CHECK(res.rows[0].get_object().contains("key"));
+   for (uint32_t i = 0; i < 7; ++i) {
+      BOOST_CHECK_EQUAL(
+         res.rows[i].get_object()["value"].get_object()["sec64"].as_uint64(), i);
+   }
+} FC_LOG_AND_RETHROW()
+
+// ---------------------------------------------------------------------------
+//  `limit == 0` paginates through every row. Populate more rows than the
+//  internal 100-row page size and assert every row comes back in order.
+//  This is the behaviour whose absence caused the epoch-25 stall — a bare
+//  50-row read dropped everything past id 49.
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(limit_zero_paginates_all_rows, validating_tester) try {
+   deploy_contract(*this);
+   populate_numobjs(*this, 205); // crosses 2 internal pages + spills into a 3rd
+
+   auto p = numobjs_params();
+   p.limit = 0;
+
+   auto ro  = make_read_only(*this);
+   auto res = run(ro, p);
+
+   BOOST_REQUIRE_EQUAL(res.rows.size(), 205u);
+   BOOST_CHECK(!res.more);
+   BOOST_CHECK(res.next_key.empty());
+   for (uint32_t i = 0; i < 205; ++i) {
+      BOOST_CHECK_EQUAL(
+         res.rows[i].get_object()["value"].get_object()["key"].as_uint64(), i);
+   }
+} FC_LOG_AND_RETHROW()
+
+// ---------------------------------------------------------------------------
+//  `unwrap_rows` strips the `{key, value, payer}` wrapper, leaving just the
+//  contract-side value. Default stays wrapped (asserted above) so HTTP
+//  clients are unaffected.
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(unwrap_rows_returns_bare_values, validating_tester) try {
+   deploy_contract(*this);
+   populate_numobjs(*this, 3);
+
+   auto p = numobjs_params();
+   p.unwrap_rows = true;
+
+   auto ro  = make_read_only(*this);
+   auto res = run(ro, p);
+
+   BOOST_REQUIRE_EQUAL(res.rows.size(), 3u);
+   for (size_t i = 0; i < res.rows.size(); ++i) {
+      BOOST_REQUIRE(res.rows[i].is_object());
+      // Unwrapped: value fields are directly addressable.
+      BOOST_CHECK(res.rows[i].get_object().contains("sec64"));
+      BOOST_CHECK(!res.rows[i].get_object().contains("value"));
+      BOOST_CHECK_EQUAL(res.rows[i].get_object()["sec64"].as_uint64(), i);
+   }
+} FC_LOG_AND_RETHROW()
+
+// ---------------------------------------------------------------------------
+//  Filter drops rows post-unwrap. Predicate sees the same shape the caller
+//  will consume.
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(filter_drops_unmatched_rows, validating_tester) try {
+   deploy_contract(*this);
+   populate_numobjs(*this, 10);
+
+   auto p = numobjs_params();
+   p.unwrap_rows = true;
+   p.filter = [](const fc::variant& row) {
+      return (row.get_object()["sec64"].as_uint64() % 2) == 0;
+   };
+
+   auto ro  = make_read_only(*this);
+   auto res = run(ro, p);
+
+   BOOST_REQUIRE_EQUAL(res.rows.size(), 5u); // 0, 2, 4, 6, 8
+   for (const auto& row : res.rows) {
+      BOOST_CHECK_EQUAL(row.get_object()["sec64"].as_uint64() % 2, 0u);
+   }
+} FC_LOG_AND_RETHROW()
+
+// ---------------------------------------------------------------------------
+//  `reverse` + a small `limit` returns the LATEST N rows. This is the exact
+//  pattern used by `batch_operator_plugin::read_pending_outbound` after the
+//  epoch-stall fix; a regression here implies the stall has returned.
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(reverse_with_limit_returns_latest, validating_tester) try {
+   deploy_contract(*this);
+   populate_numobjs(*this, 12);
+
+   auto p = numobjs_params();
+   p.reverse     = true;
+   p.limit       = 3;
+   p.unwrap_rows = true;
+
+   auto ro  = make_read_only(*this);
+   auto res = run(ro, p);
+
+   BOOST_REQUIRE_EQUAL(res.rows.size(), 3u);
+   BOOST_CHECK_EQUAL(res.rows[0].get_object()["key"].as_uint64(), 11u);
+   BOOST_CHECK_EQUAL(res.rows[1].get_object()["key"].as_uint64(), 10u);
+   BOOST_CHECK_EQUAL(res.rows[2].get_object()["key"].as_uint64(),  9u);
+} FC_LOG_AND_RETHROW()
+
+// ---------------------------------------------------------------------------
+//  `reverse` + `limit == 0` walks the table in reverse from end to start.
+//  The cursor advance has to use each page's LAST returned row as the next
+//  `upper_bound` (not `next_key`, which is the first UNSEEN row below it —
+//  setting `upper_bound = next_key` would skip a row per page boundary).
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(reverse_limit_zero_spans_pages_without_skips, validating_tester) try {
+   deploy_contract(*this);
+   populate_numobjs(*this, 205); // forces multi-page reverse walk
+
+   auto p = numobjs_params();
+   p.reverse     = true;
+   p.limit       = 0;
+   p.unwrap_rows = true;
+
+   auto ro  = make_read_only(*this);
+   auto res = run(ro, p);
+
+   BOOST_REQUIRE_EQUAL(res.rows.size(), 205u);
+   // Strictly descending keys, no gaps. A page-boundary skip would show up
+   // as two consecutive rows that differ by 2 (or more) instead of 1.
+   for (size_t i = 0; i < res.rows.size(); ++i) {
+      BOOST_CHECK_EQUAL(res.rows[i].get_object()["key"].as_uint64(), 204u - i);
+   }
+} FC_LOG_AND_RETHROW()
+
+// ---------------------------------------------------------------------------
+//  Empty table + `limit == 0` returns an empty result with no error.
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(empty_table_paginate_all_is_empty, validating_tester) try {
+   deploy_contract(*this); // no populate_numobjs call
+
+   auto p = numobjs_params();
+   p.limit = 0;
+
+   auto ro  = make_read_only(*this);
+   auto res = run(ro, p);
+   BOOST_CHECK_EQUAL(res.rows.size(), 0u);
+   BOOST_CHECK(!res.more);
+} FC_LOG_AND_RETHROW()
+
+// ---------------------------------------------------------------------------
+//  `find` + `index_name` is an exact-key lookup. With `limit == 0` the
+//  helper must still return only the matching row — pagination past a
+//  single-key match makes no sense.
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_CASE(find_with_index_returns_single_match_even_when_paginate_all,
+                        validating_tester) try {
+   deploy_contract(*this);
+   populate_numobjs(*this, 5); // keys/sec64 = 0..4
+
+   auto p = numobjs_params();
+   p.find        = R"({"bysec1":3})";
+   p.index_name  = "bysec1";
+   p.limit       = 0; // should not loop past the single match
+   p.unwrap_rows = true;
+
+   auto ro  = make_read_only(*this);
+   auto res = run(ro, p);
+
+   BOOST_REQUIRE_EQUAL(res.rows.size(), 1u);
+   BOOST_CHECK_EQUAL(res.rows[0].get_object()["sec64"].as_uint64(), 3u);
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_get_table_rows_page.cpp
+++ b/tests/test_get_table_rows_page.cpp
@@ -1,15 +1,16 @@
 /**
  * @file test_get_table_rows_page.cpp
- * @brief Unit tests for `chain_apis::read_only::get_table_rows` behaviours layered over `get_table_rows_page`.
+ * @brief Unit tests for `chain_apis::read_only::get_table_rows` covering the wrapper-level fields on
+ *        `get_table_rows_params` (the suite is named `table_reader_tests`).
  *
- * These cases pin down the wrapper-level fields on `get_table_rows_params`:
+ * These cases pin down:
  *
  * - `all_rows` walks the entire scan in a single call, ignoring `limit`, `time_limit_ms`, and the caller deadline.
  *   C++-only (not FC_REFLECT'd) so HTTP cannot trigger unbounded server work.
  * - `values_only` strips the `{key, value, payer?}` wrapper, returning just the value side of each row.
  * - `filter` drops rows post-`values_only`; the predicate sees the same shape the caller will consume.
- * - `reverse` + a small `limit` returns the latest N rows without skipping a row at every page boundary (the
- *   reverse-off-by-one fix in `get_table_rows_page`).
+ * - `reverse` + a small `limit` returns the latest N rows without skipping a row at every page boundary (pins the
+ *   reverse-off-by-one fix).
  *
  * Each case uses the `get_table_test` multi_index contract already wired up for `get_table_tests.cpp`.
  */
@@ -189,6 +190,35 @@ BOOST_FIXTURE_TEST_CASE(reverse_with_limit_returns_latest, validating_tester) tr
    BOOST_CHECK_EQUAL(res.rows[0].get_object()["key"].as_uint64(), 11u);
    BOOST_CHECK_EQUAL(res.rows[1].get_object()["key"].as_uint64(), 10u);
    BOOST_CHECK_EQUAL(res.rows[2].get_object()["key"].as_uint64(),  9u);
+} FC_LOG_AND_RETHROW()
+
+// `all_rows` + `values_only` + `filter` composed together. Pins the interaction: the full scan runs, each row is
+// unwrapped, and the filter sees the unwrapped shape. Independent coverage exists for each flag above, but this
+// test catches future regressions where (say) the filter runs before unwrap or limit/deadline sneak back in under
+// `all_rows`.
+BOOST_FIXTURE_TEST_CASE(all_rows_with_values_only_and_filter_composed, validating_tester) try {
+   deploy_contract(*this);
+   populate_numobjs(*this, 20); // keys/sec64 = 0..19
+
+   auto p = numobjs_params();
+   p.all_rows    = true;
+   p.values_only = true;
+   p.filter = [](const fc::variant& row) {
+      // Predicate sees the unwrapped value; expects `sec64` directly on the row (no `value` wrapper).
+      return (row.get_object()["sec64"].as_uint64() % 2) == 0;
+   };
+
+   auto ro  = make_read_only(*this);
+   auto res = run(ro, p);
+
+   BOOST_REQUIRE_EQUAL(res.rows.size(), 10u); // 0, 2, 4, ..., 18
+   for (size_t i = 0; i < res.rows.size(); ++i) {
+      // Unwrapped: no `value` key, field is directly on the row.
+      BOOST_CHECK(!res.rows[i].get_object().contains("value"));
+      BOOST_CHECK_EQUAL(res.rows[i].get_object()["sec64"].as_uint64(), i * 2);
+   }
+   BOOST_CHECK(!res.more);
+   BOOST_CHECK(res.next_key.empty());
 } FC_LOG_AND_RETHROW()
 
 // `reverse` + `all_rows` walks the table from highest to lowest key with no skips. The page-impl's reverse branch


### PR DESCRIPTION
## Summary
- Fold `limit == 0` = paginate-all, `unwrap_rows`, and a `filter` predicate into `chain_apis::read_only::get_table_rows`; the original body moves to a single-page primitive `get_table_rows_page`. HTTP callers on the default `limit=50` / no-filter / no-unwrap path take a fast-path forward with zero added indirection.
- Fix a one-row skip at every reverse-page boundary: the wrapper resumes reverse scans using the last returned row's `key` (exclusive `upper_bound`) instead of `next_key` (which points at the first *unseen* row and would be excluded by the exclusive bound).
- `batch_operator_plugin` and `underwriter_plugin` drop their hand-rolled `read_table` pagination/filter/unwrap helpers. Plugin call sites now construct `get_table_rows_params` directly and go through a ~10-line plumbing wrapper that just binds each plugin's timeout. Underwriter gains two indexed queries: `parse_swap_from_attestation` (primary-key `find` on `attestations.id`) and `scan_pending_requests` (`bystatus` range on `uwreqs` for `UNDERWRITE_REQUEST_STATUS_PENDING`).
- Fixes the deterministic epoch-25 → 26 stall in `wire-test-cluster`: the old batch operator read clipped to 50 rows, so once `outenvelopes` had 2 outposts × 25 epochs = 50 rows, epoch-26 envelopes at ids 50-51 were invisible and delivery stopped forever.
- `CLAUDE.md` "Enums over raw values" now mandates `magic_enum::enum_integer|enum_name|enum_value|enum_cast` instead of `static_cast` / hand-rolled tables, with the single exception of protobuf-generated enums (keep using the generated `<Enum>_Name` / `<Enum>_Parse`).

See the commit message (`ff752fd2`) for the line-level walk-through and rationale.

## Test plan
- [ ] `cmake --build build -- -j$(nproc)` — `all` target builds (nodeop, contracts, plugin_test, unit_test, contracts_unit_test, test_fc, per-plugin tests).
- [ ] `./build/tests/plugin_test --run_test=table_reader_tests` — 8/8 green (default wrapped single page, `limit==0` pagination across internal 100-row pages, `unwrap_rows`, `filter` after unwrap, `reverse` + small `limit` latest-N, `reverse` + `limit==0` multi-page without skips, empty-table, `find`+`index_name` exits on single match even with `limit==0`).
- [ ] `./build/plugins/batch_operator_plugin/test_batch_operator_plugin` — 21/21 green.
- [ ] `./build/plugins/underwriter_plugin/test_underwriter_plugin` — 3/3 green.
- [ ] `./build/tests/plugin_test --run_test=get_table_tests` — existing suite unaffected (HTTP fast path preserved).
- [ ] Live validation on a fresh `wire-test-cluster` (`--prod-count=5 --batch-operators=3 --underwriters=1 --epoch-duration=60`): epochs 25 → 26 → 27 advance on 60s cadence; zero `no pending outbound for epoch 2X` log lines; `outenvelopes` grows past 50 rows without stalling delivery. (Passed on dev-023 with the refactored binary; confirmed via batch-op log line `batch_operator_plugi:386 do_poll_epoch_state ELECTED for epoch 27`.)