### PR TITLE
Bound transaction trace polling in test harness

### DIFF
--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -240,6 +240,7 @@ class NodeopQueries:
         return self.isBlockPresent(blockNum, blockType=BlockType.lib)
 
     def getTransaction(self, transId, silentErrors=False, exitOnError=False, delayedRetry=True):
+        """Fetch a transaction trace, bounding each poll so missing traces cannot stall bootstrap."""
         assert(isinstance(transId, str))
         exitOnErrorForDelayed=not delayedRetry and exitOnError
         timeout=3
@@ -247,7 +248,7 @@ class NodeopQueries:
         cmd="%s %s" % (cmdDesc, transId)
         msg="(transaction id=%s)" % (transId);
         for i in range(0,(int(60/timeout) - 1)):
-            trans=self.processClioCmd(cmd, cmdDesc, silentErrors=True, exitOnError=exitOnErrorForDelayed, exitMsg=msg)
+            trans=self.processClioCmd(cmd, cmdDesc, silentErrors=True, exitOnError=exitOnErrorForDelayed, exitMsg=msg, timeout=timeout)
             if trans is not None or not delayedRetry:
                 return trans
             if Utils.Debug: Utils.Print("Could not find transaction with id %s, delay and retry" % (transId))
@@ -255,7 +256,7 @@ class NodeopQueries:
 
         self.missingTransaction=True
         # either it is there or the transaction has timed out
-        return self.processClioCmd(cmd, cmdDesc, silentErrors=silentErrors, exitOnError=exitOnError, exitMsg=msg)
+        return self.processClioCmd(cmd, cmdDesc, silentErrors=silentErrors, exitOnError=exitOnError, exitMsg=msg, timeout=timeout)
 
     def isTransInBlock(self, transId, blockId, exitOnError=False):
         """Check if transId is within block identified by blockId"""
@@ -561,7 +562,8 @@ class NodeopQueries:
         keys=list(row["value"].keys())
         return keys
 
-    def processClioCmd(self, cmd, cmdDesc, silentErrors=True, exitOnError=False, exitMsg=None, returnType=ReturnType.json):
+    def processClioCmd(self, cmd, cmdDesc, silentErrors=True, exitOnError=False, exitMsg=None, returnType=ReturnType.json, timeout=None):
+        """Run clio and decode the requested return type, optionally bounding the subprocess runtime."""
         assert(isinstance(returnType, ReturnType))
         cmd="%s %s %s" % (Utils.SysClientPath, self.sysClientArgs(), cmd)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
@@ -576,9 +578,9 @@ class NodeopQueries:
             retries -= 1
             try:
                 if returnType==ReturnType.json:
-                    trans=Utils.runCmdReturnJson(cmd, silentErrors=silentErrors)
+                    trans=Utils.runCmdReturnJson(cmd, silentErrors=silentErrors, timeout=timeout)
                 elif returnType==ReturnType.raw:
-                    trans=Utils.runCmdReturnStr(cmd)
+                    trans=Utils.runCmdReturnStr(cmd, timeout=timeout)
                 else:
                     unhandledEnumType(returnType)
 
@@ -594,6 +596,16 @@ class NodeopQueries:
                         Utils.Print(f"Retrying {cmdDesc} due to: tx_cpu_usage_exceeded")
                         continue # try again
                     errorMsg="Exception during \"%s\". Exception message: %s.  stdout: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, out, end-start, exitMsg)
+                    if exitOnError:
+                        Utils.cmdError(errorMsg)
+                        Utils.errorExit(errorMsg)
+                    else:
+                        Utils.Print("ERROR: %s" % (errorMsg))
+                return None
+            except subprocess.TimeoutExpired as ex:
+                if not silentErrors:
+                    end=time.perf_counter()
+                    errorMsg="Timeout during \"%s\" after %.3f sec. cmd timeout=%s. %s" % (cmdDesc, end-start, ex.timeout, exitMsg)
                     if exitOnError:
                         Utils.cmdError(errorMsg)
                         Utils.errorExit(errorMsg)

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -243,20 +243,37 @@ class NodeopQueries:
         """Fetch a transaction trace, bounding each poll so missing traces cannot stall bootstrap."""
         assert(isinstance(transId, str))
         exitOnErrorForDelayed=not delayedRetry and exitOnError
