### PR TITLE
Fix OPP Bundles pnpm setup

### DIFF
--- a/.github/workflows/opp-bundles.yaml
+++ b/.github/workflows/opp-bundles.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.32.1"
+          package_json_file: libraries/opp/tools/package.json
 
       - name: Generate & Publish OPP Bundles
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
- Point `pnpm/action-setup` at `libraries/opp/tools/package.json` for the OPP Bundles workflow.
- Let the OPP tools package own the pnpm version (`pnpm@10.32.1`) instead of conflicting with the root package manager declaration (`pnpm@10.27.0`).

## Why
PR #334 exposed this workflow issue. The `Generate OPP Bundles` job failed before running bundle generation because `pnpm/action-setup@v4` detected two pnpm versions: the workflow hardcoded `10.32.1`, while the root `package.json` declares `pnpm@10.27.0`.

Failed job: https://github.com/Wire-Network/wire-sysio/actions/runs/26841997949/job/79151310488

## Verification
- `git diff --check -- .github/workflows/opp-bundles.yaml`
