### PR TITLE
Use line topology for startup catchup test

### DIFF
--- a/tests/nodeop_startup_catchup.py
+++ b/tests/nodeop_startup_catchup.py
@@ -73,7 +73,9 @@ try:
     specificExtraNodeopArgs[pnodes+13] = f' --sync-fetch-span 89 --read-mode irreversible '
     specificExtraNodeopArgs[pnodes+14] = f' --sync-fetch-span 150 --read-mode irreversible '
     specificExtraNodeopArgs[pnodes+15] = f' --sync-fetch-span 2500 --read-mode irreversible '
+    # Use a line topology so started nodes do not continuously retry every intentionally unstarted catchup node.
     if cluster.launch(prodCount=prodCount, specificExtraNodeopArgs=specificExtraNodeopArgs, activateIF=activateIF, onlyBios=False,
+                      topo="line",
                       pnodes=pnodes, totalNodes=totalNodes, totalProducers=pnodes*prodCount, unstartedNodes=catchupCount,
                       loadSystemContract=True, maximumP2pPerHost=totalNodes+trxGeneratorCnt) is False:
         Utils.errorExit("Failed to stand up eos cluster.")


### PR DESCRIPTION
## Summary

Make `nodeop_startup_catchup_lr_test` launch its test cluster with a line topology instead of the default mesh topology.

## What changed

- Pass `topo="line"` to `cluster.launch()` in `tests/nodeop_startup_catchup.py`.
- Add a short comment explaining that the topology avoids retrying intentionally unstarted catchup-node ports before the catchup phase.

## Why

The test is intended to validate startup catchup under active production and transaction load. With the default mesh topology, already-running nodes continuously try to connect to all 16 catchup nodes while those nodes are intentionally offline. On macOS arm64 this connection storm can stall the producer before the test reaches the actual catchup scenarios.

A line topology preserves the catchup behavior under test: each catchup node still starts from behind, connects into the network, syncs, restarts, and verifies the same `sync-fetch-span` behavior. It removes only the unrelated pre-start peer retry load.

## Testing

- macOS arm64:

```bash
ctest --test-dir build/macos-arm64-jit-chain-release \
  -R '^nodeop_startup_catchup_lr_test$' \
  --output-on-failure \
  --timeout 1800
```

Result: passed in `527.58 sec`.
