### PR TITLE
Test: pin locks_out_branch_of boundary cases (PR #320 follow-up)

### DIFF
--- a/libraries/chain/include/sysio/chain/block_handle.hpp
+++ b/libraries/chain/include/sysio/chain/block_handle.hpp
@@ -65,6 +65,10 @@ public:
       // QC target is in head's ancestry; head's branch shares the QC's anchor. The block_num check covers qc_target
       // older than head's last_final (outside head's tracking window): finalization past qc_target is only possible
       // when qc_target is on head's branch.
+      // get_block_reference's precondition is last_final_block_num() <= qc.block_num < current_block_num(). It holds
+      // here: a strong qc implies a non-genesis core (the genesis core's latest_qc_claim has is_strong_qc == false and
+      // would have hit the early return above), and every non-genesis core satisfies the finality_core invariant
+      // last_final_block_num() <= latest_qc_claim().block_num < current_block_num().
       const auto& qc_target_id = _bsp->core.get_block_reference(qc.block_num).block_id;
       if (head_id == qc_target_id || head_handle._bsp->core.extends(qc_target_id) ||
           qc.block_num < head_handle._bsp->core.last_final_block_num())
@@ -73,7 +77,7 @@ public:
       // Head's branch and the QC target are incompatible; locked out.
       return true;
    }
-  
+
    // Returns true if `id` is in this block's ancestry (or is this block itself within the finality_core's tracking range).
    bool extends(const block_id_type& id) const {
       return _bsp && _bsp->core.extends(id);

--- a/unittests/fork_db_tests.cpp
+++ b/unittests/fork_db_tests.cpp
@@ -324,6 +324,10 @@ BOOST_AUTO_TEST_CASE(locks_out_branch_of_test) try {
    BOOST_TEST(!h13a_weak.locks_out_branch_of(h12b));
    BOOST_TEST(!h13a_weak.locks_out_branch_of(h11b));
 
+   // `this` is the genesis block: create_core_for_genesis_block yields latest_qc_claim().is_strong_qc == false,
+   // so the strong-QC early return fires and no head is ever reported as locked out.
+   BOOST_TEST(!h_root.locks_out_branch_of(h12b));
+
 } FC_LOG_AND_RETHROW();
 
 // Tests that locks_out_branch_of returns false when the QC target is in head's ancestry but is older than head's
@@ -377,6 +381,15 @@ BOOST_AUTO_TEST_CASE(locks_out_branch_of_lib_advanced_past_shared_ancestor) try 
    block_handle h13a_shared{bsp13a_shared};
    block_handle h14b{bsp14b};
    BOOST_TEST(!h13a_shared.locks_out_branch_of(h14b));
+
+   // Boundary: qc.block_num exactly equals head's last_final_block_num. bsp13b's lib is the shared ancestor
+   // (block 11) itself, and bsp13a_shared carries a strong QC for that same block 11. The strict
+   // `qc.block_num < head.last_final` guard does NOT fire here (11 < 11 is false); the not-locked-out result
+   // must instead come from head.extends(qc_target) -- per Savanna safety, the block at head's last_final
+   // height is head's own final block, so head's core reference at 11 equals the shared qc_target.
+   block_handle h13b{bsp13b};
+   BOOST_REQUIRE_EQUAL(bsp13b->core.last_final_block_num(), 11u);
+   BOOST_TEST(!h13a_shared.locks_out_branch_of(h13b));
 
 } FC_LOG_AND_RETHROW();
 


### PR DESCRIPTION
Follow-up to #320. Adds the test coverage and doc cleanup that should have gone in with the original change to block_handle::locks_out_branch_of.

- Boundary qc.block_num == head.last_final_block_num: the new short-circuit uses a strict `<`, so the equality case relies on head.extends(qc_target) instead. Pinned in locks_out_branch_of_lib_advanced_past_shared_ancestor with a head whose lib is exactly the shared ancestor.
- Genesis core (latest_qc_claim is not strong): pinned the !is_strong_qc early return in locks_out_branch_of_test.
- Documented get_block_reference's precondition at the call site and removed trailing whitespace after the helper.

No production behavior change; producer_plugin's now-unconditional fork_db_head() call in producing mode was reviewed and is required for the lockout check (already gated by in_producing_mode(); cost is negligible).
