### PR TITLE
Test: fix data race in custom_appbase read/exclusive window test

### DIFF
--- a/libraries/custom_appbase/tests/custom_appbase_tests.cpp
+++ b/libraries/custom_appbase/tests/custom_appbase_tests.cpp
@@ -567,11 +567,34 @@ BOOST_AUTO_TEST_CASE( execute_from_read_only_and_read_exclusive_queues ) {
 
 // verify tasks from both queues (read_only, read_exclusive) are processed in read window
 BOOST_AUTO_TEST_CASE( execute_many_from_read_only_and_read_exclusive_queues ) {
-   scoped_app_thread app;
+   // Delay exec() so the read window is established before the main thread enters its exec() loop.
+   //
+   // priority_queue_executor::exec_window_ is plain, non-atomic data, and the executor relies on it being
+   // owned by the main exec thread: it is read only in execute_highest() (driven by application_base::exec()
+   // on the main thread) and never read by execute_highest_read() (the read-thread pool path). In production
+   // it is also written only on the main thread -- producer_plugin posts switch_to_read_window() to the
+   // read_write queue, and posts switch_to_write_window() to read_only only after every read task has
+   // returned, so the main thread is the sole io_context poller that runs it. The read window's lock-free
+   // write phase is therefore safe because the read pool is provably idle whenever the main thread takes it.
+   //
+   // This test instead flips the window from a third thread. With immediate exec() the constructor releases
+   // the start_exec future before set_to_read_window() runs, so there is no happens-before edge between the
+   // flip here and the main thread's reads of exec_window_. The main thread can keep observing the stale
+   // write window and run the lock-free execute_highest() path on the read_only heap while a read thread
+   // pops that same heap under the lock, corrupting the priority queue (observed as a SEGV in
+   // binomial_heap::pop() under ASan). Establishing the window before start_exec() makes the start_exec
+   // promise/future the publishing edge and leaves exec_window_ unmodified for the rest of the run, so the
+   // main thread sees a stable read window -- matching production and the execute_from_read_only_and_
+   // read_exclusive_queues sibling test.
+   scoped_app_thread app(true);
 
    // set to run functions from read_only & read_exclusive queues only
    app->executor().init_read_threads(3);
    app->executor().set_to_read_window([](){return false;});
+
+   // enter exec() now that the read window (and its locking) is published to the main thread, before any
+   // read threads start and before any tasks are posted
+   app.start_exec();
 
    // post functions
    constexpr int num_expected = 600;


### PR DESCRIPTION
`execute_many_from_read_only_and_read_exclusive_queues` is the only custom_appbase test that switches the execution window from a third (test) thread while the main exec thread is already running `exec()`, and concurrently runs read threads against the queues.

With `scoped_app_thread app;` the constructor releases the `start_exec` future before the test calls `set_to_read_window()`, so there is no happens-before edge between the window flip (`exec_window_ = read`, `lock_enabled_ = true`, both non-atomic) and the main thread's reads of that state in `execute_highest()`. The main thread can keep observing the stale write window and run the lock-free `execute_highest(read_write, read_only)` path on the `read_only` binomial_heap while a read thread pops that same heap under the lock — corrupting the priority queue. Under ASan this surfaces as the intermittent `SEGV ... WRITE ... in boost::heap::binomial_heap::pop()` reached from `exec_pri_queue::execute_highest_blocking_locked` on a read thread.

This is a test-only bug. In production `exec_window_` is owned by the main exec thread: it is read only in `execute_highest()` (driven by `application_base::exec()`), never by the read-thread pool path (`execute_highest_read`), and producer_plugin writes it only on the main thread — `switch_to_read_window()` runs from the `read_write` queue, and `switch_to_write_window()` is posted to `read_only` only after every read task has returned, so the main thread is the sole poller that runs it. The lock-free write phase is therefore safe because the read pool is provably idle whenever the main thread takes it.

Fix: switch the test to delayed exec and establish the read window before `start_exec()`. The `start_exec` promise/future becomes the publishing edge and `exec_window_` is never modified again during the run, so the main thread sees a stable read window — mirroring production and the already-correct `execute_from_read_only_and_read_exclusive_queues` sibling test.

Test failure example: https://github.com/Wire-Network/wire-sysio/actions/runs/27072146516