### PR TITLE
Speed up irreversible mode LIB waits

### DIFF
--- a/tests/nodeop_irreversible_mode_test.py
+++ b/tests/nodeop_irreversible_mode_test.py
@@ -63,19 +63,26 @@ def getHeadLibAndForkDbHead(node: Node):
    forkDbHead =  int(info["fork_db_head_block_num"])
    return head, lib, forkDbHead
 
-# Wait for some time until LIB advance
-def waitForBlksProducedAndLibAdvanced():
+# Return the conservative wait budget for LIB advancement.
+def libAdvanceTimeout():
+   """Return the timeout budget for waiting on LIB advancement in this producer schedule."""
    requiredConfirmation = int(2 / 3 * numOfProducers) + 1
    maxNumOfBlksReqToConfirmLib = (12 * requiredConfirmation - 1) * 2
    # Give 6 seconds buffer time
    bufferTime = 6
-   timeToWait = maxNumOfBlksReqToConfirmLib / 2 + bufferTime
-   time.sleep(timeToWait)
+   return maxNumOfBlksReqToConfirmLib / 2 + bufferTime
+
+# Wait until LIB advances instead of always sleeping for the worst-case LIB advancement budget.
+def waitForBlksProducedAndLibAdvanced(nodeToWatch=None):
+   """Wait for LIB to advance on a live node that should be receiving produced blocks."""
+   nodeToWatch = nodeToWatch if nodeToWatch is not None else producingNode
+   assert nodeToWatch.waitForLibToAdvance(timeout=libAdvanceTimeout()), \
+      "LIB did not advance on node #{} within {} seconds".format(nodeToWatch.nodeId, libAdvanceTimeout())
 
 # Ensure that the relaunched node received blks from producers, in other words head and lib is advancing
 def ensureHeadLibAndForkDbHeadIsAdvancing(nodeToTest):
    head, lib, forkDbHead = getHeadLibAndForkDbHead(nodeToTest)
-   waitForBlksProducedAndLibAdvanced()
+   waitForBlksProducedAndLibAdvanced(nodeToTest)
    headAfterWaiting, libAfterWaiting, forkDbHeadAfterWaiting = getHeadLibAndForkDbHead(nodeToTest)
    assert headAfterWaiting > head and libAfterWaiting > lib and forkDbHeadAfterWaiting > forkDbHead, \
       "Either Head ({} -> {})/ Lib ({} -> {})/ Fork Db Head ({} -> {}) is not advancing".format(head, headAfterWaiting, lib, libAfterWaiting, forkDbHead, forkDbHeadAfterWaiting)


### PR DESCRIPTION
## Summary

Reduce `nodeop_irreversible_mode_lr_test` runtime by replacing conservative fixed LIB-advance sleeps with active LIB advancement waits.

## What changed

- Split the LIB advancement budget calculation into `libAdvanceTimeout()`.
- Changed `waitForBlksProducedAndLibAdvanced()` to call `waitForLibToAdvance(...)` and return as soon as LIB advances.
- Passed the relaunched node into the advancement wait when checking that head, LIB, and fork DB head are advancing.

## Why

The test was paying the full worst-case LIB advancement sleep every time, even when LIB advanced much sooner. On macOS arm64 that made the test hit its test-specific `1500` second timeout. Active waits preserve the same correctness condition and timeout budget, but avoid waiting after the condition is already true.

## Testing

- `python3 -m py_compile tests/nodeop_irreversible_mode_test.py`
- `ctest --test-dir build/macos-arm64-jit-chain-release -j 1 -R '^nodeop_irreversible_mode_lr_test$' --output-on-failure --timeout 2700`

Result: `nodeop_irreversible_mode_lr_test` passed in `254.09 sec`.
