### PR TITLE
Clio: add EM/SOL external-signer key support

### DIFF
--- a/libraries/libfc/include/fc/crypto/elliptic_em.hpp
+++ b/libraries/libfc/include/fc/crypto/elliptic_em.hpp
@@ -93,9 +93,9 @@ namespace fc {
            static private_key regenerate( const private_key_secret& secret );
 
            /**
-            * @brief
-            * @param pub_key_str Public key in ethereum format 0x<128 hex chars>
-            * @return public key
+            * @brief Parse an Ethereum-native private key (the raw secret a wallet exports).
+            * @param priv_key_str 32-byte secret as hex, with or without a 0x prefix.
+            * @return the corresponding em private key
             */
            static private_key from_native_string( const std::string& priv_key_str );
 

--- a/programs/clio/main.cpp
+++ b/programs/clio/main.cpp
@@ -1904,18 +1904,33 @@ int main( int argc, char** argv ) {
 
    bool r1 = false;
    bool k1 = false;
+   bool em = false;
+   bool sol = false;
    string key_file;
    bool print_console = false;
    // create key
-   auto create_key_cmd = create_cmd->add_subcommand("key", localized("Create a new keypair and print the public and private keys"))->callback( [&r1, &k1, &key_file, &print_console](){
+   auto create_key_cmd = create_cmd->add_subcommand("key", localized("Create a new keypair and print the public and private keys"))->callback( [&r1, &k1, &em, &sol, &key_file, &print_console](){
       if (key_file.empty() && !print_console) {
          std::cerr << "ERROR: Either indicate a file using \"--file\" or pass \"--to-console\"" << std::endl;
          return;
       }
 
-      auto pk    = r1 ? private_key_type::generate(crypto::private_key::key_type::r1) : private_key_type::generate();
-      auto privs = pk.to_string({}, k1);
-      auto pubs  = pk.get_public_key().to_string({}, k1);
+      // --r1/--em/--sol select a curve and are mutually exclusive (enforced by CLI11
+      // ->excludes() below, so a bad combination is a non-zero parse error). --k1 is
+      // not a curve switch: it selects the prefixed PVT_K1_/PUB_K1_ form of the
+      // default K1 key instead of the legacy unprefixed form.
+      auto kt = crypto::private_key::key_type::k1;
+      if      (sol) kt = crypto::private_key::key_type::ed;   // Solana ed25519
+      else if (em)  kt = crypto::private_key::key_type::em;   // Ethereum-style secp256k1 (MetaMask personal_sign)
+      else if (r1)  kt = crypto::private_key::key_type::r1;
+
+      // K1 has a legacy unprefixed form; --k1 requests the prefixed PVT_K1_/PUB_K1_
+      // form. r1/em/ed are only ever emitted in their prefixed (PVT_*_/PUB_*_) form.
+      const bool include_prefix = (kt != crypto::private_key::key_type::k1) || k1;
+
+      auto pk    = private_key_type::generate(kt);
+      auto privs = pk.to_string({}, include_prefix);
+      auto pubs  = pk.get_public_key().to_string({}, include_prefix);
       if (print_console) {
          std::cout << localized("Private key: ${key}", ("key",  privs) ) << std::endl;
          std::cout << localized("Public key: ${key}", ("key", pubs ) ) << std::endl;
@@ -1927,7 +1942,12 @@ int main( int argc, char** argv ) {
       }
    });
    create_key_cmd->add_flag( "--k1", k1, "Generate a key using the K1 curve (Bitcoin) with PUB_K1_ & PVT_K1_ prefix instead of legacy"  );
-   create_key_cmd->add_flag( "--r1", r1, "Generate a key using the R1 curve (iPhone), instead of the K1 curve (Bitcoin)"  );
+   auto r1_flag  = create_key_cmd->add_flag( "--r1", r1, "Generate a key using the R1 curve (iPhone), instead of the K1 curve (Bitcoin)"  );
+   auto em_flag  = create_key_cmd->add_flag( "--em", em, "Generate an EM key (Ethereum-style secp256k1, PUB_EM_/PVT_EM_) for MetaMask/external personal_sign"  );
+   auto sol_flag = create_key_cmd->add_flag( "--sol", sol, "Generate a Solana key (ed25519, PUB_ED_/PVT_ED_) for external Solana signers"  );
+   // --r1/--em/--sol pick different curves; selecting more than one is a usage error.
+   r1_flag->excludes(em_flag)->excludes(sol_flag);
+   em_flag->excludes(sol_flag);
    create_key_cmd->add_option("-f,--file", key_file, localized("Name of file to write private/public key output to. (Must be set, unless \"--to-console\" is passed"));
    create_key_cmd->add_flag( "--to-console", print_console, localized("Print private/public keys to console."));
 
@@ -2085,6 +2105,93 @@ int main( int argc, char** argv ) {
       auto pubk = fc::crypto::public_key::from_string(k1_public_key, fc::crypto::public_key::key_type::k1);
       std::cout << localized("Public key: ${key}", ("key", pubk.to_string({}) ) ) << std::endl;
       std::cout << localized("Public key: ${key}", ("key", pubk.to_string({}, true) ) ) << std::endl;
+   });
+
+   // EM (Ethereum-style secp256k1) key utilities. These let an external Ethereum signer (MetaMask personal_sign)
+   // interoperate with Wire offline: import a raw Ethereum secret as a Wire PVT_EM_ key, and sign/recover a Wire
+   // transaction sig_digest exactly as nodeop validates it, using libfc's own em path (the same code the chain runs).
+
+   /// Parse a Wire PVT_EM_ string or a raw 0x-prefixed Ethereum hex secret into a unified em private key.
+   /// One helper, used by every em_* subcommand below.
+   auto parse_em_private_key = [](const std::string& s) -> fc::crypto::private_key {
+      if (s.rfind("PVT_EM_", 0) == 0)
+         return fc::crypto::private_key::from_string(s, fc::crypto::private_key::key_type::em);
+      // Raw Ethereum form (what MetaMask / eth tooling exports): 0x<64hex> or 64hex.
+      auto em_priv = fc::em::private_key::from_native_string(s);
+      return fc::crypto::private_key::regenerate<fc::em::private_key_shim>(em_priv.get_secret());
+   };
+
+   /// Parse a 32-byte sha256 digest given as 64 hex chars (optional 0x prefix).
+   auto parse_sha256_hex = [](std::string s) -> fc::sha256 {
+      if (s.rfind("0x", 0) == 0 || s.rfind("0X", 0) == 0)
+         s = s.substr(2);
+      SYSC_ASSERT(s.size() == 64, "ERROR: digest must be a 32-byte sha256 (64 hex chars, 0x optional)");
+      return fc::sha256(s);
+   };
+
+   string em_private_key;
+   auto em_private_key_cmd = convert_cmd->add_subcommand("em_private_key", localized("Convert a raw Ethereum secret (or PVT_EM_) to Wire PVT_EM_/PUB_EM_ key forms"));
+   em_private_key_cmd->add_option("--private-key", em_private_key, localized("PVT_EM_... or a raw 0x Ethereum hex secret; prompts if not provided"))->expected(0, 1);
+   em_private_key_cmd->add_option("-f,--file", key_file, localized("Name of file to write private/public key output to. (Must be set, unless \"--to-console\" is passed"));
+   em_private_key_cmd->add_flag("--to-console", print_console, localized("Print private/public keys to console."));
+   em_private_key_cmd->callback([&] {
+      if (key_file.empty() && !print_console) {
+         std::cerr << "ERROR: Either indicate a file using \"--file\" or pass \"--to-console\"" << std::endl;
+         return;
+      }
+      if (em_private_key.empty()) {
+         std::cout << localized("private key: ");
+         fc::set_console_echo(false);
+         std::getline(std::cin, em_private_key, '\n');
+         fc::set_console_echo(true);
+         std::cout << std::endl;
+      }
+      auto privk = parse_em_private_key(em_private_key);
+      auto pubk  = privk.get_public_key();
+      if (print_console) {
+         std::cout << localized("Private key: ${key}", ("key", privk.to_string({}, true)) ) << std::endl;
+         std::cout << localized("Public key: ${key}",  ("key", pubk.to_string({}, true))  ) << std::endl;
+      } else {
+         std::cerr << localized("saving keys to ${filename}", ("filename", key_file)) << std::endl;
+         std::ofstream out( key_file.c_str() );
+         out << localized("Private key: ${key}", ("key", privk.to_string({}, true)) ) << std::endl;
+         out << localized("Public key: ${key}",  ("key", pubk.to_string({}, true))  ) << std::endl;
+      }
+   });
+
+   string em_sign_digest;
+   string em_sign_priv;
+   auto em_sign_cmd = convert_cmd->add_subcommand("em_sign", localized("Sign a 32-byte sha256 digest with an EM key (EIP-191 personal_sign), printing SIG_EM_"));
+   em_sign_cmd->add_option("digest", em_sign_digest, localized("32-byte sha256 digest, 64 hex chars (0x optional)"))->required();
+   em_sign_cmd->add_option("--private-key", em_sign_priv, localized("PVT_EM_... or a raw 0x Ethereum hex secret; prompts if not provided"))->expected(0, 1);
+   em_sign_cmd->callback([&] {
+      if (em_sign_priv.empty()) {
+         std::cout << localized("private key: ");
+         fc::set_console_echo(false);
+         std::getline(std::cin, em_sign_priv, '\n');
+         fc::set_console_echo(true);
+         std::cout << std::endl;
+      }
+      auto privk  = parse_em_private_key(em_sign_priv);
+      auto digest = parse_sha256_hex(em_sign_digest);
+      // private_key::sign dispatches to em::sign_sha256, which wraps the digest in the EIP-191 personal_sign
+      // envelope before secp256k1 -- identical to what MetaMask produces and to what nodeop recovers. Emit the
+      // prefixed SIG_EM_ form, which is what `clio push transaction --signature` and send_transaction2 expect.
+      std::cout << localized("Signature: ${sig}", ("sig", privk.sign(digest).to_string({}, true)) ) << std::endl;
+   });
+
+   string em_recover_sig;
+   string em_recover_digest;
+   auto em_recover_cmd = convert_cmd->add_subcommand("em_recover", localized("Recover the PUB_EM_ from a SIG_EM_ over a 32-byte sha256 digest (EIP-191)"));
+   em_recover_cmd->add_option("signature", em_recover_sig, localized("SIG_EM_... signature to recover from"))->required();
+   em_recover_cmd->add_option("digest", em_recover_digest, localized("32-byte sha256 digest, 64 hex chars (0x optional)"))->required();
+   em_recover_cmd->callback([&] {
+      auto sig    = fc::crypto::signature::from_string(em_recover_sig, fc::crypto::signature::sig_type::em);
+      auto digest = parse_sha256_hex(em_recover_digest);
+      // public_key::recover dispatches to em::recover, which applies the same EIP-191 envelope before recovery.
+      // Emit the prefixed PUB_EM_ form so it compares directly against an expandauth-registered key.
+      auto pubk = fc::crypto::public_key::recover(sig, digest);
+      std::cout << localized("Public key: ${key}", ("key", pubk.to_string({}, true)) ) << std::endl;
    });
 
    string name_input;

--- a/programs/clio/main.cpp
+++ b/programs/clio/main.cpp
@@ -1915,10 +1915,10 @@ int main( int argc, char** argv ) {
          return;
       }
 
-      // --r1/--em/--sol select a curve and are mutually exclusive (enforced by CLI11
-      // ->excludes() below, so a bad combination is a non-zero parse error). --k1 is
-      // not a curve switch: it selects the prefixed PVT_K1_/PUB_K1_ form of the
-      // default K1 key instead of the legacy unprefixed form.
+      // --k1/--r1/--em/--sol are mutually exclusive (enforced by CLI11 ->excludes()
+      // below, so any combination is a non-zero parse error). No flag => the default
+      // K1 key in its legacy unprefixed form; --k1 => the same K1 key in the prefixed
+      // PVT_K1_/PUB_K1_ form; --r1/--em/--sol => that curve (always prefixed).
       auto kt = crypto::private_key::key_type::k1;
       if      (sol) kt = crypto::private_key::key_type::ed;   // Solana ed25519
       else if (em)  kt = crypto::private_key::key_type::em;   // Ethereum-style secp256k1 (MetaMask personal_sign)
@@ -1941,11 +1941,12 @@ int main( int argc, char** argv ) {
          out << localized("Public key: ${key}", ("key", pubs ) ) << std::endl;
       }
    });
-   create_key_cmd->add_flag( "--k1", k1, "Generate a key using the K1 curve (Bitcoin) with PUB_K1_ & PVT_K1_ prefix instead of legacy"  );
+   auto k1_flag  = create_key_cmd->add_flag( "--k1", k1, "Generate a key using the K1 curve (Bitcoin) with PUB_K1_ & PVT_K1_ prefix instead of legacy"  );
    auto r1_flag  = create_key_cmd->add_flag( "--r1", r1, "Generate a key using the R1 curve (iPhone), instead of the K1 curve (Bitcoin)"  );
    auto em_flag  = create_key_cmd->add_flag( "--em", em, "Generate an EM key (Ethereum-style secp256k1, PUB_EM_/PVT_EM_) for MetaMask/external personal_sign"  );
    auto sol_flag = create_key_cmd->add_flag( "--sol", sol, "Generate a Solana key (ed25519, PUB_ED_/PVT_ED_) for external Solana signers"  );
-   // --r1/--em/--sol pick different curves; selecting more than one is a usage error.
+   // --k1/--r1/--em/--sol are mutually exclusive; selecting more than one is a usage error.
+   k1_flag->excludes(r1_flag)->excludes(em_flag)->excludes(sol_flag);
    r1_flag->excludes(em_flag)->excludes(sol_flag);
    em_flag->excludes(sol_flag);
    create_key_cmd->add_option("-f,--file", key_file, localized("Name of file to write private/public key output to. (Must be set, unless \"--to-console\" is passed"));
@@ -2131,7 +2132,8 @@ int main( int argc, char** argv ) {
 
    string em_private_key;
    auto em_private_key_cmd = convert_cmd->add_subcommand("em_private_key", localized("Convert a raw Ethereum secret (or PVT_EM_) to Wire PVT_EM_/PUB_EM_ key forms"));
-   em_private_key_cmd->add_option("--private-key", em_private_key, localized("PVT_EM_... or a raw 0x Ethereum hex secret; prompts if not provided"))->expected(0, 1);
+   em_private_key_cmd->add_option("--private-key", em_private_key, localized("PVT_EM_... or a raw 0x Ethereum hex secret. Omit to enter it at the prompt; "
+                                                "passing it here exposes the secret in ps/shell history"))->expected(0, 1);
    em_private_key_cmd->add_option("-f,--file", key_file, localized("Name of file to write private/public key output to. (Must be set, unless \"--to-console\" is passed"));
    em_private_key_cmd->add_flag("--to-console", print_console, localized("Print private/public keys to console."));
    em_private_key_cmd->callback([&] {
@@ -2163,7 +2165,8 @@ int main( int argc, char** argv ) {
    string em_sign_priv;
    auto em_sign_cmd = convert_cmd->add_subcommand("em_sign", localized("Sign a 32-byte sha256 digest with an EM key (EIP-191 personal_sign), printing SIG_EM_"));
    em_sign_cmd->add_option("digest", em_sign_digest, localized("32-byte sha256 digest, 64 hex chars (0x optional)"))->required();
-   em_sign_cmd->add_option("--private-key", em_sign_priv, localized("PVT_EM_... or a raw 0x Ethereum hex secret; prompts if not provided"))->expected(0, 1);
+   em_sign_cmd->add_option("--private-key", em_sign_priv, localized("PVT_EM_... or a raw 0x Ethereum hex secret. Omit to enter it at the prompt; "
+                                                "passing it here exposes the secret in ps/shell history"))->expected(0, 1);
    em_sign_cmd->callback([&] {
       if (em_sign_priv.empty()) {
          std::cout << localized("private key: ");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cluster_launcher.py ${CMAKE_CURRENT_B
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/distributed-transactions-test.py ${CMAKE_CURRENT_BINARY_DIR}/distributed-transactions-test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sysio_util_bls_test.py ${CMAKE_CURRENT_BINARY_DIR}/sysio_util_bls_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sysio_util_snapshot_info_test.py ${CMAKE_CURRENT_BINARY_DIR}/sysio_util_snapshot_info_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/clio_em_key_test.py ${CMAKE_CURRENT_BINARY_DIR}/clio_em_key_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sample-cluster-map.json ${CMAKE_CURRENT_BINARY_DIR}/sample-cluster-map.json COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/restart-scenarios-test.py ${CMAKE_CURRENT_BINARY_DIR}/restart-scenarios-test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/terminate-scenarios-test.py ${CMAKE_CURRENT_BINARY_DIR}/terminate-scenarios-test.py COPYONLY)
@@ -252,6 +253,7 @@ add_np_test(NAME lib_advance_test COMMAND tests/lib_advance_test.py -v ${UNSHARE
 add_np_test(NAME producer_rank_test COMMAND tests/producer_rank_test.py -v ${UNSHARE})
 
 add_p_test(NAME sysio_util_bls_test COMMAND tests/sysio_util_bls_test.py)
+add_p_test(NAME clio_em_key_test COMMAND tests/clio_em_key_test.py)
 add_p_test(NAME sysio_util_snapshot_info_test COMMAND tests/sysio_util_snapshot_info_test.py)
 
 add_np_test(NAME http_plugin_test COMMAND tests/http_plugin_test.py ${UNSHARE} TIMEOUT 200)

--- a/tests/clio_em_key_test.py
+++ b/tests/clio_em_key_test.py
@@ -47,6 +47,11 @@ KAT_PUB_EM     = ("PUB_EM_044bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb6297
                   "47bb493382ce28cab79ad7119ee1ad3ebcdb98a16805211530ecc6cfefa1b88e6dff99232a")
 KAT_SIG_EM     = ("SIG_EM_0xea0847dc6f2c9a189b85f01e9a1d51931ac92ee381b67641384b523"
                   "14a803fd5064a69f67b5967f2cac3fa3b9cf3f4f0be9f08e282e0e71ed0ce13d202a892b71b")
+# KAT_DIGEST with the last hex nibble flipped: a valid but different 32-byte
+# digest. Recovering KAT_SIG_EM against this must yield a *different* key --
+# proving recovery is digest-bound (the property the stale-signature pre-flight
+# in the metamask harness relies on).
+KAT_WRONG_DIGEST = KAT_DIGEST[:-1] + ("5" if KAT_DIGEST[-1] != "5" else "6")
 
 testSuccessful = False
 
@@ -134,6 +139,20 @@ def test_known_answer_vector():
     assert clio("convert", "em_recover", KAT_SIG_EM, KAT_DIGEST)["Public key"] == KAT_PUB_EM
 
 
+def test_recover_is_digest_bound():
+    """Recovery is bound to the exact digest signed.
+
+    Recovering the reference signature against a *different* (but well-formed)
+    digest still succeeds -- ECDSA recovery yields some point for almost any
+    digest -- but must yield a DIFFERENT public key, never the reference one.
+    This is precisely what lets the metamask harness reject a stale or
+    wrong-digest paste offline instead of as an opaque unsatisfied_authorization.
+    """
+    recovered = clio("convert", "em_recover", KAT_SIG_EM, KAT_WRONG_DIGEST)["Public key"]
+    assert recovered.startswith("PUB_EM_"), recovered
+    assert recovered != KAT_PUB_EM, "recovery is not digest-bound: wrong digest recovered the reference key"
+
+
 def test_error_handling():
     """Mutually exclusive curve flags and malformed crypto inputs are hard errors.
 
@@ -142,9 +161,12 @@ def test_error_handling():
     ``ERROR:`` and emit no key, exit 0. Assert that contract rather than an exit
     code so this test does not silently encode a behavior change to it.
     """
-    # mutually exclusive curve flags -> CLI11 parse error (non-zero)
+    # mutually exclusive curve flags -> CLI11 parse error (non-zero); all of
+    # --k1/--r1/--em/--sol exclude each other
     clio("create", "key", "--em", "--sol", "--to-console", expect_fail=True)
     clio("create", "key", "--em", "--r1", "--to-console", expect_fail=True)
+    clio("create", "key", "--k1", "--em", "--to-console", expect_fail=True)
+    clio("create", "key", "--k1", "--r1", "--to-console", expect_fail=True)
 
     # neither --file nor --to-console: soft validation -> ERROR, no key, exit 0
     res = clio("create", "key", "--em", raw=True)
@@ -153,6 +175,7 @@ def test_error_handling():
 
     # malformed crypto inputs throw in libfc -> non-zero
     clio("convert", "em_sign", "deadbeef", "--private-key", KAT_PVT_EM, expect_fail=True)  # 8 hex != 64
+    clio("convert", "em_sign", "z" * 64, "--private-key", KAT_PVT_EM, expect_fail=True)    # 64 chars, not hex
     clio("convert", "em_recover", "SIG_EM_0xdeadbeef", KAT_DIGEST, expect_fail=True)       # malformed sig
 
 
@@ -161,6 +184,7 @@ try:
     test_create_key_sol()
     test_create_key_to_file()
     test_known_answer_vector()
+    test_recover_is_digest_bound()
     test_error_handling()
     testSuccessful = True
 except Exception as e:

--- a/tests/clio_em_key_test.py
+++ b/tests/clio_em_key_test.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+
+"""Offline test for clio's EM (Ethereum-style secp256k1) and SOL (ed25519) key support.
+
+Exercises, with no running node:
+
+  * ``clio create key --em``  -> PVT_EM_/PUB_EM_ keypair, round-tripped through
+    ``clio convert em_private_key`` / ``em_sign`` / ``em_recover``.
+  * ``clio create key --sol`` -> PVT_ED_/PUB_ED_ (Solana ed25519) keypair.
+  * A frozen known-answer vector proving libfc's EM path is byte-for-byte
+    identical to the Ethereum ecosystem reference (eth_account / MetaMask
+    ``personal_sign``). This is the cross-implementation anchor: a regression in
+    Wire's EIP-191 envelope, low-s normalization, or recovery-id handling fails
+    here, hermetically, with no pip/apt/browser dependency.
+  * Flag mutual-exclusion and input-validation error paths.
+
+Known-answer vector provenance (regenerate only by a deliberate, reviewed act):
+
+    Reference implementation : eth_account 0.13.7 (eth-keys/eth-utils stack),
+                               byte-identical to MetaMask personal_sign for the
+                               same key and message.
+    Ethereum private key     : 0x46 * 32   (the well-known EIP-155 example key)
+    Message / digest         : sha256(b"wire-sysio metamask external-signer KAT v1")
+                               = 7358248b67726c147e6b100d188dec3b5be0bdc08735378b6146ec0207cf58c4
+    Recipe                   : personal_sign over the 32 raw digest bytes
+                               (EIP-191: keccak256("\\x19Ethereum Signed Message:\\n32" + digest)),
+                               deterministic RFC-6979 secp256k1, low-s.
+
+The expected PUB_EM_/SIG_EM_ below were produced by that reference and MUST NOT
+be edited to match a code change -- a mismatch means clio/libfc diverged from
+the Ethereum ecosystem, which is a bug in libfc, not in this vector.
+"""
+
+import re
+import subprocess
+import tempfile
+
+from TestHarness import Utils
+
+Print = Utils.Print
+
+# --- frozen known-answer vector (see module docstring for provenance) ---
+KAT_ETH_SECRET = "0x4646464646464646464646464646464646464646464646464646464646464646"
+KAT_PVT_EM     = "PVT_EM_0x4646464646464646464646464646464646464646464646464646464646464646"
+KAT_DIGEST     = "7358248b67726c147e6b100d188dec3b5be0bdc08735378b6146ec0207cf58c4"
+KAT_PUB_EM     = ("PUB_EM_044bc2a31265153f07e70e0bab08724e6b85e217f8cd628ceb629742"
+                  "47bb493382ce28cab79ad7119ee1ad3ebcdb98a16805211530ecc6cfefa1b88e6dff99232a")
+KAT_SIG_EM     = ("SIG_EM_0xea0847dc6f2c9a189b85f01e9a1d51931ac92ee381b67641384b523"
+                  "14a803fd5064a69f67b5967f2cac3fa3b9cf3f4f0be9f08e282e0e71ed0ce13d202a892b71b")
+
+testSuccessful = False
+
+
+def clio(*args, expect_fail=False, raw=False):
+    """Run the clio binary offline with `args`.
+
+    Default: assert exit 0 and return a dict of the ``Label: value`` lines clio
+    prints. `expect_fail=True`: assert a non-zero exit (CLI11 parse error or a
+    thrown libfc exception) and return None. `raw=True`: return the
+    ``subprocess.CompletedProcess`` for callers that assert on stderr / exit code
+    directly (used for clio's soft-validation paths, which by long-standing
+    convention print ``ERROR:`` and emit nothing but still exit 0).
+    """
+    cmd = [Utils.SysClientPath, *args]
+    if Utils.Debug:
+        Print("cmd: %s" % " ".join(cmd))
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if raw:
+        return res
+    if expect_fail:
+        assert res.returncode != 0, "expected failure but clio succeeded: %s\n%s" % (cmd, res.stdout)
+        return None
+    assert res.returncode == 0, "clio failed: %s\nstderr: %s\nstdout: %s" % (cmd, res.stderr, res.stdout)
+    return {k: v for k, v in re.findall(r'(\w[^:\n]*): ([^\n]+)', res.stdout)}
+
+
+def test_create_key_em_roundtrip():
+    """create key --em yields a PVT_EM_/PUB_EM_ pair that round-trips through convert."""
+    r = clio("create", "key", "--em", "--to-console")
+    priv, pub = r["Private key"], r["Public key"]
+    assert priv.startswith("PVT_EM_"), priv
+    assert pub.startswith("PUB_EM_"), pub
+
+    # PVT_EM_ -> same PUB_EM_ via convert em_private_key
+    assert clio("convert", "em_private_key", "--private-key", priv, "--to-console")["Public key"] == pub
+
+    # sign an arbitrary digest with it, then recover -> must yield the same PUB_EM_
+    sig = clio("convert", "em_sign", KAT_DIGEST, "--private-key", priv)["Signature"]
+    assert sig.startswith("SIG_EM_"), sig
+    assert clio("convert", "em_recover", sig, KAT_DIGEST)["Public key"] == pub
+
+    # two fresh keys must differ (sanity that generation is not fixed)
+    assert clio("create", "key", "--em", "--to-console")["Private key"] != priv
+
+
+def test_create_key_sol():
+    """create key --sol yields a Solana ed25519 PVT_ED_/PUB_ED_ pair."""
+    r = clio("create", "key", "--sol", "--to-console")
+    assert r["Private key"].startswith("PVT_ED_"), r["Private key"]
+    assert r["Public key"].startswith("PUB_ED_"), r["Public key"]
+    assert clio("create", "key", "--sol", "--to-console")["Private key"] != r["Private key"]
+
+
+def test_create_key_to_file():
+    """--file persists the same forms --to-console prints."""
+    with tempfile.NamedTemporaryFile(mode="w+") as f:
+        clio("create", "key", "--em", "--file", f.name)
+        f.seek(0)
+        body = f.read()
+    assert "PVT_EM_" in body and "PUB_EM_" in body, body
+
+
+def test_known_answer_vector():
+    """libfc's EM path is byte-for-byte identical to eth_account / MetaMask.
+
+    Both the raw-Ethereum-secret import path and the PVT_EM_ path must derive
+    the reference public key; em_sign must reproduce the reference signature
+    (RFC-6979 deterministic, so this is exact); em_recover must invert it.
+    """
+    # raw Ethereum secret import -> reference PUB_EM_
+    assert clio("convert", "em_private_key", "--private-key", KAT_ETH_SECRET,
+                "--to-console")["Public key"] == KAT_PUB_EM
+    # PVT_EM_ import -> same
+    assert clio("convert", "em_private_key", "--private-key", KAT_PVT_EM,
+                "--to-console")["Public key"] == KAT_PUB_EM
+
+    # signature is deterministic and must match the reference, from either key form
+    assert clio("convert", "em_sign", KAT_DIGEST, "--private-key", KAT_ETH_SECRET)["Signature"] == KAT_SIG_EM
+    assert clio("convert", "em_sign", KAT_DIGEST, "--private-key", KAT_PVT_EM)["Signature"] == KAT_SIG_EM
+    # 0x-prefixed digest is accepted and equivalent
+    assert clio("convert", "em_sign", "0x" + KAT_DIGEST, "--private-key", KAT_PVT_EM)["Signature"] == KAT_SIG_EM
+
+    # recover the reference signature back to the reference public key
+    assert clio("convert", "em_recover", KAT_SIG_EM, KAT_DIGEST)["Public key"] == KAT_PUB_EM
+
+
+def test_error_handling():
+    """Mutually exclusive curve flags and malformed crypto inputs are hard errors.
+
+    The missing-output-sink case is clio's long-standing soft-validation
+    convention (shared by ``create key`` / ``convert k1_private_key``): print
+    ``ERROR:`` and emit no key, exit 0. Assert that contract rather than an exit
+    code so this test does not silently encode a behavior change to it.
+    """
+    # mutually exclusive curve flags -> CLI11 parse error (non-zero)
+    clio("create", "key", "--em", "--sol", "--to-console", expect_fail=True)
+    clio("create", "key", "--em", "--r1", "--to-console", expect_fail=True)
+
+    # neither --file nor --to-console: soft validation -> ERROR, no key, exit 0
+    res = clio("create", "key", "--em", raw=True)
+    assert "ERROR" in res.stderr, res.stderr
+    assert "PVT_EM_" not in res.stdout, res.stdout
+
+    # malformed crypto inputs throw in libfc -> non-zero
+    clio("convert", "em_sign", "deadbeef", "--private-key", KAT_PVT_EM, expect_fail=True)  # 8 hex != 64
+    clio("convert", "em_recover", "SIG_EM_0xdeadbeef", KAT_DIGEST, expect_fail=True)       # malformed sig
+
+
+try:
+    test_create_key_em_roundtrip()
+    test_create_key_sol()
+    test_create_key_to_file()
+    test_known_answer_vector()
+    test_error_handling()
+    testSuccessful = True
+except Exception as e:
+    Print(e)
+    Utils.errorExit("exception during processing")
+
+exit(0 if testSuccessful else 1)


### PR DESCRIPTION
Adds first-class clio support for Wire's external-signer key types, using libfc's own crypto path (the same code nodeop runs to validate these signatures). All commands are offline -- no node, no wallet.

## create key
- `--em` generates an EM key (Ethereum-style secp256k1, `PVT_EM_`/`PUB_EM_`), the key form a MetaMask / EIP-191 `personal_sign` wallet uses to sign Wire transactions.
- `--sol` generates a Solana key (ed25519, `PVT_ED_`/`PUB_ED_`).
- `--r1`/`--k1`/`--em`/`--sol` are mutually exclusive (CLI11 `->excludes()`, so a bad combination is a non-zero parse error).

## convert
- `em_private_key` imports a raw Ethereum hex secret (what MetaMask / eth tooling exports) or a `PVT_EM_` string and prints the Wire `PVT_EM_`/`PUB_EM_` forms.
- `em_sign` signs a 32-byte sha256 digest with an EM key. It dispatches to `em::sign_sha256`, which wraps the digest in the EIP-191 `personal_sign` envelope before secp256k1 -- byte-identical to MetaMask and to what nodeop recovers -- and prints the `SIG_EM_` form.
- `em_recover` recovers the `PUB_EM_` from a `SIG_EM_` over a digest.

These mirror the existing `convert k1_private_key`/`k1_public_key` idiom.

## Test
`clio_em_key_test` is a new offline, parallelizable ctest. It exercises the create-key round-trips and a frozen known-answer vector minted from `eth_account` (the Ethereum-ecosystem reference, byte-identical to MetaMask `personal_sign`). The vector pins libfc's EIP-191 envelope, low-s normalization and recovery-id handling against an independent implementation with no pip/apt/browser dependency; a divergence fails the test hermetically. The vector's provenance (reference implementation, key, message, recipe) is documented in the test so regeneration is a deliberate, reviewed act.
