### PR TITLE
Document opt-in test port avoidance

### DIFF
--- a/cmake/test-helpers.cmake
+++ b/cmake/test-helpers.cmake
@@ -1,11 +1,73 @@
 set(SYSIO_TEST_PORT_OFFSET_START 100)
 set(SYSIO_TEST_PORT_OFFSET_STRIDE 192)
+set(SYSIO_TEST_PORT_SHARD_BASE 8888)
+
+# Host-specific reservations are opt-in so CI and fresh build directories keep deterministic compact shard allocation.
+set(SYSIO_TEST_FORBIDDEN_PORTS "" CACHE STRING "Semicolon-separated actual TCP ports that test port shards must not overlap")
+option(SYSIO_DETECT_LISTENING_TEST_PORTS "Avoid test port shards that overlap TCP ports listening during CMake configure" OFF)
+
+# Append TCP listener ports that are present during configure; this is a local developer convenience, not a CI contract.
+function(append_listening_test_ports out_var)
+   set(listening_ports)
+
+   if(APPLE)
+      execute_process(
+         COMMAND lsof -nP -iTCP -sTCP:LISTEN
+         OUTPUT_VARIABLE listening_ports_output
+         ERROR_QUIET
+      )
+   elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      execute_process(
+         COMMAND ss -H -ltn
+         OUTPUT_VARIABLE listening_ports_output
+         ERROR_QUIET
+      )
+   endif()
+
+   if(listening_ports_output)
+      string(REGEX MATCHALL "[:.]([0-9]+)([ \t\r\n]|$)" listening_port_matches "${listening_ports_output}")
+      foreach(listening_port_match IN LISTS listening_port_matches)
+         string(REGEX REPLACE "^[:.]([0-9]+).*" "\\1" listening_port "${listening_port_match}")
+         if(listening_port MATCHES "^[0-9]+$")
+            list(APPEND listening_ports "${listening_port}")
+         endif()
+      endforeach()
+      list(REMOVE_DUPLICATES listening_ports)
+   endif()
+
+   set(${out_var} ${${out_var}} ${listening_ports} PARENT_SCOPE)
+endfunction()
+
+if(SYSIO_DETECT_LISTENING_TEST_PORTS)
+   append_listening_test_ports(SYSIO_TEST_FORBIDDEN_PORTS)
+endif()
+
+function(test_port_offset_overlaps_forbidden_port out_var port_offset)
+   math(EXPR shard_first_port "${SYSIO_TEST_PORT_SHARD_BASE} + ${port_offset}")
+   math(EXPR shard_last_port "${shard_first_port} + ${SYSIO_TEST_PORT_OFFSET_STRIDE} - 1")
+
+   set(overlaps_forbidden_port FALSE)
+   foreach(forbidden_port IN LISTS SYSIO_TEST_FORBIDDEN_PORTS)
+      if(forbidden_port GREATER_EQUAL shard_first_port AND forbidden_port LESS_EQUAL shard_last_port)
+         set(overlaps_forbidden_port TRUE)
+         break()
+      endif()
+   endforeach()
+
+   set(${out_var} ${overlaps_forbidden_port} PARENT_SCOPE)
+endfunction()
 
 function(next_test_port_offset out_var)
    get_property(next_offset GLOBAL PROPERTY SYSIO_NEXT_TEST_PORT_OFFSET)
    if(NOT next_offset)
       set(next_offset "${SYSIO_TEST_PORT_OFFSET_START}")
    endif()
+
+   test_port_offset_overlaps_forbidden_port(overlaps_forbidden_port "${next_offset}")
+   while(overlaps_forbidden_port)
+      math(EXPR next_offset "${next_offset} + ${SYSIO_TEST_PORT_OFFSET_STRIDE}")
+      test_port_offset_overlaps_forbidden_port(overlaps_forbidden_port "${next_offset}")
+   endwhile()
 
    math(EXPR next_next_offset "${next_offset} + ${SYSIO_TEST_PORT_OFFSET_STRIDE}")
    set_property(GLOBAL PROPERTY SYSIO_NEXT_TEST_PORT_OFFSET ${next_next_offset})

--- a/docs/port-sharding-design.md
+++ b/docs/port-sharding-design.md
@@ -35,6 +35,36 @@ Each offset reserves one 192-port shard. For a nonzero offset, category slots ar
 shard_base = 8888 + SYSIO_TEST_PORT_OFFSET
 ```
 
+## Avoiding Local Listener Ports
+
+By default, CMake assigns compact shards without reserving machine-specific ports. This keeps the allocation
+deterministic across developer machines and CI:
+
+```cmake
+SYSIO_TEST_FORBIDDEN_PORTS=""
+SYSIO_DETECT_LISTENING_TEST_PORTS=OFF
+```
+
+When a developer machine has a long-lived local service inside the generated shard range, pass a semicolon-separated
+list of actual TCP ports that tests must not overlap:
+
+```bash
+cmake -S . -B build/codex-system-contracts -DSYSIO_TEST_FORBIDDEN_PORTS='11434;19981'
+```
+
+The allocator skips any shard whose actual port range contains one of those ports. For example, with
+`SYSIO_TEST_FORBIDDEN_PORTS=11434`, the shard `11292..11483` is skipped because it contains `11434`.
+
+For local-only convenience, CMake can also snapshot currently listening TCP ports during configure and append them to
+the forbidden list:
+
+```bash
+cmake -S . -B build/codex-system-contracts -DSYSIO_DETECT_LISTENING_TEST_PORTS=ON
+```
+
+Detection is intentionally opt-in. It depends on the host state at configure time, so it is useful for local developer
+machines but should not be required for reproducible CI allocation.
+
 ## Category Mapping
 
 New test listener ports must use the logical category API:


### PR DESCRIPTION
## Summary

Document and implement opt-in avoidance for test port shards that overlap local TCP listeners.

## What changed

- Adds `SYSIO_TEST_FORBIDDEN_PORTS` as an empty-by-default CMake cache string.
- Adds `SYSIO_DETECT_LISTENING_TEST_PORTS`, an opt-in configure-time listener scan for macOS and Linux.
- Skips generated test port shards when their actual port range overlaps a configured or detected forbidden port.
- Documents the feature in `docs/port-sharding-design.md`, including why detection is local-only and disabled by default.

## Why

The port sharding allocator should stay deterministic by default, but developers sometimes have long-lived local services inside generated test shard ranges. This gives those developers an explicit escape hatch without baking host-specific ports into CI or fresh build directories.

## Testing

- `git diff --check -- cmake/test-helpers.cmake docs/port-sharding-design.md`
- `cmake -DSYSIO_TEST_FORBIDDEN_PORTS=11434 -P /dev/stdin` helper check confirmed the shard containing `11434` is skipped.
- `cmake -DSYSIO_DETECT_LISTENING_TEST_PORTS=ON -P /dev/stdin` helper check confirmed current macOS listeners are detected, including `11434`.
