### PR TITLE
Preserve exception type when rethrowing stored exceptions

### DIFF
--- a/contracts/tests/sysio.system_blockinfo_tests.cpp
+++ b/contracts/tests/sysio.system_blockinfo_tests.cpp
@@ -323,7 +323,7 @@ try {
       });
       if (!result.first.has_value()) {
          const sysio::chain::transaction_trace& trace = *result.second;
-         if (trace.except.has_value()) {
+         if (trace.except) {
             elog("{}", trace.except->to_detail_string());
          }
       }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -970,7 +970,7 @@ struct controller_impl {
          if( trace->except_ptr )
             std::rethrow_exception(trace->except_ptr);
          if( trace->except)
-            throw *trace->except;
+            assert(trace->except_ptr); // except/except_ptr always set together
          getpeerkeys_res_t res;
          if (!trace->action_traces.empty()) {
             const auto& act_trace = trace->action_traces[0];
@@ -2194,7 +2194,8 @@ struct controller_impl {
             if( onblock_trace->except ) {
                if (onblock_trace->except->code() == interrupt_exception::code_value) {
                   ilog("Interrupt of onblock {}", chain_head.block_num() + 1);
-                  throw *onblock_trace->except;
+                  assert(onblock_trace->except_ptr); // always set together
+                  std::rethrow_exception(onblock_trace->except_ptr);
                }
                wlog("onblock {} is REJECTING: {}", chain_head.block_num() + 1, fc::json::to_log_string(*onblock_trace));
             }
@@ -2631,7 +2632,8 @@ struct controller_impl {
                   } else {
                      elog("{}", fc::json::to_log_string(*trace));
                   }
-                  throw *trace->except;
+                  assert(trace->except_ptr); // always set together
+                  std::rethrow_exception(trace->except_ptr);
                }
 
                SYS_ASSERT(trx_receipts.size() > 0, block_validate_exception,

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1961,7 +1961,7 @@ struct controller_impl {
          auto handle_exception =[&](const auto& e)
          {
             trace->error_code = controller::convert_exception_to_error_code( e );
-            trace->except = e;
+            trace->except = e.dynamic_copy_exception(); // virtual copy preserves the dynamic exception type
             trace->except_ptr = std::current_exception();
             auto now = fc::time_point::now();
             trx_context.update_billed_cpu_time(now);

--- a/libraries/chain/include/sysio/chain/exceptions.hpp
+++ b/libraries/chain/include/sysio/chain/exceptions.hpp
@@ -117,7 +117,7 @@
        \
        std::shared_ptr<fc::exception> dynamic_copy_exception()const override\
        { return std::make_shared<TYPE>( *this ); } \
-       void rethrow() const override { throw *this; } \
+       void rethrow() const override { assert(typeid(*this) == typeid(TYPE)); throw *this; } \
        std::optional<uint64_t> error_code; \
    };
 

--- a/libraries/chain/include/sysio/chain/exceptions.hpp
+++ b/libraries/chain/include/sysio/chain/exceptions.hpp
@@ -115,8 +115,9 @@
        :BASE(c){} \
        TYPE():BASE(CODE, BOOST_PP_STRINGIZE(TYPE), WHAT){}\
        \
-       virtual std::shared_ptr<fc::exception> dynamic_copy_exception()const\
+       std::shared_ptr<fc::exception> dynamic_copy_exception()const override\
        { return std::make_shared<TYPE>( *this ); } \
+       void rethrow() const override { throw *this; } \
        std::optional<uint64_t> error_code; \
    };
 

--- a/libraries/chain/include/sysio/chain/trace.hpp
+++ b/libraries/chain/include/sysio/chain/trace.hpp
@@ -90,8 +90,13 @@ namespace sysio::chain {
       vector<action_trace>                       action_traces;
       std::optional<account_delta>               account_ram_delta;
 
-      std::optional<fc::exception>               except;
+      /// Copy of the failure exception, if any. Stored as a dynamic copy (fc::exception::dynamic_copy_exception)
+      /// so the pointer retains the original derived exception type; rethrowing or dynamic_pointer_cast on it
+      /// sees the same type the transaction failed with. Serializes like the exception value itself.
+      fc::exception_ptr                          except;
       std::optional<uint64_t>                    error_code;
+      /// The original exception as captured by std::current_exception(); preferred for faithful rethrow
+      /// (also covers non-fc exceptions). Not serialized.
       std::exception_ptr                         except_ptr;
    };
 

--- a/libraries/libfc/include/fc/exception/exception.hpp
+++ b/libraries/libfc/include/fc/exception/exception.hpp
@@ -6,8 +6,10 @@
 #include <fc/log/logger.hpp>
 #include <boost/core/typeinfo.hpp>
 #include <boost/interprocess/exceptions.hpp>
+#include <cassert>
 #include <exception>
 #include <functional>
+#include <typeinfo>
 
 namespace fc
 {
@@ -121,9 +123,14 @@ namespace fc
          /**
           *  Rethrows this exception preserving its dynamic type. A plain `throw *ptr;` on an
           *  `exception_ptr` slices the thrown object to fc::exception; derived types override
-          *  this so catch sites can match on the original exception type.
+          *  this so catch sites can match on the original exception type. The assert fails (in
+          *  debug builds) when a derived type is missing its override: the throw below would
+          *  slice it to the static type of the most-derived class that does implement rethrow().
           */
-         virtual void rethrow() const { throw *this; }
+         virtual void rethrow() const {
+            assert(typeid(*this) == typeid(exception));
+            throw *this;
+         }
 
          friend void to_variant( const exception& e, variant& v );
          friend void from_variant( const variant& e, exception& ll );
@@ -164,7 +171,7 @@ namespace fc
        std::exception_ptr get_inner_exception()const;
 
        std::shared_ptr<exception>   dynamic_copy_exception()const override;
-       void rethrow() const override { throw *this; }
+       void rethrow() const override { assert(typeid(*this) == typeid(unhandled_exception)); throw *this; }
       private:
        std::exception_ptr _inner;
    };
@@ -189,7 +196,7 @@ namespace fc
        static std_exception_wrapper from_current_exception(const std::exception& e);
 
        std::shared_ptr<exception>   dynamic_copy_exception()const override;
-       void rethrow() const override { throw *this; }
+       void rethrow() const override { assert(typeid(*this) == typeid(std_exception_wrapper)); throw *this; }
       private:
        std::exception_ptr _inner;
    };
@@ -236,7 +243,7 @@ namespace fc
        \
        std::shared_ptr<fc::exception> dynamic_copy_exception()const override\
        { return std::make_shared<TYPE>( *this ); } \
-       void rethrow() const override { throw *this; } \
+       void rethrow() const override { assert(typeid(*this) == typeid(TYPE)); throw *this; } \
    };
 
   #define FC_DECLARE_EXCEPTION( TYPE, CODE, WHAT ) \

--- a/libraries/libfc/include/fc/exception/exception.hpp
+++ b/libraries/libfc/include/fc/exception/exception.hpp
@@ -118,6 +118,13 @@ namespace fc
           */
           virtual std::shared_ptr<exception> dynamic_copy_exception()const;
 
+         /**
+          *  Rethrows this exception preserving its dynamic type. A plain `throw *ptr;` on an
+          *  `exception_ptr` slices the thrown object to fc::exception; derived types override
+          *  this so catch sites can match on the original exception type.
+          */
+         virtual void rethrow() const { throw *this; }
+
          friend void to_variant( const exception& e, variant& v );
          friend void from_variant( const variant& e, exception& ll );
 
@@ -156,7 +163,8 @@ namespace fc
 
        std::exception_ptr get_inner_exception()const;
 
-       virtual std::shared_ptr<exception>   dynamic_copy_exception()const;
+       std::shared_ptr<exception>   dynamic_copy_exception()const override;
+       void rethrow() const override { throw *this; }
       private:
        std::exception_ptr _inner;
    };
@@ -180,7 +188,8 @@ namespace fc
 
        static std_exception_wrapper from_current_exception(const std::exception& e);
 
-       virtual std::shared_ptr<exception>   dynamic_copy_exception()const;
+       std::shared_ptr<exception>   dynamic_copy_exception()const override;
+       void rethrow() const override { throw *this; }
       private:
        std::exception_ptr _inner;
    };
