### PR TITLE
Handle unavailable sys-vm-oc test options

### DIFF
--- a/tests/PerformanceHarness/performance_test_basic.py
+++ b/tests/PerformanceHarness/performance_test_basic.py
@@ -651,9 +651,14 @@ class PerformanceTestBasic:
     def setupClusterConfig(args) -> ClusterConfig:
 
         def supportedPluginArgs(pluginArgsClass, **kwargs):
-            """Return only constructor arguments supported by the generated plugin-args dataclass."""
+            """Drop only constructor arguments for chain-plugin options compiled out of this nodeop build."""
+            conditionallySupportedFields = {"sysVmOcCacheSizeMb", "sysVmOcCompileThreads"}
             supportedFields = {field.name for field in dataclasses.fields(pluginArgsClass)}
-            return {key: value for key, value in kwargs.items() if key in supportedFields}
+            return {
+                key: value
+                for key, value in kwargs.items()
+                if key in supportedFields or key not in conditionallySupportedFields
+            }
 
         chainPluginArgs = ChainPluginArgs(**supportedPluginArgs(
                                         ChainPluginArgs,

--- a/tests/PerformanceHarness/performance_test_basic.py
+++ b/tests/PerformanceHarness/performance_test_basic.py
@@ -85,7 +85,7 @@ class PerformanceTestBasic:
             def __str__(self) -> str:
                 args = []
                 for field in dataclasses.fields(self):
-                    match = re.search("\w*PluginArgs", field.name)
+                    match = re.search(r"\w*PluginArgs", field.name)
                     if match is not None:
                         args.append(f"{getattr(self, field.name)}")
                 return " ".join(args)
@@ -126,7 +126,7 @@ class PerformanceTestBasic:
             # Producer Nodes are index [0, producerNodeCount) and non-producer nodes (validationNodeCount, apiNodeCount) nodes follow the producer nodes [producerNodeCount, _totalNodes)
             self._producerNodeIds = list(range(0, self.producerNodeCount))
             self._validationNodeIds = list(range(self.producerNodeCount, self.producerNodeCount + self.validationNodeCount))
-            self._apiNodeIds = list(range(self.producerNodeCount + self.validationNodeCount, self.producerNodeCount + self.validationNodeCount + self.validationNodeCount))
+            self._apiNodeIds = list(range(self.producerNodeCount + self.validationNodeCount, self.producerNodeCount + self.validationNodeCount + self.apiNodeCount))
 
             def configureValidationNodes():
                 validationNodeSpecificNodeopStr = ""
@@ -654,11 +654,16 @@ class PerformanceTestBasic:
             """Drop only constructor arguments for chain-plugin options compiled out of this nodeop build."""
             conditionallySupportedFields = {"sysVmOcCacheSizeMb", "sysVmOcCompileThreads"}
             supportedFields = {field.name for field in dataclasses.fields(pluginArgsClass)}
-            return {
-                key: value
-                for key, value in kwargs.items()
-                if key in supportedFields or key not in conditionallySupportedFields
-            }
+            supportedArgs = {}
+            for key, value in kwargs.items():
+                if key in supportedFields or key not in conditionallySupportedFields:
+                    supportedArgs[key] = value
+                else:
+                    print(f"Skipping unsupported chain_plugin argument '{key}' for this nodeop build")
+            return supportedArgs
+
+        if args.non_prods_sys_vm_oc_enable and not Utils.nodeopSupportsSysVmOc():
+            Utils.errorExit("--non-prods-sys-vm-oc-enable requires a nodeop build with SYS VM OC support")
 
         chainPluginArgs = ChainPluginArgs(**supportedPluginArgs(
                                         ChainPluginArgs,

--- a/tests/PerformanceHarness/performance_test_basic.py
+++ b/tests/PerformanceHarness/performance_test_basic.py
@@ -650,12 +650,20 @@ class PerformanceTestBasic:
 
     def setupClusterConfig(args) -> ClusterConfig:
 
-        chainPluginArgs = ChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct,
+        def supportedPluginArgs(pluginArgsClass, **kwargs):
+            """Return only constructor arguments supported by the generated plugin-args dataclass."""
+            supportedFields = {field.name for field in dataclasses.fields(pluginArgsClass)}
+            return {key: value for key, value in kwargs.items() if key in supportedFields}
+
+        chainPluginArgs = ChainPluginArgs(**supportedPluginArgs(
+                                        ChainPluginArgs,
+                                        signatureCpuBillablePct=args.signature_cpu_billable_pct,
                                         chainThreads=args.chain_threads, databaseMapMode=args.database_map_mode,
                                         wasmRuntime=args.wasm_runtime, contractsConsole=args.contracts_console,
-                                        sysVmOcCacheSizeMb=args.sys_vm_oc_cache_size_mb, sysVmOcCompileThreads=args.sys_vm_oc_compile_threads,
+                                        sysVmOcCacheSizeMb=args.sys_vm_oc_cache_size_mb,
+                                        sysVmOcCompileThreads=args.sys_vm_oc_compile_threads,
                                         blockLogRetainBlocks=args.block_log_retain_blocks,
-                                        chainStateDbSizeMb=args.chain_state_db_size_mb, abiSerializerMaxTimeMs=990000)
+                                        chainStateDbSizeMb=args.chain_state_db_size_mb, abiSerializerMaxTimeMs=990000))
 
         producerPluginArgs = ProducerPluginArgs(disableSubjectiveApiBilling=args.disable_subjective_billing,
                                                 disableSubjectiveP2pBilling=args.disable_subjective_billing,

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -90,8 +90,23 @@ class Utils:
     ConfigDir=f"{DataPath}/"
 
     TimeFmt='%Y-%m-%dT%H:%M:%S.%f'
+    _nodeopHelpOutput=None
     # lock to serialize writes to subprocess_results.log across threads
     _check_output_lock = threading.Lock()
+
+    @staticmethod
+    def nodeopSupportsOption(option):
+        """Return whether the built nodeop binary advertises the given command-line option."""
+        if Utils._nodeopHelpOutput is None:
+            result=subprocess.run(
+                [Utils.SysServerPath, "--help"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                check=False)
+            Utils._nodeopHelpOutput=result.stdout
+
+        return option in Utils._nodeopHelpOutput
 
     @staticmethod
     def timestamp():

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -97,16 +97,22 @@ class Utils:
     @staticmethod
     def nodeopSupportsOption(option):
         """Return whether the built nodeop binary advertises the given command-line option."""
-        if Utils._nodeopHelpOutput is None:
-            result=subprocess.run(
-                [Utils.SysServerPath, "--help"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                universal_newlines=True,
-                check=False)
-            Utils._nodeopHelpOutput=result.stdout
+        with Utils._check_output_lock:
+            if Utils._nodeopHelpOutput is None:
+                result=subprocess.run(
+                    [Utils.SysServerPath, "--help"],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    universal_newlines=True,
+                    check=False)
+                if result.returncode != 0 or not result.stdout.strip():
+                    raise RuntimeError(
+                        f"Unable to inspect nodeop options with '{Utils.SysServerPath} --help': "
+                        f"return code {result.returncode}, output: {result.stdout}"
+                    )
+                Utils._nodeopHelpOutput=result.stdout
 
-        return option in Utils._nodeopHelpOutput
+        return re.search(rf"(^|\s){re.escape(option)}([=\s]|$)", Utils._nodeopHelpOutput) is not None
 
     @staticmethod
     def timestamp():

--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -78,6 +78,12 @@ class Utils:
 
     SysServerName="nodeop"
     SysServerPath=str(testBinPath / SysServerName)
+    SysVmOcEnableOption="--sys-vm-oc-enable"
+    SysVmOcEnableAll="all"
+    SysVmOcEnableAuto="auto"
+    SysVmOcEnableNone="none"
+    SysVmOcForcedRuntime="sys-vm-oc-forced"
+    SysVmOcExecutionLogSuffix="with sys vm oc"
 
     ShuttingDown=False
 
@@ -91,7 +97,7 @@ class Utils:
 
     TimeFmt='%Y-%m-%dT%H:%M:%S.%f'
     _nodeopHelpOutput=None
-    # lock to serialize writes to subprocess_results.log across threads
+    # Lock subprocess_results.log writes and cached nodeop option discovery across threads.
     _check_output_lock = threading.Lock()
 
     @staticmethod
@@ -99,12 +105,17 @@ class Utils:
         """Return whether the built nodeop binary advertises the given command-line option."""
         with Utils._check_output_lock:
             if Utils._nodeopHelpOutput is None:
-                result=subprocess.run(
-                    [Utils.SysServerPath, "--help"],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    universal_newlines=True,
-                    check=False)
+                try:
+                    result=subprocess.run(
+                        [Utils.SysServerPath, "--help"],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        check=False)
+                except OSError as ex:
+                    raise RuntimeError(
+                        f"Unable to inspect nodeop options with '{Utils.SysServerPath} --help': {ex}"
+                    ) from ex
                 if result.returncode != 0 or not result.stdout.strip():
                     raise RuntimeError(
                         f"Unable to inspect nodeop options with '{Utils.SysServerPath} --help': "
@@ -112,7 +123,44 @@ class Utils:
                     )
                 Utils._nodeopHelpOutput=result.stdout
 
-        return re.search(rf"(^|\s){re.escape(option)}([=\s]|$)", Utils._nodeopHelpOutput) is not None
+        return re.search(rf"^\s*{re.escape(option)}([=\s]|$)", Utils._nodeopHelpOutput, re.MULTILINE) is not None
+
+    @staticmethod
+    def nodeopSupportsSysVmOc():
+        """Return whether the built nodeop binary accepts SYS VM OC command-line options."""
+        return Utils.nodeopSupportsOption(Utils.SysVmOcEnableOption)
+
+    @staticmethod
+    def shouldSkipBecauseSysVmOcUnavailable(sysVmOcEnable, wasmRuntime):
+        """Return whether the requested test configuration requires SYS VM OC when nodeop lacks it."""
+        ocRequired = sysVmOcEnable == Utils.SysVmOcEnableAll or wasmRuntime == Utils.SysVmOcForcedRuntime
+        return ocRequired and not Utils.nodeopSupportsSysVmOc()
+
+    @staticmethod
+    def sysVmOcExecutionExpected(sysVmOcEnable):
+        """Return whether the SYS VM OC tier-up setting should produce OC execution when supported."""
+        return sysVmOcEnable in (Utils.SysVmOcEnableAll, Utils.SysVmOcEnableAuto) and Utils.nodeopSupportsSysVmOc()
+
+    @staticmethod
+    def assertInitialSysVmOcLogState(producerNode, apiNode, codeHash, sysVmOcEnable, ocSupported):
+        """Verify bootstrap SYS VM OC logging on the node whose configuration controls the expectation."""
+        logText = f"executing {codeHash} {Utils.SysVmOcExecutionLogSuffix}"
+        if sysVmOcEnable == Utils.SysVmOcEnableNone or not ocSupported:
+            Utils.Print(f"search apiNode: {logText} (expect absent)")
+            found = apiNode.findInLog(logText)
+            assert(not found)
+        else:
+            Utils.Print(f"search producerNode: {logText} (expect present)")
+            found = producerNode.findInLog(logText)
+            assert(found)
+
+    @staticmethod
+    def assertSysVmOcLogAbsent(node, codeHash, nodeLabel):
+        """Verify the selected node did not log SYS VM OC execution for the supplied code hash."""
+        logText = f"executing {codeHash} {Utils.SysVmOcExecutionLogSuffix}"
+        Utils.Print(f"search {nodeLabel}: {logText} (expect absent)")
+        found = node.findInLog(logText)
+        assert(not found)
 
     @staticmethod
     def timestamp():

--- a/tests/interrupt_read_only_trx_test.py
+++ b/tests/interrupt_read_only_trx_test.py
@@ -87,7 +87,7 @@ def startCluster():
     specificExtraNodeopArgs[pnodes]+=str(args.read_only_threads)
     if args.sys_vm_oc_enable:
         if platform.system() != "Linux":
-            Print("OC not run on Linux. Skip the test")
+            Print("sys-vm-oc is unavailable on this platform. Skip the test")
             exit(0) # Do not fail the test
         specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "
         specificExtraNodeopArgs[pnodes]+=args.sys_vm_oc_enable

--- a/tests/interrupt_read_only_trx_test.py
+++ b/tests/interrupt_read_only_trx_test.py
@@ -88,11 +88,12 @@ def startCluster():
         if allOC or args.wasm_runtime == "sys-vm-oc-forced":
             Print("sys-vm-oc is unavailable on this platform. Skip the test")
             exit(0) # Do not fail the test
+    if ocSupported:
+        specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "
+        specificExtraNodeopArgs[pnodes]+=args.sys_vm_oc_enable
     if ocRequested:
         specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-cache-size-mb "
         specificExtraNodeopArgs[pnodes]+=" 1 " # set small so there is churn
-        specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "
-        specificExtraNodeopArgs[pnodes]+=args.sys_vm_oc_enable
     if args.wasm_runtime:
         specificExtraNodeopArgs[pnodes]+=" --wasm-runtime "
         specificExtraNodeopArgs[pnodes]+=args.wasm_runtime
@@ -113,7 +114,10 @@ def startCluster():
     # sysio.* should be using oc unless oc tierup disabled
     Utils.Print(f"search: executing {sysioCodeHash} with sys vm oc")
     found = producerNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
-    assert( found or ((noOC or not ocSupported) and not found) )
+    if noOC or not ocSupported:
+        assert(not found)
+    else:
+        assert(found)
 
 def deployTestContracts():
     Utils.Print("Create payloadless account and deploy payloadless contract")

--- a/tests/interrupt_read_only_trx_test.py
+++ b/tests/interrupt_read_only_trx_test.py
@@ -20,7 +20,7 @@ errorExit=Utils.errorExit
 
 appArgs=AppArgs()
 appArgs.add(flag="--read-only-threads", type=int, help="number of read-only threads", default=0)
-appArgs.add(flag="--sys-vm-oc-enable", type=str, help="specify sys-vm-oc-enable option", default="auto")
+appArgs.add(flag="--sys-vm-oc-enable", type=str, help="specify sys-vm-oc-enable option", default=Utils.SysVmOcEnableAuto)
 appArgs.add(flag="--wasm-runtime", type=str, help="if wanting sys-vm-oc, must use 'sys-vm-oc-forced'", default="sys-vm-jit")
 
 args=TestHelper.parse_args({"-p","-n","-d","-s","--dump-error-details","-v","--leave-running"
@@ -39,10 +39,9 @@ dumpErrorDetails=args.dump_error_details
 
 Utils.Debug=debug
 testSuccessful=False
-noOC = args.sys_vm_oc_enable == "none"
-allOC = args.sys_vm_oc_enable == "all"
-ocSupported = Utils.nodeopSupportsOption("--sys-vm-oc-enable")
-ocRequested = args.sys_vm_oc_enable in ("all", "auto") and ocSupported
+noOC = args.sys_vm_oc_enable == Utils.SysVmOcEnableNone
+ocSupported = Utils.nodeopSupportsSysVmOc()
+ocRequested = Utils.sysVmOcExecutionExpected(args.sys_vm_oc_enable)
 
 # all debuglevel so that "executing ${h} with sys vm oc" is logged
 cluster=Cluster(loggingLevel="all", unshared=args.unshared, keepRunning=args.leave_running, keepLogs=args.keep_logs)
@@ -84,10 +83,9 @@ def startCluster():
     specificExtraNodeopArgs[pnodes]+=" 3600000000 " # 1hr to test interrupt of ctrl-c
     specificExtraNodeopArgs[pnodes]+=" --read-only-threads "
     specificExtraNodeopArgs[pnodes]+=str(args.read_only_threads)
-    if args.sys_vm_oc_enable != "none" and not ocSupported:
-        if allOC or args.wasm_runtime == "sys-vm-oc-forced":
-            Print("sys-vm-oc is unavailable on this platform. Skip the test")
-            exit(0) # Do not fail the test
+    if Utils.shouldSkipBecauseSysVmOcUnavailable(args.sys_vm_oc_enable, args.wasm_runtime):
+        Print("sys-vm-oc is unavailable on this platform. Skip the test")
+        exit(0) # Do not fail the test
     if ocSupported:
         specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "
         specificExtraNodeopArgs[pnodes]+=args.sys_vm_oc_enable
@@ -112,12 +110,7 @@ def startCluster():
 
     sysioCodeHash = getCodeHash(producerNode, "sysio.token")
     # sysio.* should be using oc unless oc tierup disabled
-    Utils.Print(f"search: executing {sysioCodeHash} with sys vm oc")
-    found = producerNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
-    if noOC or not ocSupported:
-        assert(not found)
-    else:
-        assert(found)
+    Utils.assertInitialSysVmOcLogState(producerNode, apiNode, sysioCodeHash, args.sys_vm_oc_enable, ocSupported)
 
 def deployTestContracts():
     Utils.Print("Create payloadless account and deploy payloadless contract")

--- a/tests/interrupt_read_only_trx_test.py
+++ b/tests/interrupt_read_only_trx_test.py
@@ -4,7 +4,6 @@ import time
 import signal
 import threading
 import os
-import platform
 
 from TestHarness import Account, Cluster, ReturnType, TestHelper, Utils, WalletMgr
 from TestHarness.TestHelper import AppArgs
@@ -42,6 +41,8 @@ Utils.Debug=debug
 testSuccessful=False
 noOC = args.sys_vm_oc_enable == "none"
 allOC = args.sys_vm_oc_enable == "all"
+ocSupported = Utils.nodeopSupportsOption("--sys-vm-oc-enable")
+ocRequested = args.sys_vm_oc_enable in ("all", "auto") and ocSupported
 
 # all debuglevel so that "executing ${h} with sys vm oc" is logged
 cluster=Cluster(loggingLevel="all", unshared=args.unshared, keepRunning=args.leave_running, keepLogs=args.keep_logs)
@@ -81,14 +82,15 @@ def startCluster():
     specificExtraNodeopArgs[pnodes]+=" --contracts-console "
     specificExtraNodeopArgs[pnodes]+=" --read-only-read-window-time-us "
     specificExtraNodeopArgs[pnodes]+=" 3600000000 " # 1hr to test interrupt of ctrl-c
-    specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-cache-size-mb "
-    specificExtraNodeopArgs[pnodes]+=" 1 " # set small so there is churn
     specificExtraNodeopArgs[pnodes]+=" --read-only-threads "
     specificExtraNodeopArgs[pnodes]+=str(args.read_only_threads)
-    if args.sys_vm_oc_enable:
-        if platform.system() != "Linux":
+    if args.sys_vm_oc_enable != "none" and not ocSupported:
+        if allOC or args.wasm_runtime == "sys-vm-oc-forced":
             Print("sys-vm-oc is unavailable on this platform. Skip the test")
             exit(0) # Do not fail the test
+    if ocRequested:
+        specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-cache-size-mb "
+        specificExtraNodeopArgs[pnodes]+=" 1 " # set small so there is churn
         specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "
         specificExtraNodeopArgs[pnodes]+=args.sys_vm_oc_enable
     if args.wasm_runtime:
@@ -111,7 +113,7 @@ def startCluster():
     # sysio.* should be using oc unless oc tierup disabled
     Utils.Print(f"search: executing {sysioCodeHash} with sys vm oc")
     found = producerNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
-    assert( found or (noOC and not found) )
+    assert( found or ((noOC or not ocSupported) and not found) )
 
 def deployTestContracts():
     Utils.Print("Create payloadless account and deploy payloadless contract")

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -53,6 +53,8 @@ testSuccessful=False
 errorInThread=False
 noOC = args.sys_vm_oc_enable == "none"
 allOC = args.sys_vm_oc_enable == "all"
+ocSupported = platform.system() == "Linux"
+ocRequested = args.sys_vm_oc_enable in ("all", "auto") and ocSupported
 
 random.seed(seed) # Use a fixed seed for repeatability.
 # all debuglevel so that "executing ${h} with sys vm oc" is logged
@@ -111,14 +113,15 @@ def startCluster():
     specificExtraNodeopArgs[pnodes]+=" 10000 "
     specificExtraNodeopArgs[pnodes]+=" --read-only-read-window-time-us "
     specificExtraNodeopArgs[pnodes]+=" 510000 "
-    specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-cache-size-mb "
-    specificExtraNodeopArgs[pnodes]+=" 1 " # set small so there is churn
     specificExtraNodeopArgs[pnodes]+=" --read-only-threads "
     specificExtraNodeopArgs[pnodes]+=str(args.read_only_threads)
-    if args.sys_vm_oc_enable:
-        if platform.system() != "Linux":
-            Print("OC not run on Linux. Skip the test")
-            exit(True) # Do not fail the test
+    if args.sys_vm_oc_enable != "none" and not ocSupported:
+        if allOC or args.wasm_runtime == "sys-vm-oc-forced":
+            Print("sys-vm-oc is unavailable on this platform. Skip the test")
+            exit(0) # Do not fail the test
+    if ocRequested:
+        specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-cache-size-mb "
+        specificExtraNodeopArgs[pnodes]+=" 1 " # set small so there is churn
         specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "
         specificExtraNodeopArgs[pnodes]+=args.sys_vm_oc_enable
     if args.wasm_runtime:
@@ -140,9 +143,9 @@ def startCluster():
     # sysio.* should be using oc unless oc tierup disabled
     Utils.Print(f"search: executing {sysioCodeHash} with sys vm oc")
     found = producerNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
-    assert( found or (noOC and not found) )
+    assert( found or ((noOC or not ocSupported) and not found) )
 
-    if args.sys_vm_oc_enable:
+    if ocRequested:
         verifyOcVirtualMemory()
 
 def verifyOcVirtualMemory():

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -24,7 +24,7 @@ errorExit=Utils.errorExit
 appArgs=AppArgs()
 appArgs.add(flag="--read-only-threads", type=int, help="number of read-only threads", default=0)
 appArgs.add(flag="--num-test-runs", type=int, help="number of times to run the tests", default=1)
-appArgs.add(flag="--sys-vm-oc-enable", type=str, help="specify sys-vm-oc-enable option", default="auto")
+appArgs.add(flag="--sys-vm-oc-enable", type=str, help="specify sys-vm-oc-enable option", default=Utils.SysVmOcEnableAuto)
 appArgs.add(flag="--wasm-runtime", type=str, help="if wanting sys-vm-oc, must use 'sys-vm-oc-forced'", default="sys-vm-jit")
 
 args=TestHelper.parse_args({"-p","-n","-d","-s","--nodes-file","--seed"
@@ -50,10 +50,9 @@ numTestRuns=args.num_test_runs
 Utils.Debug=debug
 testSuccessful=False
 errorInThread=False
-noOC = args.sys_vm_oc_enable == "none"
-allOC = args.sys_vm_oc_enable == "all"
-ocSupported = Utils.nodeopSupportsOption("--sys-vm-oc-enable")
-ocRequested = args.sys_vm_oc_enable in ("all", "auto") and ocSupported
+noOC = args.sys_vm_oc_enable == Utils.SysVmOcEnableNone
+ocSupported = Utils.nodeopSupportsSysVmOc()
+ocRequested = Utils.sysVmOcExecutionExpected(args.sys_vm_oc_enable)
 
 random.seed(seed) # Use a fixed seed for repeatability.
 # all debuglevel so that "executing ${h} with sys vm oc" is logged
@@ -114,10 +113,9 @@ def startCluster():
     specificExtraNodeopArgs[pnodes]+=" 510000 "
     specificExtraNodeopArgs[pnodes]+=" --read-only-threads "
     specificExtraNodeopArgs[pnodes]+=str(args.read_only_threads)
-    if args.sys_vm_oc_enable != "none" and not ocSupported:
-        if allOC or args.wasm_runtime == "sys-vm-oc-forced":
-            Print("sys-vm-oc is unavailable on this platform. Skip the test")
-            exit(0) # Do not fail the test
+    if Utils.shouldSkipBecauseSysVmOcUnavailable(args.sys_vm_oc_enable, args.wasm_runtime):
+        Print("sys-vm-oc is unavailable on this platform. Skip the test")
+        exit(0) # Do not fail the test
     if ocSupported:
         specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "
         specificExtraNodeopArgs[pnodes]+=args.sys_vm_oc_enable
@@ -141,16 +139,7 @@ def startCluster():
 
     sysioCodeHash = getCodeHash(producerNode, "sysio.token")
     # sysio.* should be using oc unless oc tierup disabled.
-    # Check the node where the OC setting was applied: apiNode has --sys-vm-oc-enable,
-    # producerNode runs with the default (OC enabled when supported).
-    if noOC or not ocSupported:
-        Utils.Print(f"search apiNode: executing {sysioCodeHash} with sys vm oc (expect absent)")
-        found = apiNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
-        assert(not found)
-    else:
-        Utils.Print(f"search producerNode: executing {sysioCodeHash} with sys vm oc (expect present)")
-        found = producerNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
-        assert(found)
+    Utils.assertInitialSysVmOcLogState(producerNode, apiNode, sysioCodeHash, args.sys_vm_oc_enable, ocSupported)
 
     if ocRequested:
         verifyOcVirtualMemory()
@@ -345,13 +334,15 @@ def basicTests():
 
     testAccountCodeHash = getCodeHash(producerNode, testAccountName)
     found = producerNode.findInLog(f"executing {testAccountCodeHash} with sys vm oc")
-    assert( (allOC and found) or not found )
+    assert(not found)
 
     # verify the return value (age) from read-only is the same as created.
     Print("Send a read-only Get transaction to verify previous Insert")
     results = sendTransaction(testAccountName, 'getage', {"user": userAccountName}, opts='--read')
     assert(results[0])
     assert(results[1]['processed']['action_traces'][0]['return_value_data'] == 10)
+    if noOC or not ocSupported:
+        Utils.assertSysVmOcLogAbsent(apiNode, testAccountCodeHash, "apiNode")
 
     # verify non-read-only modification works
     Print("Send a non-read-only Modify transaction")

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -140,12 +140,16 @@ def startCluster():
     apiNode = cluster.nodes[-1]
 
     sysioCodeHash = getCodeHash(producerNode, "sysio.token")
-    # sysio.* should be using oc unless oc tierup disabled
-    Utils.Print(f"search: executing {sysioCodeHash} with sys vm oc")
-    found = producerNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
+    # sysio.* should be using oc unless oc tierup disabled.
+    # Check the node where the OC setting was applied: apiNode has --sys-vm-oc-enable,
+    # producerNode runs with the default (OC enabled when supported).
     if noOC or not ocSupported:
+        Utils.Print(f"search apiNode: executing {sysioCodeHash} with sys vm oc (expect absent)")
+        found = apiNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
         assert(not found)
     else:
+        Utils.Print(f"search producerNode: executing {sysioCodeHash} with sys vm oc (expect present)")
+        found = producerNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
         assert(found)
 
     if ocRequested:

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -118,11 +118,12 @@ def startCluster():
         if allOC or args.wasm_runtime == "sys-vm-oc-forced":
             Print("sys-vm-oc is unavailable on this platform. Skip the test")
             exit(0) # Do not fail the test
+    if ocSupported:
+        specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "
+        specificExtraNodeopArgs[pnodes]+=args.sys_vm_oc_enable
     if ocRequested:
         specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-cache-size-mb "
         specificExtraNodeopArgs[pnodes]+=" 1 " # set small so there is churn
-        specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "
-        specificExtraNodeopArgs[pnodes]+=args.sys_vm_oc_enable
     if args.wasm_runtime:
         specificExtraNodeopArgs[pnodes]+=" --wasm-runtime "
         specificExtraNodeopArgs[pnodes]+=args.wasm_runtime
@@ -142,7 +143,10 @@ def startCluster():
     # sysio.* should be using oc unless oc tierup disabled
     Utils.Print(f"search: executing {sysioCodeHash} with sys vm oc")
     found = producerNode.findInLog(f"executing {sysioCodeHash} with sys vm oc")
-    assert( found or ((noOC or not ocSupported) and not found) )
+    if noOC or not ocSupported:
+        assert(not found)
+    else:
+        assert(found)
 
     if ocRequested:
         verifyOcVirtualMemory()

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -5,7 +5,6 @@ import time
 import signal
 import threading
 import os
-import platform
 import traceback
 
 from TestHarness import Account, Cluster, ReturnType, TestHelper, Utils, WalletMgr
@@ -53,7 +52,7 @@ testSuccessful=False
 errorInThread=False
 noOC = args.sys_vm_oc_enable == "none"
 allOC = args.sys_vm_oc_enable == "all"
-ocSupported = platform.system() == "Linux"
+ocSupported = Utils.nodeopSupportsOption("--sys-vm-oc-enable")
 ocRequested = args.sys_vm_oc_enable in ("all", "auto") and ocSupported
 
 random.seed(seed) # Use a fixed seed for repeatability.


### PR DESCRIPTION
## Summary

Handle test code paths that reference `sys-vm-oc` when the current `nodeop` build does not expose OC options.

## What changed

- Adds `Utils.nodeopSupportsOption()` so Python tests can check the actual built `nodeop --help` output.
- Gates read-only test `--sys-vm-oc-*` arguments on real `nodeop` option support instead of assuming every Linux build supports OC.
- Keeps forced-OC read-only tests as clean skips when OC is unavailable.
- Filters performance harness `ChainPluginArgs` constructor kwargs to the fields present in the generated plugin-args dataclass.

## Why

`sys-vm-oc` is only present on supported builds, currently Linux x86_64 with OC enabled. The generated `ChainPluginArgs` classes and `nodeop` command-line options therefore differ across platforms. These tests should keep exercising OC where it exists, skip tests that explicitly require unavailable OC, and avoid passing unsupported OC arguments on macOS arm64 or other non-OC builds.

## Testing

- `python3 -m py_compile tests/TestHarness/testUtils.py tests/read_only_trx_test.py tests/interrupt_read_only_trx_test.py tests/PerformanceHarness/performance_test_basic.py`
- Previous macOS arm64 focused CTest skip validation for the read-only forced-OC tests passed:

```bash
ctest --test-dir build/macos-arm64-jit-chain-release \
  -R '^read-only-trx-parallel-if-sys-vm-oc-test$|^interrupt-read-only-trx-parallel-if-sys-vm-oc-test$' \
  --output-on-failure \
  --timeout 120
```

Result: `2/2` passed in `0.52 sec`.

## Notes

This PR now includes the performance harness fix from PR #378. PR #378 is superseded by this combined PR.