-        timeout=3
+        pollTimeout=3
+        pollBudget=60
+        pollDeadline=time.perf_counter() + pollBudget
         cmdDesc="get transaction_trace"
         cmd="%s %s" % (cmdDesc, transId)
-        msg="(transaction id=%s)" % (transId);
-        for i in range(0,(int(60/timeout) - 1)):
-            trans=self.processClioCmd(cmd, cmdDesc, silentErrors=True, exitOnError=exitOnErrorForDelayed, exitMsg=msg, timeout=timeout)
+        msg="(transaction id=%s)" % (transId)
+        while True:
+            remainingBudget=pollDeadline - time.perf_counter()
+            if remainingBudget <= 0:
+                break
+            finalAttempt=remainingBudget <= pollTimeout
+            timeout=min(pollTimeout, remainingBudget)
+            attemptStart=time.perf_counter()
+            trans=self.processClioCmd(cmd, cmdDesc,
+                                      silentErrors=silentErrors if finalAttempt else True,
+                                      exitOnError=exitOnError if finalAttempt else exitOnErrorForDelayed,
+                                      exitMsg=msg, timeout=timeout)
             if trans is not None or not delayedRetry:
                 return trans
+            if finalAttempt:
+                break
+            remainingBudget=pollDeadline - time.perf_counter()
+            if remainingBudget <= 0:
+                break
             if Utils.Debug: Utils.Print("Could not find transaction with id %s, delay and retry" % (transId))
-            time.sleep(timeout)
+            attemptElapsed=time.perf_counter() - attemptStart
+            time.sleep(min(max(0, pollTimeout - attemptElapsed), remainingBudget))
 
         self.missingTransaction=True
         # either it is there or the transaction has timed out
-        return self.processClioCmd(cmd, cmdDesc, silentErrors=silentErrors, exitOnError=exitOnError, exitMsg=msg, timeout=timeout)
+        return None
 
     def isTransInBlock(self, transId, blockId, exitOnError=False):
         """Check if transId is within block identified by blockId"""
@@ -576,6 +593,7 @@ class NodeopQueries:
         start=time.perf_counter()
         while retries > 0:
             retries -= 1
+            attemptStart=time.perf_counter()
             try:
                 if returnType==ReturnType.json:
                     trans=Utils.runCmdReturnJson(cmd, silentErrors=silentErrors, timeout=timeout)
@@ -586,7 +604,7 @@ class NodeopQueries:
 
                 if Utils.Debug:
                     end=time.perf_counter()
-                    Utils.Print("cmd Duration: %.3f sec" % (end-start))
+                    Utils.Print("cmd Duration: %.3f sec" % (end-attemptStart))
             except subprocess.CalledProcessError as ex:
                 if not silentErrors:
                     end=time.perf_counter()
@@ -605,7 +623,10 @@ class NodeopQueries:
             except subprocess.TimeoutExpired as ex:
                 if not silentErrors:
                     end=time.perf_counter()
-                    errorMsg="Timeout during \"%s\" after %.3f sec. cmd timeout=%s. %s" % (cmdDesc, end-start, ex.timeout, exitMsg)
+                    out=ex.output.decode("utf-8") if ex.output is not None else ""
+                    msg=ex.stderr.decode("utf-8") if ex.stderr is not None else ""
+                    errorMsg=("Timeout during \"%s\" after %.3f sec. cmd timeout=%s. stderr: %s. stdout: %s. %s" %
+                              (cmdDesc, end-attemptStart, ex.timeout, msg, out, exitMsg))
                     if exitOnError:
                         Utils.cmdError(errorMsg)
                         Utils.errorExit(errorMsg)

