### PR TITLE
Fix CI asserton; fix assertions it now catches

### DIFF
--- a/.cicd/platforms/asan.Dockerfile
+++ b/.cicd/platforms/asan.Dockerfile
@@ -61,13 +61,10 @@ RUN apt-get update && apt-get upgrade -y && \
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
 
-RUN mkdir -p /opt/llvm && chmod 777 /opt/llvm
-
 # Set compiler environment variables
 ENV CC=/usr/bin/clang-18
 ENV CXX=/usr/bin/clang++-18
 ENV CMAKE_MAKE_PROGRAM=/usr/bin/ninja
-ENV CMAKE_PREFIX_PATH=/opt/llvm/llvm-11
 
 COPY <<-EOF /extras.cmake
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
@@ -79,8 +76,3 @@ EOF
 
 ENV SYSIO_PLATFORM_HAS_EXTRAS_CMAKE=1
 ENV ASAN_OPTIONS=detect_leaks=0
-
-# Copy scripts directory and run LLVM build script
-COPY scripts /scripts
-RUN chmod +x /scripts/llvm-11/llvm-11-ubuntu-build-source.sh
-RUN BASE_DIR=/opt/llvm /scripts/llvm-11/llvm-11-ubuntu-build-source.sh

--- a/.cicd/platforms/asserton.Dockerfile
+++ b/.cicd/platforms/asserton.Dockerfile
@@ -61,12 +61,9 @@ RUN apt-get update && apt-get upgrade -y && \
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
 
-RUN mkdir -p /opt/llvm && chmod 777 /opt/llvm
-
 ENV CC=/usr/bin/clang-18
 ENV CXX=/usr/bin/clang++-18
 ENV CMAKE_MAKE_PROGRAM=/usr/bin/ninja
-ENV CMAKE_PREFIX_PATH=/opt/llvm/llvm-11
 
 COPY <<-EOF /extras.cmake
   # reset the build type to empty to disable any cmake default flags
@@ -82,7 +79,3 @@ COPY <<-EOF /extras.cmake
 EOF
 
 ENV SYSIO_PLATFORM_HAS_EXTRAS_CMAKE=1
-
-COPY scripts /scripts
-RUN chmod +x /scripts/llvm-11/llvm-11-ubuntu-build-source.sh
-RUN BASE_DIR=/opt/llvm /scripts/llvm-11/llvm-11-ubuntu-build-source.sh

--- a/.cicd/platforms/asserton.Dockerfile
+++ b/.cicd/platforms/asserton.Dockerfile
@@ -73,6 +73,11 @@ COPY <<-EOF /extras.cmake
   set(CMAKE_BUILD_TYPE "" CACHE STRING "" FORCE)
   set(CMAKE_C_FLAGS "-O3" CACHE STRING "")
   set(CMAKE_CXX_FLAGS "-O3" CACHE STRING "")
+  # Workflow's command-line -DCMAKE_BUILD_TYPE=Release wins over the FORCE above,
+  # bringing back -DNDEBUG via CMAKE_*_FLAGS_RELEASE.  Force the Release flags too
+  # so asserts stay compiled regardless of which BUILD_TYPE wins.
+  set(CMAKE_C_FLAGS_RELEASE   "-O3" CACHE STRING "" FORCE)
+  set(CMAKE_CXX_FLAGS_RELEASE "-O3" CACHE STRING "" FORCE)
   set(SYSIO_ENABLE_RELEASE_BUILD_TEST "Off" CACHE BOOL "")
 EOF
 

--- a/.cicd/platforms/gcc.Dockerfile
+++ b/.cicd/platforms/gcc.Dockerfile
@@ -50,12 +50,9 @@ RUN apt-get update && apt-get upgrade -y && \
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
 
-RUN mkdir -p /opt/llvm && chmod 777 /opt/llvm
-
 ENV CC=/usr/bin/gcc-14
 ENV CXX=/usr/bin/g++-14
 ENV CMAKE_MAKE_PROGRAM=/usr/bin/ninja
-
 
 COPY <<-EOF /extras.cmake
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
@@ -66,9 +63,3 @@ COPY <<-EOF /extras.cmake
 EOF
 
 ENV SYSIO_PLATFORM_HAS_EXTRAS_CMAKE=1
-
-COPY scripts /scripts
-RUN chmod +x /scripts/llvm-11/llvm-11-ubuntu-build-source.sh
-RUN BASE_DIR=/opt/llvm /scripts/llvm-11/llvm-11-ubuntu-build-source.sh
-
-ENV CMAKE_PREFIX_PATH=/opt/llvm/llvm-11