@@ -225,8 +234,9 @@ namespace fc
        :BASE(c){} \
        TYPE():BASE(CODE, BOOST_PP_STRINGIZE(TYPE), WHAT){}\
        \
-       virtual std::shared_ptr<fc::exception> dynamic_copy_exception()const\
+       std::shared_ptr<fc::exception> dynamic_copy_exception()const override\
        { return std::make_shared<TYPE>( *this ); } \
+       void rethrow() const override { throw *this; } \
    };
 
   #define FC_DECLARE_EXCEPTION( TYPE, CODE, WHAT ) \

--- a/libraries/libfc/src/network/http/http_client.cpp
+++ b/libraries/libfc/src/network/http/http_client.cpp
@@ -319,7 +319,7 @@ public:
          }
 
          if (excp) {
-            throw *excp;
+            excp->rethrow();
          } else {
             FC_THROW("Request failed with 500 response, but response was not parseable");
          }

--- a/libraries/libfc/test/CMakeLists.txt
+++ b/libraries/libfc/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable( test_fc
         test_slug_name.cpp
         test_traits.cpp
         test_escape_str.cpp
+        test_exception.cpp
         test_bls.cpp
         test_bitset.cpp
         test_ordered_diff.cpp

--- a/libraries/libfc/test/test_exception.cpp
+++ b/libraries/libfc/test/test_exception.cpp
@@ -1,0 +1,38 @@
+#include <boost/test/unit_test.hpp>
+
+#include <fc/exception/exception.hpp>
+
+BOOST_AUTO_TEST_SUITE(exception)
+
+/**
+ * Verify fc::exception::rethrow() preserves the dynamic exception type.
+ * A plain `throw *exception_ptr;` slices to fc::exception; rethrow() must throw the
+ * original derived type (assert_exception here) so typed catch sites still match,
+ * and appended log context must survive dynamic_copy_exception().
+ */
+BOOST_AUTO_TEST_CASE(rethrow) try {
+   fc::exception_ptr exp;
+   try {
+      try {
+         FC_ASSERT(false, "test {}", 42);
+      } FC_RETHROW_EXCEPTIONS(info, "extra stuff")
+   } catch (fc::exception& e) {
+      exp = e.dynamic_copy_exception();
+   }
+
+   BOOST_TEST(exp->to_detail_string().find("test 42") != std::string::npos);
+   BOOST_TEST(exp->to_detail_string().find("extra stuff") != std::string::npos);
+
+   try {
+      exp->rethrow();
+   } catch (fc::assert_exception& e) {
+      // success
+   } catch (fc::exception& e) {
+      BOOST_FAIL("should be: assert_exception");
+   } catch (...) {
+      BOOST_FAIL("should be: assert_exception");
+   }
+
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -440,8 +440,8 @@ namespace sysio::testing {
             cpu_usage_t billed_cpu_us(trx.total_actions(), DEFAULT_BILLED_CPU_TIME_US);
             auto trace = control->test_push_transaction( itr->trx_meta, fc::time_point::maximum(), fc::microseconds::maximum(), billed_cpu_us, true );
             if(!no_throw && trace->except) {
-               // this always throws an fc::exception, since the original exception is copied into an fc::exception
-               throw *trace->except;
+               assert(trace->except_ptr);
+               std::rethrow_exception(trace->except_ptr);
             }
             itr = unapplied_transactions.erase( itr );
             res.unapplied_transaction_traces.emplace_back( std::move(trace) );
@@ -783,7 +783,6 @@ namespace sysio::testing {
          billed_cpu_us.insert(billed_cpu_us.end(), trx.get_transaction().total_actions(), billed_cpu_time_us/trx.get_transaction().total_actions());
       auto r = control->test_push_transaction( fut.get(), deadline, fc::microseconds::maximum(), billed_cpu_us, explicit_billed_cpu_time );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except ) throw *r->except;
       return r;
    } FC_RETHROW_EXCEPTIONS( warn, "transaction_header: {}", fc::json::to_log_string(transaction_header(trx.get_transaction())) ) }
 
@@ -818,7 +817,6 @@ namespace sysio::testing {
       auto r = control->test_push_transaction( fut.get(), deadline, fc::microseconds::maximum(), billed_cpu_us, explicit_billed_cpu_time );
       if (no_throw) return r;
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except)  throw *r->except;
       return r;
    } FC_RETHROW_EXCEPTIONS( warn, "transaction_header: {}, billed_cpu_time_us: {}",
                             fc::json::to_log_string(transaction_header(trx)), billed_cpu_time_us )

