### PR TITLE
Kv: split iterator slot pool into independent primary and secondary pools

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -724,35 +724,8 @@ int32_t apply_context::kv_contains(uint16_t table_id, name code, const char* key
 
 // --- Primary KV iterators ---
 
-// Resolve a primary-iterator handle to its slot.  Validates the reserved-bit
-// invariant and the primary-pool tag at every entry point so a fabricated
-// handle aborts the action cleanly instead of aliasing a real slot.
-static kv_primary_slot& get_primary_slot(kv_primary_iterator_pool& pool, uint32_t handle, const char* op) {
-   kv_handle_check_reserved_zero(handle);
-   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
-              "{} called on secondary iterator handle", op);
-   return pool.get(kv_handle_slot_index(handle));
-}
-
-// Resolve a secondary-iterator handle to its slot.  Mirrors get_primary_slot
-// on the secondary pool side.
-static kv_secondary_slot& get_secondary_slot(kv_secondary_iterator_pool& pool, uint32_t handle, const char* op) {
-   kv_handle_check_reserved_zero(handle);
-   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
-              "{} called on primary iterator handle", op);
-   return pool.get(kv_handle_slot_index(handle));
-}
-
 uint32_t apply_context::kv_it_create(uint16_t table_id, name code, const char* prefix, uint32_t prefix_size) {
-   // Cap prefix size against the absolute key-size ceiling.  The prefix bytes
-   // are memcpy'd into the iterator slot, so an unbounded prefix_size would
-   // let a contract allocate arbitrary host-side storage per iterator (up to
-   // max_kv_iterators slots per action).  The constexpr ceiling has zero
-   // runtime cost and is large enough for any legitimate CDT idiom
-   // (typically prefix_size == 0 or 8 bytes).
-   SYS_ASSERT(prefix_size <= config::max_kv_key_size_limit, kv_key_too_large,
-              "KV iterator prefix size {} exceeds limit {}",
-              prefix_size, config::max_kv_key_size_limit);
+   kv_check_prefix_size(prefix_size);
    const uint32_t handle = kv_primary_iterators.allocate(table_id, code, prefix, prefix_size);
    auto& slot = kv_primary_iterators.get(handle);
 
@@ -772,19 +745,16 @@ uint32_t apply_context::kv_it_create(uint16_t table_id, name code, const char* p
 }
 
 void apply_context::kv_it_destroy(uint32_t handle) {
-   kv_handle_check_reserved_zero(handle);
-   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
-              "kv_it_destroy called on secondary iterator handle");
-   kv_primary_iterators.release(kv_handle_slot_index(handle));
+   kv_primary_iterators.release(validate_primary_handle(handle, "kv_it_destroy"));
 }
 
 int32_t apply_context::kv_it_status(uint32_t handle) {
-   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_status");
+   auto& slot = kv_primary_iterators.get(validate_primary_handle(handle, "kv_it_status"));
    return static_cast<int32_t>(slot.status);
 }
 
 int32_t apply_context::kv_it_next(uint32_t handle) {
-   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_next");
+   auto& slot = kv_primary_iterators.get(validate_primary_handle(handle, "kv_it_next"));
 
    if (slot.status == kv_it_stat::iterator_end) return static_cast<int32_t>(kv_it_stat::iterator_end);
 
@@ -821,7 +791,7 @@ int32_t apply_context::kv_it_next(uint32_t handle) {
 }
 
 int32_t apply_context::kv_it_prev(uint32_t handle) {
-   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_prev");
+   auto& slot = kv_primary_iterators.get(validate_primary_handle(handle, "kv_it_prev"));
 
    const auto& idx = db.get_index<kv_index, by_code_key>();
 
@@ -888,7 +858,7 @@ int32_t apply_context::kv_it_prev(uint32_t handle) {
 }
 
 int32_t apply_context::kv_it_lower_bound(uint32_t handle, const char* key, uint32_t key_size) {
-   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_lower_bound");
+   auto& slot = kv_primary_iterators.get(validate_primary_handle(handle, "kv_it_lower_bound"));
 
    const auto& idx = db.get_index<kv_index, by_code_key>();
 
@@ -934,7 +904,7 @@ static const kv_object* find_current_primary(const chainbase::database& db, kv_p
 }
 
 int32_t apply_context::kv_it_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_key");
+   auto& slot = kv_primary_iterators.get(validate_primary_handle(handle, "kv_it_key"));
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -958,7 +928,7 @@ int32_t apply_context::kv_it_key(uint32_t handle, uint32_t offset, char* dest, u
 }
 
 int32_t apply_context::kv_it_value(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_value");
+   auto& slot = kv_primary_iterators.get(validate_primary_handle(handle, "kv_it_value"));
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -1120,7 +1090,7 @@ int32_t apply_context::kv_idx_lower_bound(name code, uint16_t table_id,
 }
 
 int32_t apply_context::kv_idx_next(uint32_t handle) {
-   auto& slot = get_secondary_slot(kv_secondary_iterators, handle, "kv_idx_next");
+   auto& slot = kv_secondary_iterators.get(validate_secondary_handle(handle, "kv_idx_next"));
 
    if (slot.status == kv_it_stat::iterator_end) return static_cast<int32_t>(kv_it_stat::iterator_end);
 
@@ -1160,7 +1130,7 @@ int32_t apply_context::kv_idx_next(uint32_t handle) {
 }
 
 int32_t apply_context::kv_idx_prev(uint32_t handle) {
-   auto& slot = get_secondary_slot(kv_secondary_iterators, handle, "kv_idx_prev");
+   auto& slot = kv_secondary_iterators.get(validate_secondary_handle(handle, "kv_idx_prev"));
 
    const auto& idx = db.get_index<kv_index_index, by_code_table_id_seckey>();
 
@@ -1242,7 +1212,7 @@ static const kv_index_object* find_current_secondary(const chainbase::database& 
 }
 
 int32_t apply_context::kv_idx_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = get_secondary_slot(kv_secondary_iterators, handle, "kv_idx_key");
+   auto& slot = kv_secondary_iterators.get(validate_secondary_handle(handle, "kv_idx_key"));
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -1266,7 +1236,7 @@ int32_t apply_context::kv_idx_key(uint32_t handle, uint32_t offset, char* dest, 
 }
 
 int32_t apply_context::kv_idx_primary_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = get_secondary_slot(kv_secondary_iterators, handle, "kv_idx_primary_key");
+   auto& slot = kv_secondary_iterators.get(validate_secondary_handle(handle, "kv_idx_primary_key"));
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -1290,10 +1260,7 @@ int32_t apply_context::kv_idx_primary_key(uint32_t handle, uint32_t offset, char
 }
 
 void apply_context::kv_idx_destroy(uint32_t handle) {
-   kv_handle_check_reserved_zero(handle);
-   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
-              "kv_idx_destroy called on primary iterator handle");
-   kv_secondary_iterators.release(kv_handle_slot_index(handle));
+   kv_secondary_iterators.release(validate_secondary_handle(handle, "kv_idx_destroy"));
 }
 
 } /// sysio::chain

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -724,9 +724,37 @@ int32_t apply_context::kv_contains(uint16_t table_id, name code, const char* key
 
 // --- Primary KV iterators ---
 
+// Resolve a primary-iterator handle to its slot.  Validates the reserved-bit
+// invariant and the primary-pool tag at every entry point so a fabricated
+// handle aborts the action cleanly instead of aliasing a real slot.
+static kv_primary_slot& get_primary_slot(kv_primary_iterator_pool& pool, uint32_t handle, const char* op) {
+   kv_handle_check_reserved_zero(handle);
+   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "{} called on secondary iterator handle", op);
+   return pool.get(kv_handle_slot_index(handle));
+}
+
+// Resolve a secondary-iterator handle to its slot.  Mirrors get_primary_slot
+// on the secondary pool side.
+static kv_secondary_slot& get_secondary_slot(kv_secondary_iterator_pool& pool, uint32_t handle, const char* op) {
+   kv_handle_check_reserved_zero(handle);
+   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "{} called on primary iterator handle", op);
+   return pool.get(kv_handle_slot_index(handle));
+}
+
 uint32_t apply_context::kv_it_create(uint16_t table_id, name code, const char* prefix, uint32_t prefix_size) {
-   const uint32_t handle = kv_iterators.allocate_primary(table_id, code, prefix, prefix_size);
-   auto& slot = kv_iterators.get(handle);
+   // Cap prefix size against the absolute key-size ceiling.  The prefix bytes
+   // are memcpy'd into the iterator slot, so an unbounded prefix_size would
+   // let a contract allocate arbitrary host-side storage per iterator (up to
+   // max_kv_iterators slots per action).  The constexpr ceiling has zero
+   // runtime cost and is large enough for any legitimate CDT idiom
+   // (typically prefix_size == 0 or 8 bytes).
+   SYS_ASSERT(prefix_size <= config::max_kv_key_size_limit, kv_key_too_large,
+              "KV iterator prefix size {} exceeds limit {}",
+              prefix_size, config::max_kv_key_size_limit);
+   const uint32_t handle = kv_primary_iterators.allocate(table_id, code, prefix, prefix_size);
+   auto& slot = kv_primary_iterators.get(handle);
 
    // Seek to first entry matching prefix
    const auto& idx = db.get_index<kv_index, by_code_key>();
@@ -744,16 +772,19 @@ uint32_t apply_context::kv_it_create(uint16_t table_id, name code, const char* p
 }
 
 void apply_context::kv_it_destroy(uint32_t handle) {
-   kv_iterators.release(handle);
+   kv_handle_check_reserved_zero(handle);
+   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_it_destroy called on secondary iterator handle");
+   kv_primary_iterators.release(kv_handle_slot_index(handle));
 }
 
 int32_t apply_context::kv_it_status(uint32_t handle) {
-   return static_cast<int32_t>(kv_iterators.get(handle).status);
+   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_status");
+   return static_cast<int32_t>(slot.status);
 }
 
 int32_t apply_context::kv_it_next(uint32_t handle) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(slot.is_primary, kv_invalid_iterator, "kv_it_next called on secondary iterator");
+   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_next");
 
    if (slot.status == kv_it_stat::iterator_end) return static_cast<int32_t>(kv_it_stat::iterator_end);
 
@@ -790,8 +821,7 @@ int32_t apply_context::kv_it_next(uint32_t handle) {
 }
 
 int32_t apply_context::kv_it_prev(uint32_t handle) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(slot.is_primary, kv_invalid_iterator, "kv_it_prev called on secondary iterator");
+   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_prev");
 
    const auto& idx = db.get_index<kv_index, by_code_key>();
 
@@ -858,8 +888,7 @@ int32_t apply_context::kv_it_prev(uint32_t handle) {
 }
 
 int32_t apply_context::kv_it_lower_bound(uint32_t handle, const char* key, uint32_t key_size) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(slot.is_primary, kv_invalid_iterator, "kv_it_lower_bound called on secondary iterator");
+   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_lower_bound");
 
    const auto& idx = db.get_index<kv_index, by_code_key>();
 
@@ -885,7 +914,7 @@ int32_t apply_context::kv_it_lower_bound(uint32_t handle, const char* key, uint3
 
 // Helper: find the current primary row by cached ID (fast) or key bytes (slow).
 // Updates cached_id on success. Returns nullptr if the row was erased.
-static const kv_object* find_current_primary(const chainbase::database& db, kv_iterator_slot& slot) {
+static const kv_object* find_current_primary(const chainbase::database& db, kv_primary_slot& slot) {
    // Fast path: by cached chainbase ID
    if (slot.cached_id >= 0) {
       const auto* obj = db.find<kv_object>(kv_object::id_type(slot.cached_id));
@@ -905,8 +934,7 @@ static const kv_object* find_current_primary(const chainbase::database& db, kv_i
 }
 
 int32_t apply_context::kv_it_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(slot.is_primary, kv_invalid_iterator, "kv_it_key called on secondary iterator");
+   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_key");
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -930,8 +958,7 @@ int32_t apply_context::kv_it_key(uint32_t handle, uint32_t offset, char* dest, u
 }
 
 int32_t apply_context::kv_it_value(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(slot.is_primary, kv_invalid_iterator, "kv_it_value called on secondary iterator");
+   auto& slot = get_primary_slot(kv_primary_iterators, handle, "kv_it_value");
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -1036,7 +1063,7 @@ void apply_context::kv_idx_update(uint64_t payer_val, uint16_t table_id,
    // skip entries. Invalidate the cached id on any matching slot so the next
    // op falls back to the slow re-seek using the saved old key bytes,
    // matching the prior remove+create observable behavior.
-   kv_iterators.invalidate_secondary_cache(receiver, table_id, itr->id._id);
+   kv_secondary_iterators.invalidate_cache(receiver, table_id, itr->id._id);
 
    // undo_index::post_modify handles AVL tree rebalancing when composite
    // index key fields change, avoiding node dealloc/realloc overhead.
@@ -1057,13 +1084,13 @@ int32_t apply_context::kv_idx_find_secondary(name code, uint16_t table_id,
       return -1; // not found — no iterator slot allocated
    }
 
-   const uint32_t handle = kv_iterators.allocate_secondary(code, table_id);
-   auto& slot = kv_iterators.get(handle);
+   const uint32_t slot_index = kv_secondary_iterators.allocate(code, table_id);
+   auto& slot = kv_secondary_iterators.get(slot_index);
    slot.status = kv_it_stat::iterator_ok;
    slot.current_sec_key.assign(itr->sec_key.data(), itr->sec_key.data() + itr->sec_key.size());
    slot.current_pri_key.assign(itr->pri_key.data(), itr->pri_key.data() + itr->pri_key.size());
    slot.cached_id = itr->id._id;
-   return static_cast<int32_t>(handle);
+   return static_cast<int32_t>(kv_make_secondary_handle(slot_index));
 }
 
 int32_t apply_context::kv_idx_lower_bound(name code, uint16_t table_id,
@@ -1075,26 +1102,25 @@ int32_t apply_context::kv_idx_lower_bound(name code, uint16_t table_id,
    if (itr == idx.end() || itr->code != code || itr->table_id != table_id) {
       auto first = idx.lower_bound(boost::make_tuple(code, table_id));
       if (first != idx.end() && first->code == code && first->table_id == table_id) {
-         const uint32_t handle = kv_iterators.allocate_secondary(code, table_id);
-         auto& slot = kv_iterators.get(handle);
+         const uint32_t slot_index = kv_secondary_iterators.allocate(code, table_id);
+         auto& slot = kv_secondary_iterators.get(slot_index);
          slot.status = kv_it_stat::iterator_end;
-         return static_cast<int32_t>(handle);
+         return static_cast<int32_t>(kv_make_secondary_handle(slot_index));
       }
       return -1;
    }
 
-   const uint32_t handle = kv_iterators.allocate_secondary(code, table_id);
-   auto& slot = kv_iterators.get(handle);
+   const uint32_t slot_index = kv_secondary_iterators.allocate(code, table_id);
+   auto& slot = kv_secondary_iterators.get(slot_index);
    slot.status = kv_it_stat::iterator_ok;
    slot.current_sec_key.assign(itr->sec_key.data(), itr->sec_key.data() + itr->sec_key.size());
    slot.current_pri_key.assign(itr->pri_key.data(), itr->pri_key.data() + itr->pri_key.size());
    slot.cached_id = itr->id._id;
-   return static_cast<int32_t>(handle);
+   return static_cast<int32_t>(kv_make_secondary_handle(slot_index));
 }
 
 int32_t apply_context::kv_idx_next(uint32_t handle) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(!slot.is_primary, kv_invalid_iterator, "kv_idx_next called on primary iterator");
+   auto& slot = get_secondary_slot(kv_secondary_iterators, handle, "kv_idx_next");
 
    if (slot.status == kv_it_stat::iterator_end) return static_cast<int32_t>(kv_it_stat::iterator_end);
 
@@ -1134,8 +1160,7 @@ int32_t apply_context::kv_idx_next(uint32_t handle) {
 }
 
 int32_t apply_context::kv_idx_prev(uint32_t handle) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(!slot.is_primary, kv_invalid_iterator, "kv_idx_prev called on primary iterator");
+   auto& slot = get_secondary_slot(kv_secondary_iterators, handle, "kv_idx_prev");
 
    const auto& idx = db.get_index<kv_index_index, by_code_table_id_seckey>();
 
@@ -1198,7 +1223,7 @@ int32_t apply_context::kv_idx_prev(uint32_t handle) {
 }
 
 // Helper: find the current secondary entry by cached ID (fast) or key bytes (slow).
-static const kv_index_object* find_current_secondary(const chainbase::database& db, kv_iterator_slot& slot) {
+static const kv_index_object* find_current_secondary(const chainbase::database& db, kv_secondary_slot& slot) {
    if (slot.cached_id >= 0) {
       const auto* obj = db.find<kv_index_object>(kv_index_object::id_type(slot.cached_id));
       if (obj && obj->code == slot.code && obj->table_id == slot.table_id)
@@ -1217,8 +1242,7 @@ static const kv_index_object* find_current_secondary(const chainbase::database& 
 }
 
 int32_t apply_context::kv_idx_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(!slot.is_primary, kv_invalid_iterator, "kv_idx_key called on primary iterator");
+   auto& slot = get_secondary_slot(kv_secondary_iterators, handle, "kv_idx_key");
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -1242,8 +1266,7 @@ int32_t apply_context::kv_idx_key(uint32_t handle, uint32_t offset, char* dest, 
 }
 
 int32_t apply_context::kv_idx_primary_key(uint32_t handle, uint32_t offset, char* dest, uint32_t dest_size, uint32_t& actual_size) {
-   auto& slot = kv_iterators.get(handle);
-   SYS_ASSERT(!slot.is_primary, kv_invalid_iterator, "kv_idx_primary_key called on primary iterator");
+   auto& slot = get_secondary_slot(kv_secondary_iterators, handle, "kv_idx_primary_key");
 
    if (slot.status != kv_it_stat::iterator_ok) {
       actual_size = 0;
@@ -1267,7 +1290,10 @@ int32_t apply_context::kv_idx_primary_key(uint32_t handle, uint32_t offset, char
 }
 
 void apply_context::kv_idx_destroy(uint32_t handle) {
-   kv_iterators.release(handle);
+   kv_handle_check_reserved_zero(handle);
+   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "kv_idx_destroy called on primary iterator handle");
+   kv_secondary_iterators.release(kv_handle_slot_index(handle));
 }
 
 } /// sysio::chain

--- a/libraries/chain/include/sysio/chain/apply_context.hpp
+++ b/libraries/chain/include/sysio/chain/apply_context.hpp
@@ -176,7 +176,8 @@ class apply_context {
 
    private:
 
-      kv_iterator_pool                    kv_iterators;
+      kv_primary_iterator_pool            kv_primary_iterators;
+      kv_secondary_iterator_pool          kv_secondary_iterators;
       std::optional<const account_metadata_object*> _first_receiver_metadata; ///< cached across notification dispatch
       vector< std::pair<account_name, uint32_t> > _notified; ///< keeps track of new accounts to be notifed of current message
       vector<uint32_t>                    _inline_actions; ///< action_ordinals of queued inline actions

--- a/libraries/chain/include/sysio/chain/kv_context.hpp
+++ b/libraries/chain/include/sysio/chain/kv_context.hpp
@@ -5,6 +5,7 @@
 #include <sysio/chain/exceptions.hpp>
 #include <vector>
 #include <cstring>
+#include <cstdint>
 
 namespace sysio { namespace chain {
 
@@ -14,96 +15,209 @@ enum class kv_it_stat : int32_t {
    iterator_erased = 2
 };
 
-struct kv_iterator_slot {
+// ---------------------------------------------------------------------------
+// Handle encoding (CONSENSUS-OBSERVABLE)
+//
+// Iterator handles are returned to contracts from kv_it_create /
+// kv_idx_find_secondary / kv_idx_lower_bound and accepted back by every
+// kv_it_* / kv_idx_* entry point.  Contracts may read, store, and branch on
+// these values, so the layout is part of the consensus surface.
+//
+//   [ 0.. 9]  slot index (10 bits, covers config::max_kv_iterators = 1024)
+//   [10..15]  RESERVED, must be zero
+//   [16    ]  secondary-pool tag (1 = secondary, 0 = primary)
+//   [17..30]  RESERVED, must be zero
+//   [31    ]  always zero - keeps handles positive when read as int32_t
+//             (negative returns are reserved for "not found" sentinels).
+//
+// Reserved bits give future protocol changes room to encode e.g. iterator
+// generation counters without disturbing deployed contract code.  A contract
+// that fabricates a handle by setting reserved bits fails with a clean
+// kv_invalid_iterator instead of silently aliasing a real slot through the
+// truncated slot-index mask.  Any change to this layout is a protocol change.
+// ---------------------------------------------------------------------------
+
+inline constexpr uint32_t kv_secondary_handle_tag   = 0x00010000u;
+inline constexpr uint32_t kv_handle_slot_index_mask = 0x000003FFu; // bits 0..9
+inline constexpr uint32_t kv_handle_reserved_mask   =
+   ~(kv_handle_slot_index_mask | kv_secondary_handle_tag);
+
+inline bool kv_handle_is_secondary(uint32_t handle) {
+   return (handle & kv_secondary_handle_tag) != 0;
+}
+
+inline uint32_t kv_handle_slot_index(uint32_t handle) {
+   return handle & kv_handle_slot_index_mask;
+}
+
+inline uint32_t kv_make_secondary_handle(uint32_t slot_index) {
+   return slot_index | kv_secondary_handle_tag;
+}
+
+// Throws kv_invalid_iterator if any reserved bit is set.  Called from every
+// host-intrinsic entry point that consumes a handle so a fabricated handle
+// aborts the action instead of silently aliasing a real slot.
+inline void kv_handle_check_reserved_zero(uint32_t handle) {
+   SYS_ASSERT((handle & kv_handle_reserved_mask) == 0, kv_invalid_iterator,
+              "KV iterator handle has reserved bits set: {}", handle);
+}
+
+// ---------------------------------------------------------------------------
+// Slot types
+//
+// Common fields are shared via inheritance; primary- and secondary-only fields
+// live on the respective subclass so cache lines on the hot iterator paths
+// carry only the data the operation needs.
+// ---------------------------------------------------------------------------
+
+struct kv_iterator_slot_common {
    bool              in_use = false;
-   bool              is_primary = true;
    kv_it_stat        status = kv_it_stat::iterator_end;
    account_name      code;
-   uint16_t          table_id = 0;  ///< table namespace (primary or secondary index)
-
-   // Primary iterator: prefix for bounded iteration
-   std::vector<char>  prefix;
-
-   // Current position key bytes (for re-seeking after invalidation)
-   std::vector<char>  current_key;
-   // For secondary iterators: current secondary key
-   std::vector<char>  current_sec_key;
-   // For secondary iterators: current primary key
-   std::vector<char>  current_pri_key;
-
-   // Cached chainbase ID for O(1) iterator_to fast path.
-   // -1 means no cached ID; falls back to lower_bound re-seek.
+   uint16_t          table_id = 0;
+   // Cached chainbase id for the iterator_to fast path.  -1 means no cached
+   // id; falls back to lower_bound re-seek via the saved key bytes.
    int64_t           cached_id = -1;
 };
 
-class kv_iterator_pool {
-public:
-   kv_iterator_pool() : _slots(config::max_kv_iterators) {}
+struct kv_primary_slot : kv_iterator_slot_common {
+   std::vector<char>  prefix;       ///< prefix for bounded iteration
+   std::vector<char>  current_key;  ///< current position key bytes (for re-seek)
 
-   uint32_t allocate_primary(uint16_t table_id, account_name code, const char* prefix, uint32_t prefix_size) {
+   void reset() {
+      status    = kv_it_stat::iterator_end;
+      cached_id = -1;
+      prefix.clear();
+      current_key.clear();
+   }
+};
+
+struct kv_secondary_slot : kv_iterator_slot_common {
+   std::vector<char>  current_sec_key;  ///< current secondary key bytes
+   std::vector<char>  current_pri_key;  ///< current primary key bytes
+
+   void reset() {
+      status    = kv_it_stat::iterator_end;
+      cached_id = -1;
+      current_sec_key.clear();
+      current_pri_key.clear();
+   }
+};
+
+// ---------------------------------------------------------------------------
+// Primary iterator pool (kv_it_*)
+//
+// The slot array is lazily sized on first allocate() so actions that touch no
+// KV iterators (e.g. sysio.token transfer, which routes through kv_get and
+// kv_set only) pay zero heap for this pool.  Once sized, the pool behaves
+// identically to an eagerly-allocated one.
+// ---------------------------------------------------------------------------
+class kv_primary_iterator_pool {
+public:
+   kv_primary_iterator_pool() = default;
+
+   uint32_t allocate(uint16_t table_id, account_name code,
+                     const char* prefix, uint32_t prefix_size) {
+      if (_slots.empty()) _slots.resize(config::max_kv_iterators);
       uint32_t idx = find_free();
       auto& s = _slots[idx];
-      s.in_use = true;
-      s.is_primary = true;
-      s.status = kv_it_stat::iterator_end;
-      s.code = code;
+      s.reset();
+      s.in_use   = true;
+      s.code     = code;
       s.table_id = table_id;
       s.prefix.assign(prefix, prefix + prefix_size);
-      s.current_key.clear();
-      s.current_sec_key.clear();
-      s.current_pri_key.clear();
-      s.cached_id = -1;
       return idx;
    }
 
-   uint32_t allocate_secondary(account_name code, uint16_t table_id) {
+   void release(uint32_t slot_index) {
+      SYS_ASSERT(slot_index < _slots.size() && _slots[slot_index].in_use,
+                 kv_invalid_iterator, "invalid KV primary iterator slot {}", slot_index);
+      auto& s = _slots[slot_index];
+      s.reset();
+      s.in_use = false;
+      if (slot_index < _next_free) _next_free = slot_index;
+   }
+
+   kv_primary_slot& get(uint32_t slot_index) {
+      SYS_ASSERT(slot_index < _slots.size() && _slots[slot_index].in_use,
+                 kv_invalid_iterator, "invalid KV primary iterator slot {}", slot_index);
+      return _slots[slot_index];
+   }
+
+   const kv_primary_slot& get(uint32_t slot_index) const {
+      SYS_ASSERT(slot_index < _slots.size() && _slots[slot_index].in_use,
+                 kv_invalid_iterator, "invalid KV primary iterator slot {}", slot_index);
+      return _slots[slot_index];
+   }
+
+private:
+   uint32_t find_free() {
+      for (uint32_t i = _next_free; i < _slots.size(); ++i) {
+         if (!_slots[i].in_use) {
+            _next_free = i + 1;
+            return i;
+         }
+      }
+      SYS_THROW(kv_iterator_limit_exceeded,
+                "exceeded maximum number of KV primary iterators ({})",
+                config::max_kv_iterators);
+   }
+
+   std::vector<kv_primary_slot> _slots;
+   uint32_t _next_free = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Secondary iterator pool (kv_idx_*)
+//
+// Independent free-list from the primary pool so a contract may hold up to
+// max_kv_iterators of each kind simultaneously.  Lazily sized on first
+// allocate(), same as the primary pool.
+// ---------------------------------------------------------------------------
+class kv_secondary_iterator_pool {
+public:
+   kv_secondary_iterator_pool() = default;
+
+   uint32_t allocate(account_name code, uint16_t table_id) {
+      if (_slots.empty()) _slots.resize(config::max_kv_iterators);
       uint32_t idx = find_free();
       auto& s = _slots[idx];
-      s.in_use = true;
-      s.is_primary = false;
-      s.status = kv_it_stat::iterator_end;
-      s.code = code;
+      s.reset();
+      s.in_use   = true;
+      s.code     = code;
       s.table_id = table_id;
-      s.prefix.clear();
-      s.current_key.clear();
-      s.current_sec_key.clear();
-      s.current_pri_key.clear();
-      s.cached_id = -1;
       return idx;
    }
 
-   void release(uint32_t handle) {
-      SYS_ASSERT(handle < _slots.size() && _slots[handle].in_use,
-         kv_invalid_iterator, "invalid KV iterator handle {}", handle);
-      auto& s = _slots[handle];
+   void release(uint32_t slot_index) {
+      SYS_ASSERT(slot_index < _slots.size() && _slots[slot_index].in_use,
+                 kv_invalid_iterator, "invalid KV secondary iterator slot {}", slot_index);
+      auto& s = _slots[slot_index];
+      s.reset();
       s.in_use = false;
-      s.prefix.clear();
-      s.current_key.clear();
-      s.current_sec_key.clear();
-      s.current_pri_key.clear();
-      s.cached_id = -1;
-      if (handle < _next_free) _next_free = handle;
+      if (slot_index < _next_free) _next_free = slot_index;
    }
 
-   kv_iterator_slot& get(uint32_t handle) {
-      SYS_ASSERT(handle < _slots.size() && _slots[handle].in_use,
-         kv_invalid_iterator, "invalid KV iterator handle {}", handle);
-      return _slots[handle];
+   kv_secondary_slot& get(uint32_t slot_index) {
+      SYS_ASSERT(slot_index < _slots.size() && _slots[slot_index].in_use,
+                 kv_invalid_iterator, "invalid KV secondary iterator slot {}", slot_index);
+      return _slots[slot_index];
    }
 
-   const kv_iterator_slot& get(uint32_t handle) const {
-      SYS_ASSERT(handle < _slots.size() && _slots[handle].in_use,
-         kv_invalid_iterator, "invalid KV iterator handle {}", handle);
-      return _slots[handle];
+   const kv_secondary_slot& get(uint32_t slot_index) const {
+      SYS_ASSERT(slot_index < _slots.size() && _slots[slot_index].in_use,
+                 kv_invalid_iterator, "invalid KV secondary iterator slot {}", slot_index);
+      return _slots[slot_index];
    }
 
-   // Clears cached_id on any secondary slot referencing the given kv_index_object.
-   // Preserves stored key bytes and iterator status so the next op uses the slow
-   // re-seek path from the old position. Used before db.modify of a secondary
-   // entry, where the chainbase id survives but the object's sort position moves.
-   void invalidate_secondary_cache(account_name code, uint16_t table_id, int64_t object_id) {
+   // Clears cached_id on any slot referencing the given kv_index_object id.
+   // Preserves stored key bytes and iterator status so the next op uses the
+   // slow re-seek path from the old position.  Used before db.modify of a
+   // secondary entry where the chainbase id survives but the object's sort
+   // position moves.
+   void invalidate_cache(account_name code, uint16_t table_id, int64_t object_id) {
       for (auto& s : _slots) {
-         if (s.in_use && !s.is_primary &&
+         if (s.in_use &&
              s.code == code && s.table_id == table_id &&
              s.cached_id == object_id) {
             s.cached_id = -1;
@@ -120,10 +234,11 @@ private:
          }
       }
       SYS_THROW(kv_iterator_limit_exceeded,
-         "exceeded maximum number of KV iterators ({})", config::max_kv_iterators);
+                "exceeded maximum number of KV secondary iterators ({})",
+                config::max_kv_iterators);
    }
 
-   std::vector<kv_iterator_slot> _slots;
+   std::vector<kv_secondary_slot> _slots;
    uint32_t _next_free = 0;
 };
 

--- a/libraries/chain/include/sysio/chain/kv_context.hpp
+++ b/libraries/chain/include/sysio/chain/kv_context.hpp
@@ -39,27 +39,43 @@ enum class kv_it_stat : int32_t {
 
 inline constexpr uint32_t kv_secondary_handle_tag   = 0x00010000u;
 inline constexpr uint32_t kv_handle_slot_index_mask = 0x000003FFu; // bits 0..9
-inline constexpr uint32_t kv_handle_reserved_mask   =
-   ~(kv_handle_slot_index_mask | kv_secondary_handle_tag);
+inline constexpr uint32_t kv_handle_reserved_mask   = ~(kv_handle_slot_index_mask | kv_secondary_handle_tag);
 
-inline bool kv_handle_is_secondary(uint32_t handle) {
-   return (handle & kv_secondary_handle_tag) != 0;
-}
+// Compile-time invariant: slot indices must fit in the handle's slot bits. Bumping max_kv_iterators past the mask
+// width would silently truncate high-slot handles and dispatch them to the wrong slot.
+static_assert(config::max_kv_iterators <= kv_handle_slot_index_mask + 1,
+              "kv_handle_slot_index_mask too narrow for config::max_kv_iterators");
 
-inline uint32_t kv_handle_slot_index(uint32_t handle) {
-   return handle & kv_handle_slot_index_mask;
-}
+inline bool kv_handle_is_secondary(uint32_t handle) { return (handle & kv_secondary_handle_tag) != 0; }
+inline uint32_t kv_handle_slot_index(uint32_t handle) { return handle & kv_handle_slot_index_mask; }
+inline uint32_t kv_make_secondary_handle(uint32_t slot_index) { return slot_index | kv_secondary_handle_tag; }
 
-inline uint32_t kv_make_secondary_handle(uint32_t slot_index) {
-   return slot_index | kv_secondary_handle_tag;
-}
-
-// Throws kv_invalid_iterator if any reserved bit is set.  Called from every
-// host-intrinsic entry point that consumes a handle so a fabricated handle
-// aborts the action instead of silently aliasing a real slot.
+// Throws kv_invalid_iterator if any reserved bit is set. Called at every host-intrinsic entry point that consumes
+// a handle so a fabricated handle aborts the action instead of silently aliasing a real slot.
 inline void kv_handle_check_reserved_zero(uint32_t handle) {
    SYS_ASSERT((handle & kv_handle_reserved_mask) == 0, kv_invalid_iterator,
               "KV iterator handle has reserved bits set: {}", handle);
+}
+
+// Validate handle and return its slot index; throws on fabricated or wrong-pool handles.
+inline uint32_t validate_primary_handle(uint32_t handle, const char* op) {
+   kv_handle_check_reserved_zero(handle);
+   SYS_ASSERT(!kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "{} called on secondary iterator handle", op);
+   return kv_handle_slot_index(handle);
+}
+inline uint32_t validate_secondary_handle(uint32_t handle, const char* op) {
+   kv_handle_check_reserved_zero(handle);
+   SYS_ASSERT(kv_handle_is_secondary(handle), kv_invalid_iterator,
+              "{} called on primary iterator handle", op);
+   return kv_handle_slot_index(handle);
+}
+
+// Bound iterator prefix size. Prefix bytes are copied into the slot's vector; without a cap a contract could allocate
+// arbitrary host-side storage per iterator. Uses the absolute key-size ceiling (not the dynamic max_kv_key_size).
+inline void kv_check_prefix_size(uint32_t prefix_size) {
+   SYS_ASSERT(prefix_size <= config::max_kv_key_size_limit, kv_key_too_large,
+              "KV iterator prefix size {} exceeds limit {}", prefix_size, config::max_kv_key_size_limit);
 }
 
 // ---------------------------------------------------------------------------

--- a/unittests/kv_tests.cpp
+++ b/unittests/kv_tests.cpp
@@ -311,15 +311,15 @@ BOOST_AUTO_TEST_CASE(kv_iterator_pool_basic) {
    kv_primary_iterator_pool prim_pool;
    kv_secondary_iterator_pool sec_pool;
 
-   // Allocate primary -- returns a raw slot index (no tag).
+   // Treat the value returned by primary allocate() as a contract-facing handle and route every access via the
+   // handle helpers so the test does not bake in the current "primary handle == slot index" detail.
    uint32_t h1 = prim_pool.allocate(uint16_t(0), "test"_n, "prefix", 6);
-   BOOST_CHECK_EQUAL(h1, 0u);
    BOOST_CHECK(!kv_handle_is_secondary(h1));
    auto& slot1 = prim_pool.get(kv_handle_slot_index(h1));
    BOOST_CHECK_EQUAL(slot1.code, "test"_n);
    BOOST_CHECK_EQUAL(slot1.prefix.size(), 6u);
 
-   // Allocate secondary -- slot index is wrapped with the tag bit.
+   // Secondary: wrap the slot index with the tag bit, then verify round-trip through the helpers.
    uint32_t s2 = sec_pool.allocate("test"_n, uint16_t(100));
    uint32_t h2 = kv_make_secondary_handle(s2);
    BOOST_CHECK(kv_handle_is_secondary(h2));
@@ -327,13 +327,41 @@ BOOST_AUTO_TEST_CASE(kv_iterator_pool_basic) {
    auto& slot2 = sec_pool.get(kv_handle_slot_index(h2));
    BOOST_CHECK_EQUAL(slot2.code, "test"_n);
 
-   // Release and reuse from each pool independently.
+   // Each pool has its own free-list. A primary release does not affect the secondary, and vice versa.
    prim_pool.release(kv_handle_slot_index(h1));
    uint32_t h3 = prim_pool.allocate(uint16_t(0), "other"_n, "", 0);
-   BOOST_CHECK_EQUAL(h3, 0u); // reuses slot 0
+   BOOST_CHECK_EQUAL(kv_handle_slot_index(h3), kv_handle_slot_index(h1)); // reuses the freed slot
 
    sec_pool.release(kv_handle_slot_index(h2));
    prim_pool.release(kv_handle_slot_index(h3));
+}
+
+BOOST_AUTO_TEST_CASE(kv_validate_handle_dispatch) {
+   // validate_primary_handle: well-formed primary returns its slot index; wrong-pool tag and reserved bits throw.
+   BOOST_CHECK_EQUAL(validate_primary_handle(0u, "op"), 0u);
+   BOOST_CHECK_EQUAL(validate_primary_handle(1023u, "op"), 1023u);
+   BOOST_CHECK_THROW(validate_primary_handle(kv_make_secondary_handle(5u), "op"), kv_invalid_iterator);
+   BOOST_CHECK_THROW(validate_primary_handle(0x00000400u, "op"), kv_invalid_iterator); // bit 10 reserved
+   BOOST_CHECK_THROW(validate_primary_handle(0x00020000u, "op"), kv_invalid_iterator); // bit 17 reserved
+   BOOST_CHECK_THROW(validate_primary_handle(0x80000000u, "op"), kv_invalid_iterator); // bit 31 reserved (sign)
+
+   // validate_secondary_handle: well-formed secondary returns its slot index; primary handles and reserved bits throw.
+   uint32_t sec_handle = kv_make_secondary_handle(5u);
+   BOOST_CHECK_EQUAL(validate_secondary_handle(sec_handle, "op"), 5u);
+   BOOST_CHECK_THROW(validate_secondary_handle(5u, "op"), kv_invalid_iterator);        // primary
+   BOOST_CHECK_THROW(validate_secondary_handle(0u, "op"), kv_invalid_iterator);        // primary, slot 0
+   BOOST_CHECK_THROW(validate_secondary_handle(sec_handle | 0x00000400u, "op"),
+                     kv_invalid_iterator); // sec + bit 10
+   BOOST_CHECK_THROW(validate_secondary_handle(sec_handle | 0x80000000u, "op"),
+                     kv_invalid_iterator); // sec + bit 31
+}
+
+BOOST_AUTO_TEST_CASE(kv_check_prefix_size_bounds) {
+   BOOST_CHECK_NO_THROW(kv_check_prefix_size(0));
+   BOOST_CHECK_NO_THROW(kv_check_prefix_size(8));
+   BOOST_CHECK_NO_THROW(kv_check_prefix_size(config::max_kv_key_size_limit));
+   BOOST_CHECK_THROW(kv_check_prefix_size(config::max_kv_key_size_limit + 1), kv_key_too_large);
+   BOOST_CHECK_THROW(kv_check_prefix_size(std::numeric_limits<uint32_t>::max()), kv_key_too_large);
 }
 
 BOOST_AUTO_TEST_CASE(kv_iterator_pool_independent_exhaustion) {

--- a/unittests/kv_tests.cpp
+++ b/unittests/kv_tests.cpp
@@ -308,82 +308,114 @@ BOOST_AUTO_TEST_CASE(kv_index_modify_rekeys_correctly) {
 }
 
 BOOST_AUTO_TEST_CASE(kv_iterator_pool_basic) {
-   kv_iterator_pool pool;
+   kv_primary_iterator_pool prim_pool;
+   kv_secondary_iterator_pool sec_pool;
 
-   // Allocate primary
-   uint32_t h1 = pool.allocate_primary(uint16_t(0), "test"_n, "prefix", 6);
+   // Allocate primary -- returns a raw slot index (no tag).
+   uint32_t h1 = prim_pool.allocate(uint16_t(0), "test"_n, "prefix", 6);
    BOOST_CHECK_EQUAL(h1, 0u);
-   auto& slot1 = pool.get(h1);
-   BOOST_CHECK(slot1.is_primary);
+   BOOST_CHECK(!kv_handle_is_secondary(h1));
+   auto& slot1 = prim_pool.get(kv_handle_slot_index(h1));
    BOOST_CHECK_EQUAL(slot1.code, "test"_n);
+   BOOST_CHECK_EQUAL(slot1.prefix.size(), 6u);
 
-   // Allocate secondary
-   uint32_t h2 = pool.allocate_secondary("test"_n, uint16_t(100));
-   BOOST_CHECK_EQUAL(h2, 1u);
-   auto& slot2 = pool.get(h2);
-   BOOST_CHECK(!slot2.is_primary);
+   // Allocate secondary -- slot index is wrapped with the tag bit.
+   uint32_t s2 = sec_pool.allocate("test"_n, uint16_t(100));
+   uint32_t h2 = kv_make_secondary_handle(s2);
+   BOOST_CHECK(kv_handle_is_secondary(h2));
+   BOOST_CHECK_EQUAL(kv_handle_slot_index(h2), s2);
+   auto& slot2 = sec_pool.get(kv_handle_slot_index(h2));
+   BOOST_CHECK_EQUAL(slot2.code, "test"_n);
 
-   // Release and reuse
-   pool.release(h1);
-   uint32_t h3 = pool.allocate_primary(uint16_t(0), "other"_n, "", 0);
+   // Release and reuse from each pool independently.
+   prim_pool.release(kv_handle_slot_index(h1));
+   uint32_t h3 = prim_pool.allocate(uint16_t(0), "other"_n, "", 0);
    BOOST_CHECK_EQUAL(h3, 0u); // reuses slot 0
 
-   pool.release(h2);
-   pool.release(h3);
+   sec_pool.release(kv_handle_slot_index(h2));
+   prim_pool.release(kv_handle_slot_index(h3));
 }
 
-BOOST_AUTO_TEST_CASE(kv_iterator_pool_exhaustion) {
-   kv_iterator_pool pool;
+BOOST_AUTO_TEST_CASE(kv_iterator_pool_independent_exhaustion) {
+   kv_primary_iterator_pool prim_pool;
+   kv_secondary_iterator_pool sec_pool;
 
-   // Allocate all 16 slots
+   // Exhausting one pool must not consume slots in the other.
    for (uint32_t i = 0; i < config::max_kv_iterators; ++i) {
-      pool.allocate_primary(uint16_t(0), "test"_n, "", 0);
+      prim_pool.allocate(uint16_t(0), "test"_n, "", 0);
    }
-
-   // 17th should throw
    BOOST_CHECK_THROW(
-      pool.allocate_primary(uint16_t(0), "test"_n, "", 0),
+      prim_pool.allocate(uint16_t(0), "test"_n, "", 0),
       kv_iterator_limit_exceeded
    );
 
-   // Release one and try again
-   pool.release(5);
-   uint32_t h = pool.allocate_primary(uint16_t(0), "test"_n, "", 0);
-   BOOST_CHECK_EQUAL(h, 5u);
+   // Secondary pool is still empty -- can allocate the full budget.
+   for (uint32_t i = 0; i < config::max_kv_iterators; ++i) {
+      sec_pool.allocate("test"_n, uint16_t(0));
+   }
+   BOOST_CHECK_THROW(
+      sec_pool.allocate("test"_n, uint16_t(0)),
+      kv_iterator_limit_exceeded
+   );
+
+   // Release one slot in each pool and verify reuse.
+   prim_pool.release(5);
+   BOOST_CHECK_EQUAL(prim_pool.allocate(uint16_t(0), "test"_n, "", 0), 5u);
+   sec_pool.release(7);
+   BOOST_CHECK_EQUAL(sec_pool.allocate("test"_n, uint16_t(0)), 7u);
 }
 
-// kv_idx_update uses db.modify, which preserves the chainbase id but can
-// move the object's sort position. Verify that invalidate_secondary_cache
-// clears cached_id only on the matching secondary slot and only the cached_id,
-// leaving stored key bytes and status intact for the slow re-seek path.
-BOOST_AUTO_TEST_CASE(kv_iterator_pool_invalidate_secondary_cache) {
-   kv_iterator_pool pool;
+BOOST_AUTO_TEST_CASE(kv_iterator_handle_encoding) {
+   // Round-trip: tag a slot index, recover it via the helpers.
+   for (uint32_t slot : {uint32_t{0}, uint32_t{1}, uint32_t{17}, uint32_t{1023}}) {
+      uint32_t handle = kv_make_secondary_handle(slot);
+      BOOST_CHECK(kv_handle_is_secondary(handle));
+      BOOST_CHECK_EQUAL(kv_handle_slot_index(handle), slot);
+      // Reserved bits 10..15 and 17..31 must all be zero in a freshly-encoded handle.
+      BOOST_CHECK_EQUAL(handle & ~(kv_handle_slot_index_mask | kv_secondary_handle_tag),
+                        0u);
+   }
 
-   const uint16_t users_pri = compute_table_id("users");
-   const uint16_t users_idx = compute_table_id("users.byname");
+   // Primary handles carry no tag.
+   BOOST_CHECK(!kv_handle_is_secondary(0u));
+   BOOST_CHECK(!kv_handle_is_secondary(1u));
+   BOOST_CHECK(!kv_handle_is_secondary(1023u));
+
+   // Reserved-bit guard: a fabricated handle with any reserved bit set throws.
+   BOOST_CHECK_NO_THROW(kv_handle_check_reserved_zero(0u));
+   BOOST_CHECK_NO_THROW(kv_handle_check_reserved_zero(1023u));
+   BOOST_CHECK_NO_THROW(kv_handle_check_reserved_zero(kv_make_secondary_handle(5u)));
+   BOOST_CHECK_THROW(kv_handle_check_reserved_zero(0x00000400u), kv_invalid_iterator); // bit 10
+   BOOST_CHECK_THROW(kv_handle_check_reserved_zero(0x00020000u), kv_invalid_iterator); // bit 17
+   BOOST_CHECK_THROW(kv_handle_check_reserved_zero(0x40000000u), kv_invalid_iterator); // bit 30
+}
+
+// kv_idx_update uses db.modify, which preserves the chainbase id but can move
+// the object's sort position. Verify that invalidate_cache clears cached_id
+// only on the matching secondary slot and leaves stored key bytes and status
+// intact for the slow re-seek path.
+BOOST_AUTO_TEST_CASE(kv_secondary_iterator_pool_invalidate_cache) {
+   kv_secondary_iterator_pool pool;
+
+   const uint16_t users_idx       = compute_table_id("users.byname");
    const uint16_t users_idx_other = compute_table_id("users.byage");
-   const uint16_t things_idx = compute_table_id("things.byname");
+   const uint16_t things_idx      = compute_table_id("things.byname");
 
-   uint32_t h_prim         = pool.allocate_primary(users_pri, "test"_n, "", 0);
-   uint32_t h_sec          = pool.allocate_secondary("test"_n, users_idx);
-   uint32_t h_other_idx_a  = pool.allocate_secondary("test"_n, things_idx);
-   uint32_t h_other_idx_b  = pool.allocate_secondary("test"_n, users_idx_other);
-   uint32_t h_other_code   = pool.allocate_secondary("alt"_n,  users_idx);
-   uint32_t h_other_id     = pool.allocate_secondary("test"_n, users_idx);
+   uint32_t h_sec          = pool.allocate("test"_n, users_idx);
+   uint32_t h_other_idx_a  = pool.allocate("test"_n, things_idx);
+   uint32_t h_other_idx_b  = pool.allocate("test"_n, users_idx_other);
+   uint32_t h_other_code   = pool.allocate("alt"_n,  users_idx);
+   uint32_t h_other_id     = pool.allocate("test"_n, users_idx);
 
    const int64_t target_id = 42;
    const int64_t other_id  = 99;
 
-   auto seed = [](kv_iterator_slot& s, int64_t id) {
+   auto seed = [](kv_secondary_slot& s, int64_t id) {
       s.status = kv_it_stat::iterator_ok;
       s.current_sec_key.assign({'a','l','i','c','e'});
       s.current_pri_key.assign({'\x00','\x01'});
       s.cached_id = id;
    };
-
-   // Primary slot must be ignored even when its cached_id collides.
-   pool.get(h_prim).cached_id = target_id;
-   pool.get(h_prim).status = kv_it_stat::iterator_ok;
 
    seed(pool.get(h_sec),          target_id);
    seed(pool.get(h_other_idx_a),  target_id);
@@ -391,19 +423,16 @@ BOOST_AUTO_TEST_CASE(kv_iterator_pool_invalidate_secondary_cache) {
    seed(pool.get(h_other_code),   target_id);
    seed(pool.get(h_other_id),     other_id);
 
-   pool.invalidate_secondary_cache("test"_n, users_idx, target_id);
+   pool.invalidate_cache("test"_n, users_idx, target_id);
 
-   // Matching secondary slot: cached_id cleared, key bytes and status preserved.
+   // Matching slot: cached_id cleared, key bytes and status preserved.
    const auto& matched = pool.get(h_sec);
    BOOST_CHECK_EQUAL(matched.cached_id, -1);
    BOOST_CHECK(matched.status == kv_it_stat::iterator_ok);
    BOOST_CHECK_EQUAL(matched.current_sec_key.size(), 5u);
    BOOST_CHECK_EQUAL(matched.current_pri_key.size(), 2u);
 
-   // Primary slot untouched even though id matches.
-   BOOST_CHECK_EQUAL(pool.get(h_prim).cached_id, target_id);
-
-   // Secondary slots that differ in any of code/table_id/id are untouched.
+   // Slots that differ in any of code/table_id/id are untouched.
    BOOST_CHECK_EQUAL(pool.get(h_other_idx_a).cached_id, target_id);
    BOOST_CHECK_EQUAL(pool.get(h_other_idx_b).cached_id, target_id);
    BOOST_CHECK_EQUAL(pool.get(h_other_code).cached_id,  target_id);


### PR DESCRIPTION
## Summary

Pre-split, `apply_context` kept a single 1024-slot pool with each slot a union of fields for both iterator kinds. Hot paths loaded cache lines holding data the operation did not touch, and a contract iterating both kinds concurrently competed for the same 1024-slot budget.

This change splits the pool into independent primary and secondary pools with type-specific slot layouts, hardens the contract-visible iterator handle ABI, and caps the `kv_it_create` prefix size against an unbounded-allocation vector.

## Pool split

- `kv_iterator_slot_common` holds the fields every iterator needs (in_use, status, code, table_id, cached_id).
- `kv_primary_slot` adds primary-only byte buffers (`prefix`, `current_key`).
- `kv_secondary_slot` adds secondary-only fields (`current_sec_key`, `current_pri_key`).
- `kv_primary_iterator_pool` and `kv_secondary_iterator_pool` each expose 1024 slots independently. A contract may now hold up to 1024 primary AND 1024 secondary iterators simultaneously.
- Both pools lazily resize on first `allocate()` -- actions that never touch KV iterators (e.g. `sysio.token::transfer`) pay zero heap for the pools.

## Handle encoding (CONSENSUS-OBSERVABLE)

Handle values are contract-visible. Layout:

    [ 0.. 9]  slot index (10 bits, covers max_kv_iterators = 1024)
    [10..15]  RESERVED -- must be zero
    [16    ]  secondary-pool tag (1 = secondary, 0 = primary)
    [17..30]  RESERVED -- must be zero
    [31    ]  always zero -- keeps handles positive when read as int32_t

Bit 16 was chosen over a high bit so handle values stay small and readable in logs (secondary handle `0x00010005` vs `0x40000005`). Reserved bits give future protocol features room to encode e.g. generation counters without disturbing deployed contract code. Any change to this layout is a protocol change.

`kv_handle_check_reserved_zero()` is called at every host-intrinsic entry point that consumes a handle. A contract that fabricates a handle by setting reserved bits fails with a clean `kv_invalid_iterator` exception instead of silently aliasing a real slot.

## Prefix-size bound on kv_it_create

Cap `prefix_size` at `config::max_kv_key_size_limit` (1024 B). The prefix bytes are `memcpy`'d into the iterator slot, so an unbounded `prefix_size` would let a contract allocate arbitrary host-side storage per iterator. Legitimate CDT usage passes 0 or 8 bytes, far below the cap.

## Capacity

No contract that worked pre-split gets a new error. Some that exhausted the shared 1024-slot pool mid-mixed use now succeed (primary+secondary sum up to 2048).

## Host ABI / chainbase

No change. Host intrinsic signatures, `kv_object`/`kv_index_object` layout, and serialization are all untouched.