### PR TITLE
Pin vcpkg registry references

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,6 +3,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "74e6536215718009aae747d86d84b78376bf9e09",
+    "reference": "bc71aa640f89933294f16e004b212c7fd3183eed",
     "repository": "https://github.com/Microsoft/vcpkg"
   },
   "registries": [
@@ -10,6 +11,7 @@
       "kind": "git",
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
       "baseline": "23aa4018992d85602a4b5c30104a623e708b4b3e",
+      "reference": "23aa4018992d85602a4b5c30104a623e708b4b3e",
       "packages": [
         "boost",
         "softfloat",


### PR DESCRIPTION
## Summary

- Pin the Microsoft default vcpkg registry `reference` to a commit that contains the repo's current default-registry overrides
- Pin the Wire custom vcpkg registry `reference` to match its configured `baseline`

## Why

The failed CI job in #342 showed vcpkg fetching the Wire registry from `HEAD`:

```text
Fetching registry information from https://github.com/wire-network/wire-vcpkg-registry (HEAD)...
error: boost does not exist
```

For Git registries, `baseline` anchors package versions, but `reference` controls which Git ref vcpkg uses to list available versions. Without `reference`, vcpkg defaults to the registry's moving `HEAD`, which can make old builds fail when the registry changes.

The default Microsoft registry is pinned to `bc71aa640f89933294f16e004b212c7fd3183eed`, because that commit includes the exact version database entries required by the current manifest overrides, including `protobuf 6.33.4#1`.

Closes #342

## Verification

- `jq empty vcpkg-configuration.json`
- Verified the Wire registry commit exists and its baseline contains `boost`
- Verified Microsoft/vcpkg `bc71aa640f89933294f16e004b212c7fd3183eed` contains `protobuf 6.33.4#1`
- Ran `vcpkg install --dry-run` from a temporary manifest root with both registry references pinned; dependency resolution succeeded without the previous protobuf version-database error