### PR TITLE
P2P: Fix trx listener connection type handling

### DIFF
--- a/plugins/net_plugin/include/sysio/net_plugin/net_utils.hpp
+++ b/plugins/net_plugin/include/sysio/net_plugin/net_utils.hpp
@@ -6,9 +6,12 @@
 
 #include <boost/asio/ip/address_v6.hpp>
 
+#include <set>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <regex>
+#include <vector>
 
 namespace sysio::net_utils {
 
@@ -20,6 +23,12 @@ namespace sysio::net_utils {
 // Allow for future extentions as well, hence 384.
 constexpr size_t max_p2p_address_length = 253 + 6 + 30;
 constexpr size_t max_handshake_str_length = 384;
+/// Address suffix for transaction-only p2p connections.
+inline constexpr std::string_view trx_connection_type = "trx";
+/// Address suffix for block-only p2p connections.
+inline constexpr std::string_view blk_connection_type = "blk";
+/// Length of a recognized p2p connection type suffix.
+inline constexpr size_t connection_type_length = 3;
 
 namespace detail {
 
@@ -134,11 +143,54 @@ namespace detail {
       if (host.empty() || port.empty()) return {};
 
       std::string type;
-      if (remainder.starts_with("blk") || remainder.starts_with("trx")) {
-         type = remainder.substr(0, 3);
+      if (remainder.starts_with(blk_connection_type) || remainder.starts_with(trx_connection_type)) {
+         type = remainder.substr(0, connection_type_length);
       }
 
       return {std::move(host), std::move(port), std::move(type)};
+   }
+
+   /// Connection traffic classes requested by local configuration or a peer's advertised endpoint.
+   enum class connection_type : char {
+      both,
+      transactions_only,
+      blocks_only
+   };
+
+   /// De-duplicate listen endpoints while preserving first-seen order so positionally paired
+   /// p2p-server-address values remain aligned with their p2p-listen-endpoint.
+   inline std::vector<std::string> dedupe_preserve_order(const std::vector<std::string>& addresses) {
+      std::vector<std::string> result;
+      result.reserve(addresses.size());
+      std::set<std::string> seen;
+      for (const auto& addr : addresses) {
+         if (seen.insert(addr).second) {
+            result.emplace_back(addr);
+         }
+      }
+      return result;
+   }
+
+   /// Return the requested connection type encoded in an address, or both when the address is invalid
+   /// or does not explicitly select transaction-only or block-only traffic.
+   inline connection_type type_from_address(const std::string& addr) {
+      const auto& [host, port, type] = split_host_port_type(addr);
+      if (host.empty() || type.empty()) {
+         return connection_type::both;
+      }
+      if (type == trx_connection_type) {
+         return connection_type::transactions_only;
+      }
+      if (type == blk_connection_type) {
+         return connection_type::blocks_only;
+      }
+      return connection_type::both;
+   }
+
+   /// Apply a peer's advertised type only when the local configuration has not already selected
+   /// transaction-only or block-only traffic.
+   inline connection_type narrow_connection_type(connection_type current, const std::string& peer_addr) {
+      return current == connection_type::both ? type_from_address(peer_addr) : current;
    }
 
    /// @return listen address and block sync rate limit (in bytes/sec) of address string

--- a/plugins/net_plugin/src/net_plugin.cpp
+++ b/plugins/net_plugin/src/net_plugin.cpp
@@ -642,10 +642,16 @@ namespace sysio {
 
       void set_connection_type( const string& peer_addr );
       void set_peer_connection_type( const string& peer_addr );
-      bool is_transactions_only_connection()const { return connection_type == transactions_only; } // thread safe, atomic
-      bool is_blocks_only_connection()const { return connection_type == blocks_only; }
-      bool is_transactions_connection() const { return connection_type != blocks_only; } // thread safe, atomic
-      bool is_blocks_connection() const { return connection_type != transactions_only; } // thread safe, atomic
+      bool is_transactions_only_connection()const {
+         return connection_type == net_utils::connection_type::transactions_only;
+      } // thread safe, atomic
+      bool is_blocks_only_connection()const { return connection_type == net_utils::connection_type::blocks_only; }
+      bool is_transactions_connection() const {
+         return connection_type != net_utils::connection_type::blocks_only;
+      } // thread safe, atomic
+      bool is_blocks_connection() const {
+         return connection_type != net_utils::connection_type::transactions_only;
+      } // thread safe, atomic
       uint32_t get_peer_start_block_num() const { return peer_start_block_num.load(); }
       uint32_t get_peer_fork_db_head_block_num() const { return peer_fork_db_head_block_num.load(); }
       uint32_t get_last_received_block_num() const { return last_received_block_num.load(); }
@@ -681,15 +687,10 @@ namespace sysio {
       std::atomic<connection_state> conn_state{connection_state::connecting};
 
       const string            peer_addr;
-      enum connection_types : char {
-         both,
-         transactions_only,
-         blocks_only
-      };
 
       size_t                          block_sync_rate_limit{0};  // bytes/second, default unlimited
 
-      std::atomic<connection_types>   connection_type{both};
+      std::atomic<net_utils::connection_type> connection_type{net_utils::connection_type::both};
       std::atomic<uint32_t>           peer_start_block_num{0};
       std::atomic<uint32_t>           peer_fork_db_head_block_num{0};
       std::atomic<uint32_t>           last_received_block_num{0};
@@ -1170,7 +1171,8 @@ namespace sysio {
         last_handshake_recv(),
         last_handshake_sent()
    {
-      /// Incoming listener type is authoritative; a peer's advertised address may only narrow it later.
+      /// Incoming listener's advertised address type is authoritative; a peer's advertised address may only narrow
+      /// it later.
       set_connection_type( listen_address );
       fc_dlog( p2p_conn_log, "new connection - {} object created for peer {}:{} from listener {}",
                connection_id, log_remote_endpoint_ip, log_remote_endpoint_port, listen_address );
@@ -1207,18 +1209,22 @@ namespace sysio {
       auto [host, port, type] = net_utils::split_host_port_type(peer_add);
       if (host.empty()) {
          fc_dlog( p2p_conn_log, "Invalid address: {}", peer_add);
-      } else if( type.empty() ) {
-         fc_dlog( p2p_conn_log, "Setting connection - {} type for: {} to both transactions and blocks", connection_id, peer_add );
-         connection_type = both;
-      } else if( type == "trx" ) {
+         return;
+      }
+
+      const auto new_type = net_utils::type_from_address(peer_add);
+      if( new_type == net_utils::connection_type::both ) {
+         fc_dlog( p2p_conn_log, "Setting connection - {} type for: {} to both transactions and blocks",
+                  connection_id, peer_add );
+      } else if( new_type == net_utils::connection_type::transactions_only ) {
          fc_dlog( p2p_conn_log, "Setting connection - {} type for: {} to transactions only", connection_id, peer_add );
-         connection_type = transactions_only;
-      } else if( type == "blk" ) {
+      } else if( new_type == net_utils::connection_type::blocks_only ) {
          fc_dlog( p2p_conn_log, "Setting connection - {} type for: {} to blocks only", connection_id, peer_add );
-         connection_type = blocks_only;
       } else {
          fc_wlog( p2p_conn_log, "Unknown connection - {} type: {}, for {}", connection_id, type, peer_add );
+         return;
       }
+      connection_type = new_type;
    }
 
    // called from connection strand
@@ -1227,21 +1233,30 @@ namespace sysio {
       auto [host, port, type] = net_utils::split_host_port_type(peer_add);
       if (host.empty()) {
          fc_dlog( p2p_conn_log, "Invalid peer address: {}", peer_add);
-      } else if( type.empty() ) {
+         return;
+      }
+
+      const auto current_type = connection_type.load();
+      const auto new_type = net_utils::narrow_connection_type(current_type, peer_add);
+      if( type.empty() ) {
          // peer asked for both, continue with p2p-peer-address type
-      } else if( type == "trx" ) {
-         if (connection_type == both) { // only switch to trx if p2p-peer-address didn't specify a connection type
-            fc_dlog( p2p_conn_log, "Setting peer connection - {} type for: {} to transactions only", connection_id, peer_add );
-            connection_type = transactions_only;
+      } else if( type == net_utils::trx_connection_type ) {
+         // only switch to trx if p2p-peer-address didn't specify a connection type
+         if (current_type == net_utils::connection_type::both) {
+            fc_dlog( p2p_conn_log, "Setting peer connection - {} type for: {} to transactions only",
+                     connection_id, peer_add );
          }
-      } else if( type == "blk" ) {
-         if (connection_type == both) { // only switch to blocks if p2p-peer-address didn't specify a connection type
-            fc_dlog( p2p_conn_log, "Setting peer connection - {} type for: {} to blocks only", connection_id, peer_add );
-            connection_type = blocks_only;
+      } else if( type == net_utils::blk_connection_type ) {
+         // only switch to blocks if p2p-peer-address didn't specify a connection type
+         if (current_type == net_utils::connection_type::both) {
+            fc_dlog( p2p_conn_log, "Setting peer connection - {} type for: {} to blocks only",
+                     connection_id, peer_add );
          }
       } else {
          fc_dlog( p2p_conn_log, "Unknown peer connection - {} type: {}, for {}", connection_id, type, peer_add );
+         return;
       }
+      connection_type = new_type;
    }
 
    std::string connection::state_str(connection_state s) {
@@ -4552,15 +4567,7 @@ namespace sysio {
                p2p_addresses = p2ps;
                auto addr_count = p2p_addresses.size();
                /// Preserve endpoint order because p2p-server-address values are paired positionally.
-               vector<string> deduped_p2p_addresses;
-               deduped_p2p_addresses.reserve(p2p_addresses.size());
-               chain::flat_set<string> seen_p2p_addresses;
-               for( const auto& addr : p2p_addresses ) {
-                  if( seen_p2p_addresses.insert(addr).second ) {
-                     deduped_p2p_addresses.emplace_back(addr);
-                  }
-               }
-               p2p_addresses = std::move(deduped_p2p_addresses);
+               p2p_addresses = net_utils::dedupe_preserve_order(p2p_addresses);
                if( size_t addr_diff = addr_count - p2p_addresses.size(); addr_diff != 0) {
                   fc_wlog( p2p_conn_log, "Removed {} duplicate p2p-listen-endpoint entries", addr_diff);
                }

--- a/plugins/net_plugin/src/net_plugin.cpp
+++ b/plugins/net_plugin/src/net_plugin.cpp
@@ -643,14 +643,14 @@ namespace sysio {
       void set_connection_type( const string& peer_addr );
       void set_peer_connection_type( const string& peer_addr );
       bool is_transactions_only_connection()const {
-         return connection_type == net_utils::connection_type::transactions_only;
+         return conn_type == net_utils::connection_type::transactions_only;
       } // thread safe, atomic
-      bool is_blocks_only_connection()const { return connection_type == net_utils::connection_type::blocks_only; }
+      bool is_blocks_only_connection()const { return conn_type == net_utils::connection_type::blocks_only; }
       bool is_transactions_connection() const {
-         return connection_type != net_utils::connection_type::blocks_only;
+         return conn_type != net_utils::connection_type::blocks_only;
       } // thread safe, atomic
       bool is_blocks_connection() const {
-         return connection_type != net_utils::connection_type::transactions_only;
+         return conn_type != net_utils::connection_type::transactions_only;
       } // thread safe, atomic
       uint32_t get_peer_start_block_num() const { return peer_start_block_num.load(); }
       uint32_t get_peer_fork_db_head_block_num() const { return peer_fork_db_head_block_num.load(); }
@@ -690,7 +690,7 @@ namespace sysio {
 
       size_t                          block_sync_rate_limit{0};  // bytes/second, default unlimited
 
-      std::atomic<net_utils::connection_type> connection_type{net_utils::connection_type::both};
+      std::atomic<net_utils::connection_type> conn_type{net_utils::connection_type::both};
       std::atomic<uint32_t>           peer_start_block_num{0};
       std::atomic<uint32_t>           peer_fork_db_head_block_num{0};
       std::atomic<uint32_t>           last_received_block_num{0};
@@ -1171,8 +1171,7 @@ namespace sysio {
         last_handshake_recv(),
         last_handshake_sent()
    {
-      /// Incoming listener's advertised address type is authoritative; a peer's advertised address may only narrow
-      /// it later.
+      /// The locally configured address type is authoritative; a peer's advertised address may only narrow it later.
       set_connection_type( listen_address );
       fc_dlog( p2p_conn_log, "new connection - {} object created for peer {}:{} from listener {}",
                connection_id, log_remote_endpoint_ip, log_remote_endpoint_port, listen_address );
@@ -1206,8 +1205,7 @@ namespace sysio {
 
    // called from connection strand
    void connection::set_connection_type( const std::string& peer_add ) {
-      auto [host, port, type] = net_utils::split_host_port_type(peer_add);
-      if (host.empty()) {
+      if (std::get<0>(net_utils::split_host_port_type( peer_add )).empty()) {
          fc_dlog( p2p_conn_log, "Invalid address: {}", peer_add);
          return;
       }
@@ -1220,11 +1218,8 @@ namespace sysio {
          fc_dlog( p2p_conn_log, "Setting connection - {} type for: {} to transactions only", connection_id, peer_add );
       } else if( new_type == net_utils::connection_type::blocks_only ) {
          fc_dlog( p2p_conn_log, "Setting connection - {} type for: {} to blocks only", connection_id, peer_add );
-      } else {
-         fc_wlog( p2p_conn_log, "Unknown connection - {} type: {}, for {}", connection_id, type, peer_add );
-         return;
       }
-      connection_type = new_type;
+      conn_type = new_type;
    }
 
    // called from connection strand
@@ -1236,7 +1231,7 @@ namespace sysio {
          return;
       }
 
-      const auto current_type = connection_type.load();
+      const auto current_type = conn_type.load();
       const auto new_type = net_utils::narrow_connection_type(current_type, peer_add);
       if( type.empty() ) {
          // peer asked for both, continue with p2p-peer-address type
@@ -1256,7 +1251,9 @@ namespace sysio {
          fc_dlog( p2p_conn_log, "Unknown peer connection - {} type: {}, for {}", connection_id, type, peer_add );
          return;
       }
-      connection_type = new_type;
+      if( new_type != current_type ) {
+         conn_type = new_type;
+      }
    }
 
    std::string connection::state_str(connection_state s) {

--- a/plugins/net_plugin/src/net_plugin.cpp
+++ b/plugins/net_plugin/src/net_plugin.cpp
@@ -1170,6 +1170,8 @@ namespace sysio {
         last_handshake_recv(),
         last_handshake_sent()
    {
+      /// Incoming listener type is authoritative; a peer's advertised address may only narrow it later.
+      set_connection_type( listen_address );
       fc_dlog( p2p_conn_log, "new connection - {} object created for peer {}:{} from listener {}",
                connection_id, log_remote_endpoint_ip, log_remote_endpoint_port, listen_address );
    }
@@ -3564,7 +3566,7 @@ namespace sysio {
 
          if( incoming() ) {
             if (auto [host, port, type] = net_utils::split_host_port_type(msg.p2p_address); !host.empty())
-               set_connection_type( msg.p2p_address);
+               set_peer_connection_type( msg.p2p_address);
             else
                peer_dlog(p2p_msg_log, this, "Invalid handshake p2p_address {}", msg.p2p_address);
          } else {
@@ -4549,9 +4551,16 @@ namespace sysio {
             if (!p2ps.front().empty()) { // "" for p2p-listen-endpoint means to not listen
                p2p_addresses = p2ps;
                auto addr_count = p2p_addresses.size();
-               std::sort(p2p_addresses.begin(), p2p_addresses.end());
-               auto last = std::unique(p2p_addresses.begin(), p2p_addresses.end());
-               p2p_addresses.erase(last, p2p_addresses.end());
+               /// Preserve endpoint order because p2p-server-address values are paired positionally.
+               vector<string> deduped_p2p_addresses;
+               deduped_p2p_addresses.reserve(p2p_addresses.size());
+               chain::flat_set<string> seen_p2p_addresses;
+               for( const auto& addr : p2p_addresses ) {
+                  if( seen_p2p_addresses.insert(addr).second ) {
+                     deduped_p2p_addresses.emplace_back(addr);
+                  }
+               }
+               p2p_addresses = std::move(deduped_p2p_addresses);
                if( size_t addr_diff = addr_count - p2p_addresses.size(); addr_diff != 0) {
                   fc_wlog( p2p_conn_log, "Removed {} duplicate p2p-listen-endpoint entries", addr_diff);
                }

--- a/plugins/net_plugin/test/CMakeLists.txt
+++ b/plugins/net_plugin/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable( test_net_plugin
         auto_bp_peering_unittest.cpp
+        connection_type_unittest.cpp
         rate_limit_parse_unittest.cpp
         net_msg_wire_unittest.cpp
         peer_auth_unittest.cpp

--- a/plugins/net_plugin/test/connection_type_unittest.cpp
+++ b/plugins/net_plugin/test/connection_type_unittest.cpp
@@ -1,0 +1,51 @@
+#include <sysio/net_plugin/net_utils.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+/// Normal listener from the regression configuration whose port sorts after the transaction listener.
+const std::string normal_listen_endpoint = "localhost:18115";
+/// Transaction-only listener from the regression configuration whose port sorts before the normal listener.
+const std::string trx_listen_endpoint = "localhost:17891:trx";
+/// Plain peer address used to verify that handshake data does not widen a configured transaction listener.
+const std::string plain_peer_endpoint = "localhost:18114";
+/// Conflicting block-only peer address used to verify configured listener types stay authoritative.
+const std::string blk_peer_endpoint = "localhost:17892:blk";
+
+} // namespace
+
+/// Verifies duplicate listen endpoint removal preserves CLI order so p2p-server-address entries remain paired.
+BOOST_AUTO_TEST_CASE(listen_endpoint_dedupe_preserves_server_address_pairing) {
+   using namespace sysio::net_utils;
+
+   const std::vector<std::string> listen = {normal_listen_endpoint, trx_listen_endpoint, normal_listen_endpoint};
+   std::vector<std::string>       server = {normal_listen_endpoint, trx_listen_endpoint};
+
+   const std::vector<std::string> deduped = dedupe_preserve_order(listen);
+   BOOST_REQUIRE_EQUAL(deduped.size(), 2u);
+   BOOST_CHECK_EQUAL(deduped[0], normal_listen_endpoint);
+   BOOST_CHECK_EQUAL(deduped[1], trx_listen_endpoint);
+
+   server.resize(deduped.size());
+   for (size_t i = 0; i < deduped.size(); ++i) {
+      BOOST_CHECK_EQUAL(std::get<2>(split_host_port_type(deduped[i])), std::get<2>(split_host_port_type(server[i])));
+   }
+}
+
+/// Verifies peer-advertised addresses may narrow only connections that still accept both traffic classes.
+BOOST_AUTO_TEST_CASE(incoming_trx_listener_type_cannot_be_widened) {
+   using sysio::net_utils::connection_type;
+   using sysio::net_utils::narrow_connection_type;
+   using sysio::net_utils::type_from_address;
+
+   connection_type type = type_from_address(trx_listen_endpoint);
+   BOOST_CHECK(type == connection_type::transactions_only);
+
+   type = narrow_connection_type(type, plain_peer_endpoint);
+   BOOST_CHECK(type == connection_type::transactions_only);
+   BOOST_CHECK(narrow_connection_type(type_from_address(normal_listen_endpoint), trx_listen_endpoint) ==
+               connection_type::transactions_only);
+   BOOST_CHECK(narrow_connection_type(connection_type::transactions_only, blk_peer_endpoint) ==
+               connection_type::transactions_only);
+}

--- a/tests/p2p_multiple_listen_test.py
+++ b/tests/p2p_multiple_listen_test.py
@@ -83,8 +83,10 @@ try:
     for conn in connections['payload']:
         if conn['is_socket_open']:
             open_socket_count += 1
-            assert conn['last_handshake']['agent'] == 'node-00', f"Connected node identifed as '{conn['last_handshake']['agent']}' instead of node-00"
-            assert conn['last_handshake']['p2p_address'].split()[0] == 'ext-ip0:20000', f"Connected node is advertising '{conn['last_handshake']['p2p_address'].split()[0]}' instead of ext-ip0:20000"
+            assert conn['last_handshake']['agent'] == 'node-00', f"Connected node identified as '{conn['last_handshake']['agent']}' instead of node-00"
+            # Server addresses are paired positionally with listen endpoints:
+            # 9876 -> ext-ip0:20000, 9779 -> ext-ip1:20001.
+            assert conn['last_handshake']['p2p_address'].split()[0] == 'ext-ip1:20001', f"Connected node is advertising '{conn['last_handshake']['p2p_address'].split()[0]}' instead of ext-ip1:20001"
     assert open_socket_count == 1, 'Node 2 is expected to have exactly one open socket'
 
     connections = cluster.nodes[4].processUrllibRequest('net', 'connections')
@@ -92,8 +94,8 @@ try:
     for conn in connections['payload']:
         if conn['is_socket_open']:
             open_socket_count += 1
-            assert conn['last_handshake']['agent'] == 'node-00', f"Connected node identifed as '{conn['last_handshake']['agent']}' instead of node-00"
-            assert conn['last_handshake']['p2p_address'].split()[0] == 'ext-ip1:20001', f"Connected node is advertising '{conn['last_handshake']['p2p_address'].split()[0]} 'instead of ext-ip1:20001"
+            assert conn['last_handshake']['agent'] == 'node-00', f"Connected node identified as '{conn['last_handshake']['agent']}' instead of node-00"
+            assert conn['last_handshake']['p2p_address'].split()[0] == 'ext-ip0:20000', f"Connected node is advertising '{conn['last_handshake']['p2p_address'].split()[0]}' instead of ext-ip0:20000"
     assert open_socket_count == 1, 'Node 4 is expected to have exactly one open socket'
 
     testSuccessful=True


### PR DESCRIPTION
## Why

`p2p_no_blocks_if_test` failed in the sharded CI run because a node that should only receive transactions over a `:trx` listener could still receive blocks.

Failed run reference: https://github.com/Wire-Network/wire-sysio/actions/runs/27022195099/job/79758140428

The root cause had two pieces:

- Incoming connections accepted on a `:trx` listener were initialized as `both` and could be widened by the peer's advertised normal `p2p_address`.
- `p2p-listen-endpoint` values were sorted before being paired with positional `p2p-server-address` values, which could swap the advertised normal and `:trx` addresses for multi-listener nodes.

## What changed

- Initialize incoming connection type from the listener that accepted the socket.
- For incoming handshakes, let the peer-advertised address only narrow the connection type.
- Preserve `p2p-listen-endpoint` order while de-duplicating so `p2p-server-address` pairing remains correct.
- Multi-listener nodes now advertise the `p2p-server-address` paired positionally with the listener endpoint that accepted the connection; this preserves configured order rather than sorted endpoint order.
- Extract endpoint de-duplication and connection-type selection into `net_utils.hpp` so the behavior is covered by deterministic unit tests.
- Add regression coverage for the order-preserving de-dupe case and for preventing a configured incoming `:trx` listener from being widened by a plain peer address.

## Verification

- `cmake --build build/codex-system-contracts --target nodeop -- -j6`
- Cherry-picked the fix onto post-sharding branch `codex/port-sharded-np-lr-tests` and ran:
  - `ctest -R '^p2p_no_blocks_if_test$' --output-on-failure --timeout 1000`
  - Result: passed, 98.69 sec
- Compiled touched host objects:
  - `plugins/net_plugin/CMakeFiles/net_plugin.dir/src/net_plugin.cpp.o`
  - `plugins/net_plugin/test/CMakeFiles/test_net_plugin.dir/connection_type_unittest.cpp.o`
- Relinked `test_net_plugin` and ran:
  - `./build/codex-system-contracts/plugins/net_plugin/test/test_net_plugin --run_test=listen_endpoint_dedupe_preserves_server_address_pairing,incoming_trx_listener_type_cannot_be_widened`
  - `./build/codex-system-contracts/plugins/net_plugin/test/test_net_plugin`
  - Result: passed, 66 test cases