### PR TITLE
Guard performance harness chain plugin args

### DIFF
--- a/tests/PerformanceHarness/performance_test_basic.py
+++ b/tests/PerformanceHarness/performance_test_basic.py
@@ -652,12 +652,20 @@ class PerformanceTestBasic:
 
     def setupClusterConfig(args) -> ClusterConfig:
 
-        chainPluginArgs = ChainPluginArgs(signatureCpuBillablePct=args.signature_cpu_billable_pct,
+        def supportedPluginArgs(pluginArgsClass, **kwargs):
+            """Return only constructor arguments supported by the generated plugin-args dataclass."""
+            supportedFields = {field.name for field in dataclasses.fields(pluginArgsClass)}
+            return {key: value for key, value in kwargs.items() if key in supportedFields}
+
+        chainPluginArgs = ChainPluginArgs(**supportedPluginArgs(
+                                        ChainPluginArgs,
+                                        signatureCpuBillablePct=args.signature_cpu_billable_pct,
                                         chainThreads=args.chain_threads, databaseMapMode=args.database_map_mode,
                                         wasmRuntime=args.wasm_runtime, contractsConsole=args.contracts_console,
-                                        sysVmOcCacheSizeMb=args.sys_vm_oc_cache_size_mb, sysVmOcCompileThreads=args.sys_vm_oc_compile_threads,
+                                        sysVmOcCacheSizeMb=args.sys_vm_oc_cache_size_mb,
+                                        sysVmOcCompileThreads=args.sys_vm_oc_compile_threads,
                                         blockLogRetainBlocks=args.block_log_retain_blocks,
-                                        chainStateDbSizeMb=args.chain_state_db_size_mb, abiSerializerMaxTimeMs=990000)
+                                        chainStateDbSizeMb=args.chain_state_db_size_mb, abiSerializerMaxTimeMs=990000))
 
         producerPluginArgs = ProducerPluginArgs(disableSubjectiveApiBilling=args.disable_subjective_billing,
                                                 disableSubjectiveP2pBilling=args.disable_subjective_billing,


### PR DESCRIPTION
## Summary

Make `performance_test_basic.py` tolerate generated `ChainPluginArgs` dataclasses that do not expose every chain-plugin option the harness wants to pass.

## What changed

- Added a small helper that filters constructor kwargs to fields supported by the generated plugin-args dataclass.
- Wrapped the `ChainPluginArgs` construction with that helper.
- Kept newer options available when the generated dataclass supports them.

## Why

Some builds use generated performance harness plugin-args classes that lag the full set of chain-plugin options. Passing unsupported kwargs causes `performance_test_basic_p2p` to fail before the cluster starts. Filtering by dataclass fields keeps the harness compatible without dropping supported options on newer generated classes.

## Testing

- `python3 -m py_compile tests/PerformanceHarness/performance_test_basic.py`
