### PR TITLE
Test: align nested_container_multi_index with CDT pair/map field names

### DIFF
--- a/tests/nested_container_multi_index_test.py
+++ b/tests/nested_container_multi_index_test.py
@@ -117,10 +117,10 @@ try:
     create_action('setsto', '["alice", [null, null, 500]]', 'nestcontnmi', 'alice')
 
     Print("Test action for set< map< uint16_t, uint16_t >>")
-    create_action('setstm', '["alice", [[{"key":30,"value":300},{"key":30,"value":300}],[{"key":60,"value":600},{"key":60,"value":600}]]]', 'nestcontnmi', 'alice')
+    create_action('setstm', '["alice", [[{"first":30,"second":300},{"first":30,"second":300}],[{"first":60,"second":600},{"first":60,"second":600}]]]', 'nestcontnmi', 'alice')
 
     Print("Test action for set< pair< uint16_t, uint16_t >>")
-    create_action('setstp', '["alice", [{"key": 69, "value": 129}, {"key": 69, "value": 129}]]', 'nestcontnmi', 'alice')
+    create_action('setstp', '["alice", [{"first": 69, "second": 129}, {"first": 69, "second": 129}]]', 'nestcontnmi', 'alice')
 
     Print("Test action for set< tuple< uint16_t, uint16_t >>")
     create_action('setstt', '["alice", [[1,2],[36,46], [56,66]]]', 'nestcontnmi', 'alice')
@@ -136,11 +136,11 @@ try:
     create_action('setvo', '["alice",[null, null, 500]]', 'nestcontnmi', 'alice')
 
     Print("Test action for vector< map< uint16_t, uint16_t >>")
