### PR TITLE
Add NodeOwnerTier enum to OPP types

### DIFF
--- a/libraries/opp/proto/sysio/opp/types/types.proto
+++ b/libraries/opp/proto/sysio/opp/types/types.proto
@@ -386,3 +386,12 @@ enum ChallengeStatus {
   CHALLENGE_STATUS_RESOLVED          = 2;
   CHALLENGE_STATUS_ESCALATED         = 3;
 }
+
+// Node-owner registration tier (sysio.roa::nodeownreg). Mirrors the MockWireNodes NodeInfo tier and
+// the on-chain `check(tier >= 1 && tier <= 3)` range -- T1/T2/T3 are the only valid registration tiers.
+enum NodeOwnerTier {
+  NODE_OWNER_TIER_UNKNOWN = 0;
+  NODE_OWNER_TIER_T1      = 1;
+  NODE_OWNER_TIER_T2      = 2;
+  NODE_OWNER_TIER_T3      = 3;
+}


### PR DESCRIPTION
Adds a shared `NodeOwnerTier` enum to the OPP protobuf types (`sysio/opp/types/types.proto`) so the C++/CDT/TS/Solidity models all carry it, instead of the cluster tooling hardcoding `Validator/Compute/Operator`.

```proto
enum NodeOwnerTier {
  NODE_OWNER_TIER_UNKNOWN = 0;
  NODE_OWNER_TIER_T1      = 1;
  NODE_OWNER_TIER_T2      = 2;
  NODE_OWNER_TIER_T3      = 3;
}
```

The generated TS members are `NodeOwnerTier.T1/T2/T3` (the bundler strips the `NODE_OWNER_TIER_` prefix). `sysio.roa::nodeownreg` keeps its `uint8_t tier` parameter and `check(tier >= 1 && tier <= 3)` -- this is the shared type definition, not an ABI change.

Generated bundles regenerate downstream from the proto (CMake for `.pb.h`/`.pb.hpp`, `generate-opp-bundles` for TS/Solidity/Solana); nothing else to commit here.