### PR TITLE
Copyable wrapper over std::move_only_function for next_function

### DIFF
--- a/libraries/chain/include/sysio/chain/types.hpp
+++ b/libraries/chain/include/sysio/chain/types.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <deque>
 #include <cstdint>
+#include <functional>
 
 #define OBJECT_CTOR1(NAME) \
     public: \
@@ -507,13 +508,21 @@ namespace sysio::chain {
    template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
    template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
-   // next_function is a function passed to an API (like send_transaction) and which is called at the end of
-   // the API processing on the main thread. The type T is a description of the API result that can be
+   // next_function is a function passed to an API (like send_transaction) and which is called at the end
+   // of the API processing on the main thread. The type T is a description of the API result that can be
    // serialized as output.
    // The function accepts a variant which can contain an exception_ptr (if an exception occured while
    // processing the API) or the result T.
    // The third option is a function which can be executed in a multithreaded context (likely on the
    // http_plugin thread pool) and which completes the API processing and returns the result T.
+   //
+   // The user-provided callable is held inside a std::move_only_function so consume-on-call captures
+   // (e.g. [cb = std::move(cb)] mutable {...}) work correctly. The outer wrapper is copyable via a
+   // shared_ptr indirection - required because the callback travels through paths that copy
+   // (boost::signals2 slot dispatch, boost::multi_index value storage, lambdas captured by [=],
+   // CATCH_AND_CALL fallbacks held alongside an async capture in the same scope). All copies share
+   // the same underlying callable; if the underlying lambda consumes its captures, calling through
+   // any copy after the first invocation reaches an exhausted state.
    // -------------------------------------------------------------------------------------------------------
    template<typename T>
    using t_or_exception = std::variant<T, fc::exception_ptr>;
@@ -522,7 +531,30 @@ namespace sysio::chain {
    using next_function_variant = std::variant<fc::exception_ptr, T, std::function<t_or_exception<T>()>>;
 
    template<typename T>
-   using next_function = std::function<void(const next_function_variant<T>&)>;
+   class next_function {
+   public:
+      using element_type = std::move_only_function<void(const next_function_variant<T>&)>;
+
+      next_function() = default;
+      next_function(std::nullptr_t) noexcept {}
+
+      template<typename F>
+         requires (!std::is_same_v<std::decay_t<F>, next_function>)
+      next_function(F&& f)
+         : _f(std::make_shared<element_type>(std::forward<F>(f))) {}
+
+      void operator()(const next_function_variant<T>& v) const {
+         if (!_f || !*_f) [[unlikely]] {
+            throw std::bad_function_call();
+         }
+         (*_f)(v);
+      }
+
+      explicit operator bool() const noexcept { return _f && static_cast<bool>(*_f); }
+
+   private:
+      std::shared_ptr<element_type> _f;
+   };
 
    // to configure whether a process should be done asynchronously or not
    enum class async_t { no, yes };

--- a/libraries/chain/include/sysio/chain/types.hpp
+++ b/libraries/chain/include/sysio/chain/types.hpp
@@ -523,6 +523,15 @@ namespace sysio::chain {
    // CATCH_AND_CALL fallbacks held alongside an async capture in the same scope). All copies share
    // the same underlying callable; if the underlying lambda consumes its captures, calling through
    // any copy after the first invocation reaches an exhausted state.
+   //
+   // Invocation contract (load-bearing):
+   //   * Exactly one invocation across the lifetime of all copies. Calling more than once -- whether
+   //     through one copy or across copies -- is undefined: the underlying move_only_function may
+   //     have already moved out its captures.
+   //   * Single-threaded invocation. operator() is declared const but mutates the shared
+   //     move_only_function; concurrent invocation across copies on different threads is a data race.
+   //     The bind_stream / chain_plugin response paths hand the callback off to one thread (typically
+   //     the http pool) where the single invocation runs; the producing thread must not also invoke.
    // -------------------------------------------------------------------------------------------------------
    template<typename T>
    using t_or_exception = std::variant<T, fc::exception_ptr>;
@@ -533,7 +542,11 @@ namespace sysio::chain {
    template<typename T>
    class next_function {
    public:
-      using element_type = std::move_only_function<void(const next_function_variant<T>&)>;
+      // Rvalue-ref signature lets the consuming closure move the payload out of the variant
+      // (`std::get<T>(std::move(v))`) instead of copying.  Lvalue callers must explicitly
+      // std::move; this is a deliberate compile-time forcing function rather than a silent
+      // copy at the by-value parameter boundary.
+      using element_type = std::move_only_function<void(next_function_variant<T>&&)>;
 
       next_function() = default;
       next_function(std::nullptr_t) noexcept {}
@@ -543,11 +556,11 @@ namespace sysio::chain {
       next_function(F&& f)
          : _f(std::make_shared<element_type>(std::forward<F>(f))) {}
 
-      void operator()(const next_function_variant<T>& v) const {
+      void operator()(next_function_variant<T>&& v) const {
          if (!_f || !*_f) [[unlikely]] {
             throw std::bad_function_call();
          }
-         (*_f)(v);
+         (*_f)(std::move(v));
       }
 
       explicit operator bool() const noexcept { return _f && static_cast<bool>(*_f); }

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -201,9 +201,12 @@ void snapshot_scheduler::create_snapshot(next_function<snapshot_information> nex
    if(existing != pending_by_id.end()) {
       // if a snapshot at this block is already pending, attach this requests handler to it
       pending_by_id.modify(existing, [&next](auto& entry) {
-         entry.next = [prev = entry.next, next](const next_function_variant<snapshot_information>& res) {
-            prev(res);
-            next(res);
+         entry.next = [prev = entry.next, next](next_function_variant<snapshot_information>&& res) {
+            // Fan-out to two next_functions: each must receive its own variant copy
+            // so neither sees a moved-from value.  next_function::operator() is
+            // rvalue-only, so the copy is required and visible.
+            prev(next_function_variant<snapshot_information>{res});
+            next(std::move(res));
          };
       });
    } else {

--- a/plugins/producer_plugin/src/producer_plugin.cpp
+++ b/plugins/producer_plugin/src/producer_plugin.cpp
@@ -1061,16 +1061,17 @@ public:
 
       auto is_transient = (trx_type == transaction_metadata::trx_type::read_only || trx_type == transaction_metadata::trx_type::dry_run);
       if (!is_transient) {
-         next = [this, trx, next{std::move(next)}](const next_function_variant<transaction_trace_ptr>& response) {
-            next(response);
-
+         next = [this, trx, next{std::move(next)}](next_function_variant<transaction_trace_ptr>&& response) {
+            // Extract the ack metadata (cheap shared_ptr copies) before moving the
+            // variant into the inner next; that keeps both consumers correct under
+            // the rvalue-only contract without an extra variant copy.
             fc::exception_ptr except_ptr; // rejected
             if (std::holds_alternative<fc::exception_ptr>(response)) {
                except_ptr = std::get<fc::exception_ptr>(response);
             } else if (std::get<transaction_trace_ptr>(response)->except) {
                except_ptr = std::get<transaction_trace_ptr>(response)->except->dynamic_copy_exception();
             }
-
+            next(std::move(response));
             _transaction_ack_channel.publish(priority::low, std::pair<fc::exception_ptr, packed_transaction_ptr>(except_ptr, trx));
          };
       }

--- a/plugins/producer_plugin/src/producer_plugin.cpp
+++ b/plugins/producer_plugin/src/producer_plugin.cpp
@@ -1062,17 +1062,16 @@ public:
       auto is_transient = (trx_type == transaction_metadata::trx_type::read_only || trx_type == transaction_metadata::trx_type::dry_run);
       if (!is_transient) {
          next = [this, trx, next{std::move(next)}](next_function_variant<transaction_trace_ptr>&& response) {
-            // Extract the ack metadata (cheap shared_ptr copies) before moving the
-            // variant into the inner next; that keeps both consumers correct under
-            // the rvalue-only contract without an extra variant copy.
+            // Publish before invoking next so the one-shot callback is the wrapper's last act; a throw from publish
+            // would otherwise re-enter next via the outer CATCH_AND_CALL after captures were already consumed.
             fc::exception_ptr except_ptr; // rejected
             if (std::holds_alternative<fc::exception_ptr>(response)) {
                except_ptr = std::get<fc::exception_ptr>(response);
             } else if (std::get<transaction_trace_ptr>(response)->except) {
                except_ptr = std::get<transaction_trace_ptr>(response)->except->dynamic_copy_exception();
             }
-            next(std::move(response));
             _transaction_ack_channel.publish(priority::low, std::pair<fc::exception_ptr, packed_transaction_ptr>(except_ptr, trx));
+            next(std::move(response));
          };
       }
 


### PR DESCRIPTION
## Why this change

This is prep work for a streaming/move-response pivot on the async APIs (`push_transaction`, `send_transaction`, `compute_transaction`, the read-only path, etc.). Today those callbacks are stored in a `std::function`, which forces every wrapped lambda to be copy-constructible. As soon as the response path wants to *move* the result into a streaming writer (instead of copying or going through a serialize-then-send detour) the lambda needs to capture by `std::move` and consume those captures on call - and `std::function` cannot hold such a callable.

Switching the type erasure to `std::move_only_function` fixes that, but as a bare alias it does not compile against the existing pipelines (boost::signals2, boost::multi_index, several `[=]` and `CATCH_AND_CALL` capture sites all require the outer type to be copyable). Wrapping `move_only_function` behind a shared_ptr gives the storage-side win - mutable consume-on-call captures - without rewriting the surrounding plumbing. None of the consumer sites need to change.

Doing this on master rather than on the streaming branch keeps the type change isolated and benefits any other consumer of these async APIs.

## Summary

`next_function<T>` becomes a small class holding `shared_ptr<std::move_only_function<...>>` instead of a `std::function` alias. The user-visible API matches the old alias: default-constructible, null-checkable via `operator bool`, throws `std::bad_function_call` when invoked empty.

## Why a wrapper instead of pure std::move_only_function

A direct alias swap to `std::move_only_function` was the first thing tried. The callback travels through several pipelines that need a copyable type:

- `boost::signals2`, used by `appbase::method_decl` for `incoming::methods::transaction_async` (the dispatch backing `chain_plugin::accept_transaction` and the `read_write::push_transaction` pipeline). Slot storage is `boost::function`, which copies its bound callable when forwarding through the signal pipeline. Tested with parameter forms of value, `&`, and `&&` - all fail at slot-dispatch time.
- `boost::multi_index` value storage in `unapplied_transaction_queue`, in `trx_retry_db`'s `tracked_transaction`, and in `snapshot_scheduler`'s `pending_snapshot_index`. Insertion paths use `insert(value_type)` with a default-copyable expectation.
- Many lambda captures across `chain_plugin` and `producer_plugin` that capture by `[=]` or by value, plus paired `CATCH_AND_CALL(next)` fallbacks that need access to `next` after it has been captured into an async closure.

The shared_ptr indirection keeps the outer type copyable while leaving the inner `move_only_function` move-only, so it accepts non-copyable callables. All copies of a given `next_function` share the same underlying callable.

## Performance

Per callback lifecycle:

| Phase | Before (`std::function`) | After (wrapper) |
|---|---|---|
| Construct from a lambda | 0 allocs if it fits SBO, 1 alloc otherwise | Always 1 alloc (`make_shared`) |
| Copy | Full alloc when heap-stored, byte copy when SBO | Atomic refcount bump |
| Move | Pointer swap or byte copy | Pointer swap |
| Invocation | One indirect call | Two indirect calls |
| Sizeof | ~32B (pointer + SBO buffer + manager) | 16B |

Net per request (typical: construct, 2-4 copies, one invocation): the construction cost shifts from inline-SBO to one allocation, and copies get cheaper. Multi-copy paths like `push_recurse`, the snapshot_scheduler fanout, and the read_only_trx executor chain see a real win on copies. End-to-end through `chain_plugin::push_transaction`, the wrapper cost is dominated by signature recovery, ABI serialization, and transaction execution.

## Semantic shift to flag for review

`std::function` copies are independent. Wrapper copies share state. For async-callback usage that's the desired model (one logical callback held by several lambdas in the same pipeline), and survey of the call sites did not find any code that depended on the old independence semantics. Worth a second look during review against future call sites.