-    create_action('setvm', '["alice", [[{"key": 30, "value": 300}, {"key": 30, "value": 300}], [{"key": 60, "value": 600}, {"key": 60, "value": 600}]]]'
+    create_action('setvm', '["alice", [[{"first": 30, "second": 300}, {"first": 30, "second": 300}], [{"first": 60, "second": 600}, {"first": 60, "second": 600}]]]'
     , 'nestcontnmi', 'alice')
 
     Print("Test action for vector< pair< uint16_t, uint16_t >>")
-    create_action('setvp', '["alice", [{"key": 69, "value": 129}, {"key": 69, "value": 129}]]', 'nestcontnmi', 'alice')
+    create_action('setvp', '["alice", [{"first": 69, "second": 129}, {"first": 69, "second": 129}]]', 'nestcontnmi', 'alice')
 
     Print("Test action for vector< tuple< uint16_t, uint16_t >>")
     create_action('setvt', '["alice", [[10,20],[30,40], [50,60]]]', 'nestcontnmi', 'alice')
@@ -159,11 +159,11 @@ try:
     create_action('setoo', '["bob", null]', 'nestcontnmi', 'bob')
 
     Print("Test action for optional< map< uint16_t, uint16_t >>")
-    create_action('setom', '["alice", [{"key": 10, "value": 1000}, {"key": 11,"value": 1001}] ]', 'nestcontnmi', 'alice')
+    create_action('setom', '["alice", [{"first": 10, "second": 1000}, {"first": 11,"second": 1001}] ]', 'nestcontnmi', 'alice')
     create_action('setom', '["bob", null]', 'nestcontnmi', 'bob')
 
     Print("Test action for optional< pair< uint16_t, uint16_t >>")
-    create_action('setop', '["alice", {"key": 60, "value": 61}]', 'nestcontnmi', 'alice')
+    create_action('setop', '["alice", {"first": 60, "second": 61}]', 'nestcontnmi', 'alice')
     create_action('setop', '["bob", null]', 'nestcontnmi', 'bob')
 
     Print("Test action for optional< tuple< uint16_t, uint16_t >>")
@@ -172,43 +172,43 @@ try:
 
 
     Print("Test action for map< set< uint16_t >>")
-    create_action('setmst', '["alice", [{"key": 1,"value": [10, 10, 12, 16]},  {"key": 2, "value": [200, 300]} ]]', 'nestcontnmi', 'alice')
+    create_action('setmst', '["alice", [{"first": 1,"second": [10, 10, 12, 16]},  {"first": 2, "second": [200, 300]} ]]', 'nestcontnmi', 'alice')
 
     Print("Test action for map< vector< uint16_t >>")
-    create_action('setmv', '["alice", [{"key": 1, "value": [10, 10, 12, 16]},  {"key": 2, "value": [200, 300]} ]]', 'nestcontnmi', 'alice')
+    create_action('setmv', '["alice", [{"first": 1, "second": [10, 10, 12, 16]},  {"first": 2, "second": [200, 300]} ]]', 'nestcontnmi', 'alice')
 
     Print("Test action for map< optional< uint16_t >>")
-    create_action('setmo', '["alice", [{"key": 10, "value": 1000}, {"key": 11, "value": null}]]', 'nestcontnmi', 'alice')
+    create_action('setmo', '["alice", [{"first": 10, "second": 1000}, {"first": 11, "second": null}]]', 'nestcontnmi', 'alice')
 
     Print("Test action for map< map< uint16_t, uint16_t >>")
-    create_action('setmm', '["alice", [{"key": 10, "value": [{"key": 200, "value": 2000}, \
-         {"key": 201, "value": 2001}] }, {"key": 11, "value": [{"key": 300, "value": 3000}, {"key": 301, "value": 3001}] } ]]', 'nestcontnmi', 'alice')
+    create_action('setmm', '["alice", [{"first": 10, "second": [{"first": 200, "second": 2000}, \
+         {"first": 201, "second": 2001}] }, {"first": 11, "second": [{"first": 300, "second": 3000}, {"first": 301, "second": 3001}] } ]]', 'nestcontnmi', 'alice')
 
     Print("Test action for map< pair< uint16_t, uint16_t >>")
-    create_action('setmp', '["alice", [{"key": 36, "value": {"key": 300, "value": 301}}, {"key": 37, "value": {"key": 600, "value": 601}} ]]', 'nestcontnmi', 'alice')
+    create_action('setmp', '["alice", [{"first": 36, "second": {"first": 300, "second": 301}}, {"first": 37, "second": {"first": 600, "second": 601}} ]]', 'nestcontnmi', 'alice')
 
     Print("Test action for map< tuple< uint16_t, uint16_t >>")
-    create_action('setmt', '["alice", [{"key":1,"value":[10,11]},  {"key":2,"value":[200,300]} ]]', 'nestcontnmi', 'alice')
+    create_action('setmt', '["alice", [{"first":1,"second":[10,11]},  {"first":2,"second":[200,300]} ]]', 'nestcontnmi', 'alice')
 
 
     Print("Test action for pair< set< uint16_t >>")
-    create_action('setpst', '["alice", {"key": 20, "value": [200, 200, 202]}]', 'nestcontnmi', 'alice')
+    create_action('setpst', '["alice", {"first": 20, "second": [200, 200, 202]}]', 'nestcontnmi', 'alice')
 
     Print("Test action for pair< vector< uint16_t >>")
-    create_action('setpv', '["alice", {"key": 10, "value": [100, 100, 102]}]', 'nestcontnmi', 'alice')
+    create_action('setpv', '["alice", {"first": 10, "second": [100, 100, 102]}]', 'nestcontnmi', 'alice')
 
     Print("Test action for pair< optional< uint16_t >>")
-    create_action('setpo', '["alice", {"key": 70, "value": 71}]', 'nestcontnmi', 'alice')
-    create_action('setpo', '["bob", {"key": 70, "value": null}]', 'nestcontnmi', 'bob')
+    create_action('setpo', '["alice", {"first": 70, "second": 71}]', 'nestcontnmi', 'alice')
+    create_action('setpo', '["bob", {"first": 70, "second": null}]', 'nestcontnmi', 'bob')
 
     Print("Test action for pair< map< uint16_t, uint16_t >>")
-    create_action('setpm', '["alice", {"key": 6, "value": [{"key": 20, "value": 300}, {"key": 21,"value": 301}] }]', 'nestcontnmi', 'alice')
+    create_action('setpm', '["alice", {"first": 6, "second": [{"first": 20, "second": 300}, {"first": 21,"second": 301}] }]', 'nestcontnmi', 'alice')
 
     Print("Test action for pair< pair< uint16_t, uint16_t >>")
-    create_action('setpp', '["alice", {"key": 30, "value": {"key": 301, "value": 302} }]', 'nestcontnmi', 'alice')
+    create_action('setpp', '["alice", {"first": 30, "second": {"first": 301, "second": 302} }]', 'nestcontnmi', 'alice')
 
     Print("Test action for pair< tuple< uint16_t, uint16_t >>")
-    create_action('setpt', '["alice", {"key":10, "value":[100,101]}]', 'nestcontnmi', 'alice')
+    create_action('setpt', '["alice", {"first":10, "second":[100,101]}]', 'nestcontnmi', 'alice')
 
 
     Print("Test action for tuple< uint16_t, set< uint16_t >, set< uint16_t >>")
@@ -223,10 +223,10 @@ try:
     create_action('setto', '["bob", [null, null, 10, null, 20]]', 'nestcontnmi', 'bob')
 
     Print("Test action for tuple< map< uint16_t, uint16_t >, map< uint16_t, uint16_t >>")
-    create_action('settm', '["alice", [126, [{"key":10,"value":100},{"key":11,"value":101}], [{"key":80,"value":800},{"key":81,"value":9009}] ]]', 'nestcontnmi', 'alice')
+    create_action('settm', '["alice", [126, [{"first":10,"second":100},{"first":11,"second":101}], [{"first":80,"second":800},{"first":81,"second":9009}] ]]', 'nestcontnmi', 'alice')
 
     Print("Test action for tuple< uint16_t, pair< uint16_t, uint16_t >, pair< uint16_t, uint16_t >>")
-    create_action('settp', '["alice", [127, {"key":18, "value":28}, {"key":19, "value":29}]]', 'nestcontnmi', 'alice')
+    create_action('settp', '["alice", [127, {"first":18, "second":28}, {"first":19, "second":29}]]', 'nestcontnmi', 'alice')
 
     Print("Test action for tuple< tuple< uint16_t, uint16_t >, tuple< uint16_t, uint16_t >, tuple< uint16_t, uint16_t >>")
     create_action('settt', '["alice", [[1,2],[30,40], [50,60]]]', 'nestcontnmi', 'alice')
@@ -251,10 +251,10 @@ try:
 
     assert "[None, 500]" == str(transaction_json['rows'][0]['value']['sto']), 'Content of multi-index table set< optional< uint16_t >>  is not correct'
 
-    assert "[[{'key': 30, 'value': 300}], [{'key': 60, 'value': 600}]]" \
+    assert "[[{'first': 30, 'second': 300}], [{'first': 60, 'second': 600}]]" \
         == str(transaction_json['rows'][0]['value']['stm']), 'Content of multi-index table set< map< uint16_t >> is not correct'
 
-    assert "[{'key': 69, 'value': 129}]" == str(transaction_json['rows'][0]['value']['stp']), \
+    assert "[{'first': 69, 'second': 129}]" == str(transaction_json['rows'][0]['value']['stp']), \
         'Content of multi-index table set< pair< uint16_t >> is not correct'
 
     assert "[{'field_0': 1, 'field_1': 2}, {'field_0': 36, 'field_1': 46}, {'field_0': 56, 'field_1': 66}]" == str(transaction_json['rows'][0]['value']['stt']), \
@@ -271,10 +271,10 @@ try:
     assert "[None, None, 500]" == str(transaction_json['rows'][0]['value']['vo']), \
         'Content of multi-index table vector< optional< uint16_t >>  is not correct'
 
-    assert "[[{'key': 30, 'value': 300}], [{'key': 60, 'value': 600}]]" \
+    assert "[[{'first': 30, 'second': 300}], [{'first': 60, 'second': 600}]]" \
         == str(transaction_json['rows'][0]['value']['vm']), 'Content of multi-index table vector< map< uint16_t >> is not correct'
 
-    assert "[{'key': 69, 'value': 129}, {'key': 69, 'value': 129}]" == str(transaction_json['rows'][0]['value']['vp']), \
+    assert "[{'first': 69, 'second': 129}, {'first': 69, 'second': 129}]" == str(transaction_json['rows'][0]['value']['vp']), \
         'Content of multi-index table vector< pair< uint16_t >> is not correct'
 
     assert "[{'field_0': 10, 'field_1': 20}, {'field_0': 30, 'field_1': 40}, {'field_0': 50, 'field_1': 60}]" == str(transaction_json['rows'][0]['value']['vt']), \
@@ -290,11 +290,11 @@ try:
     assert "500" == str(transaction_json['rows'][0]['value']['oo']), 'Content of multi-index table optional< optional< uint16_t >>  is not correct'
     assert "None" == str(transaction_json['rows'][1]['value']['oo']), 'Content of multi-index table optional< set< uint16_t >> is not correct'
 
-    assert "[{'key': 10, 'value': 1000}, {'key': 11, 'value': 1001}]" \
+    assert "[{'first': 10, 'second': 1000}, {'first': 11, 'second': 1001}]" \
         == str(transaction_json['rows'][0]['value']['om']), 'Content of multi-index table optional< map< uint16_t >> is not correct'
     assert "None" == str(transaction_json['rows'][1]['value']['om']), 'Content of multi-index table optional< set< uint16_t >> is not correct'
 
-    assert "{'key': 60, 'value': 61}" == str(transaction_json['rows'][0]['value']['op']), \
+    assert "{'first': 60, 'second': 61}" == str(transaction_json['rows'][0]['value']['op']), \
         'Content of multi-index table optional< pair< uint16_t >> is not correct'
     assert "None" == str(transaction_json['rows'][1]['value']['op']), 'Content of multi-index table optional< set< uint16_t >> is not correct'
 
@@ -302,44 +302,44 @@ try:
     assert "None" == str(transaction_json['rows'][1]['value']['ot']), 'Content of multi-index table optional< tuple< uint16_t, uint16_t >> is not correct'
 
 
-    assert "[{'key': 1, 'value': [10, 12, 16]}, {'key': 2, 'value': [200, 300]}]" \
+    assert "[{'first': 1, 'second': [10, 12, 16]}, {'first': 2, 'second': [200, 300]}]" \
         == str(transaction_json['rows'][0]['value']['mst']), 'Content of multi-index table map< set< uint16_t >> is not correct'
 
-    assert "[{'key': 1, 'value': [10, 10, 12, 16]}, {'key': 2, 'value': [200, 300]}]" \
+    assert "[{'first': 1, 'second': [10, 10, 12, 16]}, {'first': 2, 'second': [200, 300]}]" \
         == str(transaction_json['rows'][0]['value']['mv']), 'Content of multi-index table map< vector< uint16_t >> is not correct'
 
-    assert "[{'key': 10, 'value': 1000}, {'key': 11, 'value': None}]" == \
+    assert "[{'first': 10, 'second': 1000}, {'first': 11, 'second': None}]" == \
         str(transaction_json['rows'][0]['value']['mo']), 'Content of multi-index table map< optional< uint16_t >> is not correct'
 
-    assert "[{'key': 10, 'value': [{'key': 200, 'value': 2000}, {'key': 201, 'value': 2001}]}, {'key': 11, 'value': [{'key': 300, 'value': 3000}, {'key': 301, 'value': 3001}]}]" \
+    assert "[{'first': 10, 'second': [{'first': 200, 'second': 2000}, {'first': 201, 'second': 2001}]}, {'first': 11, 'second': [{'first': 300, 'second': 3000}, {'first': 301, 'second': 3001}]}]" \
         == str(transaction_json['rows'][0]['value']['mm']), 'Content of multi-index table map< map< uint16_t >> is not correct'
 
-    assert "[{'key': 36, 'value': {'key': 300, 'value': 301}}, {'key': 37, 'value': {'key': 600, 'value': 601}}]"\
+    assert "[{'first': 36, 'second': {'first': 300, 'second': 301}}, {'first': 37, 'second': {'first': 600, 'second': 601}}]"\
          == str(transaction_json['rows'][0]['value']['mp']), 'Content of multi-index table map< pair< uint16_t >> is not correct'
 
-    assert "[{'key': 1, 'value': {'field_0': 10, 'field_1': 11}}, {'key': 2, 'value': {'field_0': 200, 'field_1': 300}}]"\
+    assert "[{'first': 1, 'second': {'field_0': 10, 'field_1': 11}}, {'first': 2, 'second': {'field_0': 200, 'field_1': 300}}]"\
          == str(transaction_json['rows'][0]['value']['mt']), 'Content of multi-index table map< uint16_t, tuple< uint16_t, uint16_t >> is not correct'
 
 
-    assert "{'key': 20, 'value': [200, 202]}" == str(transaction_json['rows'][0]['value']['pst']), \
+    assert "{'first': 20, 'second': [200, 202]}" == str(transaction_json['rows'][0]['value']['pst']), \
         'Content of multi-index table pair< set< uint16_t >> is not correct'
 
-    assert "{'key': 10, 'value': [100, 100, 102]}" == str(transaction_json['rows'][0]['value']['pv']), \
+    assert "{'first': 10, 'second': [100, 100, 102]}" == str(transaction_json['rows'][0]['value']['pv']), \
         'Content of multi-index table pair< vector< uint16_t >> is not correct'
 
-    assert "{'key': 70, 'value': 71}" == str(transaction_json['rows'][0]['value']['po']), \
+    assert "{'first': 70, 'second': 71}" == str(transaction_json['rows'][0]['value']['po']), \
         'Content of multi-index table pair< optional< uint16_t >>  is not correct'
 
-    assert "{'key': 70, 'value': None}" == str(transaction_json['rows'][1]['value']['po']), \
+    assert "{'first': 70, 'second': None}" == str(transaction_json['rows'][1]['value']['po']), \
         'Content of multi-index table pair< optional< uint16_t >>  is not correct'
 
-    assert "{'key': 6, 'value': [{'key': 20, 'value': 300}, {'key': 21, 'value': 301}]}" \
+    assert "{'first': 6, 'second': [{'first': 20, 'second': 300}, {'first': 21, 'second': 301}]}" \
         == str(transaction_json['rows'][0]['value']['pm']), 'Content of multi-index table pair< map< uint16_t >> is not correct'
         
-    assert "{'key': 30, 'value': {'key': 301, 'value': 302}}" == str(transaction_json['rows'][0]['value']['pp']),\
+    assert "{'first': 30, 'second': {'first': 301, 'second': 302}}" == str(transaction_json['rows'][0]['value']['pp']),\
          'Content of multi-index table pair< pair< uint16_t >> is not correct'
 
-    assert "{'key': 10, 'value': {'field_0': 100, 'field_1': 101}}"\
+    assert "{'first': 10, 'second': {'field_0': 100, 'field_1': 101}}"\
          == str(transaction_json['rows'][0]['value']['pt']), 'Content of multi-index table pair< uint16_t, tuple< uint16_t, uint16_t >> is not correct'
 
 
@@ -355,10 +355,10 @@ try:
     assert "{'field_0': None, 'field_1': None, 'field_2': 10, 'field_3': None, 'field_4': 20}" == str(transaction_json['rows'][1]['value']['to']), \
         'Content of multi-index table tuple< optional< uint16_t >>  is not correct'
 
-    assert "{'field_0': 126, 'field_1': [{'key': 10, 'value': 100}, {'key': 11, 'value': 101}], 'field_2': [{'key': 80, 'value': 800}, {'key': 81, 'value': 9009}]}" \
+    assert "{'field_0': 126, 'field_1': [{'first': 10, 'second': 100}, {'first': 11, 'second': 101}], 'field_2': [{'first': 80, 'second': 800}, {'first': 81, 'second': 9009}]}" \
         == str(transaction_json['rows'][0]['value']['tm']), 'Content of multi-index table pair< map< uint16_t, uint16_t >> is not correct'
         
-    assert "{'field_0': 127, 'field_1': {'key': 18, 'value': 28}, 'field_2': {'key': 19, 'value': 29}}" == str(transaction_json['rows'][0]['value']['tp']),\
+    assert "{'field_0': 127, 'field_1': {'first': 18, 'second': 28}, 'field_2': {'first': 19, 'second': 29}}" == str(transaction_json['rows'][0]['value']['tp']),\
          'Content of multi-index table tuple< pair< uint16_t, uint16_t >> is not correct'
 
     assert "{'field_0': {'field_0': 1, 'field_1': 2}, 'field_1': {'field_0': 30, 'field_1': 40}, 'field_2': {'field_0': 50, 'field_1': 60}}"\

--- a/unittests/test-contracts/nested_container_multi_index/nested_container_multi_index.abi
+++ b/unittests/test-contracts/nested_container_multi_index/nested_container_multi_index.abi
@@ -55,11 +55,11 @@
             "base": "",
             "fields": [
                 {
-                    "name": "key",
+                    "name": "first",
                     "type": "uint16"
                 },
                 {
-                    "name": "value",
+                    "name": "second",
                     "type": "mp_uint16"
                 }
             ]
@@ -69,11 +69,11 @@
             "base": "",
             "fields": [
                 {
-                    "name": "key",
+                    "name": "first",
                     "type": "uint16"
                 },
                 {
-                    "name": "value",
+                    "name": "second",
                     "type": "op_uint16"
                 }
             ]
@@ -83,11 +83,11 @@
             "base": "",
             "fields": [
                 {
-                    "name": "key",
+                    "name": "first",
                     "type": "uint16"
                 },
                 {
-                    "name": "value",
+                    "name": "second",
                     "type": "pr_uint16"
                 }
             ]
@@ -97,11 +97,11 @@
             "base": "",
             "fields": [
                 {
-                    "name": "key",
+                    "name": "first",
                     "type": "uint16"
                 },
                 {
-                    "name": "value",
+                    "name": "second",
                     "type": "set_uint16"
                 }
             ]
@@ -111,11 +111,11 @@
             "base": "",
             "fields": [
                 {
-                    "name": "key",
+                    "name": "first",
                     "type": "uint16"
                 },
                 {
-                    "name": "value",
+                    "name": "second",
                     "type": "tup_uint16"
                 }
             ]
@@ -125,11 +125,11 @@
             "base": "",
             "fields": [
                 {
-                    "name": "key",
+                    "name": "first",
                     "type": "uint16"
                 },
                 {
-                    "name": "value",
+                    "name": "second",
                     "type": "uint16"
                 }
             ]
@@ -153,11 +153,11 @@
             "base": "",
             "fields": [
                 {
-                    "name": "key",
+                    "name": "first",
                     "type": "uint16"
                 },
                 {
-                    "name": "value",
+                    "name": "second",
                     "type": "vec_uint16"
                 }
             ]


### PR DESCRIPTION
## Summary

Wire CDT emits `first`/`second` for `std::pair` and `std::map` fields in generated ABIs. The previous workaround swapped in a Leap-derived ABI using `key`/`value`, but it regressed every time the WASM was regenerated and diverged from Wire CDT's toolchain tests.

This change removes the workaround: the contract ABI uses `first`/`second` matching CDT output, and the Python test inputs/assertions are updated to match. WASM is unchanged.

Originally authored as commit 057ba3c1a2 on feature/kv-secondary-primary-id. Lifted as a standalone change since it is independent of the KV secondary-index work on that branch.