--- a/.cicd/platforms/ubsan.Dockerfile
+++ b/.cicd/platforms/ubsan.Dockerfile
@@ -61,8 +61,6 @@ RUN apt-get update && apt-get upgrade -y && \
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
 
-RUN mkdir -p /opt/llvm && chmod 777 /opt/llvm
-
 COPY <<-EOF /ubsan.supp
   vptr:wasm_sysio_validation.hpp
   vptr:wasm_sysio_injection.hpp
@@ -71,7 +69,6 @@ EOF
 ENV CC=/usr/bin/clang-18
 ENV CXX=/usr/bin/clang++-18
 ENV CMAKE_MAKE_PROGRAM=/usr/bin/ninja
-ENV CMAKE_PREFIX_PATH=/opt/llvm/llvm-11
 
 COPY <<-EOF /extras.cmake
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "" FORCE)
@@ -83,8 +80,3 @@ EOF
 
 ENV SYSIO_PLATFORM_HAS_EXTRAS_CMAKE=1
 ENV UBSAN_OPTIONS=print_stacktrace=1,suppressions=/ubsan.supp
-
-# Copy scripts directory and run LLVM build script
-COPY scripts /scripts
-RUN chmod +x /scripts/llvm-11/llvm-11-ubuntu-build-source.sh
-RUN BASE_DIR=/opt/llvm /scripts/llvm-11/llvm-11-ubuntu-build-source.sh

--- a/.cicd/platforms/ubuntu24.Dockerfile
+++ b/.cicd/platforms/ubuntu24.Dockerfile
@@ -50,13 +50,6 @@ RUN apt-get update && apt-get upgrade -y && \
     gcc-12               \
     autoconf automake libtool libltdl-dev
 
-RUN mkdir -p /opt/llvm && chmod 777 /opt/llvm
-
 ENV CC=/usr/bin/clang-18
 ENV CXX=/usr/bin/clang++-18
 ENV CMAKE_MAKE_PROGRAM=/usr/bin/ninja
