### PR TITLE
Assert extra packed-data API error response

### DIFF
--- a/tests/nodeop_extra_packed_data_test.py
+++ b/tests/nodeop_extra_packed_data_test.py
@@ -50,6 +50,11 @@ WalletdName=Utils.SysWalletName
 ClientName="clio"
 timeout = .5 * 12 * 2 + 60 # time for finalization with 1 producer + 60 seconds padding
 Utils.setIrreversibleTimeout(timeout)
+expectedExtraPackedDataError="packed_transaction contains extra data beyond transaction struct"
+
+def responseContainsExpectedError(response):
+    """Return true when an HTTP error response contains the expected extra packed-data rejection."""
+    return response is not None and expectedExtraPackedDataError in json.dumps(response)
 
 try:
     TestHelper.printSystemInfo("BEGIN")
@@ -158,11 +163,10 @@ try:
         if i == 0:
             packedTrx["packed_trx"] = packed_trx_param + "00000000"
 
-        sentTrx = node.processUrllibRequest("chain", "send_transaction2", {"transaction": packedTrx}, silentErrors=True, exitOnError=False)
+        sentTrx = node.processUrllibRequest("chain", "send_transaction2", {"transaction": packedTrx}, silentErrors=i != 0, exitOnError=False)
         Print("sent transaction json: %s" % (sentTrx))
         if i == 0:
-            assert sentTrx is None, "Should have failed to send transaction with extra data"
-            assert node.findInLog("packed_transaction contains extra data"), "Should have found failed log message"
+            assert responseContainsExpectedError(sentTrx), "Should have rejected transaction with extra packed data"
             continue
 
         trx_id = sentTrx["payload"]["transaction_id"]


### PR DESCRIPTION
## Summary

Fix `nodeop_extra_packed_data_test` so it validates the stable API rejection payload for malformed packed transactions instead of looking for the diagnostic in node stderr.

## What changed

- Added an `expectedExtraPackedDataError` helper for the `tx_extra_data` rejection message.
- Calls `send_transaction2` with `silentErrors=False` for the negative extra-packed-data case so the HTTP error payload is preserved.
- Asserts the returned response contains `packed_transaction contains extra data beyond transaction struct`.

## Why

On macOS arm64, the node rejected the malformed packed transaction correctly, but the diagnostic was returned in the API error response rather than written to the node log. The previous assertion expected `sentTrx is None` and then searched stderr, which made the test fail despite correct node behavior.

## Testing

- `python3 -m py_compile tests/nodeop_extra_packed_data_test.py`
- macOS arm64: `ctest --test-dir build/macos-arm64-jit-chain-release -j 1 -R "^nodeop_extra_packed_data_test$" --output-on-failure --timeout 1000` passed in `98.55 sec`
- Linux sandbox: `ctest --test-dir build/codex-system-contracts -j 1 -R "^nodeop_extra_packed_data_test$" --output-on-failure --timeout 1000` passed in `92.64 sec`