--- a/tests/TestHarness/queries.py
+++ b/tests/TestHarness/queries.py
@@ -251,25 +251,19 @@ class NodeopQueries:
         msg="(transaction id=%s)" % (transId)
         while True:
             remainingBudget=pollDeadline - time.perf_counter()
-            if remainingBudget <= 0:
-                break
             finalAttempt=remainingBudget <= pollTimeout
-            timeout=min(pollTimeout, remainingBudget)
             attemptStart=time.perf_counter()
             trans=self.processClioCmd(cmd, cmdDesc,
                                       silentErrors=silentErrors if finalAttempt else True,
                                       exitOnError=exitOnError if finalAttempt else exitOnErrorForDelayed,
-                                      exitMsg=msg, timeout=timeout)
+                                      exitMsg=msg, timeout=pollTimeout)
             if trans is not None or not delayedRetry:
                 return trans
             if finalAttempt:
                 break
-            remainingBudget=pollDeadline - time.perf_counter()
-            if remainingBudget <= 0:
-                break
             if Utils.Debug: Utils.Print("Could not find transaction with id %s, delay and retry" % (transId))
             attemptElapsed=time.perf_counter() - attemptStart
-            time.sleep(min(max(0, pollTimeout - attemptElapsed), remainingBudget))
+            time.sleep(max(0, pollTimeout - attemptElapsed))
 
         self.missingTransaction=True
         # either it is there or the transaction has timed out
@@ -608,12 +602,12 @@ class NodeopQueries:
             except subprocess.CalledProcessError as ex:
                 if not silentErrors:
                     end=time.perf_counter()
-                    out=ex.output.decode("utf-8")
-                    msg=ex.stderr.decode("utf-8")
+                    out=Utils.decodeProcessOutput(ex.output)
+                    msg=Utils.decodeProcessOutput(ex.stderr)
                     if retries > 0 and "tx_cpu_usage_exceeded" in out:
                         Utils.Print(f"Retrying {cmdDesc} due to: tx_cpu_usage_exceeded")
                         continue # try again
-                    errorMsg="Exception during \"%s\". Exception message: %s.  stdout: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, out, end-start, exitMsg)
+                    errorMsg="Exception during \"%s\". Exception message: %s.  stdout: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, out, end-attemptStart, exitMsg)
                     if exitOnError:
                         Utils.cmdError(errorMsg)
                         Utils.errorExit(errorMsg)
@@ -623,8 +617,8 @@ class NodeopQueries:
             except subprocess.TimeoutExpired as ex:
                 if not silentErrors:
                     end=time.perf_counter()
-                    out=ex.output.decode("utf-8") if ex.output is not None else ""
-                    msg=ex.stderr.decode("utf-8") if ex.stderr is not None else ""
+                    out=Utils.decodeProcessOutput(ex.output)
+                    msg=Utils.decodeProcessOutput(ex.stderr)
                     errorMsg=("Timeout during \"%s\" after %.3f sec. cmd timeout=%s. stderr: %s. stdout: %s. %s" %
                               (cmdDesc, end-attemptStart, ex.timeout, msg, out, exitMsg))
                     if exitOnError:

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -199,6 +199,8 @@ class Utils:
     @staticmethod
     def checkOutput(cmd, ignoreError=False, timeout=None):
         """Run a command and return stdout, optionally bounding the subprocess runtime."""
+        assert timeout is None or isinstance(cmd, list), (
+            "timeout with shell command strings can leave orphaned children")
         popen = Utils.delayedCheckOutput(cmd)
         return Utils.checkDelayedOutput(popen, cmd, ignoreError=ignoreError, timeout=timeout)
 
@@ -226,7 +228,12 @@ class Utils:
         Utils.checkOutputFileWrite(start, cmd, output, error)
         if popen.returncode != 0 and not ignoreError:
             raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=output, stderr=error)
