### PR TITLE
Remove gcc10 coroutine workarounds; require gcc >= 11.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,8 @@ set(SYS_UTIL_EXECUTABLE_NAME sys-util)
 
 # http://stackoverflow.com/a/18369825
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.2)
-    message(FATAL_ERROR "GCC version must be at least 10.2.0!")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.4)
+    message(FATAL_ERROR "GCC version must be at least 11.4.0!")
   endif()
 endif()
 

--- a/plugins/state_history_plugin/CMakeLists.txt
+++ b/plugins/state_history_plugin/CMakeLists.txt
@@ -7,7 +7,3 @@ plugin_target(
         sysio_chain
         appbase
 )
-
-if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11 )
-   target_compile_options( state_history_plugin PRIVATE "-fcoroutines" )
-endif()

--- a/plugins/state_history_plugin/include/sysio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/sysio/state_history_plugin/session.hpp
@@ -145,31 +145,30 @@ private:
             co_await stream.async_read(b);
             const state_request req = fc::raw::unpack<std::remove_const_t<decltype(req)>>(static_cast<const char*>(b.cdata().data()), b.size());
 
-            auto& self = *this; //gcc10 ICE workaround wrt capturing 'this' in a coro
             co_await boost::asio::co_spawn(app().get_io_context(), [&]() -> boost::asio::awaitable<void> {
                /**
                 * This lambda executes on the main thread; upon returning, the enclosing coroutine continues execution on the connection's strand
                 */
                std::visit(chain::overloaded {
-                  [&self]<typename GetStatusRequestV0orV1, typename = std::enable_if_t<std::is_base_of_v<get_status_request_v0, GetStatusRequestV0orV1>>>(const GetStatusRequestV0orV1&) {
-                     self.queued_status_requests.emplace_back(std::is_same_v<GetStatusRequestV0orV1, get_status_request_v1>);
+                  [&]<typename GetStatusRequestV0orV1, typename = std::enable_if_t<std::is_base_of_v<get_status_request_v0, GetStatusRequestV0orV1>>>(const GetStatusRequestV0orV1&) {
+                     queued_status_requests.emplace_back(std::is_same_v<GetStatusRequestV0orV1, get_status_request_v1>);
                   },
-                  [&self]<typename GetBlocksRequestV0orV1, typename = std::enable_if_t<std::is_base_of_v<get_blocks_request_v0, GetBlocksRequestV0orV1>>>(const GetBlocksRequestV0orV1& gbr) {
-                     self.current_blocks_request_v1_finality.reset();
-                     self.current_blocks_request = gbr;
+                  [&]<typename GetBlocksRequestV0orV1, typename = std::enable_if_t<std::is_base_of_v<get_blocks_request_v0, GetBlocksRequestV0orV1>>>(const GetBlocksRequestV0orV1& gbr) {
+                     current_blocks_request_v1_finality.reset();
+                     current_blocks_request = gbr;
                      if constexpr(std::is_same_v<GetBlocksRequestV0orV1, get_blocks_request_v1>)
-                        self.current_blocks_request_v1_finality = gbr.fetch_finality_data;
+                        current_blocks_request_v1_finality = gbr.fetch_finality_data;
 
-                     for(const block_position& haveit : self.current_blocks_request.have_positions) {
-                        if(self.current_blocks_request.start_block_num <= haveit.block_num)
+                     for(const block_position& haveit : current_blocks_request.have_positions) {
+                        if(current_blocks_request.start_block_num <= haveit.block_num)
                            continue;
-                        if(const std::optional<chain::block_id_type> id = self.get_block_id(haveit.block_num); !id || *id != haveit.block_id)
-                           self.current_blocks_request.start_block_num = std::min(self.current_blocks_request.start_block_num, haveit.block_num);
+                        if(const std::optional<chain::block_id_type> id = get_block_id(haveit.block_num); !id || *id != haveit.block_id)
+                           current_blocks_request.start_block_num = std::min(current_blocks_request.start_block_num, haveit.block_num);
                      }
-                     self.current_blocks_request.have_positions.clear();
+                     current_blocks_request.have_positions.clear();
                   },
-                  [&self](const get_blocks_ack_request_v0& gbar0) {
-                     self.send_credits += gbar0.num_messages;
+                  [&](const get_blocks_ack_request_v0& gbar0) {
+                     send_credits += gbar0.num_messages;
                   }
                }, req);
                co_return;
@@ -235,43 +234,42 @@ private:
             std::deque<bool>             status_requests;
             std::optional<block_package> block_to_send;
 
-            auto& self = *this; //gcc10 ICE workaround wrt capturing 'this' in a coro
             co_await boost::asio::co_spawn(app().get_io_context(), [&]() -> boost::asio::awaitable<void> {
                /**
                 * This lambda executes on the main thread; upon returning, the enclosing coroutine continues execution on the connection's strand
                 */
-               status_requests = std::move(self.queued_status_requests);
+               status_requests = std::move(queued_status_requests);
 
                //decide what block -- if any -- to send out
-               const chain::block_num_type latest_to_consider = self.current_blocks_request.irreversible_only ?
-                                                                self.controller.fork_db_root().block_num() : self.controller.head().block_num();
-               if(self.send_credits && self.next_block_cursor <= latest_to_consider && self.next_block_cursor < self.current_blocks_request.end_block_num) {
+               const chain::block_num_type latest_to_consider = current_blocks_request.irreversible_only ?
+                                                                controller.fork_db_root().block_num() : controller.head().block_num();
+               if(send_credits && next_block_cursor <= latest_to_consider && next_block_cursor < current_blocks_request.end_block_num) {
                   block_to_send.emplace( block_package{
                      .blocks_result_base = {
-                        .head = {self.controller.head().block_num(), self.controller.head().id()},
-                        .last_irreversible = {self.controller.fork_db_root().block_num(), self.controller.fork_db_root().id()}
+                        .head = {controller.head().block_num(), controller.head().id()},
+                        .last_irreversible = {controller.fork_db_root().block_num(), controller.fork_db_root().id()}
                      },
-                     .is_v1_request = self.current_blocks_request_v1_finality.has_value()
+                     .is_v1_request = current_blocks_request_v1_finality.has_value()
                   });
-                  if(const std::optional<chain::block_id_type> this_block_id = self.get_block_id(self.next_block_cursor)) {
-                     block_to_send->blocks_result_base.this_block  = {self.current_blocks_request.start_block_num, *this_block_id};
-                     if(const std::optional<chain::block_id_type> last_block_id = self.get_block_id(self.next_block_cursor - 1))
-                        block_to_send->blocks_result_base.prev_block = {self.next_block_cursor - 1, *last_block_id};
-                     if (self.current_blocks_request.fetch_block) {
+                  if(const std::optional<chain::block_id_type> this_block_id = get_block_id(next_block_cursor)) {
+                     block_to_send->blocks_result_base.this_block  = {current_blocks_request.start_block_num, *this_block_id};
+                     if(const std::optional<chain::block_id_type> last_block_id = get_block_id(next_block_cursor - 1))
+                        block_to_send->blocks_result_base.prev_block = {next_block_cursor - 1, *last_block_id};
+                     if (current_blocks_request.fetch_block) {
                         if (chain::signed_block_ptr sbp = get_block(*this_block_id)) {
                            block_to_send->blocks_result_base.block = fc::raw::pack(*sbp);
                         }
                      }
-                     if(self.current_blocks_request.fetch_traces && self.trace_log)
-                        block_to_send->trace_entry = self.trace_log->get_entry(self.next_block_cursor);
-                     if(self.current_blocks_request.fetch_deltas && self.chain_state_log)
-                        block_to_send->state_entry = self.chain_state_log->get_entry(self.next_block_cursor);
-                     if(block_to_send->is_v1_request && *self.current_blocks_request_v1_finality && self.finality_data_log)
-                        block_to_send->finality_entry = self.finality_data_log->get_entry(self.next_block_cursor);
+                     if(current_blocks_request.fetch_traces && trace_log)
+                        block_to_send->trace_entry = trace_log->get_entry(next_block_cursor);
+                     if(current_blocks_request.fetch_deltas && chain_state_log)
+                        block_to_send->state_entry = chain_state_log->get_entry(next_block_cursor);
+                     if(block_to_send->is_v1_request && *current_blocks_request_v1_finality && finality_data_log)
+                        block_to_send->finality_entry = finality_data_log->get_entry(next_block_cursor);
                   }
                   // increment next_block_cursor even if unable to retrieve block to avoid tight busy loop
-                  ++self.next_block_cursor;
-                  --self.send_credits;
+                  ++next_block_cursor;
+                  --send_credits;
                }
 
                if(status_requests.size())


### PR DESCRIPTION
Ports Spring PR AntelopeIO/spring#1452, plus the gcc 11.4 minimum from AntelopeIO/spring#1711 -- removing `-fcoroutines` makes gcc 10 unable to build the SHiP plugin at all, so the floor moves with it.

Removes the gcc10 ICE workaround in the state_history session coroutines (`auto& self = *this;` + `[&self]` captures become plain `[&]`/member access) and the conditional `-fcoroutines` block. No behavior change; wire builds with clang-18 and gcc 10 is past EOL.

Tests: full build + `ship_streamer_test.py` pass (exercises both rewritten coroutine loops).
