### PR TITLE
chain_plugin: run read_table_rows inline on main thread

### DIFF
--- a/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/sysio/chain_plugin/chain_plugin.hpp
@@ -668,11 +668,20 @@ public:
    chain_apis::read_write get_read_write_api(const fc::microseconds& http_max_response_time);
    chain_apis::read_only get_read_only_api(const fc::microseconds& http_max_response_time) const;
 
-   /// Runs a `get_table_rows` scan on the app executor's read_only queue and blocks the caller on the result. The
-   /// scan runs during the controller's read window, avoiding races with block apply that would occur if the caller
-   /// iterated chainbase directly from its own thread. `shutdown_flag` is polled every 200ms so the caller returns
-   /// early on plugin shutdown instead of stalling up to `timeout` for the executor to drain. `log_prefix` is a
-   /// short tag (plugin name) used in error log lines.
+   /// Runs a `get_table_rows` scan and returns its result.
+   ///
+   /// When called off the main app thread (typical case: a cron worker), the scan is posted onto the executor's
+   /// read_only queue and the calling thread blocks on the result. Running through the queue ensures chainbase
+   /// iteration happens during the controller's read window, avoiding races with block apply.
+   ///
+   /// When called from the main app thread (e.g. during `plugin_startup`), the scan runs inline. Posting + waiting
+   /// would deadlock there because the main thread is the very thread that drains the queue; running inline is safe
+   /// because the read-window discipline is already satisfied (write window: main thread is the sole chainbase
+   /// mutator; read window: main thread is one of the legitimate readers).
+   ///
+   /// `shutdown_flag` is polled every 200ms on the off-thread path so the caller returns early on plugin shutdown
+   /// instead of stalling up to `timeout` for the executor to drain. `log_prefix` is a short tag (plugin name) used
+   /// in error log lines.
    chain_apis::read_only::get_table_rows_result
    read_table_rows(chain_apis::read_only::get_table_rows_params params,
                    fc::microseconds timeout,

--- a/plugins/chain_plugin/src/chain_plugin.cpp
+++ b/plugins/chain_plugin/src/chain_plugin.cpp
@@ -1355,6 +1355,45 @@ chain_plugin::read_table_rows(chain_apis::read_only::get_table_rows_params param
    using result_t = chain_apis::read_only::get_table_rows_result;
    const auto deadline = fc::time_point::now() + timeout;
 
+   // Performs the actual chainbase scan and converts the result variant into a
+   // `get_table_rows_result`. Any exception path or embedded fc::exception_ptr is logged and
+   // collapsed to an empty result so the caller observes a single "no rows" outcome regardless
+   // of how the read failed. `log_prefix` is captured by value because this lambda is moved
+   // into the posted task below and may outlive the outer stack frame on timeout/shutdown.
+   auto run_scan = [this, log_prefix, timeout, deadline](
+      chain_apis::read_only::get_table_rows_params& p) -> result_t {
+      try {
+         auto ro      = get_read_only_api(timeout);
+         auto variant = ro.get_table_rows(p, deadline)();
+         if (auto* err = std::get_if<fc::exception_ptr>(&variant)) {
+            elog("{}: table read failed {}::{} -- {}",
+                 log_prefix, p.code.to_string(), p.table, (*err)->to_string());
+            return {};
+         }
+         return std::get<result_t>(std::move(variant));
+      } catch (const fc::exception& e) {
+         elog("{}: table read threw {}::{} -- {}",
+              log_prefix, p.code.to_string(), p.table, e.to_string());
+      } catch (const std::exception& e) {
+         elog("{}: table read threw {}::{} -- {}",
+              log_prefix, p.code.to_string(), p.table, e.what());
+      } catch (...) {
+         elog("{}: table read threw unknown exception {}::{}",
+              log_prefix, p.code.to_string(), p.table);
+      }
+      return {};
+   };
+
+   // Main-thread fast path: posting onto the executor and then blocking the main thread on the
+   // future would deadlock during `plugin_startup` (write window is the default, the read pool
+   // is not yet active, and `application::exec()` has not started its loop, so nothing drains
+   // the read_only queue while we wait). Running inline is safe because the read-window
+   // discipline is already satisfied: in the write window the main thread is the sole chainbase
+   // mutator, and in the read window the main thread is one of the legitimate readers.
+   if (std::this_thread::get_id() == app().executor().get_main_thread_id()) {
+      return run_scan(params);
+   }
+
    // Pre-capture log fields; `params` is moved into the posted lambda below, so the outer error paths cannot read
    // from it.
    const std::string log_code  = params.code.to_string();
@@ -1369,30 +1408,8 @@ chain_plugin::read_table_rows(chain_apis::read_only::get_table_rows_params param
    // `shutdown_plugins()` and `destroy_plugins()` (see `libraries/appbase/include/appbase/application_base.hpp`),
    // so any lambda still queued when the plugin impl is about to be destroyed is destructed first.
    app().executor().post(appbase::priority::medium, appbase::exec_queue::read_only,
-      [this, params = std::move(params), deadline, timeout, prom, log_prefix]() mutable {
-         try {
-            auto ro      = get_read_only_api(timeout);
-            auto variant = ro.get_table_rows(params, deadline)();
-            if (auto* err = std::get_if<fc::exception_ptr>(&variant)) {
-               elog("{}: table read failed {}::{} -- {}",
-                    log_prefix, params.code.to_string(), params.table, (*err)->to_string());
-               prom->set_value({});
-            } else {
-               prom->set_value(std::get<result_t>(std::move(variant)));
-            }
-         } catch (const fc::exception& e) {
-            elog("{}: table read threw {}::{} -- {}",
-                 log_prefix, params.code.to_string(), params.table, e.to_string());
-            prom->set_value({});
-         } catch (const std::exception& e) {
-            elog("{}: table read threw {}::{} -- {}",
-                 log_prefix, params.code.to_string(), params.table, e.what());
-            prom->set_value({});
-         } catch (...) {
-            elog("{}: table read threw unknown exception {}::{}",
-                 log_prefix, params.code.to_string(), params.table);
-            prom->set_value({});
-         }
+      [params = std::move(params), prom, run_scan = std::move(run_scan)]() mutable {
+         prom->set_value(run_scan(params));
       });
 
    // Poll every 200ms so we can abandon the wait if the caller is shutting down or if the deadline expires before


### PR DESCRIPTION
`read_table_rows` posts onto the executor's read_only queue and blocks the caller on the future. From a main-thread context (e.g. a plugin's `plugin_startup`), the main thread is the only drain for that queue during write window, so the post sits until the deadline and returns empty rows. This silently broke `batch_operator_plugin::refresh_outposts` at startup -- the cron pool came up sized for zero OPP jobs.

When `std::this_thread::get_id() == executor().get_main_thread_id()`, run the scan inline; the read-window discipline is already satisfied on the main thread. Off-thread callers keep the post + wait path so cron threads still iterate chainbase during the read window. Scan body is factored into a `run_scan` lambda shared by both paths.

Follow-on to #312.