### PR TITLE
Use wire-vcpkg-registry boringssl-custom 1.0.3 (drops libssl-dev runtime dep)

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
-      "baseline": "54d969e98171c7447dc07b57b3420df4ae246eb0",
+      "baseline": "23aa4018992d85602a4b5c30104a623e708b4b3e",
       "packages": [
         "boost",
         "softfloat",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -96,7 +96,7 @@
     },
     {
       "name": "boringssl-custom",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     {
       "name": "catch2",


### PR DESCRIPTION
Picks up Wire-Network/wire-vcpkg-registry#11 which adds `libssl.pc` and `libcrypto.pc` to the boringssl-custom port.

With those .pc files installed, vcpkg curl's `dependencies.patch` (`pkg_check_modules(REQUIRED libssl)` / `pkg_check_modules(REQUIRED libcrypto)`) resolves to our boringssl-custom static archives instead of falling back to a system `libssl-dev` install. Removes a latent system dependency that surfaced in CICD when curl's binary cache was invalidated by the prior boringssl-custom 1.0.1 -> 1.0.2 bump.