### PR TITLE
Increase startup catchup launch timeout

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -724,14 +724,15 @@ class Cluster(object):
         nodes += self.getNodes()
         return nodes
 
-    def launchUnstarted(self, numToLaunch=1):
+    def launchUnstarted(self, numToLaunch=1, timeout=Utils.systemWaitTimeout):
+        """Launch queued unstarted nodes and wait up to timeout seconds for each node to answer get_info."""
         assert(isinstance(numToLaunch, int))
         assert(numToLaunch>0)
         launchList=self.unstartedNodes[:numToLaunch]
         del self.unstartedNodes[:numToLaunch]
         for node in launchList:
             # the node number is indexed off of the started nodes list
-            node.launchUnstarted()
+            node.launchUnstarted(timeout=timeout)
             self.nodes.append(node)
 
     # Spread funds across accounts with transactions spread through cluster nodes.

--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -471,7 +471,8 @@ class Node(Transactions):
             Utils.errorExit("Cannot find unstarted node since %s file does not exist" % startFile)
         return startFile
 
-    def launchUnstarted(self, waitForAlive=True):
+    def launchUnstarted(self, waitForAlive=True, timeout=Utils.systemWaitTimeout):
+        """Launch a previously configured node and wait up to timeout seconds for it to answer get_info."""
         Utils.Print("launchUnstarted cmd: %s" % (self.cmd))
         self.popenProc = self.launchCmd(self.cmd, self.data_dir, self.launch_time)
 
@@ -486,7 +487,7 @@ class Node(Transactions):
                 pass
             return False
 
-        isAlive=Utils.waitForBool(isNodeAlive)
+        isAlive=Utils.waitForBool(isNodeAlive, timeout=timeout)
 
         if isAlive:
             if Utils.Debug: Utils.Print("Node launch was successful.")

--- a/tests/nodeop_startup_catchup.py
+++ b/tests/nodeop_startup_catchup.py
@@ -160,9 +160,10 @@ try:
     Print("Cycle through catchup scenarios")
     twoRounds=21*2*12
     twoRoundsTimeout=(twoRounds/2 + 10)  #2 rounds in seconds + some leeway
+    catchupLaunchTimeout=180
     for catchup_num in range(0, catchupCount):
         Print("Start catchup node")
-        cluster.launchUnstarted()
+        cluster.launchUnstarted(timeout=catchupLaunchTimeout)
         lastLibNum=lib(node0)
         # verify producer lib is still advancing
         waitForBlock(node0, lastLibNum+1, timeout=twoRoundsTimeout, blockType=BlockType.lib)


### PR DESCRIPTION
## Summary
Increase the startup catchup test's wait time for delayed catchup nodes to become responsive.

## What changed
- Added an optional timeout parameter to `Node.launchUnstarted()`.
- Threaded that timeout through `Cluster.launchUnstarted()`.
- Set `nodeop_startup_catchup.py` catchup-node launch timeout to 180 seconds.

## Why
Catchup nodes can take longer than the default wait under load, especially in parallel NP/LR runs. This avoids failing the test before the node has had enough time to answer `get_info`.

## Testing
- `python3 -m py_compile tests/TestHarness/Cluster.py tests/TestHarness/Node.py tests/nodeop_startup_catchup.py`
- `git diff --check`

## Notes
This branch is based on `master` and contains only the startup catchup timeout fix.
