### PR TITLE
Test: hold io_context work guard in custom_appbase read-thread test

### DIFF
--- a/libraries/custom_appbase/tests/custom_appbase_tests.cpp
+++ b/libraries/custom_appbase/tests/custom_appbase_tests.cpp
@@ -5,6 +5,7 @@
 
 #include <fc/log/logger_config.hpp>
 
+#include <atomic>
 #include <thread>
 #include <iostream>
 
@@ -67,7 +68,7 @@ private:
 
 
 std::thread start_read_thread(scoped_app_thread& app) {
-   static int num = 0;
+   static std::atomic<int> num = 0; // read threads of one test start concurrently; plain int is a data race
    std::thread read_thread( [&]() {
       std::string name ="read-" + std::to_string(num++);
       fc::set_thread_name(name);
@@ -260,11 +261,15 @@ BOOST_AUTO_TEST_CASE( exec_with_handler_id ) {
 
 // verify functions only from read_only queue are processed during read window on the main thread
 BOOST_AUTO_TEST_CASE( execute_from_read_only_queue ) {
-   scoped_app_thread app;
+   // Delay exec() so the read window is established before the main thread enters its exec() loop;
+   // exec_window_ is plain data published to the main thread by the start_exec promise/future. See
+   // execute_many_from_read_only_and_read_exclusive_queues below for the full analysis.
+   scoped_app_thread app(true);
 
    // set to run functions from read_only queue only
    app->executor().init_read_threads(1);
    app->executor().set_to_read_window([](){return false;});
+   app.start_exec();
 
    // post functions
    std::map<int, int> rslts {};
@@ -307,11 +312,14 @@ BOOST_AUTO_TEST_CASE( execute_from_read_only_queue ) {
 
 // verify no functions are executed during read window if read_only & read_exclusive queue is empty
 BOOST_AUTO_TEST_CASE( execute_from_empty_read_only_queue ) {
-   scoped_app_thread app;
+   // Delay exec() so the read window is established before the main thread enters its exec() loop;
+   // see execute_from_read_only_queue above.
+   scoped_app_thread app(true);
 
    // set to run functions from read_only & read_exclusive queues only
    app->executor().init_read_threads(1);
    app->executor().set_to_read_window([](){return false;});
+   app.start_exec();
 
    // post functions
    std::map<int, int> rslts {};
@@ -501,9 +509,12 @@ BOOST_AUTO_TEST_CASE( execute_from_read_only_and_read_exclusive_queues ) {
 
    // Use lowest at the end to make sure this executes the last
    app->executor().post( priority::lowest, exec_queue::read_exclusive, [&]() {
-      BOOST_REQUIRE_EQUAL( app->executor().read_only_queue_size(), 0u); // pop()s before execute
-      BOOST_REQUIRE_EQUAL( app->executor().read_exclusive_queue_size(), 0u);
-      BOOST_REQUIRE_EQUAL( app->executor().read_write_queue_size(), 3u );
+      // executes on a read thread while other threads may still push/pop under the queue mutex;
+      // readable_queue() returns a view that holds that mutex for the duration of the checks
+      auto read_queue = app->executor().readable_queue();
+      BOOST_REQUIRE_EQUAL( read_queue.size(exec_queue::read_only), 0u); // pop()s before execute
+      BOOST_REQUIRE_EQUAL( read_queue.size(exec_queue::read_exclusive), 0u);
+      BOOST_REQUIRE_EQUAL( read_queue.size(exec_queue::read_write), 3u );
       } );
 
    auto work = make_work_guard(app->get_io_context());
@@ -592,6 +603,16 @@ BOOST_AUTO_TEST_CASE( execute_many_from_read_only_and_read_exclusive_queues ) {
    app->executor().init_read_threads(3);
    app->executor().set_to_read_window([](){return false;});
 
+   // Hold a work guard so the io_context cannot run out of work before the main thread enters exec()
+   // and installs its own guard. The read threads below call get_io_context().poll() in their loop; a
+   // poll() that drains the last queued handler while no work guard exists flags the io_context
+   // stopped, which makes exec() break out of its loop immediately and run its UNLOCKED shutdown
+   // clear() of the priority queues concurrently with this thread's posts and the read threads' pops,
+   // corrupting the queues (observed as a SEGV in binomial_heap::pop() on a read thread, or as posted
+   // tasks vanishing so fewer than num_expected results are recorded). The sibling test above holds
+   // the same guard for the same reason.
+   auto work = make_work_guard(app->get_io_context());
+
    // enter exec() now that the read window (and its locking) is published to the main thread, before any
    // read threads start and before any tasks are posted
    app.start_exec();
@@ -630,9 +651,12 @@ BOOST_AUTO_TEST_CASE( execute_many_from_read_only_and_read_exclusive_queues ) {
 
    // Use lowest at the end to make sure this executes the last
    app->executor().post( priority::lowest, exec_queue::read_exclusive, [&]() {
-      BOOST_REQUIRE_EQUAL( app->executor().read_only_queue_size(), 0u); // pop()s before execute
-      BOOST_REQUIRE_EQUAL( app->executor().read_exclusive_queue_size(), 0u);
-      BOOST_REQUIRE_EQUAL( app->executor().read_write_queue_size(), 0u );
+      // executes on a read thread while other threads may still push/pop under the queue mutex;
+      // readable_queue() returns a view that holds that mutex for the duration of the checks
+      auto read_queue = app->executor().readable_queue();
+      BOOST_REQUIRE_EQUAL( read_queue.size(exec_queue::read_only), 0u); // pop()s before execute
+      BOOST_REQUIRE_EQUAL( read_queue.size(exec_queue::read_exclusive), 0u);
+      BOOST_REQUIRE_EQUAL( read_queue.size(exec_queue::read_write), 0u );
       } );
 
    read_thread1.join();
@@ -646,6 +670,7 @@ BOOST_AUTO_TEST_CASE( execute_many_from_read_only_and_read_exclusive_queues ) {
          break;
    };
 
+   work.reset();
    app->quit();
    app.join();
 


### PR DESCRIPTION
`custom_appbase_test` has continued to fail intermittently in the asan CI job after #383, both as a SEGV in `binomial_heap::pop()` on a read thread and as `[N != 600]` count failures in `execute_many_from_read_only_and_read_exclusive_queues`.

Root cause: asio's `poll()`/`run_one()` stop the io_context when outstanding work reaches zero. The test's read threads poll the io_context from the moment they start; if such a poll drains the last queued handler before the app thread reaches `exec()` and installs its work guard, the io_context flags itself stopped. `exec()` then exits its loop immediately and runs its unlocked shutdown `clear()` of the priority queues concurrently with the test thread's posts and the read threads' locked pops, corrupting the queues. Reproduced locally under sanitizer stress at the CI commit; the mechanism was confirmed with TSAN (which catches `clear()` racing a locked push) and by instrumenting `exec()`, which showed every failing run exiting the loop with the io_context stopped before any `quit()` call.

Fix: hold a work guard across the test, released before `quit()`, matching `execute_from_read_only_and_read_exclusive_queues` which already does this. Also fixes three more data races TSAN reports in this file: the two single-read-thread-window tests flipped the exec window while the app thread was already in `exec()` (same class as #383), the `static int` thread-name counter in `start_read_thread`, and the unlocked queue-size reads in the read-thread tests' final check lambdas.

Production is not exposed: producer_plugin read threads only run `execute_highest_read()` inside read windows initiated from the main exec loop, after the work guard exists, and they are joined during plugin shutdown before `exec.clear()`.