### PR TITLE
Remove unused sysio string include

### DIFF
--- a/contracts/sysio.roa/sysio.roa.hpp
+++ b/contracts/sysio.roa/sysio.roa.hpp
@@ -8,7 +8,6 @@
 #include <sysio/asset.hpp>
 #include <sysio/dispatcher.hpp> // For SYSIO_DISPATCH of native action
 #include <sysio/privileged.hpp>
-#include <sysio/string.hpp> // Need for is_sysio_account?
 
 /**
  *  ---- General TODOs ----


### PR DESCRIPTION
## Summary
Remove the unused `<sysio/string.hpp>` include from the `sysio.roa` contract header.

## What changed
- Deleted the stale `#include <sysio/string.hpp>` line from `contracts/sysio.roa/sysio.roa.hpp`.

## Why
`sysio.roa` does not use `sysio::string`, and the include comment was only speculative. Removing it lets CDT drop the unused sysio string wrapper without breaking this contract.

## Testing
- `cmake --build build/sysio-roa-cdt-check --target sysio.roa -v`

## Notes
- Focused CDT contract build successfully regenerated `sysio.roa.abi` and linked `sysio.roa.wasm` locally.
