### PR TITLE
Fix get_table_rows reverse pagination and secondary next_key format

### DIFF
--- a/plugins/chain_plugin/src/chain_plugin.cpp
+++ b/plugins/chain_plugin/src/chain_plugin.cpp
@@ -1869,6 +1869,29 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
          return r;
       };
 
+      // Format a secondary-index `next_key` value. When `p.json` is set, emit
+      // a JSON object matching the bound syntax (e.g. `{"byowner":"u4"}`) so
+      // `upper_bound = next_key` round-trips through the bound parser, which
+      // expects JSON when `p.json` is set. Otherwise emit hex of the raw sk
+      // bytes. Falls back to hex on any decode failure.
+      auto emit_secondary_next_key = [&](std::string_view sk) {
+         if (p.json) {
+            try {
+               std::string_view sv = sk;
+               if (!scope_prefix_bytes.empty() && sv.size() >= scope_prefix_bytes.size()) {
+                  sv.remove_prefix(scope_prefix_bytes.size());
+               }
+               auto key_var = chain::be_key_codec::decode_key(sv.data(), sv.size(),
+                                                              bound_key_names, bound_key_types);
+               hp.next_key = fc::json::to_string(key_var, fc::time_point::maximum());
+               return;
+            } catch (...) {
+               // fall through to hex
+            }
+         }
+         hp.next_key = fc::to_hex(sk.data(), sk.size());
+      };
+
       if (!reverse) {
          auto itr = sec_idx.lower_bound(boost::make_tuple(p.code, sec_tid, lb_sv));
          uint32_t count = 0;
@@ -1877,7 +1900,7 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
             if (has_upper && sk >= ub_sv) break;
             if (count >= limit) {
                hp.more = true;
-               hp.next_key = fc::to_hex(sk.data(), sk.size());
+               emit_secondary_next_key(sk);
                break;
             }
             hp.rows.push_back(fetch_primary(*itr));
@@ -1886,14 +1909,21 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
             if (fc::time_point::now() >= params_deadline) {
                if (itr != sec_idx.end() && itr->code == p.code && itr->table_id == sec_tid) {
                   hp.more = true;
-                  auto next_sk = itr->sec_key_view();
-                  hp.next_key = fc::to_hex(next_sk.data(), next_sk.size());
+                  emit_secondary_next_key(itr->sec_key_view());
                }
                break;
             }
          }
       } else {
-         // Reverse iteration
+         // Reverse iteration.
+         //
+         // Resume cursor semantics: `next_key` is the LAST RETURNED row's sk,
+         // not the first unseen row's sk. Callers resume with
+         // `upper_bound = next_key`; since `upper_bound` is exclusive and the
+         // reverse loop starts at `lower_bound(upper_bound)` then `--itr`, the
+         // next page yields the first row strictly below the last returned
+         // one -- i.e. the first unseen row. Setting `next_key` to the first
+         // unseen row's sk instead would skip that row at every page boundary.
          decltype(sec_idx.end()) itr;
          if (has_upper) {
             itr = sec_idx.lower_bound(boost::make_tuple(p.code, sec_tid, ub_sv));
@@ -1902,6 +1932,12 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
          }
          auto begin = sec_idx.lower_bound(boost::make_tuple(p.code, sec_tid, lb_sv));
          uint32_t count = 0;
+         // Remember the last-returned row's sec_key bytes so the cutoff
+         // branches below can feed them to `emit_secondary_next_key`.
+         std::vector<char> last_added_sk_bytes;
+         auto last_added_sv = [&]() {
+            return std::string_view(last_added_sk_bytes.data(), last_added_sk_bytes.size());
+         };
          if (itr != begin) {
             do {
                --itr;
@@ -1909,20 +1945,19 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
                auto sk = itr->sec_key_view();
                if (!lb_bytes.empty() && sk < lb_sv) break;
                if (count >= limit) {
-                  hp.more = true;
-                  hp.next_key = fc::to_hex(sk.data(), sk.size());
+                  if (!last_added_sk_bytes.empty()) {
+                     hp.more = true;
+                     emit_secondary_next_key(last_added_sv());
+                  }
                   break;
                }
                hp.rows.push_back(fetch_primary(*itr));
+               last_added_sk_bytes.assign(sk.data(), sk.data() + sk.size());
                ++count;
                if (fc::time_point::now() >= params_deadline) {
                   if (itr != begin) {
-                     auto prev = itr; --prev;
-                     if (prev->code == p.code && prev->table_id == sec_tid) {
-                        hp.more = true;
-                        auto prev_sk = prev->sec_key_view();
-                        hp.next_key = fc::to_hex(prev_sk.data(), prev_sk.size());
-                     }
+                     hp.more = true;
+                     emit_secondary_next_key(last_added_sv());
                   }
                   break;
                }
@@ -2045,6 +2080,9 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
 
       if (itr != begin) {
          uint32_t count = 0;
+         // Resume cursor is the LAST RETURNED row, not the first unseen. See
+         // the secondary-index reverse branch above for the full rationale.
+         auto last_added_itr = kv_idx.end();
          do {
             --itr;
             if (itr->code != p.code || itr->table_id != table_id)
@@ -2055,8 +2093,10 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
                break;
 
             if (count >= limit) {
-               hp.more = true;
-               collect_next_key(*itr);
+               if (last_added_itr != kv_idx.end()) {
+                  hp.more = true;
+                  collect_next_key(*last_added_itr);
+               }
                break;
             }
 
@@ -2065,6 +2105,7 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
             row.value.assign(itr->value.data(), itr->value.data() + itr->value.size());
             row.payer = itr->payer;
             hp.rows.emplace_back(std::move(row));
+            last_added_itr = itr;
 
             ++count;
             if (itr == begin) {
@@ -2073,17 +2114,8 @@ read_only::get_table_rows( const read_only::get_table_rows_params& p, const fc::
             }
 
             if (fc::time_point::now() >= params_deadline) {
-               if (itr != begin) {
-                  auto prev = itr;
-                  --prev;
-                  if (prev->code == p.code && prev->table_id == table_id) {
-                     auto prev_kv = prev->key_view();
-                     if (lb_bytes.empty() || prev_kv >= lb_sv) {
-                        hp.more = true;
-                        collect_next_key(*prev);
-                     }
-                  }
-               }
+               hp.more = true;
+               collect_next_key(*last_added_itr);
                break;
             }
          } while (true);

--- a/tests/get_kv_rows_test.py
+++ b/tests/get_kv_rows_test.py
@@ -191,21 +191,26 @@ try:
     # ---------------------------------------------------------------
     # Test 6: Reverse pagination
     # ---------------------------------------------------------------
+    # In reverse mode, next_key is the LAST RETURNED row's key. Callers
+    # resume with upper_bound = next_key (exclusive), which yields the
+    # first row strictly below -- i.e. the next previously unseen row.
+    # Four rows reverse with limit=2 yields two pages:
+    #   [us-west, us-east], [eu-west, ap-south].
     Print("Test 6: Reverse pagination with limit=2")
     page1 = get_table_rows({"code": "kvmap", "table": "geodata", "limit": 2, "reverse": True})
+    Print(f"  Page 1 (reverse): {[r['key']['region'] for r in page1['rows']]}, next_key={page1['next_key']}")
     assert len(page1["rows"]) == 2
     assert page1["more"] == True
-    Print(f"  Page 1 (reverse): {[r['key']['region'] for r in page1['rows']]}, next_key={page1['next_key']}")
+    assert [r["key"]["region"] for r in page1["rows"]] == ["us-west", "us-east"], \
+        f"Page 1 region mismatch: {[r['key']['region'] for r in page1['rows']]}"
 
-    # In reverse mode, next_key is the key we stopped at; use it as upper_bound for next page
     page2 = get_table_rows({"code": "kvmap", "table": "geodata", "limit": 2,
                           "reverse": True, "upper_bound": page1["next_key"]})
     Print(f"  Page 2 (reverse): {[r['key']['region'] for r in page2['rows']]}")
-    assert len(page2["rows"]) == 1, f"Page 2 expected 1 row, got {len(page2['rows'])}"
-    # us-west, us-east from page1; eu-west from page2; ap-south excluded by upper_bound
-    # Actually: reverse with upper_bound=eu-west means we iterate backward from before eu-west
-    # ap-south is the only entry < eu-west
-    assert page2["rows"][0]["key"]["region"] == "ap-south"
+    assert len(page2["rows"]) == 2, f"Page 2 expected 2 rows, got {len(page2['rows'])}"
+    assert [r["key"]["region"] for r in page2["rows"]] == ["eu-west", "ap-south"], \
+        f"Page 2 region mismatch: {[r['key']['region'] for r in page2['rows']]}"
+    assert page2["more"] == False
     Print("  PASSED")
 
     testSuccessful = True

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -643,18 +643,12 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
       BOOST_CHECK_EQUAL(page1.rows[0].get_object()["value"].get_object()["sec64"].as_uint64(), 2u);
       BOOST_CHECK_EQUAL(page1.rows[1].get_object()["value"].get_object()["sec64"].as_uint64(), 5u);
 
-      // next_key for secondary queries is the secondary key bytes (hex). Use
-      // it as lower_bound on a json=false call so the bytes are interpreted
-      // directly without re-encoding.
-      chain_apis::read_only::get_table_rows_params p2;
-      p2.json = false;
-      p2.code = "test"_n;
-      p2.scope = "test";
-      p2.table = "numobjs";
-      p2.index_name = "bysec1";
-      p2.lower_bound = page1.next_key;
-      p2.limit = 50;
-      auto page2 = get_table_rows_full(plugin, p2, fc::time_point::maximum());
+      // With `p.json = true`, `next_key` for secondary queries is a JSON
+      // object matching the bound syntax. Feed it back directly as
+      // `lower_bound` on another json=true call for seamless pagination.
+      p.lower_bound = page1.next_key;
+      p.limit       = 50;
+      auto page2 = get_table_rows_full(plugin, p, fc::time_point::maximum());
       BOOST_REQUIRE_EQUAL(page2.rows.size(), 1u);
       BOOST_REQUIRE_EQUAL(page2.more, false);
    }
@@ -1094,50 +1088,241 @@ BOOST_FIXTURE_TEST_CASE( get_kv_rows_basic_test, validating_tester ) try {
 
 } FC_LOG_AND_RETHROW()
 
+// Shared setup for the two primary-index reverse-pagination tests below.
+// `test_kv_sec_query` primary is a single-field uint64 `id`. Seeds ids 1..5.
+static void setup_kvrev_primary(validating_tester& t, account_name acct) {
+   t.produce_block();
+   t.create_accounts({acct});
+   t.produce_block();
+   t.set_code(acct, test_contracts::test_kv_sec_query_wasm());
+   t.set_abi(acct,  test_contracts::test_kv_sec_query_abi());
+   t.produce_block();
+   for (uint64_t id = 1; id <= 5; ++id) {
+      t.push_action(acct, "adduser"_n, acct,
+                    mutable_variant_object()("id", id)
+                                            ("owner", std::string("u") + std::to_string(id))
+                                            ("balance", id * 100));
+   }
+   t.produce_block();
+}
+
+// Reverse pagination over a primary key with `json=true`. Pins the
+// reverse-pagination resume contract: `upper_bound = prev.next_key` must
+// walk every row exactly once with no boundary drop. `next_key` in json
+// mode is a JSON object matching the bound syntax.
+//
+// Five rows with primary ids 1..5. With limit=2 reverse, a correct scan
+// returns three pages: [5,4], [3,2], [1].
 BOOST_FIXTURE_TEST_CASE( get_kv_rows_reverse_pagination_test, validating_tester ) try {
-   produce_block();
-   create_accounts({"kvrev"_n});
-   produce_block();
-
-   set_code("kvrev"_n, test_contracts::test_kv_map_wasm());
-   set_abi("kvrev"_n, test_contracts::test_kv_map_abi());
-   produce_block();
-
-   kv_put(*this, "kvrev"_n, "a", 1, "val1", 10);
-   kv_put(*this, "kvrev"_n, "b", 1, "val2", 20);
-   kv_put(*this, "kvrev"_n, "c", 1, "val3", 30);
-   kv_put(*this, "kvrev"_n, "d", 1, "val4", 40);
-   kv_put(*this, "kvrev"_n, "e", 1, "val5", 50);
-   produce_block();
+   setup_kvrev_primary(*this, "kvrev"_n);
 
    std::optional<sysio::chain_apis::tracked_votes> _tracked_votes;
    chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes,
                                 fc::microseconds::maximum(), fc::microseconds::maximum(), {});
 
-   // Reverse pagination with limit=2
    chain_apis::read_only::get_table_rows_params p;
-   p.json = true;
-   p.code = "kvrev"_n;
-   p.table = "geodata";
-   p.limit = 2;
+   p.json    = true;
+   p.code    = "kvrev"_n;
+   p.table   = "users";
+   p.limit   = 2;
    p.reverse = true;
 
-   // Page 1 (reverse): e/1, d/1
+   auto id_of = [](const fc::variant& row) {
+      return row.get_object()["key"].get_object()["id"].as_uint64();
+   };
+
+   // Page 1: id=5, id=4. next_key = JSON form of id=4 (last returned).
    auto page1 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
    BOOST_REQUIRE_EQUAL(2u, page1.rows.size());
    BOOST_REQUIRE_EQUAL(true, page1.more);
-   BOOST_REQUIRE(!page1.next_key.empty());
-   BOOST_REQUIRE_EQUAL("e", page1.rows[0]["key"].get_object()["region"].as_string());
-   BOOST_REQUIRE_EQUAL("d", page1.rows[1]["key"].get_object()["region"].as_string());
+   BOOST_CHECK_EQUAL(5u, id_of(page1.rows[0]));
+   BOOST_CHECK_EQUAL(4u, id_of(page1.rows[1]));
+   BOOST_CHECK_EQUAL(R"({"id":4})", page1.next_key);
 
-   // Page 2 (reverse): use next_key as upper_bound
-   // next_key from page1 points to "c" (exclusive), so page2 gets b, a
+   // Page 2: id=3, id=2. `upper_bound = {"id":4}` must NOT drop id=3.
    p.upper_bound = page1.next_key;
    auto page2 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
    BOOST_REQUIRE_EQUAL(2u, page2.rows.size());
-   BOOST_REQUIRE_EQUAL(false, page2.more); // only b, a remain
-   BOOST_REQUIRE_EQUAL("b", page2.rows[0]["key"].get_object()["region"].as_string());
-   BOOST_REQUIRE_EQUAL("a", page2.rows[1]["key"].get_object()["region"].as_string());
+   BOOST_REQUIRE_EQUAL(true, page2.more);
+   BOOST_CHECK_EQUAL(3u, id_of(page2.rows[0]));
+   BOOST_CHECK_EQUAL(2u, id_of(page2.rows[1]));
+   BOOST_CHECK_EQUAL(R"({"id":2})", page2.next_key);
+
+   // Page 3: id=1. Scan exhausted.
+   p.upper_bound = page2.next_key;
+   auto page3 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(1u, page3.rows.size());
+   BOOST_REQUIRE_EQUAL(false, page3.more);
+   BOOST_REQUIRE(page3.next_key.empty());
+   BOOST_CHECK_EQUAL(1u, id_of(page3.rows[0]));
+
+} FC_LOG_AND_RETHROW()
+
+// Same contract and data as the json=true test above, but `json=false`
+// end-to-end. Pins the hex `next_key` path.
+BOOST_FIXTURE_TEST_CASE( get_kv_rows_reverse_pagination_hex_test, validating_tester ) try {
+   setup_kvrev_primary(*this, "kvrevh"_n);
+
+   auto be8_hex = [](uint64_t v) {
+      char buf[8];
+      chain::kv_encode_be64(buf, v);
+      return fc::to_hex(buf, 8);
+   };
+
+   std::optional<sysio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes,
+                                fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+
+   chain_apis::read_only::get_table_rows_params p;
+   p.json    = false;
+   p.code    = "kvrevh"_n;
+   p.table   = "users";
+   p.limit   = 2;
+   p.reverse = true;
+
+   // Page 1: id=5, id=4. next_key = hex(be64(4)).
+   auto page1 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page1.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page1.more);
+   BOOST_CHECK_EQUAL(be8_hex(5), page1.rows[0].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(4), page1.rows[1].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(4), page1.next_key);
+
+   // Page 2: id=3, id=2. next_key = hex(be64(2)).
+   p.upper_bound = page1.next_key;
+   auto page2 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page2.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page2.more);
+   BOOST_CHECK_EQUAL(be8_hex(3), page2.rows[0].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(2), page2.rows[1].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(2), page2.next_key);
+
+   // Page 3: id=1. Scan exhausted.
+   p.upper_bound = page2.next_key;
+   auto page3 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(1u, page3.rows.size());
+   BOOST_REQUIRE_EQUAL(false, page3.more);
+   BOOST_REQUIRE(page3.next_key.empty());
+   BOOST_CHECK_EQUAL(be8_hex(1), page3.rows[0].get_object()["key"].as_string());
+
+} FC_LOG_AND_RETHROW()
+
+// Shared setup for the two secondary-index reverse-pagination tests below.
+// test_kv_sec_query has a single-field uint64 primary (`id`) and a `byowner`
+// name secondary. Five users u1-u5 with id=1..5 sort in byowner ascending as
+// u1, u2, u3, u4, u5; reverse walks them u5, u4, u3, u2, u1.
+static void setup_secrev(validating_tester& t, account_name acct) {
+   t.produce_block();
+   t.create_accounts({acct});
+   t.produce_block();
+   t.set_code(acct, test_contracts::test_kv_sec_query_wasm());
+   t.set_abi(acct,  test_contracts::test_kv_sec_query_abi());
+   t.produce_block();
+   for (uint64_t id = 1; id <= 5; ++id) {
+      t.push_action(acct, "adduser"_n, acct,
+                    mutable_variant_object()("id", id)
+                                            ("owner", std::string("u") + std::to_string(id))
+                                            ("balance", id * 100));
+   }
+   t.produce_block();
+}
+
+// Reverse pagination over a secondary index with `json=true`. Exercises the
+// secondary-index reverse branch AND the JSON next_key path: `upper_bound =
+// prev.next_key` must round-trip through the bound parser (which expects
+// JSON when `p.json` is set), and must not drop a row at each page boundary.
+BOOST_FIXTURE_TEST_CASE( get_kv_rows_reverse_pagination_secondary_test, validating_tester ) try {
+   setup_secrev(*this, "secrev"_n);
+
+   std::optional<sysio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes,
+                                fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+
+   chain_apis::read_only::get_table_rows_params p;
+   p.json       = true;
+   p.code       = "secrev"_n;
+   p.table      = "users";
+   p.index_name = "byowner";
+   p.limit      = 2;
+   p.reverse    = true;
+
+   auto owner_of = [](const fc::variant& row) {
+      return row.get_object()["value"].get_object()["owner"].as_string();
+   };
+
+   // Page 1: rows for u5, u4. next_key = JSON form of the byowner key for u4.
+   auto page1 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page1.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page1.more);
+   BOOST_CHECK_EQUAL("u5", owner_of(page1.rows[0]));
+   BOOST_CHECK_EQUAL("u4", owner_of(page1.rows[1]));
+   BOOST_CHECK_EQUAL(R"({"byowner":"u4"})", page1.next_key);
+
+   // Page 2: u3, u2. `upper_bound = {"byowner":"u4"}` must NOT drop u3.
+   p.upper_bound = page1.next_key;
+   auto page2 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page2.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page2.more);
+   BOOST_CHECK_EQUAL("u3", owner_of(page2.rows[0]));
+   BOOST_CHECK_EQUAL("u2", owner_of(page2.rows[1]));
+   BOOST_CHECK_EQUAL(R"({"byowner":"u2"})", page2.next_key);
+
+   // Page 3: u1. Scan exhausted.
+   p.upper_bound = page2.next_key;
+   auto page3 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(1u, page3.rows.size());
+   BOOST_REQUIRE_EQUAL(false, page3.more);
+   BOOST_REQUIRE(page3.next_key.empty());
+   BOOST_CHECK_EQUAL("u1", owner_of(page3.rows[0]));
+} FC_LOG_AND_RETHROW()
+
+// Same as above but with `json=false` end-to-end. Pins the hex next_key
+// path for secondary-index reverse pagination.
+BOOST_FIXTURE_TEST_CASE( get_kv_rows_reverse_pagination_secondary_hex_test, validating_tester ) try {
+   setup_secrev(*this, "secrevh"_n);
+
+   auto be8_hex = [](uint64_t v) {
+      char buf[8];
+      chain::kv_encode_be64(buf, v);
+      return fc::to_hex(buf, 8);
+   };
+   auto owner_sk_hex = [&](const char* owner) {
+      return be8_hex(chain::name(owner).to_uint64_t());
+   };
+
+   std::optional<sysio::chain_apis::tracked_votes> _tracked_votes;
+   chain_apis::read_only plugin(*(this->control), {}, {}, _tracked_votes,
+                                fc::microseconds::maximum(), fc::microseconds::maximum(), {});
+
+   chain_apis::read_only::get_table_rows_params p;
+   p.json       = false;
+   p.code       = "secrevh"_n;
+   p.table      = "users";
+   p.index_name = "byowner";
+   p.limit      = 2;
+   p.reverse    = true;
+
+   auto page1 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page1.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page1.more);
+   BOOST_CHECK_EQUAL(be8_hex(5),            page1.rows[0].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(4),            page1.rows[1].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(owner_sk_hex("u4"),    page1.next_key);
+
+   p.upper_bound = page1.next_key;
+   auto page2 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(2u, page2.rows.size());
+   BOOST_REQUIRE_EQUAL(true, page2.more);
+   BOOST_CHECK_EQUAL(be8_hex(3),            page2.rows[0].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(be8_hex(2),            page2.rows[1].get_object()["key"].as_string());
+   BOOST_CHECK_EQUAL(owner_sk_hex("u2"),    page2.next_key);
+
+   p.upper_bound = page2.next_key;
+   auto page3 = get_table_rows_kv(plugin, p, fc::time_point::maximum());
+   BOOST_REQUIRE_EQUAL(1u, page3.rows.size());
+   BOOST_REQUIRE_EQUAL(false, page3.more);
+   BOOST_REQUIRE(page3.next_key.empty());
+   BOOST_CHECK_EQUAL(be8_hex(1),            page3.rows[0].get_object()["key"].as_string());
 
 } FC_LOG_AND_RETHROW()
 


### PR DESCRIPTION
Two related fixes to `read_only::get_table_rows`.

(1) Reverse off-by-one. Reverse iteration set `next_key` to the first unseen row's key. Since callers resume with `upper_bound = next_key` and `upper_bound` is exclusive, the reverse loop starts at `lower_bound(upper_bound)` then `--itr` and yields the first row strictly below next_key -- so next_key itself was skipped. Each reverse page boundary dropped one row. Fix: in reverse, `next_key` is now the LAST RETURNED row's key. `upper_bound = next_key` yields the first previously unseen row on the next page. Applies to both primary- and secondary-index reverse branches; forward is unchanged (lower_bound is inclusive).

Example (keys 1..5, reverse, limit=2): pre-fix [5,4] -> [2,1] (3 dropped); post-fix [5,4] -> [3,2] -> [1] (every row exactly once).

(2) Secondary index next_key format. Secondary `next_key` was always hex of the raw sec_key bytes, regardless of `p.json`. But the bound parser expects JSON when `p.json` is set, so `upper_bound = next_key` did not round-trip on json=true. Fix: when `p.json` is set, secondary `next_key` is now a JSON object matching the bound syntax (e.g. `{"byowner":"u4"}`), decoded via `be_key_codec::decode_key` over `{si.name, si.key_type}` after stripping any scope prefix. Falls back to hex on decode failure. Hex behavior is preserved for json=false.

Tests: primary and secondary reverse pagination over 5 rows with limit=2, mirrored json=true and json=false cases (four test cases total). `get_table_next_key_test` (sec-6) updated to use the natural json=true round-trip instead of the old json=true -> json=false hex workaround.