### PR TITLE
build: add CMakePresets.json for clang-18/Ninja/vcpkg presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,78 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base-sysio",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "toolchainFile": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+      "environment": {
+        "CC": "/usr/bin/clang-18",
+        "CXX": "/usr/bin/clang++-18"
+      },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "/usr/bin/clang-18",
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++-18",
+        "BUILD_SYSTEM_CONTRACTS": "ON",
+        "BUILD_TEST_CONTRACTS": "ON",
+        "ENABLE_TESTS": "ON",
+        "ENABLE_CCACHE": "ON",
+        "ENABLE_DISTCC": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "VCPKG_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "debug-sysio",
+      "displayName": "Debug SYSIO (clang-18, Ninja, vcpkg)",
+      "description": "Debug SYSIO build matching //wire-sysio:build with WIRE_BUILD_TYPE=Debug (the Bazel default). Resolves the CDT package from the sibling wire-cdt debug tree; vcpkg ports always build Release.",
+      "inherits": "base-sysio",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_PREFIX_PATH": "${sourceDir}/../wire-cdt/build/debug"
+      }
+    },
+    {
+      "name": "release-sysio",
+      "displayName": "Release SYSIO (clang-18, Ninja, vcpkg)",
+      "description": "Release SYSIO build matching //wire-sysio:build with WIRE_BUILD_TYPE=Release. Resolves the CDT package from the sibling wire-cdt release tree; vcpkg ports always build Release.",
+      "inherits": "base-sysio",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_PREFIX_PATH": "${sourceDir}/../wire-cdt/build/release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug-sysio",
+      "configurePreset": "debug-sysio"
+    },
+    {
+      "name": "release-sysio",
+      "configurePreset": "release-sysio"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "debug-sysio",
+      "configurePreset": "debug-sysio",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "release-sysio",
+      "configurePreset": "release-sysio",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a `CMakePresets.json` defining `debug-sysio` and `release-sysio` configure/build/test presets for the standard clang-18 + Ninja + vcpkg toolchain.

- `base-sysio` (hidden) carries the common config: Ninja generator, vcpkg toolchain file, clang-18 CC/CXX, system+test contracts on, tests on, ccache on, `compile_commands.json` export, vcpkg ports built Release.
- `debug-sysio` / `release-sysio` inherit the base, set `CMAKE_BUILD_TYPE`, and resolve the CDT package from the sibling `wire-cdt/build/{debug,release}` tree — matching the `//wire-sysio:build` Bazel targets.
- Build and test presets wired for both with `outputOnFailure`.

## Test plan
- `cmake --preset debug-sysio` / `--preset release-sysio` configure cleanly.
- `cmake --build --preset {debug,release}-sysio` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)