-        return output.decode("utf-8") if popen.returncode == 0 else error.decode("utf-8")
+        return Utils.decodeProcessOutput(output) if popen.returncode == 0 else Utils.decodeProcessOutput(error)
+
+    @staticmethod
+    def decodeProcessOutput(output):
+        """Decode subprocess bytes without hiding diagnostics if a killed process wrote partial UTF-8."""
+        return output.decode("utf-8", errors="replace") if output is not None else ""
 
     @staticmethod
     def errorExit(msg="", raw=False, errorCode=1):
@@ -367,7 +374,7 @@ class Utils:
         except subprocess.CalledProcessError as ex:
             if not silentErrors:
                 end=time.perf_counter()
-                msg=ex.stderr.decode("utf-8")
+                msg=Utils.decodeProcessOutput(ex.stderr)
                 errorMsg="Exception during \"%s\". Exception message: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, end-start, exitMsg)
                 if exitOnError:
                     Utils.cmdError(errorMsg)
@@ -378,8 +385,8 @@ class Utils:
         except subprocess.TimeoutExpired as ex:
             if not silentErrors:
                 end=time.perf_counter()
-                out=ex.output.decode("utf-8") if ex.output is not None else ""
-                msg=ex.stderr.decode("utf-8") if ex.stderr is not None else ""
+                out=Utils.decodeProcessOutput(ex.output)
+                msg=Utils.decodeProcessOutput(ex.stderr)
                 errorMsg=("Timeout during \"%s\" after %.3f sec. cmd timeout=%s. stderr: %s. stdout: %s. %s" %
                           (cmdDesc, end-start, ex.timeout, msg, out, exitMsg))
                 if exitOnError:

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -222,7 +222,7 @@ class Utils:
             popen.kill()
             (output,error)=popen.communicate()
             Utils.checkOutputFileWrite(start, cmd, output, error)
-            raise subprocess.TimeoutExpired(cmd=cmd, timeout=ex.timeout, output=output, stderr=error)
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=ex.timeout, output=output, stderr=error) from ex
         Utils.checkOutputFileWrite(start, cmd, output, error)
         if popen.returncode != 0 and not ignoreError:
             raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=output, stderr=error)
@@ -348,7 +348,8 @@ class Utils:
         return Utils.runCmdArrReturnJson(cmdArr, trace=trace, silentErrors=silentErrors, timeout=timeout)
 
     @staticmethod
-    def processSysioUtilCmd(cmd, cmdDesc, silentErrors=True, exitOnError=False, exitMsg=None):
+    def processSysioUtilCmd(cmd, cmdDesc, silentErrors=True, exitOnError=False, exitMsg=None, timeout=None):
+        """Run sys-util and return stdout, optionally bounding the subprocess runtime."""
         cmd="%s %s" % (Utils.SysioClientPath, cmd)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         if exitMsg is not None:
@@ -358,7 +359,7 @@ class Utils:
         output=None
         start=time.perf_counter()
         try:
-            output=Utils.runCmdReturnStr(cmd)
+            output=Utils.runCmdReturnStr(cmd, timeout=timeout)
 
             if Utils.Debug:
                 end=time.perf_counter()
@@ -368,6 +369,19 @@ class Utils:
                 end=time.perf_counter()
                 msg=ex.stderr.decode("utf-8")
                 errorMsg="Exception during \"%s\". Exception message: %s.  cmd Duration=%.3f sec. %s" % (cmdDesc, msg, end-start, exitMsg)
+                if exitOnError:
+                    Utils.cmdError(errorMsg)
+                    Utils.errorExit(errorMsg)
+                else:
+                    Utils.Print("ERROR: %s" % (errorMsg))
+            return None
+        except subprocess.TimeoutExpired as ex:
+            if not silentErrors:
+                end=time.perf_counter()
+                out=ex.output.decode("utf-8") if ex.output is not None else ""
+                msg=ex.stderr.decode("utf-8") if ex.stderr is not None else ""
+                errorMsg=("Timeout during \"%s\" after %.3f sec. cmd timeout=%s. stderr: %s. stdout: %s. %s" %
+                          (cmdDesc, end-start, ex.timeout, msg, out, exitMsg))
                 if exitOnError:
                     Utils.cmdError(errorMsg)
                     Utils.errorExit(errorMsg)

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -197,9 +197,10 @@ class Utils:
         return chainSyncStrategies
 
     @staticmethod
