### PR TITLE
Libfc: add keccak-256 cross-impl smoke tests + bench

### DIFF
--- a/libraries/libfc/benchmark/CMakeLists.txt
+++ b/libraries/libfc/benchmark/CMakeLists.txt
@@ -4,3 +4,10 @@ target_link_libraries(variant_bench
    fc
    ${PLATFORM_SPECIFIC_LIBS}
 )
+
+add_executable(keccak_bench EXCLUDE_FROM_ALL keccak_bench.cpp)
+
+target_link_libraries(keccak_bench
+   fc
+   ${PLATFORM_SPECIFIC_LIBS}
+)

--- a/libraries/libfc/benchmark/keccak_bench.cpp
+++ b/libraries/libfc/benchmark/keccak_bench.cpp
@@ -12,6 +12,7 @@
 #include <ethash/keccak.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -27,17 +28,35 @@ using std::chrono::steady_clock;
 
 namespace {
 
+// Volatile sink prevents the optimizer from eliding the measured call.
+// Reading two bytes of the digest is sufficient because Keccak's output
+// depends on every input byte (the sponge absorbs the full message into
+// the state before squeezing any output), so the compiler cannot reduce
+// the hash computation while preserving the observable XOR into `bench_sink`.
 volatile uint8_t bench_sink = 0;
 inline void sink(const void* p, size_t n) {
    const uint8_t* b = static_cast<const uint8_t*>(p);
-   bench_sink ^= static_cast<uint8_t>(b[0] ^ b[n - 1]);
+   bench_sink ^= b[0] ^ b[n - 1];
 }
 
+// Re-seeds with the same constant on every call, so buffers of different
+// sizes share a common prefix. Irrelevant for throughput measurement but
+// worth noting if anyone expects independent random samples across sizes.
 std::vector<uint8_t> make_buffer(size_t n) {
    std::mt19937_64 rng{0xC0FFEEULL};
    std::vector<uint8_t> v(n);
    for (auto& byte : v) byte = static_cast<uint8_t>(rng());
    return v;
+}
+
+// Format a byte count in the largest power-of-1024 unit that gives a whole
+// number, for readable scenario output (e.g. 34603008 -> "33 MiB").
+std::string fmt_size(size_t bytes) {
+   if (bytes >= 1024 * 1024 && bytes % (1024 * 1024) == 0)
+      return std::to_string(bytes / (1024 * 1024)) + " MiB";
+   if (bytes >= 1024 && bytes % 1024 == 0)
+      return std::to_string(bytes / 1024) + " KiB";
+   return std::to_string(bytes) + " B";
 }
 
 struct result {
@@ -50,6 +69,10 @@ struct result {
 
 template <typename F>
 result time_it(const std::string& name, size_t size, int runs, F&& f) {
+   // `runs` must be odd so `times[runs / 2]` returns the exact median rather
+   // than the upper of the two middle values.
+   assert(runs > 0 && runs % 2 == 1);
+
    std::vector<double> times;
    times.reserve(runs);
    for (int i = 0; i < 2; ++i) f();  // warmup
@@ -67,13 +90,13 @@ void print_header() {
    std::cout << std::left
              << std::setw(38) << "scenario"
              << std::right
-             << std::setw(13) << "size(bytes)"
+             << std::setw(10) << "size"
              << std::setw(13) << "median(ms)"
              << std::setw(12) << "min(ms)"
              << std::setw(12) << "max(ms)"
              << std::setw(14) << "MB/s(median)"
              << "\n";
-   std::cout << std::string(102, '-') << "\n";
+   std::cout << std::string(99, '-') << "\n";
 }
 
 void print(const result& r) {
@@ -83,7 +106,7 @@ void print(const result& r) {
    std::cout << std::left
              << std::setw(38) << r.name
              << std::right
-             << std::setw(13) << r.size
+             << std::setw(10) << fmt_size(r.size)
              << std::setw(13) << std::fixed << std::setprecision(4) << r.median_ms
              << std::setw(12) << std::fixed << std::setprecision(4) << r.min_ms
              << std::setw(12) << std::fixed << std::setprecision(4) << r.max_ms
@@ -95,7 +118,7 @@ void print(const result& r) {
 
 int main() {
    std::cout << "Keccak / SHA3 microbenchmark (warmup=2, median of runs)\n";
-   std::cout << "sizes: 32 B (typical digest input) / 4 KiB / 1 MiB / 33 MiB (max wasm memory)\n\n";
+   std::cout << "sizes: 32 B (small) / 4 KiB / 1 MiB / 33 MiB (default max wasm linear memory)\n\n";
 
    print_header();
 
@@ -129,8 +152,9 @@ int main() {
       });
       print(r3);
 
-      // Chunked at 10 KiB (the WASM intrinsic's hashing_checktime_block_size)
-      // -- isolates the streaming-vs-one-shot overhead for fc::sha3.
+      // Chunked at 10 KiB to mirror the WASM intrinsic's per-block checktime
+      // loop (sysio::chain::config::hashing_checktime_block_size). Isolates
+      // the streaming-vs-one-shot overhead for fc::sha3.
       auto r4 = time_it("fc::sha3 keccak (10 KiB chunks)", sz, runs, [&]() {
          fc::sha3::encoder enc;
          constexpr size_t bs = 10 * 1024;
@@ -147,19 +171,22 @@ int main() {
       });
       print(r4);
 
+      // Final cross-impl agreement check at the scenario's input size.
+      // Complements ethash_fc_sha3_cross_impl_agreement in
+      // libraries/libfc/test/crypto/test_hash_functions.cpp, which covers
+      // smaller corpora; the bench reaches sizes up to 33 MiB which the
+      // test suite does not exercise.
+      auto h_ethash = ethash::keccak256(buf.data(), buf.size());
+      auto h_fcsha3 = fc::sha3::hash(reinterpret_cast<const char*>(buf.data()),
+                                     static_cast<uint32_t>(buf.size()), false);
+      if (std::memcmp(h_ethash.bytes, h_fcsha3.data(), 32) != 0) {
+         std::cout << "  !! cross-impl MISMATCH at size " << fmt_size(sz) << "\n";
+         return 1;
+      }
+
       std::cout << "\n";
    }
 
-   // Correctness smoke: ethash vs fc::sha3 keccak must agree byte-for-byte at
-   // the largest size, otherwise consensus parity between the two impls is
-   // already broken.
-   auto buf = make_buffer(33 * 1024 * 1024);
-   auto h_ethash = ethash::keccak256(buf.data(), buf.size());
-   auto h_fcsha3 = fc::sha3::hash(reinterpret_cast<const char*>(buf.data()),
-                                  static_cast<uint32_t>(buf.size()), false);
-   bool agree = std::memcmp(h_ethash.bytes, h_fcsha3.data(), 32) == 0;
-   std::cout << "Cross-impl agreement (ethash vs fc::sha3 keccak, 33 MiB): "
-             << (agree ? "OK" : "MISMATCH") << "\n";
-
-   return agree ? 0 : 1;
+   std::cout << "Cross-impl agreement (ethash vs fc::sha3 keccak, all sizes): OK\n";
+   return 0;
 }

--- a/libraries/libfc/benchmark/keccak_bench.cpp
+++ b/libraries/libfc/benchmark/keccak_bench.cpp
@@ -1,0 +1,165 @@
+// Microbenchmark for Keccak-256 / SHA3-256 implementations on the consensus
+// path.  Measures fc::sha3 (hand-rolled, used by the WASM sha3() host
+// intrinsic) and ethash::keccak256 (used by EM signature recovery), at sizes
+// spanning the realistic input range -- from 32 B (typical contract digest)
+// to 33 MiB (default max wasm linear memory = 528 * 64 KiB pages).
+//
+// Build (RelWithDebInfo / Release; Debug numbers are not comparable):
+//   ninja -C cmake-build-relwithdebinfo -j8 keccak_bench
+//   ./cmake-build-relwithdebinfo/libraries/libfc/benchmark/keccak_bench
+
+#include <fc/crypto/sha3.hpp>
+#include <ethash/keccak.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+using std::chrono::duration_cast;
+using std::chrono::microseconds;
+using std::chrono::steady_clock;
+
+namespace {
+
+volatile uint8_t bench_sink = 0;
+inline void sink(const void* p, size_t n) {
+   const uint8_t* b = static_cast<const uint8_t*>(p);
+   bench_sink ^= static_cast<uint8_t>(b[0] ^ b[n - 1]);
+}
+
+std::vector<uint8_t> make_buffer(size_t n) {
+   std::mt19937_64 rng{0xC0FFEEULL};
+   std::vector<uint8_t> v(n);
+   for (auto& byte : v) byte = static_cast<uint8_t>(rng());
+   return v;
+}
+
+struct result {
+   std::string name;
+   size_t size = 0;
+   double median_ms = 0;
+   double min_ms = 0;
+   double max_ms = 0;
+};
+
+template <typename F>
+result time_it(const std::string& name, size_t size, int runs, F&& f) {
+   std::vector<double> times;
+   times.reserve(runs);
+   for (int i = 0; i < 2; ++i) f();  // warmup
+   for (int i = 0; i < runs; ++i) {
+      auto t0 = steady_clock::now();
+      f();
+      auto t1 = steady_clock::now();
+      times.push_back(duration_cast<microseconds>(t1 - t0).count() / 1000.0);
+   }
+   std::sort(times.begin(), times.end());
+   return {name, size, times[runs / 2], times.front(), times.back()};
+}
+
+void print_header() {
+   std::cout << std::left
+             << std::setw(38) << "scenario"
+             << std::right
+             << std::setw(13) << "size(bytes)"
+             << std::setw(13) << "median(ms)"
+             << std::setw(12) << "min(ms)"
+             << std::setw(12) << "max(ms)"
+             << std::setw(14) << "MB/s(median)"
+             << "\n";
+   std::cout << std::string(102, '-') << "\n";
+}
+
+void print(const result& r) {
+   double mb_per_s = r.median_ms > 0
+                        ? (static_cast<double>(r.size) / (1024.0 * 1024.0)) / (r.median_ms / 1000.0)
+                        : 0;
+   std::cout << std::left
+             << std::setw(38) << r.name
+             << std::right
+             << std::setw(13) << r.size
+             << std::setw(13) << std::fixed << std::setprecision(4) << r.median_ms
+             << std::setw(12) << std::fixed << std::setprecision(4) << r.min_ms
+             << std::setw(12) << std::fixed << std::setprecision(4) << r.max_ms
+             << std::setw(14) << std::fixed << std::setprecision(1) << mb_per_s
+             << "\n";
+}
+
+}  // namespace
+
+int main() {
+   std::cout << "Keccak / SHA3 microbenchmark (warmup=2, median of runs)\n";
+   std::cout << "sizes: 32 B (typical digest input) / 4 KiB / 1 MiB / 33 MiB (max wasm memory)\n\n";
+
+   print_header();
+
+   const std::vector<std::pair<size_t, int>> scenarios = {
+      {32, 1001},
+      {4 * 1024, 501},
+      {1024 * 1024, 51},
+      {33 * 1024 * 1024, 11},
+   };
+
+   for (auto [sz, runs] : scenarios) {
+      auto buf = make_buffer(sz);
+
+      auto r1 = time_it("ethash::keccak256 (one-shot)", sz, runs, [&]() {
+         auto h = ethash::keccak256(buf.data(), buf.size());
+         sink(h.bytes, 32);
+      });
+      print(r1);
+
+      auto r2 = time_it("fc::sha3 keccak (one-shot)", sz, runs, [&]() {
+         auto h = fc::sha3::hash(reinterpret_cast<const char*>(buf.data()),
+                                 static_cast<uint32_t>(buf.size()), false);
+         sink(h.data(), 32);
+      });
+      print(r2);
+
+      auto r3 = time_it("fc::sha3 nist (one-shot)", sz, runs, [&]() {
+         auto h = fc::sha3::hash(reinterpret_cast<const char*>(buf.data()),
+                                 static_cast<uint32_t>(buf.size()), true);
+         sink(h.data(), 32);
+      });
+      print(r3);
+
+      // Chunked at 10 KiB (the WASM intrinsic's hashing_checktime_block_size)
+      // -- isolates the streaming-vs-one-shot overhead for fc::sha3.
+      auto r4 = time_it("fc::sha3 keccak (10 KiB chunks)", sz, runs, [&]() {
+         fc::sha3::encoder enc;
+         constexpr size_t bs = 10 * 1024;
+         const char* d = reinterpret_cast<const char*>(buf.data());
+         size_t left = buf.size();
+         while (left > bs) {
+            enc.write(d, bs);
+            d += bs;
+            left -= bs;
+         }
+         enc.write(d, static_cast<uint32_t>(left));
+         auto h = enc.result(false);
+         sink(h.data(), 32);
+      });
+      print(r4);
+
+      std::cout << "\n";
+   }
+
+   // Correctness smoke: ethash vs fc::sha3 keccak must agree byte-for-byte at
+   // the largest size, otherwise consensus parity between the two impls is
+   // already broken.
+   auto buf = make_buffer(33 * 1024 * 1024);
+   auto h_ethash = ethash::keccak256(buf.data(), buf.size());
+   auto h_fcsha3 = fc::sha3::hash(reinterpret_cast<const char*>(buf.data()),
+                                  static_cast<uint32_t>(buf.size()), false);
+   bool agree = std::memcmp(h_ethash.bytes, h_fcsha3.data(), 32) == 0;
+   std::cout << "Cross-impl agreement (ethash vs fc::sha3 keccak, 33 MiB): "
+             << (agree ? "OK" : "MISMATCH") << "\n";
+
+   return agree ? 0 : 1;
+}

--- a/libraries/libfc/test/crypto/test_hash_functions.cpp
+++ b/libraries/libfc/test/crypto/test_hash_functions.cpp
@@ -85,8 +85,8 @@ BOOST_AUTO_TEST_CASE(keccak256) try {
 /// itself.
 BOOST_AUTO_TEST_CASE(keccak256_class_golden) try {
 
-   using test_kv = std::tuple<std::string, std::string>;
-   const std::vector<test_kv> tests {
+   using test_keccak256_class = std::tuple<std::string, std::string>;
+   const std::vector<test_keccak256_class> tests {
       {
          "",
          "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
@@ -117,6 +117,13 @@ BOOST_AUTO_TEST_CASE(keccak256_class_golden) try {
 ///
 /// Inputs cover the Keccak-256 sponge rate boundary (1088 bits / 136 bytes)
 /// and a multi-block buffer to exercise the absorbing phase across rounds.
+///
+/// This test is one leg of a three-way pin: the keccak256 case anchors
+/// fc::sha3 against published vectors, keccak256_class_golden anchors
+/// fc::crypto::keccak256 against the same vectors, and this case asserts the
+/// two impls agree across additional inputs. A bug that shifted both impls
+/// identically off-spec would be caught by the golden cases, not this one --
+/// they are complementary, not redundant.
 BOOST_AUTO_TEST_CASE(ethash_fc_sha3_cross_impl_agreement) try {
 
    const std::vector<std::string> corpus = {
@@ -131,7 +138,7 @@ BOOST_AUTO_TEST_CASE(ethash_fc_sha3_cross_impl_agreement) try {
    };
 
    for(const auto& msg : corpus) {
-      BOOST_CHECK_EQUAL(fc::sha3::hash(msg.data(), msg.size(), false).str(),
+      BOOST_CHECK_EQUAL(fc::sha3::hash(msg, false).str(),
                         fc::crypto::keccak256::hash(msg).str());
    }
 
@@ -140,7 +147,7 @@ BOOST_AUTO_TEST_CASE(ethash_fc_sha3_cross_impl_agreement) try {
    std::mt19937_64 rng{0xC0FFEEULL};
    std::string big(100 * 1024, '\0');
    for(auto& c : big) c = static_cast<char>(rng());
-   BOOST_CHECK_EQUAL(fc::sha3::hash(big.data(), big.size(), false).str(),
+   BOOST_CHECK_EQUAL(fc::sha3::hash(big, false).str(),
                      fc::crypto::keccak256::hash(big).str());
 
 } FC_LOG_AND_RETHROW();

--- a/libraries/libfc/test/crypto/test_hash_functions.cpp
+++ b/libraries/libfc/test/crypto/test_hash_functions.cpp
@@ -1,8 +1,14 @@
 #include <boost/test/unit_test.hpp>
 
 #include <fc/crypto/hex.hpp>
+#include <fc/crypto/keccak256.hpp>
 #include <fc/crypto/sha3.hpp>
 #include <fc/utility.hpp>
+
+#include <random>
+#include <string>
+#include <tuple>
+#include <vector>
 
 using namespace fc;
 
@@ -57,12 +63,85 @@ BOOST_AUTO_TEST_CASE(keccak256) try {
       {
          "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
          "45d3b367a6904e6e8d502ee04999a7c27647f91fa845d456525fd352ae3d7371",
-      }
+      },
+
+      // ERC-20 Transfer event topic -- a recognizable Ethereum constant that
+      // any drift in the Keccak-256 padding domain separator would corrupt.
+      {
+         "Transfer(address,address,uint256)",
+         "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+      },
    };
 
    for(const auto& test : tests) {
       BOOST_CHECK_EQUAL(fc::sha3::hash(std::get<0>(test), false).str(), std::get<1>(test));
    }
+
+} FC_LOG_AND_RETHROW();
+
+/// Sanity-check that fc::crypto::keccak256 (the ethash-backed wrapper used by
+/// EM signature recovery and Ethereum tooling) returns the expected bytes for
+/// standard vectors. Catches wiring bugs in the wrapper independent of ethash
+/// itself.
+BOOST_AUTO_TEST_CASE(keccak256_class_golden) try {
+
+   using test_kv = std::tuple<std::string, std::string>;
+   const std::vector<test_kv> tests {
+      {
+         "",
+         "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+      },
+      {
+         "abc",
+         "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45",
+      },
+      {
+         "Transfer(address,address,uint256)",
+         "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+      },
+   };
+
+   for(const auto& test : tests) {
+      BOOST_CHECK_EQUAL(fc::crypto::keccak256::hash(std::get<0>(test)).str(),
+                        std::get<1>(test));
+   }
+
+} FC_LOG_AND_RETHROW();
+
+/// Cross-impl agreement between fc::sha3 (hand-rolled, on the consensus path
+/// via the WASM sha3() host intrinsic) and fc::crypto::keccak256 (ethash-
+/// backed, on the consensus path via EM signature recovery). Both must
+/// produce bit-identical Keccak-256 output for every input or chains carrying
+/// EM-signed transactions alongside contracts that hash via sysio::keccak()
+/// will desynchronize.
+///
+/// Inputs cover the Keccak-256 sponge rate boundary (1088 bits / 136 bytes)
+/// and a multi-block buffer to exercise the absorbing phase across rounds.
+BOOST_AUTO_TEST_CASE(ethash_fc_sha3_cross_impl_agreement) try {
+
+   const std::vector<std::string> corpus = {
+      "",
+      "a",
+      "abc",
+      "Transfer(address,address,uint256)",
+      std::string(135, 'A'),   // rate boundary minus one byte
+      std::string(136, 'A'),   // exactly one Keccak-256 rate
+      std::string(137, 'A'),   // rate plus one byte (forces a second block)
+      std::string(1024, 'Z'),  // multi-block input
+   };
+
+   for(const auto& msg : corpus) {
+      BOOST_CHECK_EQUAL(fc::sha3::hash(msg.data(), msg.size(), false).str(),
+                        fc::crypto::keccak256::hash(msg).str());
+   }
+
+   // Large deterministic buffer beyond the small vector corpus, to ensure the
+   // agreement holds at sizes that absorb many sponge blocks.
+   std::mt19937_64 rng{0xC0FFEEULL};
+   std::string big(100 * 1024, '\0');
+   for(auto& c : big) c = static_cast<char>(rng());
+   BOOST_CHECK_EQUAL(fc::sha3::hash(big.data(), big.size(), false).str(),
+                     fc::crypto::keccak256::hash(big).str());
 
 } FC_LOG_AND_RETHROW();
 


### PR DESCRIPTION
## Summary

Wire has two Keccak-256 implementations sitting on the consensus path:
- `fc::sha3` (hand-rolled) is reached by the WASM `sha3()` host intrinsic; every contract call to `sysio::keccak()` runs through it.
- `ethash::keccak256` (via the `fc::crypto::keccak256` wrapper) is reached by EM signature recovery in `em::public_key::recover`; every EM-signed transaction's verification runs through it.

Both must produce bit-identical output or chains carrying EM-signed traffic alongside contracts that hash via `sysio::keccak()` will desynchronize. Until now this invariant was implicit -- the `sysio.authex` contract tests happen to exercise both paths against the same digest, so a divergence would have failed the link verification, but nothing pinned the invariant explicitly.

This PR locks the invariant in a libfc-level test that runs on every CI build, and adds a microbenchmark so future performance work has a baseline.

## What's added

**Tests** (`libraries/libfc/test/crypto/test_hash_functions.cpp`):
- `keccak256_class_golden` -- pins `fc::crypto::keccak256` to standard published vectors (empty input, `"abc"`, the ERC-20 `Transfer(address,address,uint256)` event topic). Catches wiring bugs in the ethash wrapper independent of ethash itself.
- `ethash_fc_sha3_cross_impl_agreement` -- runs both impls over the empty input, short strings, the ERC-20 Transfer topic, the Keccak-256 sponge rate boundary (135 / 136 / 137 bytes), a multi-block input, and a 100 KiB deterministic buffer; asserts byte equality.
- Add the Transfer event topic to the existing `keccak256` case so the same recognizable constant is anchored against `fc::sha3` too.

The three cases form a three-way pin: each impl is independently anchored against published vectors, and they are cross-checked against each other across additional inputs.

**Benchmark** (`libraries/libfc/benchmark/keccak_bench.cpp`, `EXCLUDE_FROM_ALL`):
- Measures `ethash::keccak256` and `fc::sha3` (Keccak and NIST padding, one-shot and chunked-at-10-KiB) at 32 B / 4 KiB / 1 MiB / 33 MiB (the default max wasm linear memory, 528 x 64 KiB pages).
- The chunked variant mirrors the WASM `sha3()` host intrinsic's `hashing_checktime_block_size` loop, so the overhead of the inter-block checktime is directly visible.
- Verifies cross-impl agreement at each scenario size; the bench exits non-zero on any mismatch.

Build and run:

    ninja -C cmake-build-release -j8 keccak_bench
    ./cmake-build-release/libraries/libfc/benchmark/keccak_bench

## Why now

Pre-launch. The cleanest moment to lock cross-impl invariants is before any contract has hashed anything on a live chain. A future refactor of either implementation (vcpkg bump of ethash, perf work on `fc::sha3`, eventual consolidation onto a single library) now has a CI guardrail.