--- a/plugins/http_plugin/include/sysio/http_plugin/macros.hpp
+++ b/plugins/http_plugin/include/sysio/http_plugin/macros.hpp
@@ -13,7 +13,7 @@
            (const chain::next_function_variant<call_result>& result) mutable {                                  \
               if (std::holds_alternative<fc::exception_ptr>(result)) {                                          \
                  try {                                                                                          \
-                    throw *std::get<fc::exception_ptr>(result);                                                 \
+                    std::get<fc::exception_ptr>(result)->rethrow();                                           \
                  } catch (...) {                                                                                \
                     http_plugin::handle_exception(#api_name, #call_name, body, cb);                             \
                  }                                                                                              \
@@ -28,7 +28,7 @@
                     chain::t_or_exception<call_result> result = http_fwd();                                     \
                     if (std::holds_alternative<fc::exception_ptr>(result)) {                                    \
                        try {                                                                                    \
-                          throw *std::get<fc::exception_ptr>(result);                                           \
+                          std::get<fc::exception_ptr>(result)->rethrow();                                     \
                        } catch (...) {                                                                          \
                           http_plugin::handle_exception(#api_name, #call_name, body, cb);                       \
                        }                                                                                        \
@@ -65,7 +65,7 @@
                    chain::t_or_exception<call_result> result = http_fwd();                                      \
                    if (std::holds_alternative<fc::exception_ptr>(result)) {                                     \
                       try {                                                                                     \
-                         throw *std::get<fc::exception_ptr>(result);                                            \
+                         std::get<fc::exception_ptr>(result)->rethrow();                                      \
                       } catch (...) {                                                                           \
                          http_plugin::handle_exception(#api_name, #call_name, body, cb);                        \
                       }                                                                                         \

--- a/plugins/producer_api_plugin/src/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/src/producer_api_plugin.cpp
@@ -38,7 +38,7 @@ using namespace sysio;
       auto next = [cb=std::move(cb), body=std::move(body)](const chain::next_function_variant<call_result>& result){ \
          if (std::holds_alternative<fc::exception_ptr>(result)) {\
             try {\
-               throw *std::get<fc::exception_ptr>(result);\
+               std::get<fc::exception_ptr>(result)->rethrow();\
             } catch (...) {\
                http_plugin::handle_exception(#api_name, #call_name, body, cb);\
             }\

--- a/plugins/producer_plugin/src/producer_plugin.cpp
+++ b/plugins/producer_plugin/src/producer_plugin.cpp
@@ -1092,7 +1092,7 @@ public:
             if (std::holds_alternative<fc::exception_ptr>(response)) {
                except_ptr = std::get<fc::exception_ptr>(response);
             } else if (std::get<transaction_trace_ptr>(response)->except) {
-               except_ptr = std::get<transaction_trace_ptr>(response)->except->dynamic_copy_exception();
+               except_ptr = std::get<transaction_trace_ptr>(response)->except;
             }
             _transaction_ack_channel.publish(priority::low, std::pair<fc::exception_ptr, packed_transaction_ptr>(except_ptr, trx));
             next(std::move(response));
@@ -2724,8 +2724,7 @@ producer_plugin_impl::handle_push_result(const transaction_metadata_ptr&        
             if (return_failure_trace) {
                next(trace);
             } else {
-               auto e_ptr = trace->except->dynamic_copy_exception();
-               next(e_ptr);
+               next(trace->except);
             }
          }
       }

--- a/tests/chain_test_utils.hpp
+++ b/tests/chain_test_utils.hpp
@@ -103,13 +103,13 @@ inline auto push_input_trx(appbase::scoped_app& app, sysio::chain::controller& c
            [trx_promise](const next_function_variant<transaction_trace_ptr>& result) {
               if( std::holds_alternative<fc::exception_ptr>( result ) ) {
                  try {
-                    throw *std::get<fc::exception_ptr>(result);
+                    std::get<fc::exception_ptr>(result)->rethrow();
                  } catch(...) {
                     trx_promise->set_exception(std::current_exception());
                  }
               } else if ( std::get<chain::transaction_trace_ptr>( result )->except ) {
                  try {
-                    throw *std::get<chain::transaction_trace_ptr>(result)->except;
+                    std::get<chain::transaction_trace_ptr>(result)->except->rethrow();
                  } catch(...) {
                     trx_promise->set_exception(std::current_exception());
                  }

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1036,7 +1036,6 @@ void transaction_tests(T& chain) {
          billed_cpu_us.insert(billed_cpu_us.end(), trx.total_actions(), T::DEFAULT_BILLED_CPU_TIME_US);
       auto r = chain.control->test_push_transaction( fut.get(), fc::time_point::maximum(), fc::microseconds::maximum(), billed_cpu_us, true );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except) throw *r->except;
       tx_trace = r;
       chain.produce_block();
       BOOST_CHECK(tx_trace->action_traces.front().console == sha_expect);

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -60,10 +60,7 @@ BOOST_AUTO_TEST_CASE( block_with_invalid_tx_test )
    auto [best_head, obh] = validator.control->accept_block( signed_copy_b->calculate_id(), signed_copy_b );
    BOOST_REQUIRE(obh);
    validator.control->abort_block();
-   BOOST_REQUIRE_EXCEPTION(validator.control->apply_blocks( {}, trx_meta_cache_lookup{} ), fc::exception ,
-   [] (const fc::exception &e)->bool {
-      return e.code() == account_name_exists_exception::code_value ;
-   }) ;
+   BOOST_REQUIRE_THROW(validator.control->apply_blocks( {}, trx_meta_cache_lookup{} ), account_name_exists_exception);
 
 }
 
@@ -95,10 +92,9 @@ BOOST_AUTO_TEST_CASE( block_with_invalid_tx_mroot_test )
    // Push block with invalid transaction to other chain
    savanna_tester validator;
    auto signed_copy_b = signed_block::create_signed_block(std::move(copy_b));
-   BOOST_REQUIRE_EXCEPTION(validator.control->accept_block( signed_copy_b->calculate_id(), signed_copy_b ), fc::exception,
-                           [] (const fc::exception &e)->bool {
-                              return e.code() == block_validate_exception::code_value &&
-                                     e.to_detail_string().find("invalid block transaction merkle root") != std::string::npos;
+   BOOST_REQUIRE_EXCEPTION(validator.control->accept_block( signed_copy_b->calculate_id(), signed_copy_b ), block_validate_exception,
+                           [] (const fc::exception& e)->bool {
+                              return e.to_detail_string().find("invalid block transaction merkle root") != std::string::npos;
                            }) ;
 }
 
@@ -208,10 +204,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( untrusted_producer_test, T, validating_testers )
    }
 
    auto blocks = corrupt_trx_in_block<T>(main, "tstproducera"_n);
-   BOOST_REQUIRE_EXCEPTION(main.validate_push_block( blocks.second ), fc::exception ,
-   [] (const fc::exception &e)->bool {
-      return e.code() == unsatisfied_authorization::code_value ;
-   }) ;
+   BOOST_REQUIRE_THROW(main.validate_push_block( blocks.second ), unsatisfied_authorization);
 }
 
 /**
@@ -380,10 +373,9 @@ BOOST_FIXTURE_TEST_CASE( invalid_qc_claim_block_num_test, validating_tester ) {
    copy_b->producer_signatures = {get_private_key(config::system_account_name, "active").sign(copy_b->calculate_id())};
 
    // Push the corrupted block. It must be rejected.
-   BOOST_REQUIRE_EXCEPTION(validate_push_block(signed_block::create_signed_block(std::move(copy_b))), fc::exception,
-                           [] (const fc::exception &e)->bool {
-                              return e.code() == invalid_qc_claim::code_value &&
-                                     e.to_detail_string().find("that is greater than the previous block number") != std::string::npos;
+   BOOST_REQUIRE_EXCEPTION(validate_push_block(signed_block::create_signed_block(std::move(copy_b))), invalid_qc_claim,
+                           [] (const fc::exception& e)->bool {
+                              return e.to_detail_string().find("that is greater than the previous block number") != std::string::npos;
                            }) ;
 }
 
@@ -405,10 +397,9 @@ BOOST_FIXTURE_TEST_CASE( invalid_finality_mroot_test, tester )
 
    // Push the block containing corrupted finality mroot. It should fail
    BOOST_REQUIRE_EXCEPTION(push_block(signed_block::create_signed_block(std::move(copy_b))),
-                           fc::exception,
-                           [] (const fc::exception &e)->bool {
-                              return e.code() == block_validate_exception::code_value &&
-                                     e.to_detail_string().find("computed finality mroot") != std::string::npos &&
+                           block_validate_exception,
+                           [] (const fc::exception& e)->bool {
+                              return e.to_detail_string().find("computed finality mroot") != std::string::npos &&
                                      e.to_detail_string().find("does not match supplied finality mroot") != std::string::npos;
                            });
 }
@@ -429,10 +420,9 @@ BOOST_FIXTURE_TEST_CASE( no_block_extensions_allowed_test, validating_tester ) {
    copy_b->producer_signatures = {get_private_key(config::system_account_name, "active").sign(copy_b->calculate_id())};
 
    // Push the block with extensions. It must be rejected.
-   BOOST_REQUIRE_EXCEPTION(validate_push_block(signed_block::create_signed_block(std::move(copy_b))), fc::exception,
+   BOOST_REQUIRE_EXCEPTION(validate_push_block(signed_block::create_signed_block(std::move(copy_b))), invalid_block_extension,
                            [] (const fc::exception& e)->bool {
-                              return e.code() == invalid_block_extension::code_value &&
-                                     e.to_detail_string().find("No block extensions currently supported") != std::string::npos;
+                              return e.to_detail_string().find("No block extensions currently supported") != std::string::npos;
                            });
 }
 

--- a/unittests/checktime_tests.cpp
+++ b/unittests/checktime_tests.cpp
@@ -179,8 +179,7 @@ BOOST_AUTO_TEST_CASE( checktime_interrupt_test) { try {
    } );
 
    // apply block, caught in an "infinite" loop
-   BOOST_CHECK_EXCEPTION( other.push_block(signed_block::create_signed_block(std::move(copy_b))), fc::exception,
-                          [](const fc::exception& e) { return e.code() == interrupt_exception::code_value; } );
+   BOOST_CHECK_THROW( other.push_block(signed_block::create_signed_block(std::move(copy_b))), interrupt_exception);
 
    th.join();
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -1,6 +1,8 @@
 #include <sysio/chain/asset.hpp>
 #include <sysio/chain/authority.hpp>
 #include <sysio/chain/authority_checker.hpp>
+#include <sysio/chain/exceptions.hpp>
+#include <sysio/chain/trace.hpp>
 #include <sysio/chain/types.hpp>
 #include <sysio/chain/thread_utils.hpp>
 #include <sysio/testing/tester.hpp>
@@ -1218,6 +1220,40 @@ BOOST_AUTO_TEST_CASE(public_key_from_hash) {
    fc::ecc::public_key_shim shim(data);
    fc::crypto::public_key sys_unknown_pk(std::move(shim));
    ilog( "public key with no known private key: {}", sys_unknown_pk.to_string({}, true) );
+}
+
+/**
+ * transaction_trace::except must retain the original dynamic exception type: the controller stores
+ * a dynamic copy (fc::exception::dynamic_copy_exception) rather than a sliced fc::exception value,
+ * so failure consumers (transaction acks, API error responses) can rethrow or dynamic_pointer_cast
+ * to the precise type the transaction failed with.
+ */
+BOOST_AUTO_TEST_CASE(transaction_trace_except_preserves_type) {
+   tester chain;
+   chain.create_account("alice"_n);
+   chain.produce_block();
+
+   // attempt to create the same account again; the controller captures the failure on the trace
+   signed_transaction trx;
+   trx.actions.emplace_back( vector<permission_level>{{config::system_account_name, config::active_name}},
+                             newaccount{
+                                .creator = config::system_account_name,
+                                .name    = "alice"_n,
+                                .owner   = authority( chain.get_public_key( "alice"_n, "owner" ) ),
+                                .active  = authority( chain.get_public_key( "alice"_n, "active" ) ),
+                             });
+   chain.set_transaction_headers(trx);
+   trx.sign( chain.get_private_key( config::system_account_name, "active" ), chain.get_chain_id() );
+   auto trace = chain.push_transaction( trx, fc::time_point::maximum(), base_tester::DEFAULT_BILLED_CPU_TIME_US,
+                                        true /* no_throw */ );
+
+   BOOST_REQUIRE(!!trace);
+   BOOST_REQUIRE(!!trace->except);
+   BOOST_CHECK_EQUAL(trace->except->code(), account_name_exists_exception::code_value);
+   // the stored copy retains the original dynamic exception type...
+   BOOST_CHECK(!!std::dynamic_pointer_cast<account_name_exists_exception>(trace->except));
+   // ...so typed catch sites see the type the transaction actually failed with
+   BOOST_CHECK_THROW(trace->except->rethrow(), account_name_exists_exception);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/subjective_billing_tests.cpp
+++ b/unittests/subjective_billing_tests.cpp
@@ -634,7 +634,6 @@ BOOST_AUTO_TEST_CASE( subjective_billing_integration_test ) {
                      const cpu_usage_t& billed_cpu_us, bool explicit_billed_cpu_time ) {
       auto r = chain.control->test_push_transaction( trx, deadline, fc::microseconds::maximum(), billed_cpu_us, explicit_billed_cpu_time );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except ) throw *r->except;
       return r;
    };
 

--- a/unittests/test_utils.hpp
+++ b/unittests/test_utils.hpp
@@ -102,7 +102,6 @@ void push_trx(Tester& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cpu
    auto res = test.control->test_push_transaction( trx_meta, fc::time_point::now() + fc::milliseconds(max_block_cpu_ms),
                                               fc::milliseconds(max_cpu_usage_ms), billed_cpu_us, explicit_bill );
    if( res->except_ptr ) std::rethrow_exception( res->except_ptr );
-   if( res->except ) throw *res->except;
 };
 
 static constexpr unsigned int DJBH(const char* cp) {

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -1781,7 +1781,6 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
          billed_cpu_us.insert(billed_cpu_us.end(), trx->packed_trx()->get_transaction().total_actions(), billed_cpu_time_us);
       auto r = chain.control->test_push_transaction( trx, deadline, fc::microseconds::maximum(), billed_cpu_us, explicit_billed_cpu_time );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except ) throw *r->except;
       return r;
    };
 
@@ -2005,7 +2004,6 @@ BOOST_AUTO_TEST_CASE( more_billed_cpu_test ) try {
                      const cpu_usage_t& billed_cpu_us, bool explicit_billed_cpu_time ) {
       auto r = chain.control->test_push_transaction( trx, deadline, fc::microseconds::maximum(), billed_cpu_us, explicit_billed_cpu_time );
       if( r->except_ptr ) std::rethrow_exception( r->except_ptr );
-      if( r->except ) throw *r->except;
       return r;
    };
 


### PR DESCRIPTION
Ports Spring PRs AntelopeIO/spring#1535 and AntelopeIO/spring#1669.

`throw *ptr` on a stored `fc::exception_ptr`/`optional<fc::exception>` slices to `fc::exception`, losing the derived type. This adds a virtual `fc::exception::rethrow()` (overridden by the exception-declaration macros and wrapper classes), switches `transaction_trace` rethrow sites to `std::rethrow_exception(trace->except_ptr)` -- the unsliced original -- and converts remaining `throw *exception_ptr` sites to `rethrow()`. Unit tests now catch specific exception types (e.g. `BOOST_REQUIRE_THROW(..., account_name_exists_exception)`, `interrupt_exception`), which doubles as the regression test that types survive the apply-block path.

Deviations from upstream: `unhandled_exception` also gets the `rethrow()` override (upstream only covered `std_exception_wrapper`), and three wire-only sites are converted for consistency (`subjective_billing_tests.cpp`, a second `wasm_tests.cpp` site, `no_block_extensions_allowed_test`).

Tests: full `unit_test`/`plugin_test`/`contracts_unit_test`/`test_fc` pass (only the known local-contract reference-data failures remain, identical to a clean-tree baseline); new `test_fc --run_test=exception` covers the rethrow round-trip.