-    def checkOutput(cmd, ignoreError=False):
+    def checkOutput(cmd, ignoreError=False, timeout=None):
+        """Run a command and return stdout, optionally bounding the subprocess runtime."""
         popen = Utils.delayedCheckOutput(cmd)
-        return Utils.checkDelayedOutput(popen, cmd, ignoreError=ignoreError)
+        return Utils.checkDelayedOutput(popen, cmd, ignoreError=ignoreError, timeout=timeout)
 
     @staticmethod
     def delayedCheckOutput(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
@@ -210,11 +211,18 @@ class Utils:
         return popen
 
     @staticmethod
-    def checkDelayedOutput(popen, cmd, ignoreError=False):
+    def checkDelayedOutput(popen, cmd, ignoreError=False, timeout=None):
+        """Collect a subprocess result and terminate it if it exceeds the requested timeout."""
         assert isinstance(popen, subprocess.Popen)
         assert isinstance(cmd, (str,list))
         start=Utils.timestamp()
-        (output,error)=popen.communicate()
+        try:
+            (output,error)=popen.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired as ex:
+            popen.kill()
+            (output,error)=popen.communicate()
+            Utils.checkOutputFileWrite(start, cmd, output, error)
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=ex.timeout, output=output, stderr=error)
         Utils.checkOutputFileWrite(start, cmd, output, error)
         if popen.returncode != 0 and not ignoreError:
             raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=output, stderr=error)
@@ -315,25 +323,29 @@ class Utils:
             raise
 
     @staticmethod
-    def runCmdArrReturnJson(cmdArr, trace=False, silentErrors=True):
-        retStr=Utils.checkOutput(cmdArr)
+    def runCmdArrReturnJson(cmdArr, trace=False, silentErrors=True, timeout=None):
+        """Run a command array and parse its JSON output, optionally with a subprocess timeout."""
+        retStr=Utils.checkOutput(cmdArr, timeout=timeout)
         return Utils.toJson(retStr, trace, silentErrors)
 
     @staticmethod
-    def runCmdReturnStr(cmd, trace=False, ignoreError=False):
+    def runCmdReturnStr(cmd, trace=False, ignoreError=False, timeout=None):
+        """Run a shell command string and return stdout, optionally with a subprocess timeout."""
         cmdArr=shlex.split(cmd)
-        return Utils.runCmdArrReturnStr(cmdArr, ignoreError=ignoreError)
+        return Utils.runCmdArrReturnStr(cmdArr, ignoreError=ignoreError, timeout=timeout)
 
     @staticmethod
-    def runCmdArrReturnStr(cmdArr, trace=False, ignoreError=False):
-        retStr=Utils.checkOutput(cmdArr, ignoreError=ignoreError)
+    def runCmdArrReturnStr(cmdArr, trace=False, ignoreError=False, timeout=None):
+        """Run a command array and return stdout, optionally with a subprocess timeout."""
+        retStr=Utils.checkOutput(cmdArr, ignoreError=ignoreError, timeout=timeout)
         if trace: Utils.Print ("RAW > %s" % (retStr))
         return retStr
 
     @staticmethod
-    def runCmdReturnJson(cmd, trace=False, silentErrors=False):
+    def runCmdReturnJson(cmd, trace=False, silentErrors=False, timeout=None):
+        """Run a shell command string and parse its JSON output, optionally with a subprocess timeout."""
         cmdArr=shlex.split(cmd)
-        return Utils.runCmdArrReturnJson(cmdArr, trace=trace, silentErrors=silentErrors)
+        return Utils.runCmdArrReturnJson(cmdArr, trace=trace, silentErrors=silentErrors, timeout=timeout)
 
     @staticmethod
     def processSysioUtilCmd(cmd, cmdDesc, silentErrors=True, exitOnError=False, exitMsg=None):

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -12,7 +12,7 @@ from .testUtils import Utils
 
 class Transactions(NodeopQueries):
     retry_num_blocks_default = 1
