### PR TITLE
Producer plugin: gate 2x retry max_trx_time clamp on prior success

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1997,6 +1997,7 @@ struct controller_impl {
 
             trx->prev_accounts_billing = trx_context.accounts_billing;
             trx->elapsed = std::max(trx->elapsed, trace->elapsed);
+            trx->prev_succeeded = true;
             if (!trx->implicit() && !trx->is_read_only()) {
                trace->receipt = push_receipt(*trx->packed_trx(), trx_context.billed_cpu_us);
                bb.pending_trx_metas().emplace_back(trx);

--- a/libraries/chain/include/sysio/chain/transaction_metadata.hpp
+++ b/libraries/chain/include/sysio/chain/transaction_metadata.hpp
@@ -44,6 +44,7 @@ class transaction_metadata {
    public:
       fc::microseconds                                           elapsed;                // not thread safe
       accounts_billing_t                                         prev_accounts_billing;  // not thread safe
+      bool                                                       prev_succeeded = false; // not thread safe
 
    private:
       struct private_type{};

--- a/plugins/producer_plugin/src/producer_plugin.cpp
+++ b/plugins/producer_plugin/src/producer_plugin.cpp
@@ -2607,10 +2607,11 @@ producer_plugin_impl::push_result producer_plugin_impl::push_transaction(const f
          return pr;
       }
 
-      // On retry, cap the allowed wall-clock time to 2x the prior run. Prevents a
-      // single slow retry from consuming most of the block budget when prev_elapsed
-      // is a reasonable proxy for the trx's real cost.
-      max_trx_time = std::min(max_trx_time, prev_elapsed * 2);
+      // elapsed can be set on failure, but prev_succeeded indicates a real cost
+      // measurement -- only then is 2x prev_elapsed a sound cap on this retry.
+      if (trx->prev_succeeded) {
+         max_trx_time = std::min(max_trx_time, prev_elapsed * 2);
+      }
    }
 
    auto trace = chain.push_transaction(trx, block_deadline, max_trx_time);


### PR DESCRIPTION
The retry-time clamp in `producer_plugin_impl::push_transaction` added in cc6701fa0f (`max_trx_time = std::min(max_trx_time, prev_elapsed * 2)`) was applied unconditionally whenever `trx->elapsed > 0`. That is unsound for the block-boundary cutoff path: when a trx hits `block_cpu_usage_exceeded` mid-execution, controller's `handle_exception` still sets `trx->elapsed` and `trx->prev_accounts_billing`, but elapsed is now the wall-clock at which the producer stopped attempting because it ran out of block budget -- not a measurement of the trx's real cost. Capping `max_trx_time` to `2 * truncated_prev_elapsed` can be arbitrarily smaller than the trx's actual cost, which combined with non-empty `prev_accounts_billing` causes `transaction_context` to fire `tx_cpu_usage_exceeded_reason::speculative_executed_adjusted_max_transaction_time` on every retry until the trx expires.

Observed on the [ubsan NP run for PR #324](https://github.com/Wire-Network/wire-sysio/actions/runs/25516388732/job/74895052476): bootstrap `sysio.token::create` truncated to 303us at the block 99 boundary, then capped to 606us on each retry while the trx really needed ~3.8ms under ubsan; trx expired after 30s of failures (`interrupt-read-only-trx-parallel-if-sys-vm-oc-test`).

Spring has the same clamp in producer_plugin's `push_transaction` but gates it on `prev_billed_cpu_time_us > 0`, where `billed_cpu_time_us` is set only on successful execution -- restricting the 2x to the success-then-aborted-speculation case where `prev_elapsed` is a real cost measurement. Wire collapsed billed/elapsed into a single `trx->elapsed` field, so this PR adds a `prev_succeeded` bool on `transaction_metadata`, set in controller's success path, and gates the producer's clamp on it. Equivalent semantics to Spring's gate without re-introducing the billed/elapsed split.