-ENV CMAKE_PREFIX_PATH=/opt/llvm/llvm-11
-
-COPY scripts /scripts
-RUN chmod +x /scripts/llvm-11/llvm-11-ubuntu-build-source.sh
-RUN BASE_DIR=/opt/llvm /scripts/llvm-11/llvm-11-ubuntu-build-source.sh

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -698,6 +698,15 @@ namespace sysio::chain {
    void transaction_context::update_billed_cpu_time( fc::time_point now ) {
       if( explicit_billed_cpu_time || is_cpu_updated ) return; // updated in init() for explicit_billed_cpu
 
+      // Read-only trxs are never billed (objective or subjective): they don't change chain state,
+      // they may legitimately have zero authorizations, and any accounts_billing accumulation here
+      // would be discarded by the read-only rollback anyway.  Implicit trxs (onblock is the only
+      // type) are objectively billed to sysio but skip the subjective path -- they're chain-generated,
+      // never appear in block->transactions (so on_block() can't clear a subjective entry), and the
+      // sysio authorizer doesn't need subjective throttling.
+      const bool bill_objectively  = !is_read_only();
+      const bool bill_subjectively = bill_objectively && !is_implicit();
+
       const int64_t cpu_sum = std::ranges::fold_left(billed_cpu_us, int64_t{0}, std::plus());
       SYS_ASSERT(cpu_sum >= 0 && cpu_sum <= std::numeric_limits<uint32_t>::max(),
                  transaction_exception,
@@ -713,41 +722,39 @@ namespace sysio::chain {
          // +1 so total is above min_transaction_cpu_usage
          int64_t delta_per_action = (( total_cpu_time_us - trace->total_cpu_usage_us ) / billed_cpu_us.size()) + 1;
          total_cpu_time_us = 0;
-         bool subjectively_bill_payer_disabled = control.get_subjective_billing().is_payer_billing_disabled();
-         auto trx_first_authorizer = packed_trx.get_transaction().first_authorizer(); // use if no authorizer
+         const bool subjectively_bill_payer_disabled = control.get_subjective_billing().is_payer_billing_disabled();
+         const auto trx_first_authorizer = packed_trx.get_transaction().first_authorizer(); // used if action has no authorizer
          for (auto&& [i, b] : std::views::enumerate(billed_cpu_us)) {
             // if exception thrown, action_traces may not be the same size as billed_cpu_us
             auto& act_trace = trace->action_traces[i];
             b.value += delta_per_action;
-            auto payer = act_trace.act.payer();
-            accounts_billing[payer].cpu_usage_us += b.value;
             total_cpu_time_us += b.value;
-            act_trace.cpu_usage_us = b.value;
-            auto first_auth = act_trace.act.first_authorizer();
-            if (first_auth.empty())
-               first_auth = trx_first_authorizer;
-            // validate_referenced_accounts rejects non-read-only trxs with zero auths
-            // (tx_no_auths), and read-only trxs skip subjective billing below, so
-            // first_auth must be populated by here.
-            assert(!first_auth.empty());
-            // When an action has an explicit sysio.payer at position 0, first_authorizer()
-            // returns the payer (same as payer()), so the guard below skips the insert.
-            // Only the payer bears the subjective cost in that case — the non-payer
-            // authorizer (e.g. {active, Y} at position 1) is intentionally NOT tracked
-            // separately, matching the objective-billing semantic where the payer absorbs
-            // the full cost.
-            if (first_auth != payer || subjectively_bill_payer_disabled) // don't subjectively bill payer twice if billing payer
-               authorizers_cpu[first_auth] += fc::microseconds{b.value};
+            act_trace.cpu_usage_us = b.value;  // trace bookkeeping for the response, regardless of billing
+            if (bill_objectively) {
+               auto payer = act_trace.act.payer();
+               accounts_billing[payer].cpu_usage_us += b.value;
+               if (bill_subjectively) {
+                  auto first_auth = act_trace.act.first_authorizer();
+                  if (first_auth.empty())
+                     first_auth = trx_first_authorizer;
+                  // validate_referenced_accounts rejects non-read-only, non-implicit trxs with zero
+                  // auths (tx_no_auths), so first_auth must be populated by here on the subjective path.
+                  assert(!first_auth.empty());
+                  // When an action has an explicit sysio.payer at position 0, first_authorizer()
+                  // returns the payer (same as payer()), so the guard below skips the insert.
+                  // Only the payer bears the subjective cost in that case -- the non-payer
+                  // authorizer (e.g. {active, Y} at position 1) is intentionally NOT tracked
+                  // separately, matching the objective-billing semantic where the payer absorbs
+                  // the full cost.
+                  if (first_auth != payer || subjectively_bill_payer_disabled) // don't subjectively bill payer twice if billing payer
+                     authorizers_cpu[first_auth] += fc::microseconds{b.value};
+               }
+            }
          }
       }
       trace->total_cpu_usage_us = total_cpu_time_us;
 
-      // update subjective billing
-      // Skip implicit trxs (onblock is the only implicit trx type): chain-generated,
-      // never appear in block->transactions (so remove_subjective_billing via on_block()
-      // would never clear them), and the sysio authorizer does not need subjective
-      // throttling.
-      if (!is_read_only() && !is_implicit()) {
+      if (bill_subjectively) {
          auto& subjective_bill = control.get_mutable_subjective_billing();
          if( trace->except ) {
             const fc::exception& e = *trace->except;

--- a/libraries/custom_appbase/include/sysio/chain/app.hpp
+++ b/libraries/custom_appbase/include/sysio/chain/app.hpp
@@ -260,6 +260,9 @@ public:
       try {
          app_->startup();
          app_->set_thread_priority_max();
+         // Capture this thread as the loop thread so executor.get_main_thread_id() reflects
+         // the thread driving exec(), not whichever thread happened to construct the app.
+         app_->executor().set_main_thread_id();
          app_->exec();
       } catch (...) {
          return handle_exception();

--- a/libraries/custom_appbase/include/sysio/chain/priority_queue_executor.hpp
+++ b/libraries/custom_appbase/include/sysio/chain/priority_queue_executor.hpp
@@ -49,6 +49,8 @@ public:
    }
 
    // Called by application::exec(); refreshes main_thread_id_ to the thread driving the loop.
+   // main_thread_id_ is a plain std::thread::id (not std::atomic): only call this during setup,
+   // before any thread starts reading get_main_thread_id() concurrently with this write.
    void set_main_thread_id() {
       main_thread_id_ = std::this_thread::get_id();
    }

--- a/libraries/custom_appbase/include/sysio/chain/priority_queue_executor.hpp
+++ b/libraries/custom_appbase/include/sysio/chain/priority_queue_executor.hpp
@@ -40,9 +40,17 @@ public:
       return pri_queue_.get_read_threads();
    }
 
-   // assume application is started on the main thread
+   // Thread running application::exec() -- the loop thread for main-thread-only work.
+   // Captured at construction and refreshed by application::exec() so embeddings that
+   // construct the app on a different thread than the one that calls exec() still see
+   // the loop thread.
    std::thread::id get_main_thread_id() const {
       return main_thread_id_;
+   }
+
+   // Called by application::exec(); refreshes main_thread_id_ to the thread driving the loop.
+   void set_main_thread_id() {
+      main_thread_id_ = std::this_thread::get_id();
    }
 
    template <typename Func>

--- a/plugins/chain_plugin/test/test_trx_retry_db.cpp
+++ b/plugins/chain_plugin/test/test_trx_retry_db.cpp
@@ -196,6 +196,9 @@ BOOST_AUTO_TEST_CASE(trx_retry_logic) {
             std::vector<const char*> argv = {"test"};
             app->initialize(argv.size(), (char**)&argv[0]);
             app->startup();
+            // app was constructed on the outer thread; capture this thread as main_thread_id_
+            // before releasing the promise so producer_plugin's main-thread asserts see the loop thread.
+            app->executor().set_main_thread_id();
             plugin_promise.set_value(app->find_plugin<chain_plugin>());
             app->exec();
             return;

--- a/plugins/http_plugin/test/unit_tests.cpp
+++ b/plugins/http_plugin/test/unit_tests.cpp
@@ -269,6 +269,9 @@ struct http_plugin_test_fixture {
          app_thread = std::thread([&]() {
             try {
                app->startup();
+               // app was constructed on the outer thread; capture this thread as main_thread_id_
+               // so producer_plugin's main-thread asserts see the loop thread.
+               app->executor().set_main_thread_id();
                app->exec();
             } catch (...) {
                plugin = nullptr;

--- a/plugins/producer_plugin/test/test_disallow_delayed_trx.cpp
+++ b/plugins/producer_plugin/test/test_disallow_delayed_trx.cpp
@@ -58,6 +58,9 @@ BOOST_AUTO_TEST_CASE(delayed_trx) {
                "-p", "sysio", "-e", "--disable-subjective-p2p-billing=true" };
          app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
          app->startup();
+         // app was constructed on the outer thread; capture this thread as main_thread_id_
+         // before releasing the promise so producer_plugin's main-thread asserts see the loop thread.
+         app->executor().set_main_thread_id();
          plugin_promise.set_value(
             {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
          app->exec();

--- a/plugins/producer_plugin/test/test_options.cpp
+++ b/plugins/producer_plugin/test/test_options.cpp
@@ -40,6 +40,9 @@ BOOST_AUTO_TEST_CASE(state_dir) {
              "-p", "sysio", "-e" };
          app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
          app->startup();
+         // app was constructed on the outer thread; capture this thread as main_thread_id_
+         // before releasing the promise so producer_plugin's main-thread asserts see the loop thread.
+         app->executor().set_main_thread_id();
          plugin_promise.set_value( {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
          app->exec();
          return;

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -115,6 +115,9 @@ BOOST_AUTO_TEST_CASE(producer) {
                    "-p", "sysio", "-e", "--disable-subjective-p2p-billing=true" };
             app->initialize<signature_provider_manager_plugin,chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
             app->startup();
+            // app was constructed on the outer thread; capture this thread as main_thread_id_
+            // before releasing the promise so producer_plugin's main-thread asserts see the loop thread.
+            app->executor().set_main_thread_id();
             plugin_promise.set_value(
                   {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
             app->exec();

--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -117,6 +117,10 @@ void test_trxs_common(std::vector<const char*>& specific_args) {
                app->find_plugin<chain_plugin>()->chain();
                app->startup();
                plugin_promise.set_value({app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()});
+               // The app was constructed on the outer thread; capture this thread (which
+               // runs the loop) as main_thread_id_ so producer_plugin's main-thread asserts
+               // compare against the right thread.
+               app->executor().set_main_thread_id();
                app->exec();
                return;
             } FC_LOG_AND_DROP()

--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -116,11 +116,12 @@ void test_trxs_common(std::vector<const char*>& specific_args) {
                app->initialize<chain_plugin, producer_plugin>(argv.size(), (char**)&argv[0]);
                app->find_plugin<chain_plugin>()->chain();
                app->startup();
-               plugin_promise.set_value({app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()});
-               // The app was constructed on the outer thread; capture this thread (which
-               // runs the loop) as main_thread_id_ so producer_plugin's main-thread asserts
-               // compare against the right thread.
+               // Capture this thread as main_thread_id_ before releasing the promise so
+               // any work the outer thread enqueues after plugin_fut.get() observes the
+               // correct loop thread.  scoped_app was constructed on the outer thread, so
+               // without this refresh main_thread_id_ would point there instead of here.
                app->executor().set_main_thread_id();
+               plugin_promise.set_value({app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()});
                app->exec();
                return;
             } FC_LOG_AND_DROP()

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -78,6 +78,9 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_test) {
 
                producer_plugin* prod_plug = app->find_plugin<producer_plugin>();
                chain_plugin* chain_plug = app->find_plugin<chain_plugin>();
+               // app was constructed on the outer thread; capture this thread as main_thread_id_
+               // before releasing the promise so producer_plugin's main-thread asserts see the loop thread.
+               app->executor().set_main_thread_id();
                plugin_promise.set_value({prod_plug, chain_plug});
 
                auto bs = chain_plug->chain().block_start().connect([&prod_plug, &at_block_20_promise](uint32_t bn) {
@@ -221,6 +224,9 @@ BOOST_AUTO_TEST_CASE(snapshot_scheduler_old_json) {
                at_block_16.set_value();
          });
 
+         // app was constructed on the outer thread; capture this thread as main_thread_id_
+         // so producer_plugin's main-thread asserts see the loop thread.
+         app->executor().set_main_thread_id();
          app->exec();
          return;
       } FC_LOG_AND_DROP()

--- a/unittests/read_only_trx_tests.cpp
+++ b/unittests/read_only_trx_tests.cpp
@@ -2,6 +2,7 @@
 #include <boost/test/unit_test.hpp>
 #include <sysio/testing/tester.hpp>
 #include <sysio/chain/global_property_object.hpp>
+#include <sysio/chain/subjective_billing.hpp>
 #include <fc/variant_object.hpp>
 #include <test_contracts.hpp>
 
@@ -317,6 +318,40 @@ BOOST_FIXTURE_TEST_CASE(sequence_numbers_test, read_only_trx_tester) { try {
    BOOST_CHECK_EQUAL( prev_global_action_sequence, p.global_action_sequence );
    BOOST_CHECK_EQUAL( prev_recv_sequence, receiver_account->recv_sequence );
    BOOST_CHECK_EQUAL( prev_auth_sequence, amo->auth_sequence );
+} FC_LOG_AND_RETHROW() }
+
+// Read-only trxs that throw inside the contract must NOT add to subjective billing.
+// Pre-fix the exception handler in controller_impl::push_transaction called
+// transaction_context::update_billed_cpu_time, which fired
+// `assert(!first_auth.empty())` before reaching the read-only / implicit guard
+// at the bottom of the function.  The fix hoists the gating predicate to the
+// top so read-only trxs short-circuit billing entirely (objective and subjective);
+// this test locks in the invariant by sending a read-only trx with empty auths
+// that throws inside the contract and asserting subjective billing stays at zero.
+BOOST_FIXTURE_TEST_CASE(read_only_throw_no_subjective_billing, read_only_trx_tester) { try {
+   set_up_test_contract();
+
+   const auto& subj_bill = control->get_subjective_billing();
+   const auto now = fc::time_point::now();
+
+   // Baseline: no subjective billing for any account that could plausibly be billed
+   // (alice as the test signer for non-read-only trxs, noauthtable as the contract).
+   BOOST_CHECK_EQUAL( 0, subj_bill.get_subjective_bill("alice"_n,       now).count() );
+   BOOST_CHECK_EQUAL( 0, subj_bill.get_subjective_bill("noauthtable"_n, now).count() );
+
+   // Read-only `getage` against a non-existent record throws inside the contract with
+   // an empty trx-level and action-level first_authorizer.  Pre-fix this aborted via
+   // assertion failure inside the controller's exception handler.
+   BOOST_CHECK_EXCEPTION(
+      send_db_api_transaction("getage"_n, getage_data, {}, transaction_metadata::trx_type::read_only),
+      fc::exception, [](const fc::exception& e) {
+         return expect_assert_message(e, "Record does not exist");
+      });
+
+   // After the read-only failure, subjective billing must still be zero: read-only
+   // trxs are never billed (objective or subjective), even when they fail.
+   BOOST_CHECK_EQUAL( 0, subj_bill.get_subjective_bill("alice"_n,       now).count() );
+   BOOST_CHECK_EQUAL( 0, subj_bill.get_subjective_bill("noauthtable"_n, now).count() );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The asserton platform's extras.cmake set CMAKE_BUILD_TYPE="" with FORCE so C-style asserts would survive into test binaries.  But the workflow runs

    cmake -C /extras.cmake -DCMAKE_BUILD_TYPE=Release ...

and `-D` wins over `-C` FORCE, so BUILD_TYPE ends up Release, CMAKE_CXX_FLAGS_RELEASE adds -DNDEBUG, and asserts have been silently stripped.  The platform has been compiling effectively as plain Release; two real bugs that fail loudly when asserts are actually compiled in had been masked.

This PR is seven commits, ordered so each one's effect is visible to CI:

**1. `ci: keep asserts compiled in on asserton platform`** — Force CMAKE_*_FLAGS_RELEASE to "-O3" (no -DNDEBUG) in the asserton extras.cmake so the Release config that wins the `-D` vs `-C` race carries assert-friendly flags.

**2. `ci: drop dead LLVM 11 references from all platform Dockerfiles`** — `5b6fac0f7e` (Feb 2026) deleted `scripts/llvm-11/llvm-11-ubuntu-build-source.sh` but every platform Dockerfile (asserton, gcc, asan, ubsan, ubuntu24) kept the COPY/chmod/RUN steps invoking it.  Dead-but-cached on master; commit 1 invalidated the asserton cache and surfaced the failure.  Drop the dead references from all five.

**3. `chain: skip billing for read-only trxs in update_billed_cpu_time`** — `transaction_context.cpp:732`'s `assert(!first_auth.empty())` fires on `dry_run_trx_tests/db_insert_test`.  The assertion's premise ("read-only trxs skip subjective billing below") is violated because the assertion sits BEFORE the `if (!is_read_only() && !is_implicit())` guard at line 750, so a read-only trx that throws inside an action reaches the assertion via `controller_impl::push_transaction`'s `handle_exception` lambda with empty action_trace authorizers and an empty trx-level first_authorizer.  Hoist the gating predicate (`bill_objectively = !is_read_only()`, `bill_subjectively = bill_objectively && !is_implicit()`) and apply it at every billing-related site so read-only trxs skip both objective and subjective billing entirely.

**4. `custom_appbase: refresh main_thread_id_ on application::exec()`** — `producer_plugin.cpp:2550`'s main-thread assertion fires on `read_only_trxs/with_1_read_only_threads`.  `priority_queue_executor::main_thread_id_` was captured at construction time, but the test creates `appbase::scoped_app` on the outer thread and calls `app->exec()` on a secondary `std::thread`, leaving `main_thread_id_` pointing at the wrong thread.  Add a public `set_main_thread_id()` on the executor and call it from `sysio::chain::application::exec()` before delegating up; add the same explicit call in `test_read_only_trx.cpp` (the only test using raw `appbase::scoped_app` known at the time).

**5. `test: regression test for read-only trx no-billing on throw`** — Targeted unit test in `read_only_trx_tests` that captures the chain's `subjective_billing` baseline, sends a read-only trx that throws inside the contract, and re-checks `subjective_billing` is still zero.  Locks in commit 3's behavioural invariant rather than just the absence of an abort.

**6. `custom_appbase: tighten main_thread_id_ thread-safety doc and test ordering`** — Two PR-review follow-ups to commit 4: document `main_thread_id_` is non-atomic and `set_main_thread_id()` is setup-only; move the `set_main_thread_id()` call in `test_read_only_trx.cpp` before `plugin_promise.set_value(...)` so the inner thread takes ownership before announcing readiness.

**7. `test: refresh main_thread_id_ in tests that exec on a secondary thread`** — Six more test files share the same construct-on-outer-thread / exec-on-inner-thread pattern as `test_read_only_trx`: `tests/test_snapshot_scheduler.cpp`, `plugins/http_plugin/test/unit_tests.cpp`, `plugins/chain_plugin/test/test_trx_retry_db.cpp`, `plugins/producer_plugin/test/test_disallow_delayed_trx.cpp`, `plugins/producer_plugin/test/test_trx_full.cpp`, `plugins/producer_plugin/test/test_options.cpp`.  Asserton CI surfaced one of them (test_producer_plugin's `ordered_trxs_full/producer`); apply the same one-line fix to all six pre-emptively.

Both bugs (commits 3 and 4) are real and predate this branch; commit 1 makes them visible.  All fixes are minimal-blast-radius (one .cpp body restructure, three small custom_appbase edits, ten one-line test additions).