-    # Default clio action-push timeout, in seconds, used to keep intentionally interrupting transactions bounded.
+    # Default clio action-push subprocess timeout, in seconds, used to bound a stuck push.
     push_message_timeout_default = 45
 
     def __init__(self, host, port, walletMgr=None):
@@ -299,11 +299,15 @@ class Transactions(NodeopQueries):
                     continue # try again
                 return (False, msg)
             except subprocess.TimeoutExpired as ex:
+                msg=str(ex)
+                output=ex.output.decode("utf-8") if ex.output is not None else ""
+                error=ex.stderr.decode("utf-8") if ex.stderr is not None else ""
                 if not silentErrors:
                     end=time.perf_counter()
-                    Utils.Print("ERROR: Timeout during push message. retry %s. cmd timeout=%s. cmd Duration=%.3f sec." %
-                                (retries, ex.timeout, end - start))
-                return (False, ex)
+                    Utils.Print(
+                        "ERROR: Timeout during push message. retry %s. cmd timeout=%s. stderr: %s. stdout: %s. cmd Duration=%.3f sec." %
+                        (retries, ex.timeout, error, output, end - start))
+                return (False, msg)
 
     def setPermission(self, account, code, pType, requirement, waitForTransBlock=False, exitOnError=False, sign=False):
         assert(isinstance(account, Account))

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -12,6 +12,8 @@ from .testUtils import Utils
 
 class Transactions(NodeopQueries):
     retry_num_blocks_default = 1
+    # Default clio action-push timeout, in seconds, used to keep intentionally interrupting transactions bounded.
+    push_message_timeout_default = 45
 
     def __init__(self, host, port, walletMgr=None):
         super().__init__(host, port, walletMgr)
@@ -261,7 +263,9 @@ class Transactions(NodeopQueries):
             return (False, msg)
 
     # returns tuple with transaction execution status and transaction
-    def pushMessage(self, account, action, data, opts, silentErrors=False, signatures=None, expectTrxTrace=True):
+    def pushMessage(self, account, action, data, opts, silentErrors=False, signatures=None, expectTrxTrace=True,
+                    timeout=push_message_timeout_default):
+        """Push an action with clio, bounding the clio subprocess runtime by default."""
         cmd="%s %s push action -j %s %s" % (Utils.SysClientPath, self.sysClientArgs(), account, action)
         cmdArr=cmd.split()
         # not using sign_str, since cmdArr messes up the string
@@ -278,7 +282,7 @@ class Transactions(NodeopQueries):
         while retries > 0:
             retries -= 1
             try:
-                trans=Utils.runCmdArrReturnJson(cmdArr)
+                trans=Utils.runCmdArrReturnJson(cmdArr, timeout=timeout)
                 self.trackCmdTransaction(trans, ignoreNonTrans=True)
                 if Utils.Debug:
                     end=time.perf_counter()
@@ -294,6 +298,12 @@ class Transactions(NodeopQueries):
                     Utils.Print(f"Retrying {cmd} due to: tx_cpu_usage_exceeded")
                     continue # try again
                 return (False, msg)
+            except subprocess.TimeoutExpired as ex:
+                if not silentErrors:
+                    end=time.perf_counter()
+                    Utils.Print("ERROR: Timeout during push message. retry %s. cmd timeout=%s. cmd Duration=%.3f sec." %
+                                (retries, ex.timeout, end - start))
+                return (False, ex)
 
     def setPermission(self, account, code, pType, requirement, waitForTransBlock=False, exitOnError=False, sign=False):
         assert(isinstance(account, Account))

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -123,7 +123,7 @@ class Transactions(NodeopQueries):
                 self.trackCmdTransaction(trans, reportStatus=reportStatus)
         except subprocess.CalledProcessError as ex:
             end=time.perf_counter()
