### PR TITLE
ci: add OPP bundles publish workflow

### DIFF
--- a/.github/workflows/opp-bundles.yaml
+++ b/.github/workflows/opp-bundles.yaml
@@ -1,0 +1,48 @@
+name: "OPP Bundles"
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "libraries/opp/**"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - master
+    paths:
+      - "libraries/opp/**"
+
+permissions:
+  contents: read
+
+jobs:
+  opp-bundles:
+    name: Generate OPP Bundles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install fish shell
+        run: |
+          sudo apt-add-repository -y ppa:fish-shell/release-4
+          sudo apt-get update
+          sudo apt-get install -y fish
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.32.1"
+
+      - name: Generate & Publish OPP Bundles
+        if: github.event_name == 'push'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: fish ./libraries/opp/tools/scripts/generate-opp-bundles.fish --publish
+
+      - name: Validate OPP Bundles
+        if: github.event_name == 'pull_request'
+        run: fish ./libraries/opp/tools/scripts/generate-opp-bundles.fish


### PR DESCRIPTION
Adds a GitHub Actions workflow that:
- On push to master with changes in \`libraries/opp/**\`: runs \`generate-opp-bundles.fish --publish\`
- On PR targeting master with changes in \`libraries/opp/**\`: validates bundle generation (dry-run)

Requires \`NPM_TOKEN\` secret to be configured on the repo for publishing.

Co-Authored-By: Oz <oz-agent@warp.dev>