-            msg=ex.stderr.decode("utf-8")
+            msg=Utils.decodeProcessOutput(ex.stderr)
             Utils.Print("ERROR: Exception during funds transfer.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
             if exitOnError:
                 Utils.cmdError("could not transfer \"%s\" from %s to %s" % (amountStr, source, destination))
@@ -264,8 +264,10 @@ class Transactions(NodeopQueries):
 
     # returns tuple with transaction execution status and transaction
     def pushMessage(self, account, action, data, opts, silentErrors=False, signatures=None, expectTrxTrace=True,
-                    timeout=push_message_timeout_default):
+                    timeout=None):
         """Push an action with clio, bounding the clio subprocess runtime by default."""
+        if timeout is None:
+            timeout = self.push_message_timeout_default
         cmd="%s %s push action -j %s %s" % (Utils.SysClientPath, self.sysClientArgs(), account, action)
         cmdArr=cmd.split()
         # not using sign_str, since cmdArr messes up the string
@@ -289,8 +291,8 @@ class Transactions(NodeopQueries):
                     Utils.Print("cmd Duration: %.3f sec" % (end-start))
                 return (NodeopQueries.getTransStatus(trans) == 'executed' if expectTrxTrace else True, trans)
             except subprocess.CalledProcessError as ex:
-                msg=ex.stderr.decode("utf-8")
-                output=ex.output.decode("utf-8")
+                msg=Utils.decodeProcessOutput(ex.stderr)
+                output=Utils.decodeProcessOutput(ex.output)
                 if not silentErrors:
                     end=time.perf_counter()
                     Utils.Print("ERROR: Exception during push message. retry %s. stderr: %s. stdout: %s.  cmd Duration=%.3f sec." % (retries, msg, output, end - start))
@@ -300,13 +302,14 @@ class Transactions(NodeopQueries):
                 return (False, msg)
             except subprocess.TimeoutExpired as ex:
                 msg=str(ex)
-                output=ex.output.decode("utf-8") if ex.output is not None else ""
-                error=ex.stderr.decode("utf-8") if ex.stderr is not None else ""
+                output=Utils.decodeProcessOutput(ex.output)
+                error=Utils.decodeProcessOutput(ex.stderr)
                 if not silentErrors:
                     end=time.perf_counter()
                     Utils.Print(
                         "ERROR: Timeout during push message. retry %s. cmd timeout=%s. stderr: %s. stdout: %s. cmd Duration=%.3f sec." %
                         (retries, ex.timeout, error, output, end - start))
+                # The killed clio process may have already broadcast the transaction before timing out; do not retry.
                 return (False, msg)
 
     def setPermission(self, account, code, pType, requirement, waitForTransBlock=False, exitOnError=False, sign=False):


### PR DESCRIPTION
## Summary

Bound TestHarness `clio get transaction_trace` polling so a single stuck `clio` subprocess cannot outlive the harness wait budget.

## What changed

- Added optional subprocess timeout plumbing to the shared TestHarness command helpers.
- Passed the existing 3-second transaction-trace poll interval as a per-command timeout.
- Handled `subprocess.TimeoutExpired` in `processClioCmd` the same way other silent polling failures are handled.

## Why

`publishContract(..., waitForTransBlock=True)` uses a bounded wait for transaction inclusion, but the nested `clio get transaction_trace` call previously had no subprocess timeout. If that command blocked, bootstrap could stall for many minutes and later contract-publish transactions could expire against the advanced chain time.

This was observed while validating `performance_test_basic_p2p` on macOS arm64 after PR #369.

## Testing

- `python3 -m py_compile tests/TestHarness/testUtils.py tests/TestHarness/queries.py`
- On the source worktree with the same patch applied:
  - `ctest --test-dir build/macos-arm64-jit-chain-release -j 1 -R "^performance_test_basic_p2p$" --output-on-failure --timeout 1000`
  - Result: passed in 104.73 sec

