### PR TITLE
transaction_dedup: drive undo via chainbase (fix restart-persistence, remove desync class)

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -6,3 +6,8 @@ target_include_directories( benchmark PUBLIC
                             "${CMAKE_CURRENT_SOURCE_DIR}"
                             "${CMAKE_CURRENT_BINARY_DIR}/../unittests/include"
                           )
+
+# Standalone dedup head-to-head benchmark. Links only sysio_chain + chainbase (no testing
+# harness / contracts), so it builds without the system-contract WASMs. Not built by default.
+add_executable( dedup_bench EXCLUDE_FROM_ALL dedup/dedup_bench.cpp )
+target_link_libraries( dedup_bench sysio_chain chainbase fc )

--- a/benchmark/dedup/dedup_bench.cpp
+++ b/benchmark/dedup/dedup_bench.cpp
@@ -1,0 +1,344 @@
+// Head-to-head microbenchmark: Wire's custom transaction_dedup (boost::unordered_flat_map +
+// std::set sorted index + hand-rolled revision/session undo) vs the chainbase transaction
+// dedup it replaced (Spring's transaction_multi_index: three ordered B-tree indices in a
+// chainbase segment, undone for free by the chainbase undo stack).
+//
+// Both sides run IDENTICAL, pre-generated workloads. The question this answers: how large is
+// the per-transaction performance gain from moving dedup out of chainbase, and is it worth the
+// recurring consensus-correctness cost of hand-maintaining a parallel undo/revision/persistence
+// system (the bug class found in PR #391 and the 2026-06-11 re-review)?
+//
+// Build (release):  ninja -C <build> dedup_bench
+// Run:              ./benchmark/dedup/dedup_bench [--big] [--tps N] [--blocks N]
+
+#include <sysio/chain/transaction_dedup.hpp>
+#include <sysio/chain/multi_index_includes.hpp>
+
+#include <chainbase/chainbase.hpp>
+
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/composite_key.hpp>
+
+#include <fc/filesystem.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+using namespace sysio::chain;
+using clk = std::chrono::steady_clock;
+
+namespace {
+
+double ns_since(clk::time_point t0) {
+   return std::chrono::duration<double, std::nano>(clk::now() - t0).count();
+}
+
+// Resident set size in bytes, from /proc/self/statm (field 2 = resident pages).
+size_t rss_bytes() {
+   std::ifstream f("/proc/self/statm");
+   size_t total_pages = 0, resident_pages = 0;
+   f >> total_pages >> resident_pages;
+   return resident_pages * static_cast<size_t>(sysconf(_SC_PAGESIZE));
+}
+
+// splitmix64 fills a 32-byte id the way a real (uniformly random) transaction id is distributed
+// across both the hash map's buckets and the B-tree's comparison paths.
+uint64_t splitmix64(uint64_t& s) {
+   uint64_t z = (s += 0x9e3779b97f4a7c15ULL);
+   z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
+   z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
+   return z ^ (z >> 31);
+}
+
+transaction_id_type make_id(uint64_t n) {
+   transaction_id_type id;
+   uint64_t s = n + 1;
+   auto* w = reinterpret_cast<uint64_t*>(id.data());
+   w[0] = splitmix64(s); w[1] = splitmix64(s); w[2] = splitmix64(s); w[3] = splitmix64(s);
+   return id;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Chainbase dedup: a faithful copy of Spring's transaction_object / transaction_multi_index
+// (the exact thing Wire removed in commit dd935a5b0e), driven through real chainbase undo
+// sessions exactly as the old controller / transaction_context drove it.
+// ---------------------------------------------------------------------------
+namespace bench {
+
+constexpr uint16_t bench_transaction_object_type = 1000;
+
+class transaction_object : public chainbase::object<bench_transaction_object_type, transaction_object> {
+   OBJECT_CTOR(transaction_object)
+   id_type             id;
+   fc::time_point_sec  expiration;
+   transaction_id_type trx_id;
+};
+
+struct by_expiration;
+struct by_trx_id;
+using transaction_multi_index = chainbase::shared_multi_index_container<
+   transaction_object,
+   boost::multi_index::indexed_by<
+      boost::multi_index::ordered_unique<boost::multi_index::tag<by_id>,
+         BOOST_MULTI_INDEX_MEMBER(transaction_object, transaction_object::id_type, id)>,
+      boost::multi_index::ordered_unique<boost::multi_index::tag<by_trx_id>,
+         BOOST_MULTI_INDEX_MEMBER(transaction_object, transaction_id_type, trx_id)>,
+      boost::multi_index::ordered_unique<boost::multi_index::tag<by_expiration>,
+         boost::multi_index::composite_key<transaction_object,
+            BOOST_MULTI_INDEX_MEMBER(transaction_object, fc::time_point_sec, expiration),
+            BOOST_MULTI_INDEX_MEMBER(transaction_object, transaction_object::id_type, id)>>
+   >
+>;
+
+} // namespace bench
+
+CHAINBASE_SET_INDEX_TYPE(bench::transaction_object, bench::transaction_multi_index)
+
+namespace {
+
+// Wraps a chainbase::database to expose the same surface as transaction_dedup, mapping each
+// operation to exactly what the old controller / transaction_context did.
+struct chainbase_dedup {
+   fc::temp_directory tmp;
+   chainbase::database db;
+   std::vector<chainbase::database::session> trx_sessions;
+   std::optional<chainbase::database::session> block_session;
+
+   explicit chainbase_dedup(uint64_t segment_bytes, chainbase::pinnable_mapped_file::map_mode mode)
+   : db(tmp.path(), chainbase::database::read_write, segment_bytes, false, mode) {
+      db.add_index<bench::transaction_multi_index>();
+   }
+
+   void record(const transaction_id_type& id, fc::time_point_sec exp) {
+      db.create<bench::transaction_object>([&](auto& t) { t.trx_id = id; t.expiration = exp; });
+   }
+   bool is_known(const transaction_id_type& id) const {
+      return db.find<bench::transaction_object, bench::by_trx_id>(id) != nullptr;
+   }
+   uint32_t clear_expired(fc::time_point now) {
+      auto& idx = db.get_mutable_index<bench::transaction_multi_index>();
+      const auto& by_exp = idx.indices().get<bench::by_expiration>();
+      uint32_t n = 0;
+      while (!by_exp.empty() && now > by_exp.begin()->expiration.to_time_point()) {
+         idx.remove(*by_exp.begin());
+         ++n;
+      }
+      return n;
+   }
+   void push_session()   { trx_sessions.emplace_back(db.start_undo_session(true)); }
+   void squash_session() { trx_sessions.back().squash(); trx_sessions.pop_back(); }
+   void undo_session()   { trx_sessions.back().undo();   trx_sessions.pop_back(); }
+   void start_block_revision(uint32_t) { block_session.emplace(db.start_undo_session(true)); }
+   void commit_block_revision()        { block_session->push(); block_session.reset(); }
+   void abort_block_revision()         { block_session->undo(); block_session.reset(); }
+   void pop_block_revision()           { db.undo(); }
+   void commit_to_lib(int64_t rev)     { db.commit(rev); }   // chainbase commits by revision
+
+   int64_t revision() const { return db.revision(); }
+   size_t  free_mem() const { return db.get_free_memory(); }
+};
+
+// --- Adapters bridging the small API differences between the two implementations ----------
+// (custom clear_expired returns {removed,total}; custom commit_to_lib takes a block_num while
+//  chainbase commits a revision; custom has no revision()).
+uint32_t do_clear_expired(transaction_dedup& d, fc::time_point now) { return d.clear_expired(now).first; }
+uint32_t do_clear_expired(chainbase_dedup& d, fc::time_point now)   { return d.clear_expired(now); }
+int64_t  cur_revision(const transaction_dedup&)      { return 0; }
+int64_t  cur_revision(const chainbase_dedup& d)      { return d.revision(); }
+void     commit_lib(transaction_dedup& d, uint32_t lib_block, int64_t /*rev*/) { d.commit_to_lib(lib_block); }
+void     commit_lib(chainbase_dedup& d, uint32_t /*lib_block*/, int64_t rev)   { d.commit_to_lib(rev); }
+
+// --- Workload ------------------------------------------------------------
+
+struct params {
+   size_t per_block = 2000;        // transactions per block (== TPS at 1s cadence)
+   size_t blocks    = 200;         // simulated blocks
+   size_t lifetime_blocks = 3600;  // entries live this many blocks before expiring
+};
+
+struct workload {
+   std::vector<transaction_id_type> ids;
+   std::vector<fc::time_point_sec>  exps;
+};
+
+// Entry i is born in block i/per_block and expires lifetime_blocks later, so advancing the clock
+// one block expires ~per_block of the oldest entries (steady state: inflow == outflow).
+workload gen_workload(size_t count, size_t per_block, size_t lifetime_blocks) {
+   workload w;
+   w.ids.reserve(count);
+   w.exps.reserve(count);
+   for (size_t i = 0; i < count; ++i) {
+      w.ids.push_back(make_id(i));
+      uint32_t born_block = static_cast<uint32_t>(i / per_block);
+      w.exps.emplace_back(fc::time_point_sec(static_cast<uint32_t>(born_block + lifetime_blocks)));
+   }
+   return w;
+}
+
+template<typename D>
+void prefill(D& d, const workload& w, size_t live) {
+   for (size_t i = 0; i < live; ++i) d.record(w.ids[i], w.exps[i]);
+}
+
+struct phase_times {
+   double is_known_hit_ns = 0, is_known_miss_ns = 0;
+   double producer_ns = 0, relay_ns = 0;
+   size_t lookups = 0, producer_trx = 0, relay_trx = 0;
+   size_t mem_per_entry = 0;
+};
+
+// Pure is_known cost at steady state: half hits (present ids), half misses (never-recorded ids).
+template<typename D>
+void bench_is_known(D& d, const workload& w, size_t live, phase_times& pt) {
+   constexpr size_t probes = 1'000'000;
+   volatile uint64_t sink = 0;
+   auto t0 = clk::now();
+   for (size_t i = 0; i < probes; ++i) sink = sink + d.is_known(w.ids[(i * 2654435761ull) % live]); // hits
+   pt.is_known_hit_ns += ns_since(t0);
+   t0 = clk::now();
+   for (size_t i = 0; i < probes; ++i) sink = sink + d.is_known(make_id(w.ids.size() + i));          // misses
+   pt.is_known_miss_ns += ns_since(t0);
+   pt.lookups += probes;
+   (void)sink;
+}
+
+// One realistic block: clear_expired, then per trx { is_known (dup check); push/record/squash },
+// commit, and advance LIB ~5 blocks back. If `relay`, first speculate an entire block of records
+// and abort it (the validator/relay worst case: an extra block of work plus a full undo).
+template<typename D>
+void bench_block_cycle(D& d, const workload& w, size_t start_idx, const params& p, bool relay,
+                       phase_times& pt) {
+   size_t idx = start_idx;
+   uint32_t now_block = static_cast<uint32_t>(start_idx / p.per_block);
+   volatile uint64_t sink = 0;
+   std::vector<std::pair<uint32_t, int64_t>> committed; // (block_num, revision) for LIB advance
+
+   auto t0 = clk::now();
+   for (size_t b = 0; b < p.blocks && idx + 2 * p.per_block < w.ids.size(); ++b) {
+      ++now_block;
+      if (relay) {
+         // Speculative block: clear + record a block's worth, then discard it.
+         d.start_block_revision(now_block);
+         do_clear_expired(d, fc::time_point(fc::seconds(now_block)));
+         for (size_t k = 0; k < p.per_block; ++k) {
+            d.push_session();
+            d.record(w.ids[idx + k], w.exps[idx + k]);
+            d.squash_session();
+         }
+         d.abort_block_revision();
+      }
+      // Real block.
+      d.start_block_revision(now_block);
+      do_clear_expired(d, fc::time_point(fc::seconds(now_block)));
+      for (size_t k = 0; k < p.per_block; ++k, ++idx) {
+         sink = sink + d.is_known(w.ids[idx]);
+         d.push_session();
+         d.record(w.ids[idx], w.exps[idx]);
+         d.squash_session();
+      }
+      d.commit_block_revision();
+      committed.emplace_back(now_block, cur_revision(d));
+      if (committed.size() > 5) {
+         auto [lib_block, lib_rev] = committed[committed.size() - 6];
+         commit_lib(d, lib_block, lib_rev);
+      }
+   }
+   double elapsed = ns_since(t0);
+   if (relay) { pt.relay_ns += elapsed; pt.relay_trx += (idx - start_idx); }
+   else       { pt.producer_ns += elapsed; pt.producer_trx += (idx - start_idx); }
+   (void)sink;
+}
+
+template<typename D>
+void measure(D& d, const workload& w, size_t live, const params& p, phase_times& pt) {
+   bench_is_known(d, w, live, pt);
+   bench_block_cycle(d, w, live, p, /*relay*/false, pt);
+   // Re-fill the consumed indices for an independent relay run starting where producer left off.
+   bench_block_cycle(d, w, live + p.blocks * p.per_block, p, /*relay*/true, pt);
+}
+
+void run_custom(const params& p, const workload& w, size_t live, phase_times& pt) {
+   size_t rss0 = rss_bytes();
+   transaction_dedup d;
+   prefill(d, w, live);
+   pt.mem_per_entry = live ? (rss_bytes() - rss0) / live : 0;
+   measure(d, w, live, p, pt);
+}
+
+void run_chainbase(const params& p, const workload& w, size_t live, uint64_t segment,
+                   chainbase::pinnable_mapped_file::map_mode mode, phase_times& pt) {
+   chainbase_dedup d(segment, mode);
+   size_t free0 = d.free_mem();
+   prefill(d, w, live);
+   pt.mem_per_entry = live ? (free0 - d.free_mem()) / live : 0;
+   measure(d, w, live, p, pt);
+}
+
+void print_row(const char* tag, const phase_times& pt) {
+   double hit  = pt.is_known_hit_ns  / pt.lookups;
+   double miss = pt.is_known_miss_ns / pt.lookups;
+   double prod = pt.producer_trx ? pt.producer_ns / pt.producer_trx : 0;
+   double rly  = pt.relay_trx    ? pt.relay_ns    / pt.relay_trx    : 0;
+   printf("  %-21s  is_known: hit %6.1f  miss %6.1f |  per-trx: producer %7.1f  relay %7.1f  (ns) | mem %4zu B/entry\n",
+          tag, hit, miss, prod, rly, pt.mem_per_entry);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+   params p;
+   bool big = false;
+   for (int i = 1; i < argc; ++i) {
+      std::string a = argv[i];
+      if (a == "--big") big = true;
+      else if (a == "--tps"    && i + 1 < argc) p.per_block = std::stoul(argv[++i]);
+      else if (a == "--blocks" && i + 1 < argc) p.blocks    = std::stoul(argv[++i]);
+   }
+
+   std::vector<size_t> live_sets = big ? std::vector<size_t>{100'000, 1'000'000, 6'000'000}
+                                       : std::vector<size_t>{100'000, 1'000'000};
+
+   using mm = chainbase::pinnable_mapped_file::map_mode;
+   struct cb_mode { const char* name; mm mode; };
+   // heap = anonymous + huge pages (best case); mapped = MAP_SHARED file-backed (production
+   // default, real writeback); mapped_private = MAP_PRIVATE COW (file written only at exit).
+   std::vector<cb_mode> modes = { {"chainbase/heap", mm::heap},
+                                  {"chainbase/mapped", mm::mapped},
+                                  {"chainbase/mapped_priv", mm::mapped_private} };
+
+   printf("transaction dedup head-to-head: custom (flat_map + sorted set) vs chainbase (3 ordered B-trees)\n");
+   printf("per_block=%zu  blocks=%zu  lifetime=%zu blocks   (producer = no fork; relay = speculate+abort+apply)\n\n",
+          p.per_block, p.blocks, p.lifetime_blocks);
+
+   for (size_t live : live_sets) {
+      // Enough ids for prefill + a producer run + a relay run (relay records 2x per block).
+      size_t total = live + 2 * (p.blocks + 2) * p.per_block + p.blocks * p.per_block;
+      workload w = gen_workload(total, p.per_block, p.lifetime_blocks);
+      // chainbase segment must be a multiple of 1 MiB; size for ~512 B/entry plus 1 GiB headroom.
+      uint64_t segment = static_cast<uint64_t>(total) * 512 + (1ull << 30);
+      constexpr uint64_t MiB = 1ull << 20;
+      segment = (segment + MiB - 1) & ~(MiB - 1);
+
+      printf("live set = %zu entries:\n", live);
+      phase_times cpt;
+      run_custom(p, w, live, cpt);
+      print_row("custom", cpt);
+      for (const auto& m : modes) {
+         phase_times hpt;
+         run_chainbase(p, w, live, segment, m.mode, hpt);
+         print_row(m.name, hpt);
+      }
+      printf("\n");
+   }
+   return 0;
+}

--- a/benchmark/dedup/dedup_bench.cpp
+++ b/benchmark/dedup/dedup_bench.cpp
@@ -111,8 +111,6 @@ namespace {
 struct chainbase_dedup {
    fc::temp_directory tmp;
    chainbase::database db;
-   std::vector<chainbase::database::session> trx_sessions;
-   std::optional<chainbase::database::session> block_session;
 
    explicit chainbase_dedup(uint64_t segment_bytes, chainbase::pinnable_mapped_file::map_mode mode)
    : db(tmp.path(), chainbase::database::read_write, segment_bytes, false, mode) {
@@ -135,28 +133,25 @@ struct chainbase_dedup {
       }
       return n;
    }
-   void push_session()   { trx_sessions.emplace_back(db.start_undo_session(true)); }
-   void squash_session() { trx_sessions.back().squash(); trx_sessions.pop_back(); }
-   void undo_session()   { trx_sessions.back().undo();   trx_sessions.pop_back(); }
-   void start_block_revision(uint32_t) { block_session.emplace(db.start_undo_session(true)); }
-   void commit_block_revision()        { block_session->push(); block_session.reset(); }
-   void abort_block_revision()         { block_session->undo(); block_session.reset(); }
-   void pop_block_revision()           { db.undo(); }
-   void commit_to_lib(int64_t rev)     { db.commit(rev); }   // chainbase commits by revision
+   // Unified undo lifecycle, mirroring transaction_dedup's: a block revision and a transaction
+   // session are the same add_undo_session, driven straight through the chainbase undo stack.
+   // start_undo_session(true).push() opens a revision and keeps it on the stack (exactly as the
+   // controller keeps a block's db session until LIB advances); commit(revision) drops it later.
+   void add_undo_session() { db.start_undo_session(true).push(); }
+   void squash()           { db.squash(); }
+   void undo()             { db.undo(); }
+   void commit(int64_t rev){ db.commit(rev); }
 
    int64_t revision() const { return db.revision(); }
    size_t  free_mem() const { return db.get_free_memory(); }
 };
 
-// --- Adapters bridging the small API differences between the two implementations ----------
-// (custom clear_expired returns {removed,total}; custom commit_to_lib takes a block_num while
-//  chainbase commits a revision; custom has no revision()).
+// --- Adapter bridging the one remaining API difference --------------------------------------
+// Both sides now present the same chainbase-aligned surface (add_undo_session / squash / undo /
+// commit(revision) / revision()); only clear_expired's return type still differs (the custom one
+// returns {removed,total}, chainbase a bare count), and the benchmark loop ignores it either way.
 uint32_t do_clear_expired(transaction_dedup& d, fc::time_point now) { return d.clear_expired(now).first; }
 uint32_t do_clear_expired(chainbase_dedup& d, fc::time_point now)   { return d.clear_expired(now); }
-int64_t  cur_revision(const transaction_dedup&)      { return 0; }
-int64_t  cur_revision(const chainbase_dedup& d)      { return d.revision(); }
-void     commit_lib(transaction_dedup& d, uint32_t lib_block, int64_t /*rev*/) { d.commit_to_lib(lib_block); }
-void     commit_lib(chainbase_dedup& d, uint32_t /*lib_block*/, int64_t rev)   { d.commit_to_lib(rev); }
 
 // --- Workload ------------------------------------------------------------
 
@@ -221,37 +216,36 @@ void bench_block_cycle(D& d, const workload& w, size_t start_idx, const params& 
    size_t idx = start_idx;
    uint32_t now_block = static_cast<uint32_t>(start_idx / p.per_block);
    volatile uint64_t sink = 0;
-   std::vector<std::pair<uint32_t, int64_t>> committed; // (block_num, revision) for LIB advance
+   std::vector<int64_t> committed; // block revisions, for LIB advance
 
    auto t0 = clk::now();
    for (size_t b = 0; b < p.blocks && idx + 2 * p.per_block < w.ids.size(); ++b) {
       ++now_block;
       if (relay) {
-         // Speculative block: clear + record a block's worth, then discard it.
-         d.start_block_revision(now_block);
+         // Speculative block: open a block session, clear + record a block's worth, then discard
+         // the whole block with one undo (the validator/relay worst case: an extra block + a full undo).
+         d.add_undo_session();
          do_clear_expired(d, fc::time_point(fc::seconds(now_block)));
          for (size_t k = 0; k < p.per_block; ++k) {
-            d.push_session();
+            d.add_undo_session();
             d.record(w.ids[idx + k], w.exps[idx + k]);
-            d.squash_session();
+            d.squash();
          }
-         d.abort_block_revision();
+         d.undo();
       }
-      // Real block.
-      d.start_block_revision(now_block);
+      // Real block: open a block session; each trx is a nested session squashed into the block.
+      // The block session is kept on the stack (no explicit commit) until LIB advances past it.
+      d.add_undo_session();
       do_clear_expired(d, fc::time_point(fc::seconds(now_block)));
       for (size_t k = 0; k < p.per_block; ++k, ++idx) {
          sink = sink + d.is_known(w.ids[idx]);
-         d.push_session();
+         d.add_undo_session();
          d.record(w.ids[idx], w.exps[idx]);
-         d.squash_session();
+         d.squash();
       }
-      d.commit_block_revision();
-      committed.emplace_back(now_block, cur_revision(d));
-      if (committed.size() > 5) {
-         auto [lib_block, lib_rev] = committed[committed.size() - 6];
-         commit_lib(d, lib_block, lib_rev);
-      }
+      committed.push_back(d.revision());
+      if (committed.size() > 5)
+         d.commit(committed[committed.size() - 6]);
    }
    double elapsed = ns_since(t0);
    if (relay) { pt.relay_ns += elapsed; pt.relay_trx += (idx - start_idx); }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -13,6 +13,7 @@
 #include <sysio/chain/protocol_state_object.hpp>
 #include <sysio/chain/kv_table_objects.hpp>
 #include <sysio/chain/transaction_dedup.hpp>
+#include <sysio/chain/transaction_dedup_undo_index.hpp>
 #include <sysio/chain/genesis_intrinsics.hpp>
 #include <sysio/chain/whitelisted_intrinsics.hpp>
 #include <sysio/chain/database_header_object.hpp>
@@ -916,8 +917,7 @@ struct controller_impl {
 
    void pop_block() {
       uint32_t prev_block_num = pop_prev_block();
-      db.undo();
-      trx_dedup.pop_block_revision();
+      db.undo();   // drives the registered dedup participant to revert this block's reversible changes
       protocol_features.popped_blocks_to(prev_block_num);
    }
 
@@ -1122,8 +1122,7 @@ struct controller_impl {
             // Do it before commit so that in case it throws, DB can be rolled back.
             blog.append( (*bitr)->block, (*bitr)->id(), (*bitr)->block->packed_signed_block() );
 
-            db.commit( (*bitr)->block_num() );
-            trx_dedup.commit_to_lib( (*bitr)->block_num() );
+            db.commit( (*bitr)->block_num() );   // drives the dedup participant's commit (revision == block num)
             root_id = (*bitr)->id();
 
             if (irreversible_mode()) {
@@ -1471,6 +1470,18 @@ struct controller_impl {
       while( db.revision() > chain_head.block_num() ) {
          db.undo();
       }
+
+      // Register the transaction dedup as a chainbase undo participant, so the database drives its
+      // undo lifecycle (add_undo_session / squash / undo / commit) in lockstep with the segment
+      // indices -- the controller no longer hand-pairs dedup undo calls with the database's. The db
+      // is now at head revision; align the dedup before registering. genesis/snapshot loaded the
+      // membership only (revision 0), so set the revision to the database's; existing_state restored
+      // the dedup's revision and undo stack from its file and must already match (a clean shutdown
+      // writes both; an unclean one leaves chainbase dirty and refuses to open, so they cannot
+      // disagree). add_undo_participant validates the revision range, failing loud on any mismatch.
+      if (startup != startup_t::existing_state)
+         trx_dedup.set_revision(static_cast<uint64_t>(db.revision()));
+      db.add_undo_participant(std::make_unique<dedup_undo_index>(trx_dedup));
 
       SYS_ASSERT(conf.terminate_at_block == 0 || conf.terminate_at_block > chain_head.block_num(),
                  plugin_config_exception, "--terminate-at-block {} not greater than chain head {}",
@@ -2085,8 +2096,7 @@ struct controller_impl {
       }
 
       auto guard_pending = fc::make_scoped_exit([this, head_block_num=chain_head.block_num()]() {
-         trx_dedup.abort_block_revision(); // no-op if no pending revision
-         pending.reset();
+         pending.reset();   // destroying the unpushed block session drives the dedup participant's undo
          protocol_features.popped_blocks_to( head_block_num );
       });
 
@@ -2094,9 +2104,10 @@ struct controller_impl {
                   "db revision {} is not on par with head block {}, fork db head {}",
                   db.revision(), chain_head.block_num(), fork_db_head().block_num() );
 
+      // Opening the block's db undo session drives the dedup participant's add_undo_session; for
+      // skip_db_sessions blocks (irreversible/ephemeral) there is no session and the dedup records
+      // permanently, matching the database.
       maybe_session        session = skip_db_sessions(s) ? maybe_session() : maybe_session(db);
-      if (!skip_db_sessions(s))
-         trx_dedup.start_block_revision(chain_head.block_num() + 1);
       building_block_input bbi{chain_head.id(), chain_head.timestamp(), when, chain_head.internal()->get_producer_for_block_at(when).producer_name,
                                new_protocol_feature_activations};
       pending.emplace(std::move(session), *chain_head.internal(), bbi);
@@ -2371,9 +2382,9 @@ struct controller_impl {
          throw;
       }
 
-      // push the state for pending.
+      // push the state for pending. The block's db undo session is kept (not undone), so the dedup
+      // participant's matching undo session likewise remains on its stack until LIB advances.
       pending->push();
-      trx_dedup.commit_block_revision();
    }
 
    void log_applied(controller::block_status s) const {
@@ -3030,8 +3041,7 @@ struct controller_impl {
             emit( irreversible_block, std::tie(bsp->block, bsp->id()), __FILE__, __LINE__ );
 
             if (!skip_db_sessions(controller::block_status::irreversible)) {
-               db.commit(bsp->block_num());
-               trx_dedup.commit_to_lib(bsp->block_num());
+               db.commit(bsp->block_num());   // drives the dedup participant's commit (revision == block num)
             }
          }
 
@@ -3201,8 +3211,7 @@ struct controller_impl {
       deque<transaction_metadata_ptr> applied_trxs;
       if( pending ) {
          applied_trxs = pending->extract_trx_metas();
-         trx_dedup.abort_block_revision();
-         pending.reset();
+         pending.reset();   // destroying the unpushed block session drives the dedup participant's undo
          protocol_features.popped_blocks_to( chain_head.block_num() );
       }
       return applied_trxs;
@@ -4471,17 +4480,6 @@ void controller::record_transaction( const transaction_id_type& id, fc::time_poi
    my->trx_dedup.record(id, expire);
 }
 
-void controller::push_dedup_session() {
-   my->trx_dedup.push_session();
-}
-
-void controller::squash_dedup_session() {
-   my->trx_dedup.squash_session();
-}
-
-void controller::undo_dedup_session() {
-   my->trx_dedup.undo_session();
-}
 
 void controller::set_subjective_cpu_leeway(fc::microseconds leeway) {
    my->subjective_cpu_leeway = leeway;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -730,8 +730,18 @@ struct controller_impl {
    controller::config              conf;
    // persist chain_head after vote_processor shutdown, avoids concurrent access, after chain_head & conf since this uses them
    fc::scoped_exit<std::function<void()>> write_chain_head = [&]() { chain_head.write(conf.state_dir / config::chain_head_filename); };
+   // Set true by init() once trx_dedup has been registered as an undo participant and is consistent
+   // with the database. Until then trx_dedup is empty at revision 0; writing it over a good file
+   // would brick the next existing_state restart (the empty range no longer matches the database).
+   bool                            okay_to_persist_dedup = false;
    transaction_dedup               trx_dedup;
-   fc::scoped_exit<std::function<void()>> write_trx_dedup = [&]() { trx_dedup.write_to_file(conf.state_dir / config::transaction_dedup_filename); };
+   // Persist the dedup undo stack only after a successful start (see okay_to_persist_dedup). A
+   // startup that aborts before init() registers the dedup -- e.g. a corrupt SHiP log failing
+   // state_history_plugin::plugin_initialize before chain_plugin::plugin_startup runs -- must NOT
+   // overwrite the previous good file with the still-empty revision-0 dedup.
+   fc::scoped_exit<std::function<void()>> write_trx_dedup = [&]() {
+      if( okay_to_persist_dedup ) trx_dedup.write_to_file(conf.state_dir / config::transaction_dedup_filename);
+   };
    const chain_id_type             chain_id; // read by thread_pool threads, value will not be changed
    std::atomic<bool>               replaying = false;
    bool                            is_producer_node = false; // true if node is configured as a block producer
@@ -1474,14 +1484,43 @@ struct controller_impl {
       // Register the transaction dedup as a chainbase undo participant, so the database drives its
       // undo lifecycle (add_undo_session / squash / undo / commit) in lockstep with the segment
       // indices -- the controller no longer hand-pairs dedup undo calls with the database's. The db
-      // is now at head revision; align the dedup before registering. genesis/snapshot loaded the
-      // membership only (revision 0), so set the revision to the database's; existing_state restored
-      // the dedup's revision and undo stack from its file and must already match (a clean shutdown
-      // writes both; an unclean one leaves chainbase dirty and refuses to open, so they cannot
-      // disagree). add_undo_participant validates the revision range, failing loud on any mismatch.
-      if (startup != startup_t::existing_state)
+      // is now at head revision and is the authoritative source of the reversible revision range;
+      // align the dedup to it before registering:
+      //  - genesis/snapshot loaded membership only (revision 0); a snapshot is an irreversible root,
+      //    so the db has no reversible undo sessions and a plain set_revision matches it.
+      //  - existing_state restored the dedup's revision and undo stack from its on-disk file. That
+      //    file is a best-effort cache, NOT an authoritative store like chainbase's mmap'd segment:
+      //    it can legitimately be missing (first start after upgrading to dedup persistence), stale,
+      //    or empty at revision 0 (a startup that aborts before the chain loads -- e.g. a corrupt
+      //    SHiP log failing another plugin's initialize -- still runs the write-on-exit; the guard on
+      //    write_trx_dedup prevents most such clobbers, but an older build or external tooling could
+      //    still leave one). If the loaded range does not match the db exactly, discard it and
+      //    rebuild an empty undo stack aligned to the db: the node starts with degraded dedup memory
+      //    (self-healing as reversible blocks become irreversible) instead of refusing to start. A
+      //    clean restart matches and keeps the full set -- the fast path.
+      // add_undo_participant re-validates the range, so a logic error here still fails loud rather
+      // than registering a divergent participant.
+      if (startup == startup_t::existing_state) {
+         const auto db_range = db.undo_stack_revision_range();
+         if (trx_dedup.undo_stack_revision_range() != db_range) {
+            const auto dedup_range = trx_dedup.undo_stack_revision_range();
+            wlog( "transaction dedup file revision range [{},{}] does not match database [{},{}]; "
+                  "rebuilding empty dedup aligned to the database (dedup replay protection over the "
+                  "reversible window is rebuilt as those blocks become irreversible)",
+                  dedup_range.first, dedup_range.second, db_range.first, db_range.second );
+            trx_dedup.reset();
+            trx_dedup.set_revision( db_range.first );
+            for( uint64_t r = db_range.first; r < db_range.second; ++r )
+               trx_dedup.add_undo_session();
+         }
+      } else {
          trx_dedup.set_revision(static_cast<uint64_t>(db.revision()));
+      }
       db.add_undo_participant(std::make_unique<dedup_undo_index>(trx_dedup));
+      // The dedup is now registered and consistent with the database; from here a clean shutdown (or
+      // an abort after this point) may safely persist it. Before this point trx_dedup is empty at
+      // revision 0 and must never be written over a good file.
+      okay_to_persist_dedup = true;
 
       SYS_ASSERT(conf.terminate_at_block == 0 || conf.terminate_at_block > chain_head.block_num(),
                  plugin_config_exception, "--terminate-at-block {} not greater than chain head {}",

--- a/libraries/chain/include/sysio/chain/controller.hpp
+++ b/libraries/chain/include/sysio/chain/controller.hpp
@@ -417,9 +417,6 @@ namespace sysio::chain {
          bool is_known_unexpired_transaction( const transaction_id_type& id) const;
 
          void record_transaction( const transaction_id_type& id, fc::time_point_sec expire );
-         void push_dedup_session();
-         void squash_dedup_session();
-         void undo_dedup_session();
 
          // called by host function
          int64_t set_proposed_producers( transaction_context& trx_context, vector<producer_authority> producers );

--- a/libraries/chain/include/sysio/chain/transaction_context.hpp
+++ b/libraries/chain/include/sysio/chain/transaction_context.hpp
@@ -190,16 +190,16 @@ namespace sysio::chain {
          /// was called, both sessions are automatically undone.
          struct trx_session {
             chainbase::database::session db_session;
-            controller&                  ctrl;
-            bool                         active = true;
 
-            trx_session(chainbase::database& db, controller& c)
-               : db_session(db.start_undo_session(true)), ctrl(c) { ctrl.push_dedup_session(); }
+            explicit trx_session(chainbase::database& db)
+               : db_session(db.start_undo_session(true)) {}
             trx_session(trx_session&&) = delete;
 
-            void squash() { db_session.squash(); ctrl.squash_dedup_session(); active = false; }
-            void undo()   { db_session.undo();   ctrl.undo_dedup_session();   active = false; }
-            ~trx_session() { if (active) ctrl.undo_dedup_session(); }
+            // The dedup is a registered chainbase undo participant, so the database session drives
+            // its add_undo_session / squash / undo automatically -- including the implicit undo from
+            // db_session's destructor when neither squash() nor undo() is called.
+            void squash() { db_session.squash(); }
+            void undo()   { db_session.undo();   }
          };
 
          controller&                    control;

--- a/libraries/chain/include/sysio/chain/transaction_dedup.hpp
+++ b/libraries/chain/include/sysio/chain/transaction_dedup.hpp
@@ -24,8 +24,10 @@ namespace sysio::chain {
 /// makes levels at or below a revision irreversible. Block revisions and transaction sessions are
 /// the SAME mechanism at different nesting depths -- this is what lets the database drive the
 /// dedup as a registered undo participant (see add_undo_participant / dedup_undo_index), so the
-/// controller no longer has to hand-pair every chainbase undo op with a dedup one. The legacy
-/// start_block_revision / push_session / ... names are retained as thin wrappers.
+/// controller no longer has to hand-pair every chainbase undo op with a dedup one. There are no
+/// block-specific entry points (start_block_revision / commit_block_revision / commit_to_lib / ...):
+/// a block revision and a transaction session are the same add_undo_session, the database drives
+/// them, and a block's revision is simply its block number.
 ///
 /// Determinism contract: the entry set and its serialized order are a pure function of the logical
 /// chain state, independent of the path a node took to reach it (live sync, replay, fork switches,

--- a/libraries/chain/include/sysio/chain/transaction_dedup.hpp
+++ b/libraries/chain/include/sysio/chain/transaction_dedup.hpp
@@ -5,6 +5,7 @@
 
 #include <boost/unordered/unordered_flat_map.hpp>
 
+#include <cstdint>
 #include <deque>
 #include <filesystem>
 #include <set>
@@ -14,17 +15,24 @@
 namespace sysio::chain {
 
 /// High-performance transaction deduplication index.
-/// Replaces the chainbase transaction_multi_index with O(1) membership tests.
+/// Replaces the chainbase transaction_multi_index with O(1) membership tests, while keeping a
+/// chainbase-style nested undo stack so that fork switches and aborts restore state exactly.
 ///
-/// Supports revision-based undo (like chainbase) so that pop_block during a fork
-/// switch correctly restores the dedup state.
+/// Undo model: a single stack of undo sessions (levels_), keyed by a monotonic revision exactly
+/// like a chainbase index. add_undo_session opens a level; record/clear_expired mutate the top
+/// level's tracking; squash merges the top level into its parent; undo reverts it; commit(rev)
+/// makes levels at or below a revision irreversible. Block revisions and transaction sessions are
+/// the SAME mechanism at different nesting depths -- this is what lets the database drive the
+/// dedup as a registered undo participant (see add_undo_participant / dedup_undo_index), so the
+/// controller no longer has to hand-pair every chainbase undo op with a dedup one. The legacy
+/// start_block_revision / push_session / ... names are retained as thin wrappers.
 ///
-/// Determinism contract: the entry set and its serialized order are a pure function of the
-/// logical chain state, independent of the path a node took to reach it (live sync, replay,
-/// fork switches, snapshot load). The sorted index makes serialization order canonical, and
-/// clear_expired removes ALL expired entries (a complete prefix of the sorted order), so two
-/// honest nodes at the same block always serialize byte-identical sections. This matters
-/// because the serialized form feeds calculate_integrity_hash and snapshots.
+/// Determinism contract: the entry set and its serialized order are a pure function of the logical
+/// chain state, independent of the path a node took to reach it (live sync, replay, fork switches,
+/// snapshot load). The sorted index makes serialization order canonical, and clear_expired removes
+/// ALL expired entries (a complete prefix of the sorted order), so two honest nodes at the same
+/// block always serialize byte-identical sections. This matters because the serialized form feeds
+/// calculate_integrity_hash and snapshots.
 class transaction_dedup {
 public:
    using dedup_entry = std::pair<transaction_id_type, fc::time_point_sec>;
@@ -33,7 +41,7 @@ public:
 
    transaction_dedup();
 
-   /// Clear all entries and revision state.
+   /// Clear all entries and undo state.
    void reset();
 
    /// Insert a transaction; throws tx_duplicate if already present.
@@ -43,28 +51,29 @@ public:
    bool is_known(const transaction_id_type& id) const;
 
    /// Remove ALL entries with expiration earlier than block_time, saving removed entries in the
-   /// current block revision so they can be restored on undo. Returns {num_removed, total_before_removal}.
+   /// current undo level so they can be restored on undo. Returns {num_removed, total_before_removal}.
    std::pair<uint32_t, size_t> clear_expired(fc::time_point block_time);
 
-   /// Transaction-level undo session management (within current block).
-   void push_session();
-   void squash_session();
-   void undo_session();
+   // --- chainbase-aligned undo lifecycle (drives, or is driven by, a chainbase database) -------
 
-   /// Block-level revision management (mirrors chainbase session lifecycle).
-   /// start: called at start_block, creates a new pending revision.
-   /// commit: called at commit_block, finalizes the pending revision onto the committed stack.
-   /// abort: called at abort_block, undoes the pending revision (restores cleared + added entries).
-   void start_block_revision(uint32_t block_num);
-   void commit_block_revision();
-   void abort_block_revision();
-
-   /// Undo one committed block revision. Called from pop_block during fork switches.
-   void pop_block_revision();
-
-   /// Discard committed revisions at or below the given block number.
-   /// Called when LIB advances (mirrors chainbase db.commit(block_num)).
-   void commit_to_lib(uint32_t block_num);
+   /// Open a new (nested) undo session on top of the stack. Subsequent record/clear_expired are
+   /// tracked here and reverted as a unit by undo().
+   void add_undo_session();
+   /// Merge the top undo session into its parent (or into permanent state if it is the only one).
+   void squash();
+   /// Revert the top undo session: remove what it recorded and restore what it expired.
+   void undo();
+   /// Revert every open undo session (mirrors chainbase database::undo_all).
+   void undo_all();
+   /// Discard undo sessions at or below the given revision (they become irreversible).
+   void commit(int64_t revision);
+   /// Set the current revision; only valid with no open undo sessions (used to align with the db).
+   void set_revision(uint64_t revision);
+   /// Current revision (highest open session, or the committed base if none are open).
+   int64_t revision() const { return revision_; }
+   /// {oldest undoable revision, current revision} -- matches chainbase so a registered participant
+   /// can be validated for consistency against the segment indices.
+   std::pair<uint64_t, uint64_t> undo_stack_revision_range() const;
 
    /// Persistence -- uses snapshot format for integrity (BLAKE3) and code reuse.
    void write_to_file(const std::filesystem::path& filepath) const;
@@ -73,6 +82,12 @@ public:
    /// Snapshot support. Rows are written in (expiration, id) order -- canonical for any node at
    /// the same logical state -- and re-sorted on read, so snapshots produced by older versions
    /// (insertion order) load correctly.
+   ///
+   /// Membership ONLY. The undo stack is deliberately excluded: a chain snapshot is loaded as an
+   /// irreversible root with no reversible blocks beneath it, so the loading node's undo stack is
+   /// correctly empty (read_from_snapshot calls reset()). The on-restart undo stack is persisted
+   /// separately by write_to_file/read_from_file, which mirror chainbase's persisted reversible
+   /// undo stack -- see write_revisions_to_file.
    void add_to_snapshot(const snapshot_writer_ptr& snapshot) const;
    void read_from_snapshot(const snapshot_reader_ptr& snapshot);
 
@@ -87,34 +102,31 @@ private:
    /// prefix; id second to break ties canonically.
    using sorted_entry = std::pair<fc::time_point_sec, transaction_id_type>;
 
-   /// Per-block revision for undo support. Tracks what changed so it can be reversed.
-   struct block_revision {
-      uint32_t                 block_num = 0;
-      std::vector<dedup_entry> added;             // entries recorded during this block (removed on undo)
+   /// One undo session, keyed by chainbase revision. Tracks what it changed so it can be reversed
+   /// (undo) or merged into its parent (squash); commit(revision) drops it once irreversible.
+   struct undo_level {
+      int64_t                  revision = 0;
+      std::vector<dedup_entry> added;             // entries recorded during this session (removed on undo)
       std::vector<dedup_entry> expired;           // entries removed by clear_expired (restored on undo)
    };
 
-   /// Re-insert entries removed by clear_expired during the given revision. The sorted index
-   /// makes reinsertion order irrelevant, so undo reproduces the exact pre-block state (and
-   /// serialization order) on every node.
-   void restore_expired(const block_revision& rev);
-
-   /// Remove entries recorded during the current (pending) block from map_ and index_.
-   void erase_current_added_from(size_t first);
+   /// Serialize/deserialize the undo stack (levels_) and current revision to the dedup FILE only.
+   /// Chainbase persists its reversible undo stack across a clean restart; this mirrors that for
+   /// the dedup so that a fork switch after restart -- which pops pre-restart reversible blocks --
+   /// reverts the dedup entries those blocks added (and restores the ones they expired) instead of
+   /// leaving them stranded (which would make the restarted node reject the canonical fork with
+   /// tx_duplicate). Intentionally NOT part of add_to_snapshot/read_from_snapshot (see those for
+   /// why a chain snapshot's undo stack is empty).
+   void write_revisions_to_file(const snapshot_writer_ptr& snapshot) const;
+   void read_revisions_from_file(const snapshot_reader_ptr& snapshot);
 
    boost::unordered_flat_map<transaction_id_type, fc::time_point_sec> map_;
    std::set<sorted_entry> index_;   // same contents as map_, in canonical (expiration, id) order
 
-   std::deque<block_revision>    committed_revisions_;  // committed blocks (trimmed at LIB)
-   std::optional<block_revision> pending_revision_;     // current in-progress block
-
-   /// Entries recorded since block start while an undo context (block revision or session) was
-   /// active, in record order. Pure undo bookkeeping for the current block (session watermarks
-   /// index into it); never serialized, so its insertion ordering cannot leak into snapshots or
-   /// the integrity hash. Records made with no undo context (irreversible replay) bypass it --
-   /// they are not undoable, and appending them would grow this vector for an entire replay.
-   std::vector<dedup_entry> current_added_;
-   std::vector<size_t>      session_stack_;  // watermarks into current_added_ for trx-level undo
+   /// Nested undo sessions, oldest (lowest revision) at the front. Trimmed at the front by commit/
+   /// commit_to_lib (irreversible), pushed/popped at the back by add_undo_session/undo/squash.
+   std::deque<undo_level> levels_;
+   int64_t                revision_ = 0;
 };
 
 /// Snapshot row type for transaction dedup entries.
@@ -123,6 +135,23 @@ struct snapshot_transaction_dedup_entry {
    fc::time_point_sec  expiration;
 };
 
+/// File-persistence row type for one undo session (NOT used by chain snapshots). Carries the
+/// session's revision plus the entries it added and the entries its clear_expired removed, so the
+/// undo stack can be reconstructed exactly on restart.
+struct snapshot_transaction_dedup_revision {
+   int64_t                                       revision = 0;
+   std::vector<snapshot_transaction_dedup_entry> added;
+   std::vector<snapshot_transaction_dedup_entry> expired;
+};
+
+/// File-persistence header carrying the current revision, so it survives even when the undo stack
+/// is empty (everything irreversible) and the restored dedup can be validated against the database.
+struct snapshot_transaction_dedup_meta {
+   int64_t revision = 0;
+};
+
 } // namespace sysio::chain
 
 FC_REFLECT(sysio::chain::snapshot_transaction_dedup_entry, (trx_id)(expiration))
+FC_REFLECT(sysio::chain::snapshot_transaction_dedup_revision, (revision)(added)(expired))
+FC_REFLECT(sysio::chain::snapshot_transaction_dedup_meta, (revision))

--- a/libraries/chain/include/sysio/chain/transaction_dedup_undo_index.hpp
+++ b/libraries/chain/include/sysio/chain/transaction_dedup_undo_index.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <sysio/chain/transaction_dedup.hpp>
+
+#include <chainbase/chainbase.hpp>
+
+#include <string>
+#include <utility>
+
+namespace sysio::chain {
+
+/// Adapts transaction_dedup to chainbase::abstract_index so the database drives its undo lifecycle
+/// (add_undo_session / squash / undo / commit / set_revision) in lockstep with the segment indices.
+/// Register it with database::add_undo_participant once at startup; thereafter every db.start_undo_session
+/// / squash / undo / commit also drives the dedup, so the controller no longer hand-pairs its own
+/// dedup undo calls with the database's -- removing the desync surface that caused fork-switch and
+/// restart bugs.
+///
+/// The dedup keeps its rows on the heap, so the database only dispatches lifecycle EVENTS here; the
+/// data path (record / is_known / clear_expired) never goes through chainbase, preserving the
+/// dedup's O(1) performance and keeping its churn out of the shared segment.
+class dedup_undo_index final : public chainbase::abstract_index {
+public:
+   /// Reserved type id, above any real chainbase object type, so the participant slots into the
+   /// database's index map without colliding with a segment index.
+   static constexpr uint16_t reserved_type_id = 0xFFFE;
+
+   explicit dedup_undo_index(transaction_dedup& dedup)
+   : chainbase::abstract_index(&dedup), _dedup(dedup) {}
+
+   void     set_revision(uint64_t revision) override { _dedup.set_revision(revision); }
+   void     add_undo_session() override              { _dedup.add_undo_session(); }
+   int64_t  revision() const override                { return _dedup.revision(); }
+   void     undo() const override                    { _dedup.undo(); }
+   void     squash() const override                  { _dedup.squash(); }
+   void     commit(int64_t revision) const override  { _dedup.commit(revision); }
+   void     undo_all() const override                { _dedup.undo_all(); }
+   uint32_t type_id() const override                 { return reserved_type_id; }
+   uint64_t row_count() const override               { return _dedup.size(); }
+   size_t   freelist_memory_usage() const override   { return 0; }   // heap-backed, no segment freelist
+   const std::string& type_name() const override     { return _type_name; }
+   std::pair<uint64_t, uint64_t> undo_stack_revision_range() const override {
+      return _dedup.undo_stack_revision_range();
+   }
+   void     remove_object(int64_t) override          {}   // not used: the dedup has no segment objects
+
+private:
+   transaction_dedup& _dedup;
+   const std::string  _type_name = "transaction_dedup";
+};
+
+} // namespace sysio::chain

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -96,7 +96,7 @@ namespace sysio::chain {
 
    void transaction_context::initialize() {
       if (!control.skip_db_sessions() && !is_read_only()) {
-         undo_session.emplace(control.mutable_db(), control);
+         undo_session.emplace(control.mutable_db());
       }
 
       trace->id = packed_trx.id();

--- a/libraries/chain/transaction_dedup.cpp
+++ b/libraries/chain/transaction_dedup.cpp
@@ -4,6 +4,7 @@
 #include <fc/log/logger.hpp>
 
 #include <filesystem>
+#include <iterator>
 
 namespace sysio::chain {
 
@@ -15,24 +16,19 @@ void transaction_dedup::reset() {
    map_.clear();
    index_.clear();
    map_.reserve(default_map_capacity);
-   committed_revisions_.clear();
-   pending_revision_.reset();
-   current_added_.clear();
-   session_stack_.clear();
+   levels_.clear();
+   revision_ = 0;
 }
 
 void transaction_dedup::record(const transaction_id_type& id, fc::time_point_sec expiration) {
    auto [it, inserted] = map_.emplace(id, expiration);
    SYS_ASSERT(inserted, tx_duplicate, "duplicate transaction {}", id);
    index_.emplace(expiration, id);
-   // Keep undo bookkeeping only while an undo context exists -- an open block revision or an
-   // active session -- because only those paths can ever revert the entry. Recording without one
-   // must not append: nothing would consume or clear the entries until the next
-   // start_block_revision, and an irreversible replay (which records every input transaction
-   // with no revisions and no sessions) would otherwise accumulate bookkeeping for every
-   // replayed transaction for the entire duration of the replay.
-   if (pending_revision_ || !session_stack_.empty())
-      current_added_.emplace_back(id, expiration);
+   // Track the insertion in the open undo session so it can be reverted; with no session open
+   // (irreversible replay) nothing tracks it -- it is not undoable, and recording the bookkeeping
+   // would grow unbounded for the entire replay.
+   if (!levels_.empty())
+      levels_.back().added.emplace_back(id, expiration);
 }
 
 bool transaction_dedup::is_known(const transaction_id_type& id) const {
@@ -40,120 +36,87 @@ bool transaction_dedup::is_known(const transaction_id_type& id) const {
 }
 
 std::pair<uint32_t, size_t> transaction_dedup::clear_expired(fc::time_point block_time) {
-   // clear_expired must not be called after record() within the same block; record() appends to
-   // current_added_, which start_block_revision just cleared.
-   assert(!pending_revision_ || current_added_.empty());
    const auto total = index_.size();
-   // The index is sorted by (expiration, id), so expired entries form a complete prefix:
-   // everything expired is removed, not just a run that happens to sit at the front of
-   // insertion order. Leaving stragglers behind would make the retained set -- and the
-   // integrity hash derived from it -- depend on the order entries were recorded.
+   // The index is sorted by (expiration, id), so expired entries form a complete prefix: everything
+   // expired is removed, not just a run that happens to sit at the front of insertion order. Leaving
+   // stragglers behind would make the retained set -- and the integrity hash derived from it --
+   // depend on the order entries were recorded.
    uint32_t num_removed = 0;
    auto it = index_.begin();
    while (it != index_.end() && block_time > it->first.to_time_point()) {
       map_.erase(it->second);
-      if (pending_revision_)
-         pending_revision_->expired.emplace_back(it->second, it->first);
+      if (!levels_.empty())
+         levels_.back().expired.emplace_back(it->second, it->first);
       it = index_.erase(it);
       ++num_removed;
    }
    return {num_removed, total};
 }
 
-// --- Transaction-level undo session management ---
+// --- chainbase-aligned undo lifecycle ---
 
-void transaction_dedup::push_session() {
-   session_stack_.push_back(current_added_.size());
+void transaction_dedup::add_undo_session() {
+   ++revision_;
+   levels_.push_back(undo_level{revision_, {}, {}});
 }
 
-void transaction_dedup::squash_session() {
-   if (!session_stack_.empty())
-      session_stack_.pop_back();
-}
-
-void transaction_dedup::undo_session() {
-   if (session_stack_.empty())
+void transaction_dedup::squash() {
+   if (levels_.empty())
       return;
-   const size_t restore_size = session_stack_.back();
-   session_stack_.pop_back();
-   assert(restore_size <= current_added_.size());
-   erase_current_added_from(restore_size);
+   undo_level top = std::move(levels_.back());
+   levels_.pop_back();
+   --revision_;
+   if (levels_.empty())
+      return;   // merged into permanent state: map_/index_ already reflect the changes, nothing tracks them
+   // Otherwise the parent session now owns this session's changes.
+   auto& parent = levels_.back();
+   parent.added.insert(parent.added.end(),
+                       std::make_move_iterator(top.added.begin()), std::make_move_iterator(top.added.end()));
+   parent.expired.insert(parent.expired.end(),
+                         std::make_move_iterator(top.expired.begin()), std::make_move_iterator(top.expired.end()));
 }
 
-// --- Block-level revision management ---
-
-void transaction_dedup::start_block_revision(uint32_t block_num) {
-   // If there's an uncommitted pending revision, abort it first (shouldn't happen normally)
-   if (pending_revision_)
-      abort_block_revision();
-   pending_revision_ = block_revision{block_num, {}, {}};
-   // Entries recorded outside any block revision belong to pre-block state and are not undoable.
-   current_added_.clear();
-   session_stack_.clear();
-}
-
-void transaction_dedup::commit_block_revision() {
-   if (!pending_revision_)
+void transaction_dedup::undo() {
+   if (levels_.empty())
       return;
-   session_stack_.clear();
-   pending_revision_->added = std::move(current_added_);
-   current_added_.clear();
-   committed_revisions_.push_back(std::move(*pending_revision_));
-   pending_revision_.reset();
-}
-
-void transaction_dedup::abort_block_revision() {
-   if (!pending_revision_)
-      return;
-   session_stack_.clear();
-   // Undo entries added during this block
-   erase_current_added_from(0);
-   // Restore entries that were cleared by clear_expired during this block
-   restore_expired(*pending_revision_);
-   pending_revision_.reset();
-}
-
-void transaction_dedup::pop_block_revision() {
-   // pop_block always runs with no block in progress; abort defensively if that ever changes so
-   // the pending revision's cleared entries are restored rather than stranded.
-   if (pending_revision_)
-      abort_block_revision();
-   if (committed_revisions_.empty())
-      return;
-
-   const auto& rev = committed_revisions_.back();
-   // Undo entries added during this block
-   for (const auto& [id, exp] : rev.added) {
+   const undo_level top = std::move(levels_.back());
+   levels_.pop_back();
+   --revision_;
+   // Remove what this session added, then restore what it expired. The sorted index makes
+   // reinsertion order irrelevant, so undo reproduces the exact pre-session state (and serialization
+   // order) on every node.
+   for (const auto& [id, exp] : top.added) {
       map_.erase(id);
       index_.erase(sorted_entry{exp, id});
    }
-   // Restore entries that were cleared by clear_expired during this block
-   restore_expired(rev);
-   committed_revisions_.pop_back();
-}
-
-void transaction_dedup::commit_to_lib(uint32_t block_num) {
-   auto it = committed_revisions_.begin();
-   while (it != committed_revisions_.end() && it->block_num <= block_num) {
-      ++it;
-   }
-   committed_revisions_.erase(committed_revisions_.begin(), it);
-}
-
-void transaction_dedup::restore_expired(const block_revision& rev) {
-   for (const auto& [id, exp] : rev.expired) {
+   for (const auto& [id, exp] : top.expired) {
       map_.emplace(id, exp);
       index_.emplace(exp, id);
    }
 }
 
-void transaction_dedup::erase_current_added_from(size_t first) {
-   for (size_t i = first; i < current_added_.size(); ++i) {
-      const auto& [id, exp] = current_added_[i];
-      map_.erase(id);
-      index_.erase(sorted_entry{exp, id});
-   }
-   current_added_.resize(first);
+void transaction_dedup::undo_all() {
+   while (!levels_.empty())
+      undo();
+}
+
+void transaction_dedup::commit(int64_t revision) {
+   // Sessions at or below this revision are irreversible; drop their tracking (the entries stay in
+   // map_/index_). The front of the deque is the oldest, lowest-revision session. The controller's
+   // LIB advance (db.commit(block_num), with revision == block_num) drives this via the participant.
+   while (!levels_.empty() && levels_.front().revision <= revision)
+      levels_.pop_front();
+}
+
+void transaction_dedup::set_revision(uint64_t revision) {
+   SYS_ASSERT(levels_.empty(), chain_exception,
+              "cannot set transaction dedup revision while undo sessions are open");
+   revision_ = static_cast<int64_t>(revision);
+}
+
+std::pair<uint64_t, uint64_t> transaction_dedup::undo_stack_revision_range() const {
+   const int64_t begin = revision_ - static_cast<int64_t>(levels_.size());
+   return { static_cast<uint64_t>(begin), static_cast<uint64_t>(revision_) };
 }
 
 // --- File persistence (uses snapshot format for integrity and code reuse) ---
@@ -162,7 +125,8 @@ void transaction_dedup::write_to_file(const std::filesystem::path& filepath) con
    const auto tmp = filepath.string() + ".tmp";
 
    auto writer = std::make_shared<threaded_snapshot_writer>(tmp);
-   add_to_snapshot(writer);
+   add_to_snapshot(writer);            // membership set
+   write_revisions_to_file(writer);    // reversible undo stack + current revision (file-only; see header)
    writer->finalize();
 
    std::filesystem::rename(tmp, filepath);
@@ -175,7 +139,8 @@ bool transaction_dedup::read_from_file(const std::filesystem::path& filepath) {
    try {
       auto reader = std::make_shared<threaded_snapshot_reader>(filepath);
       reader->validate();
-      read_from_snapshot(reader);
+      read_from_snapshot(reader);         // resets, then loads membership (revision_ -> 0)
+      read_revisions_from_file(reader);   // loads the undo stack and current revision
 
       std::filesystem::remove(filepath);
       return true;
@@ -186,13 +151,63 @@ bool transaction_dedup::read_from_file(const std::filesystem::path& filepath) {
    }
 }
 
+void transaction_dedup::write_revisions_to_file(const snapshot_writer_ptr& snapshot) const {
+   // Current revision first, so it is restored even when the undo stack is empty (everything
+   // irreversible) and the restored dedup can be validated against the database's revision.
+   snapshot->write_section("sysio::chain::transaction_dedup_meta", [this](auto& section) {
+      section.add_row(snapshot_transaction_dedup_meta{revision_});
+   });
+   snapshot->write_section("sysio::chain::transaction_dedup_revisions", [this](auto& section) {
+      for (const auto& lvl : levels_) {
+         snapshot_transaction_dedup_revision row;
+         row.revision  = lvl.revision;
+         row.added.reserve(lvl.added.size());
+         for (const auto& [id, exp] : lvl.added)
+            row.added.emplace_back(snapshot_transaction_dedup_entry{id, exp});
+         row.expired.reserve(lvl.expired.size());
+         for (const auto& [id, exp] : lvl.expired)
+            row.expired.emplace_back(snapshot_transaction_dedup_entry{id, exp});
+         section.add_row(row);
+      }
+   });
+}
+
+void transaction_dedup::read_revisions_from_file(const snapshot_reader_ptr& snapshot) {
+   // read_from_snapshot already reset() the stack; restore the revision then the sessions in
+   // committed (revision-ascending) order so commit / commit_to_lib / undo see exactly the
+   // pre-shutdown stack.
+   snapshot->read_section("sysio::chain::transaction_dedup_meta", [this](auto& section) {
+      if (!section.empty()) {
+         snapshot_transaction_dedup_meta meta;
+         section.read_row(meta);
+         revision_ = meta.revision;
+      }
+   });
+   snapshot->read_section("sysio::chain::transaction_dedup_revisions", [this](auto& section) {
+      bool more = !section.empty();
+      while (more) {
+         snapshot_transaction_dedup_revision row;
+         more = section.read_row(row);
+         undo_level lvl;
+         lvl.revision  = row.revision;
+         lvl.added.reserve(row.added.size());
+         for (const auto& e : row.added)
+            lvl.added.emplace_back(e.trx_id, e.expiration);
+         lvl.expired.reserve(row.expired.size());
+         for (const auto& e : row.expired)
+            lvl.expired.emplace_back(e.trx_id, e.expiration);
+         levels_.push_back(std::move(lvl));
+      }
+   });
+}
+
 // --- Snapshot support ---
 
 void transaction_dedup::add_to_snapshot(const snapshot_writer_ptr& snapshot) const {
    snapshot->write_section("sysio::chain::transaction_dedup", [this](auto& section) {
-      // index_ iterates in (expiration, id) order: canonical for a given logical entry set, so
-      // the serialized section -- and the integrity hash folded over it -- is identical across
-      // nodes regardless of the record/undo path that produced the set.
+      // index_ iterates in (expiration, id) order: canonical for a given logical entry set, so the
+      // serialized section -- and the integrity hash folded over it -- is identical across nodes
+      // regardless of the record/undo path that produced the set.
       for (const auto& [exp, id] : index_) {
          section.add_row(snapshot_transaction_dedup_entry{id, exp});
       }
@@ -208,21 +223,21 @@ void transaction_dedup::read_from_snapshot(const snapshot_reader_ptr& snapshot) 
          snapshot_transaction_dedup_entry entry;
          more = section.read_row(entry);
          // Honest nodes serialize each id exactly once, so a repeated id means the section is
-         // corrupt or hand-crafted. Silently ignoring the failed insert would break the
-         // map/index invariant: the map keeps only the first row while the index gains an
-         // (expiration, id) entry per row, so size() disagrees with the serialized contents and
-         // the phantom index entry outlives its map entry -- clear_expired then erases the id at
-         // the WRONG expiration (or re-recording the id strands the stale index row for good).
+         // corrupt or hand-crafted. Silently ignoring the failed insert would break the map/index
+         // invariant: the map keeps only the first row while the index gains an (expiration, id)
+         // entry per row, so size() disagrees with the serialized contents and the phantom index
+         // entry outlives its map entry -- clear_expired then erases the id at the WRONG expiration
+         // (or re-recording the id strands the stale index row for good).
          const bool inserted = map_.emplace(entry.trx_id, entry.expiration).second;
          SYS_ASSERT(inserted, snapshot_exception,
                     "duplicate transaction {} in dedup snapshot section", entry.trx_id);
-         // Current-format rows arrive in (expiration, id) order, so hinting the end makes the
-         // tree build amortized O(1) per row instead of O(log n) -- ~11x faster on large sets.
-         // Old insertion-ordered snapshots ignore a wrong hint and insert correctly at full cost.
+         // Current-format rows arrive in (expiration, id) order, so hinting the end makes the tree
+         // build amortized O(1) per row instead of O(log n) -- ~11x faster on large sets. Old
+         // insertion-ordered snapshots ignore a wrong hint and insert correctly at full cost.
          index_.emplace_hint(index_.end(), entry.expiration, entry.trx_id);
       }
-      // map_ keys on the id alone, so every accepted row's (expiration, id) pair is necessarily
-      // new to index_; equal sizes prove the index insert landed for every row as well.
+      // map_ keys on the id alone, so every accepted row's (expiration, id) pair is necessarily new
+      // to index_; equal sizes prove the index insert landed for every row as well.
       SYS_ASSERT(map_.size() == index_.size(), snapshot_exception,
                  "transaction dedup map/index size mismatch after snapshot load ({} vs {})",
                  map_.size(), index_.size());

--- a/libraries/chaindb/include/chainbase/chainbase.hpp
+++ b/libraries/chaindb/include/chainbase/chainbase.hpp
@@ -372,6 +372,36 @@ namespace chainbase {
             _index_list.push_back( new_index );
          }
 
+         /// Register a non-segment undo participant (e.g. a heap-backed structure such as the
+         /// transaction dedup) so that start_undo_session / squash / undo / commit / set_revision
+         /// drive it in lockstep with the segment indices -- removing the need for any caller to
+         /// hand-pair its own undo operations with the database's. The participant must already be
+         /// at a revision range consistent with the existing indices, exactly as add_index requires,
+         /// so a stale or mismatched participant is rejected at registration rather than diverging
+         /// silently later.
+         void add_undo_participant( std::unique_ptr<abstract_index> participant ) {
+            const uint32_t type_id = participant->type_id();
+            if( !( _index_map.size() <= type_id || _index_map[ type_id ] == nullptr ) ) {
+               BOOST_THROW_EXCEPTION( std::logic_error( participant->type_name() + "::type_id is already in use" ) );
+            }
+            if( _index_list.size() > 0 ) {
+               auto expected = _index_list.front()->undo_stack_revision_range();
+               auto got      = participant->undo_stack_revision_range();
+               if( got.first != expected.first || got.second != expected.second ) {
+                  BOOST_THROW_EXCEPTION( std::logic_error(
+                     "undo participant " + participant->type_name() + " has revision range [" +
+                     std::to_string(got.first) + ", " + std::to_string(got.second) +
+                     "] inconsistent with the database (revision range [" +
+                     std::to_string(expected.first) + ", " + std::to_string(expected.second) +
+                     "]); corrupted or mismatched state?" ) );
+               }
+            }
+            if( type_id >= _index_map.size() )
+               _index_map.resize( type_id + 1 );
+            _index_list.push_back( participant.get() );
+            _index_map[ type_id ].reset( participant.release() );
+         }
+
          segment_manager* get_segment_manager() {
             return _db_file.get_segment_manager();
          }

--- a/libraries/chaindb/include/chainbase/chainbase.hpp
+++ b/libraries/chaindb/include/chainbase/chainbase.hpp
@@ -289,6 +289,15 @@ namespace chainbase {
              return _index_list[0]->revision();
          }
 
+         /// {oldest undoable revision, current revision} for the database. Mirrors revision():
+         /// delegates to the first index, which add_index/add_undo_participant keep in lockstep with
+         /// every other index. Returns {0,0} before any index is registered. Used to align a
+         /// heap-backed undo participant with the segment indices before registering it.
+         std::pair<uint64_t, uint64_t> undo_stack_revision_range()const {
+             if( _index_list.size() == 0 ) return { 0, 0 };
+             return _index_list[0]->undo_stack_revision_range();
+         }
+
          void undo();
          void squash();
          void commit( int64_t revision );

--- a/unittests/transaction_dedup_tests.cpp
+++ b/unittests/transaction_dedup_tests.cpp
@@ -1,11 +1,22 @@
 #include <sysio/chain/transaction_dedup.hpp>
+#include <sysio/chain/transaction_dedup_undo_index.hpp>
 #include <sysio/chain/exceptions.hpp>
+
+#include <chainbase/chainbase.hpp>
 
 #include <boost/test/unit_test.hpp>
 
 #include <fc/crypto/sha256.hpp>
 #include <fc/filesystem.hpp>
 #include <fc/io/json.hpp>
+
+#include <algorithm>
+#include <deque>
+#include <map>
+#include <optional>
+#include <set>
+#include <utility>
+#include <vector>
 
 using namespace sysio::chain;
 
@@ -15,7 +26,39 @@ namespace sysio::chain {
 /// replay records every input transaction with no undo context, and the bookkeeping must not
 /// accumulate for the duration of the replay.
 struct transaction_dedup_test_access {
-   static size_t undo_bookkeeping_size(const transaction_dedup& d) { return d.current_added_.size(); }
+   /// Total entries currently tracked for undo across all open sessions. Records made with no undo
+   /// session open (irreversible replay) are not tracked, so this stays 0 for them.
+   static size_t undo_bookkeeping_size(const transaction_dedup& d) {
+      size_t n = 0;
+      for (const auto& lvl : d.levels_) n += lvl.added.size();
+      return n;
+   }
+   /// Depth of the undo session stack. Must survive a write_to_file/read_from_file round trip so a
+   /// fork switch after a clean restart can revert pre-restart reversible blocks.
+   static size_t committed_revision_count(const transaction_dedup& d) { return d.levels_.size(); }
+
+   /// Core integrity invariant: the membership map and the sorted index hold exactly the same
+   /// (id, expiration) pairs. Every operation must preserve it. A future change that mutates one
+   /// structure but not the other is a silent consensus hazard -- size()/serialization would
+   /// disagree, or clear_expired would erase an id at the wrong expiration. Checked after each
+   /// step of the randomized cross-check below.
+   static bool invariant_holds(const transaction_dedup& d) {
+      if (d.map_.size() != d.index_.size()) return false;
+      for (const auto& [exp, id] : d.index_) {
+         auto it = d.map_.find(id);
+         if (it == d.map_.end() || it->second != exp) return false;
+      }
+      for (const auto& [id, exp] : d.map_)
+         if (d.index_.find(std::make_pair(exp, id)) == d.index_.end()) return false;
+      return true;
+   }
+
+   /// The sorted index in iteration order -- the exact (expiration, id) sequence add_to_snapshot
+   /// serializes and calculate_integrity_hash folds over. Comparing this to an independent model
+   /// pins the determinism contract directly, without going through JSON.
+   static std::vector<std::pair<fc::time_point_sec, transaction_id_type>> index_order(const transaction_dedup& d) {
+      return { d.index_.begin(), d.index_.end() };
+   }
 };
 } // namespace sysio::chain
 
@@ -37,6 +80,47 @@ static std::string serialize(const transaction_dedup& d) {
    writer->finalize();
    return fc::json::to_string(fc::variant(storage), fc::time_point::maximum());
 }
+
+// Deterministic, platform-independent PRNG (splitmix64) so the randomized cross-check below
+// reproduces exactly from its seed.
+static uint64_t rng_next(uint64_t& s) {
+   uint64_t z = (s += 0x9e3779b97f4a7c15ull);
+   z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ull;
+   z = (z ^ (z >> 27)) * 0x94d049bb133111ebull;
+   return z ^ (z >> 31);
+}
+
+// Independent reference model of the dedup's documented semantics, built from a plain std::map
+// plus a stack of membership snapshots that mirrors transaction_dedup::levels_ one-for-one (the
+// unified undo-session model: block revisions and transaction sessions are the same primitive).
+// The randomized test drives identical operations through this and the real dedup and asserts
+// they never disagree -- so a regression in the undo lifecycle or the canonical serialization
+// order is caught even when no named test describes the scenario.
+struct dedup_oracle {
+   using membership = std::map<transaction_id_type, fc::time_point_sec>;
+   struct level { int64_t revision; membership before; };
+   membership         m;
+   std::deque<level>  levels;       // mirrors transaction_dedup::levels_
+   int64_t            revision = 0;
+
+   void record(const transaction_id_type& id, fc::time_point_sec e) { m[id] = e; }
+   void clear_expired(fc::time_point now) {
+      for (auto it = m.begin(); it != m.end(); ) {
+         if (now > it->second.to_time_point()) it = m.erase(it);
+         else ++it;
+      }
+   }
+   void add_undo_session() { ++revision; levels.push_back({revision, m}); }     // snapshot pre-session m
+   void squash()           { if (levels.empty()) return; levels.pop_back(); --revision; }              // keep m
+   void undo()             { if (levels.empty()) return; m = levels.back().before; levels.pop_back(); --revision; }
+   void commit(int64_t rev){ while (!levels.empty() && levels.front().revision <= rev) levels.pop_front(); }
+   // Same (expiration, id) ordering the dedup's std::set index uses, for a direct comparison.
+   std::vector<std::pair<fc::time_point_sec, transaction_id_type>> index_order() const {
+      std::set<std::pair<fc::time_point_sec, transaction_id_type>> s;
+      for (const auto& [id, e] : m) s.emplace(e, id);
+      return { s.begin(), s.end() };
+   }
+};
 
 BOOST_AUTO_TEST_SUITE(transaction_dedup_tests)
 
@@ -97,10 +181,10 @@ BOOST_AUTO_TEST_CASE(session_squash) {
    transaction_dedup d;
    d.record(make_id(1), make_exp(100));
 
-   d.push_session();
+   d.add_undo_session();
    d.record(make_id(2), make_exp(100));
    BOOST_CHECK_EQUAL(d.size(), 2u);
-   d.squash_session();
+   d.squash();
 
    // Entry persists after squash
    BOOST_CHECK(d.is_known(make_id(2)));
@@ -111,12 +195,12 @@ BOOST_AUTO_TEST_CASE(session_undo) {
    transaction_dedup d;
    d.record(make_id(1), make_exp(100));
 
-   d.push_session();
+   d.add_undo_session();
    d.record(make_id(2), make_exp(100));
    d.record(make_id(3), make_exp(100));
    BOOST_CHECK_EQUAL(d.size(), 3u);
 
-   d.undo_session();
+   d.undo();
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK(!d.is_known(make_id(2)));
    BOOST_CHECK(!d.is_known(make_id(3)));
@@ -128,18 +212,18 @@ BOOST_AUTO_TEST_CASE(nested_sessions) {
    d.record(make_id(1), make_exp(100));
 
    // Outer session
-   d.push_session();
+   d.add_undo_session();
    d.record(make_id(2), make_exp(100));
 
    // Inner session
-   d.push_session();
+   d.add_undo_session();
    d.record(make_id(3), make_exp(100));
-   d.undo_session(); // undo inner
+   d.undo(); // undo inner
 
    BOOST_CHECK(d.is_known(make_id(2)));
    BOOST_CHECK(!d.is_known(make_id(3)));
 
-   d.squash_session(); // squash outer
+   d.squash(); // squash outer
    BOOST_CHECK(d.is_known(make_id(2)));
    BOOST_CHECK_EQUAL(d.size(), 2u);
 }
@@ -149,10 +233,10 @@ BOOST_AUTO_TEST_CASE(nested_sessions) {
 BOOST_AUTO_TEST_CASE(block_commit) {
    transaction_dedup d;
 
-   d.start_block_revision(1);
+   d.add_undo_session();
    d.record(make_id(1), make_exp(100));
    d.record(make_id(2), make_exp(100));
-   d.commit_block_revision();
+   
 
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK(d.is_known(make_id(2)));
@@ -163,10 +247,10 @@ BOOST_AUTO_TEST_CASE(block_abort) {
    transaction_dedup d;
    d.record(make_id(0), make_exp(100)); // pre-existing entry
 
-   d.start_block_revision(1);
+   d.add_undo_session();
    d.record(make_id(1), make_exp(100));
    d.record(make_id(2), make_exp(100));
-   d.abort_block_revision();
+   d.undo();
 
    BOOST_CHECK(d.is_known(make_id(0)));
    BOOST_CHECK(!d.is_known(make_id(1)));
@@ -180,14 +264,14 @@ BOOST_AUTO_TEST_CASE(block_abort_restores_expired) {
    d.record(make_id(2), make_exp(20));
    d.record(make_id(3), make_exp(30));
 
-   d.start_block_revision(1);
+   d.add_undo_session();
    // clear_expired at now=15 removes entry 1
    d.clear_expired(fc::time_point(fc::seconds(15)));
    BOOST_CHECK(!d.is_known(make_id(1)));
    BOOST_CHECK_EQUAL(d.size(), 2u);
 
    d.record(make_id(4), make_exp(40));
-   d.abort_block_revision();
+   d.undo();
 
    // Entry 1 is restored, entry 4 is removed
    BOOST_CHECK(d.is_known(make_id(1)));
@@ -200,18 +284,18 @@ BOOST_AUTO_TEST_CASE(block_abort_restores_expired) {
 BOOST_AUTO_TEST_CASE(pop_single_block) {
    transaction_dedup d;
 
-   d.start_block_revision(1);
+   d.add_undo_session();
    d.record(make_id(1), make_exp(100));
-   d.commit_block_revision();
+   
 
-   d.start_block_revision(2);
+   d.add_undo_session();
    d.record(make_id(2), make_exp(100));
-   d.commit_block_revision();
+   
 
    BOOST_CHECK_EQUAL(d.size(), 2u);
 
    // Pop block 2
-   d.pop_block_revision();
+   d.undo();
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK(!d.is_known(make_id(2)));
    BOOST_CHECK_EQUAL(d.size(), 1u);
@@ -220,21 +304,21 @@ BOOST_AUTO_TEST_CASE(pop_single_block) {
 BOOST_AUTO_TEST_CASE(pop_multiple_blocks) {
    transaction_dedup d;
 
-   d.start_block_revision(1);
+   d.add_undo_session();
    d.record(make_id(1), make_exp(100));
-   d.commit_block_revision();
+   
 
-   d.start_block_revision(2);
+   d.add_undo_session();
    d.record(make_id(2), make_exp(100));
-   d.commit_block_revision();
+   
 
-   d.start_block_revision(3);
+   d.add_undo_session();
    d.record(make_id(3), make_exp(100));
-   d.commit_block_revision();
+   
 
    // Pop blocks 3 and 2 (simulating 2-block fork switch)
-   d.pop_block_revision();
-   d.pop_block_revision();
+   d.undo();
+   d.undo();
 
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK(!d.is_known(make_id(2)));
@@ -248,17 +332,17 @@ BOOST_AUTO_TEST_CASE(pop_restores_expired) {
    d.record(make_id(2), make_exp(20));
 
    // Block 1: clears entry 1 (exp=10) at now=15, adds entry 3
-   d.start_block_revision(1);
+   d.add_undo_session();
    d.clear_expired(fc::time_point(fc::seconds(15)));
    d.record(make_id(3), make_exp(30));
-   d.commit_block_revision();
+   
 
    BOOST_CHECK(!d.is_known(make_id(1)));
    BOOST_CHECK(d.is_known(make_id(2)));
    BOOST_CHECK(d.is_known(make_id(3)));
 
    // Pop block 1: restores entry 1, removes entry 3
-   d.pop_block_revision();
+   d.undo();
 
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK(d.is_known(make_id(2)));
@@ -269,7 +353,7 @@ BOOST_AUTO_TEST_CASE(pop_restores_expired) {
 BOOST_AUTO_TEST_CASE(pop_empty_is_noop) {
    transaction_dedup d;
    d.record(make_id(1), make_exp(100));
-   d.pop_block_revision(); // no committed revisions, should be a no-op
+   d.undo(); // no committed revisions, should be a no-op
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK_EQUAL(d.size(), 1u);
 }
@@ -280,23 +364,23 @@ BOOST_AUTO_TEST_CASE(commit_to_lib_trims) {
    transaction_dedup d;
 
    for (uint32_t i = 1; i <= 5; ++i) {
-      d.start_block_revision(i);
+      d.add_undo_session();
       d.record(make_id(i), make_exp(100));
-      d.commit_block_revision();
+      
    }
 
    // Trim revisions at LIB=3
-   d.commit_to_lib(3);
+   d.commit(3);
 
    // Blocks 1-3 are trimmed, can't be popped
    // Blocks 4-5 can still be popped
-   d.pop_block_revision(); // pop block 5
+   d.undo(); // pop block 5
    BOOST_CHECK(!d.is_known(make_id(5)));
-   d.pop_block_revision(); // pop block 4
+   d.undo(); // pop block 4
    BOOST_CHECK(!d.is_known(make_id(4)));
 
    // No more revisions to pop -- no-op, matches chainbase db.undo() behavior
-   d.pop_block_revision();
+   d.undo();
 
    // Entries from blocks 1-3 are still present (committed, not undoable)
    BOOST_CHECK(d.is_known(make_id(1)));
@@ -309,24 +393,24 @@ BOOST_AUTO_TEST_CASE(commit_to_lib_trims) {
 BOOST_AUTO_TEST_CASE(block_with_transaction_sessions) {
    transaction_dedup d;
 
-   d.start_block_revision(1);
+   d.add_undo_session();
 
    // Tx A succeeds
-   d.push_session();
+   d.add_undo_session();
    d.record(make_id(1), make_exp(100));
-   d.squash_session();
+   d.squash();
 
    // Tx B fails
-   d.push_session();
+   d.add_undo_session();
    d.record(make_id(2), make_exp(100));
-   d.undo_session();
+   d.undo();
 
    // Tx C succeeds
-   d.push_session();
+   d.add_undo_session();
    d.record(make_id(3), make_exp(100));
-   d.squash_session();
+   d.squash();
 
-   d.commit_block_revision();
+   
 
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK(!d.is_known(make_id(2))); // was undone
@@ -334,11 +418,11 @@ BOOST_AUTO_TEST_CASE(block_with_transaction_sessions) {
    BOOST_CHECK_EQUAL(d.size(), 2u);
 
    // B can be retried (not a duplicate)
-   d.start_block_revision(2);
-   d.push_session();
+   d.add_undo_session();
+   d.add_undo_session();
    d.record(make_id(2), make_exp(100));
-   d.squash_session();
-   d.commit_block_revision();
+   d.squash();
+   
 
    BOOST_CHECK(d.is_known(make_id(2)));
    BOOST_CHECK_EQUAL(d.size(), 3u);
@@ -350,29 +434,29 @@ BOOST_AUTO_TEST_CASE(fork_switch_reapply) {
    transaction_dedup d;
 
    // Block 1 on fork A: records tx1 and tx2
-   d.start_block_revision(1);
-   d.push_session();
+   d.add_undo_session();
+   d.add_undo_session();
    d.record(make_id(1), make_exp(100));
-   d.squash_session();
-   d.push_session();
+   d.squash();
+   d.add_undo_session();
    d.record(make_id(2), make_exp(100));
-   d.squash_session();
-   d.commit_block_revision();
+   d.squash();
+   
 
    // Block 2 on fork A: records tx3
-   d.start_block_revision(2);
-   d.push_session();
+   d.add_undo_session();
+   d.add_undo_session();
    d.record(make_id(3), make_exp(100));
-   d.squash_session();
-   d.commit_block_revision();
+   d.squash();
+   
 
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK(d.is_known(make_id(2)));
    BOOST_CHECK(d.is_known(make_id(3)));
 
    // Fork switch: pop blocks 2 and 1
-   d.pop_block_revision(); // undo block 2
-   d.pop_block_revision(); // undo block 1
+   d.undo(); // undo block 2
+   d.undo(); // undo block 1
 
    BOOST_CHECK(!d.is_known(make_id(1)));
    BOOST_CHECK(!d.is_known(make_id(2)));
@@ -380,14 +464,14 @@ BOOST_AUTO_TEST_CASE(fork_switch_reapply) {
    BOOST_CHECK_EQUAL(d.size(), 0u);
 
    // Re-apply on fork B: tx1 and tx3 are in fork B's block 1 (tx2 is not)
-   d.start_block_revision(1);
-   d.push_session();
+   d.add_undo_session();
+   d.add_undo_session();
    d.record(make_id(1), make_exp(100)); // no duplicate error
-   d.squash_session();
-   d.push_session();
+   d.squash();
+   d.add_undo_session();
    d.record(make_id(3), make_exp(100)); // no duplicate error
-   d.squash_session();
-   d.commit_block_revision();
+   d.squash();
+   
 
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK(!d.is_known(make_id(2)));
@@ -426,6 +510,104 @@ BOOST_AUTO_TEST_CASE(file_round_trip) {
 BOOST_AUTO_TEST_CASE(file_missing_returns_false) {
    transaction_dedup d;
    BOOST_CHECK(!d.read_from_file("/tmp/nonexistent_dedup_file.bin"));
+}
+
+// Regression: the committed reversible undo stack must survive a clean restart, exactly like
+// chainbase's persisted undo stack. Before the fix, write_to_file/read_from_file restored only
+// the membership set, leaving committed_revisions_ empty -- so pop_block_revision (run by a fork
+// switch over pre-restart reversible blocks) was a silent no-op while db.undo() reverted chainbase,
+// stranding the popped blocks' transaction ids in the dedup set and rejecting the canonical fork
+// with tx_duplicate.
+BOOST_AUTO_TEST_CASE(file_round_trip_preserves_revision_stack) {
+   fc::temp_directory tmp_dir;
+   auto tmp = tmp_dir.path() / "test_dedup_revisions.bin";
+
+   {
+      transaction_dedup d;
+      // Two irreversible/base entries recorded with no revision context.
+      d.record(make_id(1), make_exp(10));
+      d.record(make_id(2), make_exp(20));
+
+      // Block 1: expires entry 1 (exp=10) at now=15 and adds entry 3 -- populates BOTH the added
+      // and expired lists of a committed revision, the exact data that must round-trip.
+      d.add_undo_session();
+      d.clear_expired(fc::time_point(fc::seconds(15)));
+      d.record(make_id(3), make_exp(30));
+      
+
+      // Block 2: adds entry 4.
+      d.add_undo_session();
+      d.record(make_id(4), make_exp(40));
+      
+
+      BOOST_CHECK_EQUAL(transaction_dedup_test_access::committed_revision_count(d), 2u);
+      d.write_to_file(tmp);
+   }
+
+   transaction_dedup d;
+   BOOST_CHECK(d.read_from_file(tmp));
+
+   // Membership matches the pre-shutdown head state...
+   BOOST_CHECK(!d.is_known(make_id(1))); // expired in block 1
+   BOOST_CHECK(d.is_known(make_id(2)));
+   BOOST_CHECK(d.is_known(make_id(3)));
+   BOOST_CHECK(d.is_known(make_id(4)));
+   // ...and so does the reversible undo stack.
+   BOOST_CHECK_EQUAL(transaction_dedup_test_access::committed_revision_count(d), 2u);
+
+   // Fork switch pops block 2: removes entry 4. (No-op before the fix.)
+   d.undo();
+   BOOST_CHECK(!d.is_known(make_id(4)));
+   BOOST_CHECK(d.is_known(make_id(3)));
+
+   // Fork switch pops block 1: removes entry 3 AND restores the entry it expired (entry 1) --
+   // proves both lists of the committed revision survived the round trip, not just block_num.
+   d.undo();
+   BOOST_CHECK(!d.is_known(make_id(3)));
+   BOOST_CHECK(d.is_known(make_id(1)));
+   BOOST_CHECK(d.is_known(make_id(2)));
+   BOOST_CHECK_EQUAL(d.size(), 2u);
+}
+
+// Regression: a restored instance must be pop-for-pop equivalent to one that never restarted.
+// This is the property the restart bug violated -- the restarted node diverged from its peers on
+// the very next fork switch. Build two identical instances, serialize/restore one, then drive both
+// through the same fork-switch pops and assert byte-identical serialized state at every step.
+BOOST_AUTO_TEST_CASE(restart_is_pop_equivalent_to_no_restart) {
+   fc::temp_directory tmp_dir;
+   auto tmp = tmp_dir.path() / "test_dedup_equiv.bin";
+
+   auto build = [](transaction_dedup& d) {
+      d.record(make_id(100), make_exp(50));
+      for (uint32_t b = 1; b <= 3; ++b) {
+         d.add_undo_session();
+         d.clear_expired(fc::time_point(fc::seconds(5 * b))); // nothing expires (exp=50), exercises the path
+         d.record(make_id(b), make_exp(50));
+         
+      }
+   };
+
+   transaction_dedup control;
+   build(control);
+
+   {
+      transaction_dedup d;
+      build(d);
+      d.write_to_file(tmp);
+   }
+   transaction_dedup restored;
+   BOOST_CHECK(restored.read_from_file(tmp));
+
+   BOOST_CHECK_EQUAL(serialize(restored), serialize(control));
+
+   // Two-block fork switch on both; serialized state must stay identical throughout.
+   control.undo();
+   restored.undo();
+   BOOST_CHECK_EQUAL(serialize(restored), serialize(control));
+
+   control.undo();
+   restored.undo();
+   BOOST_CHECK_EQUAL(serialize(restored), serialize(control));
 }
 
 BOOST_AUTO_TEST_CASE(snapshot_load_accepts_unsorted_rows) {
@@ -580,15 +762,15 @@ BOOST_AUTO_TEST_CASE(serialization_identical_after_abort) {
    d.record(make_id(3), make_exp(20));
    const auto before = serialize(d);
 
-   d.start_block_revision(1);
+   d.add_undo_session();
    d.clear_expired(fc::time_point(fc::seconds(100))); // removes ids 1 and 3
-   d.push_session();
+   d.add_undo_session();
    d.record(make_id(4), make_exp(300));
-   d.squash_session();
-   d.push_session();
+   d.squash();
+   d.add_undo_session();
    d.record(make_id(5), make_exp(250));
-   d.undo_session();
-   d.abort_block_revision();
+   d.undo();
+   d.undo();
 
    BOOST_CHECK_EQUAL(serialize(d), before);
 }
@@ -600,14 +782,14 @@ BOOST_AUTO_TEST_CASE(serialization_identical_after_pop) {
    d.record(make_id(3), make_exp(20));
    const auto before = serialize(d);
 
-   d.start_block_revision(1);
+   d.add_undo_session();
    d.clear_expired(fc::time_point(fc::seconds(100)));
    d.record(make_id(4), make_exp(300));
-   d.commit_block_revision();
+   
    BOOST_CHECK(!d.is_known(make_id(1)));
    BOOST_CHECK(d.is_known(make_id(4)));
 
-   d.pop_block_revision();
+   d.undo();
 
    BOOST_CHECK_EQUAL(serialize(d), before);
 }
@@ -617,24 +799,24 @@ BOOST_AUTO_TEST_CASE(serialization_path_independent_across_fork_switch) {
    // Same final logical chain -> byte-identical serialization.
    transaction_dedup a, b;
    auto apply_block1 = [&](transaction_dedup& d) {
-      d.start_block_revision(1);
+      d.add_undo_session();
       d.record(make_id(1), make_exp(100));
-      d.commit_block_revision();
+      
    };
    auto apply_block2 = [&](transaction_dedup& d) {
-      d.start_block_revision(2);
+      d.add_undo_session();
       d.record(make_id(2), make_exp(60));
       d.record(make_id(3), make_exp(90));
-      d.commit_block_revision();
+      
    };
    apply_block1(a);
    apply_block2(a);
 
    apply_block1(b);
-   b.start_block_revision(2);
+   b.add_undo_session();
    b.record(make_id(9), make_exp(70)); // fork block 2'
-   b.commit_block_revision();
-   b.pop_block_revision();             // switch forks
+   
+   b.undo();             // switch forks
    apply_block2(b);
 
    BOOST_CHECK_EQUAL(serialize(a), serialize(b));
@@ -660,11 +842,14 @@ BOOST_AUTO_TEST_CASE(no_undo_bookkeeping_without_undo_context) {
    BOOST_CHECK_EQUAL(removed, 49u); // expirations 101..149 (strict <)
    BOOST_CHECK_EQUAL(total, 100u);
 
-   // With an undo context open, bookkeeping tracks records again and drains on commit.
-   d.start_block_revision(1);
+   // With an undo session open, records ARE tracked for undo, and stay tracked (reversible) until
+   // the session becomes irreversible at LIB.
+   d.add_undo_session();
    d.record(make_id(200), make_exp(300));
    BOOST_CHECK_EQUAL(transaction_dedup_test_access::undo_bookkeeping_size(d), 1u);
-   d.commit_block_revision();
+      // the block's undo session remains on the stack -- still reversible
+   BOOST_CHECK_EQUAL(transaction_dedup_test_access::undo_bookkeeping_size(d), 1u);
+   d.commit(1);          // now irreversible: tracking is dropped, the entry stays
    BOOST_CHECK_EQUAL(transaction_dedup_test_access::undo_bookkeeping_size(d), 0u);
    BOOST_CHECK(d.is_known(make_id(200)));
 }
@@ -675,11 +860,11 @@ BOOST_AUTO_TEST_CASE(undo_session_without_block_revision_reverts_records) {
    // though replay-style records outside any context bypass the bookkeeping.
    transaction_dedup d;
    d.record(make_id(1), make_exp(100)); // pre-session, not undoable
-   d.push_session();
+   d.add_undo_session();
    d.record(make_id(2), make_exp(200));
    BOOST_CHECK_EQUAL(transaction_dedup_test_access::undo_bookkeeping_size(d), 1u);
    BOOST_CHECK(d.is_known(make_id(2)));
-   d.undo_session();
+   d.undo();
    BOOST_CHECK(!d.is_known(make_id(2)));
    BOOST_CHECK(d.is_known(make_id(1)));
    BOOST_CHECK_EQUAL(d.size(), 1u);
@@ -690,11 +875,11 @@ BOOST_AUTO_TEST_CASE(undo_session_without_block_revision_reverts_records) {
 
 BOOST_AUTO_TEST_CASE(reset_clears_all) {
    transaction_dedup d;
-   d.start_block_revision(1);
+   d.add_undo_session();
    d.record(make_id(1), make_exp(100));
-   d.commit_block_revision();
+   
 
-   d.start_block_revision(2);
+   d.add_undo_session();
    d.record(make_id(2), make_exp(100));
    // pending revision active
 
@@ -704,7 +889,474 @@ BOOST_AUTO_TEST_CASE(reset_clears_all) {
    BOOST_CHECK(!d.is_known(make_id(1)));
    BOOST_CHECK(!d.is_known(make_id(2)));
    // No committed revisions -- no-op, matches chainbase db.undo() behavior
-   d.pop_block_revision();
+   d.undo();
+}
+
+// ============================================================================
+// Exhaustive scenario coverage + regression guards (added 2026-06-11).
+// ============================================================================
+
+// ---- Internal map/index invariant ----
+
+BOOST_AUTO_TEST_CASE(invariant_holds_through_basic_ops) {
+   using acc = transaction_dedup_test_access;
+   transaction_dedup d;
+   BOOST_CHECK(acc::invariant_holds(d));
+   d.record(make_id(1), make_exp(100));
+   d.record(make_id(2), make_exp(50));
+   d.record(make_id(3), make_exp(150));
+   BOOST_CHECK(acc::invariant_holds(d));
+   d.clear_expired(fc::time_point(fc::seconds(120)));   // removes id 2 (exp 50) and id 1 (exp 100)
+   BOOST_CHECK(acc::invariant_holds(d));
+   auto order = acc::index_order(d);
+   BOOST_REQUIRE_EQUAL(order.size(), 1u);
+   BOOST_CHECK(d.is_known(make_id(3)));
+}
+
+// ---- clear_expired exhaustive boundaries ----
+
+BOOST_AUTO_TEST_CASE(clear_expired_exact_second_boundary) {
+   // Removal is strict (block_time > expiration). At equality the entry is still live -- it can be
+   // included in a block at exactly its expiration second -- so it must survive.
+   transaction_dedup d;
+   d.record(make_id(99),  make_exp(99));
+   d.record(make_id(100), make_exp(100));
+   d.record(make_id(101), make_exp(101));
+   auto [removed, total] = d.clear_expired(fc::time_point(fc::seconds(100)));
+   BOOST_CHECK_EQUAL(removed, 1u);      // only exp=99
+   BOOST_CHECK_EQUAL(total, 3u);
+   BOOST_CHECK(!d.is_known(make_id(99)));
+   BOOST_CHECK(d.is_known(make_id(100))); // equality survives
+   BOOST_CHECK(d.is_known(make_id(101)));
+}
+
+BOOST_AUTO_TEST_CASE(clear_expired_empty_and_none_and_all) {
+   using acc = transaction_dedup_test_access;
+   transaction_dedup d;
+   { auto [r, t] = d.clear_expired(fc::time_point(fc::seconds(1000))); BOOST_CHECK_EQUAL(r, 0u); BOOST_CHECK_EQUAL(t, 0u); }
+   for (uint64_t i = 1; i <= 40; ++i) d.record(make_id(i), make_exp(100 + static_cast<uint32_t>(i)));
+   { auto [r, t] = d.clear_expired(fc::time_point(fc::seconds(50)));   BOOST_CHECK_EQUAL(r, 0u);  BOOST_CHECK_EQUAL(t, 40u); }   // none expired
+   { auto [r, t] = d.clear_expired(fc::time_point(fc::seconds(10000))); BOOST_CHECK_EQUAL(r, 40u); BOOST_CHECK_EQUAL(t, 40u); }  // all expired
+   BOOST_CHECK_EQUAL(d.size(), 0u);
+   BOOST_CHECK(acc::invariant_holds(d));
+}
+
+BOOST_AUTO_TEST_CASE(zero_expiration_boundary) {
+   transaction_dedup d;
+   d.record(make_id(1), make_exp(0));
+   d.record(make_id(2), make_exp(1));
+   auto [removed, total] = d.clear_expired(fc::time_point(fc::seconds(1)));
+   BOOST_CHECK_EQUAL(removed, 1u);       // exp=0 < 1
+   BOOST_CHECK(!d.is_known(make_id(1)));
+   BOOST_CHECK(d.is_known(make_id(2)));  // exp=1 == 1, survives
+}
+
+BOOST_AUTO_TEST_CASE(far_future_expiration_survives_clear) {
+   using acc = transaction_dedup_test_access;
+   transaction_dedup d;
+   d.record(make_id(1), make_exp(0xFFFFFFF0u)); // far future
+   d.record(make_id(2), make_exp(100));
+   auto [removed, total] = d.clear_expired(fc::time_point(fc::seconds(1000)));
+   BOOST_CHECK_EQUAL(removed, 1u);
+   BOOST_CHECK(d.is_known(make_id(1)));
+   BOOST_CHECK(acc::invariant_holds(d));
+}
+
+// ---- id reuse after removal ----
+
+BOOST_AUTO_TEST_CASE(id_recordable_again_after_expiry) {
+   transaction_dedup d;
+   d.record(make_id(1), make_exp(100));
+   d.clear_expired(fc::time_point(fc::seconds(200)));
+   BOOST_CHECK(!d.is_known(make_id(1)));
+   BOOST_CHECK_NO_THROW(d.record(make_id(1), make_exp(300)));
+   BOOST_CHECK(d.is_known(make_id(1)));
+   BOOST_CHECK_EQUAL(d.size(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(id_recordable_again_after_undo) {
+   transaction_dedup d;
+   d.add_undo_session();
+   d.record(make_id(1), make_exp(100));
+   d.undo();
+   BOOST_CHECK(!d.is_known(make_id(1)));
+   BOOST_CHECK_NO_THROW(d.record(make_id(1), make_exp(100)));
+   BOOST_CHECK(d.is_known(make_id(1)));
+}
+
+// ---- duplicate rejection leaves state intact ----
+
+BOOST_AUTO_TEST_CASE(duplicate_record_does_not_corrupt_state) {
+   using acc = transaction_dedup_test_access;
+   transaction_dedup d;
+   d.record(make_id(1), make_exp(100));
+   d.record(make_id(2), make_exp(200));
+   const auto before = serialize(d);
+   // A duplicate, even under a different expiration, throws and changes nothing.
+   BOOST_CHECK_THROW(d.record(make_id(1), make_exp(999)), tx_duplicate);
+   BOOST_CHECK_EQUAL(d.size(), 2u);
+   BOOST_CHECK_EQUAL(serialize(d), before);
+   BOOST_CHECK(acc::invariant_holds(d));
+   // The original expiration is untouched: id 1 still clears at 100, not 999.
+   d.clear_expired(fc::time_point(fc::seconds(150)));
+   BOOST_CHECK(!d.is_known(make_id(1)));
+   BOOST_CHECK(d.is_known(make_id(2)));
+}
+
+// ---- canonical ordering with shared expirations ----
+
+BOOST_AUTO_TEST_CASE(same_expiration_ordered_by_id) {
+   using acc = transaction_dedup_test_access;
+   transaction_dedup a, b;
+   for (uint64_t i = 1; i <= 20; ++i) a.record(make_id(i), make_exp(100));
+   for (uint64_t i = 20; i >= 1; --i) b.record(make_id(i), make_exp(100));
+   BOOST_CHECK_EQUAL(serialize(a), serialize(b));   // tie-broken by id, order-independent
+   BOOST_CHECK(acc::invariant_holds(a));
+   auto [removed, total] = a.clear_expired(fc::time_point(fc::seconds(101)));
+   BOOST_CHECK_EQUAL(removed, 20u);                 // the whole shared-expiration band
+}
+
+BOOST_AUTO_TEST_CASE(large_set_serialization_is_order_independent) {
+   using acc = transaction_dedup_test_access;
+   constexpr uint64_t N = 2000;
+   transaction_dedup fwd, perm;
+   for (uint64_t i = 0; i < N; ++i) fwd.record(make_id(i), make_exp(static_cast<uint32_t>(i % 500) + 1));
+   for (uint64_t k = 0; k < N; ++k) {                // 1999 is coprime to 2000 -> a bijection
+      uint64_t i = (k * 1999ull) % N;
+      perm.record(make_id(i), make_exp(static_cast<uint32_t>(i % 500) + 1));
+   }
+   BOOST_CHECK_EQUAL(serialize(fwd), serialize(perm));
+   BOOST_CHECK_EQUAL(fwd.size(), N);
+   BOOST_CHECK(acc::invariant_holds(fwd));
+}
+
+// ---- block-revision defensive paths ----
+
+BOOST_AUTO_TEST_CASE(nested_sessions_stack_and_unwind) {
+   // A block revision is just an undo session; nesting stacks them and undo unwinds one at a time.
+   // (The controller commits a block before starting the next, so it never nests blocks -- this
+   // pins the underlying primitive the unified model and the chainbase-driven path both rely on.)
+   transaction_dedup d;
+   d.record(make_id(0), make_exp(100));   // permanent (no session open)
+   d.add_undo_session();
+   d.record(make_id(1), make_exp(100));
+   d.add_undo_session();             // nests on top of session 1
+   d.record(make_id(2), make_exp(100));
+   d.undo();                // unwinds session 2 only
+   BOOST_CHECK(!d.is_known(make_id(2)));
+   BOOST_CHECK(d.is_known(make_id(1)));
+   d.undo();                // unwinds session 1
+   BOOST_CHECK(!d.is_known(make_id(1)));
+   BOOST_CHECK(d.is_known(make_id(0)));
+   BOOST_CHECK_EQUAL(d.size(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(undo_and_commit_without_open_session_are_noops) {
+   transaction_dedup d;
+   d.record(make_id(1), make_exp(100));   // permanent (no session open)
+   BOOST_CHECK_NO_THROW(d.commit(0));      // nothing to trim
+   BOOST_CHECK_NO_THROW(d.undo());         // nothing to undo
+   BOOST_CHECK_EQUAL(d.size(), 1u);
+   BOOST_CHECK(d.is_known(make_id(1)));
+}
+
+BOOST_AUTO_TEST_CASE(empty_session_ops_are_safe) {
+   transaction_dedup d;
+   d.record(make_id(1), make_exp(100));
+   BOOST_CHECK_NO_THROW(d.undo());
+   BOOST_CHECK_NO_THROW(d.squash());
+   BOOST_CHECK_EQUAL(d.size(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(undo_reverts_one_session_at_a_time) {
+   transaction_dedup d;
+   d.add_undo_session();
+   d.record(make_id(1), make_exp(100));
+                 // committed block 1
+   d.add_undo_session();
+   d.record(make_id(2), make_exp(100));    // open session for block 2
+   d.undo();                 // reverts the top session (block 2) only
+   BOOST_CHECK(!d.is_known(make_id(2)));
+   BOOST_CHECK(d.is_known(make_id(1)));    // block 1 remains
+   d.undo();                 // reverts block 1
+   BOOST_CHECK(!d.is_known(make_id(1)));
+   BOOST_CHECK_EQUAL(d.size(), 0u);
+}
+
+// ---- commit_to_lib edges ----
+
+BOOST_AUTO_TEST_CASE(commit_to_lib_below_all_keeps_poppable) {
+   transaction_dedup d;
+   for (uint32_t b = 1; b <= 3; ++b) { d.add_undo_session(); d.record(make_id(b), make_exp(100));  }
+   d.commit(0);                     // below all block nums: nothing trimmed
+   d.undo(); d.undo(); d.undo();
+   BOOST_CHECK_EQUAL(d.size(), 0u);        // all popped
+}
+
+BOOST_AUTO_TEST_CASE(commit_to_lib_above_all_makes_permanent) {
+   transaction_dedup d;
+   for (uint32_t b = 1; b <= 3; ++b) { d.add_undo_session(); d.record(make_id(b), make_exp(100));  }
+   d.commit(3);                     // at/above all: irreversible
+   d.undo(); d.undo(); d.undo();  // all no-ops
+   BOOST_CHECK_EQUAL(d.size(), 3u);
+}
+
+BOOST_AUTO_TEST_CASE(pop_after_partial_commit_to_lib) {
+   transaction_dedup d;
+   for (uint32_t b = 1; b <= 5; ++b) { d.add_undo_session(); d.record(make_id(b), make_exp(100));  }
+   d.commit(3);                     // blocks 1-3 permanent, 4-5 poppable
+   d.undo(); BOOST_CHECK(!d.is_known(make_id(5)));
+   d.undo(); BOOST_CHECK(!d.is_known(make_id(4)));
+   d.undo();                 // nothing left to pop -- no-op
+   BOOST_CHECK(d.is_known(make_id(1)) && d.is_known(make_id(2)) && d.is_known(make_id(3)));
+   BOOST_CHECK_EQUAL(d.size(), 3u);
+}
+
+// ---- snapshot / file edge cases ----
+
+BOOST_AUTO_TEST_CASE(empty_snapshot_round_trip) {
+   using acc = transaction_dedup_test_access;
+   fc::mutable_variant_object storage;
+   auto writer = std::make_shared<variant_snapshot_writer>(storage);
+   transaction_dedup{}.add_to_snapshot(writer);
+   writer->finalize();
+   fc::variant snap(storage);
+   transaction_dedup loaded;
+   loaded.record(make_id(9), make_exp(1));   // read_from_snapshot resets first, so this is dropped
+   loaded.read_from_snapshot(std::make_shared<variant_snapshot_reader>(snap));
+   BOOST_CHECK_EQUAL(loaded.size(), 0u);
+   BOOST_CHECK(acc::invariant_holds(loaded));
+}
+
+BOOST_AUTO_TEST_CASE(snapshot_excludes_revision_stack) {
+   // A chain snapshot is loaded as an irreversible root with no reversible blocks beneath it, so
+   // its revision stack must be empty -- add_to_snapshot serializes membership only. (The on-restart
+   // dedup FILE additionally persists the stack; see file_round_trip_preserves_revision_stack.)
+   using acc = transaction_dedup_test_access;
+   transaction_dedup d;
+   d.add_undo_session(); d.record(make_id(1), make_exp(100)); 
+   d.add_undo_session(); d.record(make_id(2), make_exp(100)); 
+   BOOST_REQUIRE_EQUAL(acc::committed_revision_count(d), 2u);
+
+   fc::mutable_variant_object storage;
+   auto writer = std::make_shared<variant_snapshot_writer>(storage);
+   d.add_to_snapshot(writer);
+   writer->finalize();
+   fc::variant snap(storage);
+
+   transaction_dedup loaded;
+   loaded.read_from_snapshot(std::make_shared<variant_snapshot_reader>(snap));
+   BOOST_CHECK_EQUAL(loaded.size(), 2u);
+   BOOST_CHECK(loaded.is_known(make_id(1)) && loaded.is_known(make_id(2)));
+   BOOST_CHECK_EQUAL(acc::committed_revision_count(loaded), 0u);  // stack NOT carried by snapshots
+   loaded.undo();
+   BOOST_CHECK(loaded.is_known(make_id(2)));                      // nothing to pop
+}
+
+BOOST_AUTO_TEST_CASE(empty_file_round_trip) {
+   using acc = transaction_dedup_test_access;
+   fc::temp_directory tmp_dir;
+   auto tmp = tmp_dir.path() / "empty_dedup.bin";
+   { transaction_dedup d; d.write_to_file(tmp); }
+   transaction_dedup d;
+   BOOST_CHECK(d.read_from_file(tmp));
+   BOOST_CHECK_EQUAL(d.size(), 0u);
+   BOOST_CHECK_EQUAL(acc::committed_revision_count(d), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(file_read_consumes_file) {
+   fc::temp_directory tmp_dir;
+   auto tmp = tmp_dir.path() / "consume_dedup.bin";
+   { transaction_dedup d; d.record(make_id(1), make_exp(100)); d.write_to_file(tmp); }
+   transaction_dedup d;
+   BOOST_CHECK(d.read_from_file(tmp));
+   BOOST_CHECK(!std::filesystem::exists(tmp));   // removed on success
+   transaction_dedup d2;
+   BOOST_CHECK(!d2.read_from_file(tmp));          // second read: gone
+}
+
+BOOST_AUTO_TEST_CASE(restored_instance_is_fully_functional) {
+   // After a file round trip the instance must remain operational, not merely readable: clear_expired
+   // on restored membership and pop of a restored committed revision both behave correctly.
+   using acc = transaction_dedup_test_access;
+   fc::temp_directory tmp_dir;
+   auto tmp = tmp_dir.path() / "func_dedup.bin";
+   {
+      transaction_dedup d;
+      d.record(make_id(1), make_exp(10));
+      d.record(make_id(2), make_exp(500));
+      d.add_undo_session();
+      d.record(make_id(3), make_exp(500));
+      
+      d.write_to_file(tmp);
+   }
+   transaction_dedup d;
+   BOOST_REQUIRE(d.read_from_file(tmp));
+   auto [removed, total] = d.clear_expired(fc::time_point(fc::seconds(100)));
+   BOOST_CHECK_EQUAL(removed, 1u);            // id 1 (exp 10)
+   BOOST_CHECK_EQUAL(total, 3u);
+   d.undo();                    // pops restored block 1 -> removes id 3
+   BOOST_CHECK(!d.is_known(make_id(3)));
+   BOOST_CHECK(d.is_known(make_id(2)));
+   BOOST_CHECK(acc::invariant_holds(d));
+}
+
+// ============================================================================
+// Randomized oracle cross-check -- the catch-all regression guard.
+//
+// Drives identical pseudo-random operation sequences (expiry sweeps, transactions with
+// commit/undo, block commit/abort, fork pops, LIB advances) through the real dedup and the
+// independent dedup_oracle, asserting after every step that they agree on size, membership, the
+// canonical serialization order, and the internal map/index invariant -- then that the final
+// state survives file and snapshot round trips. Fixed seeds => failures reproduce exactly.
+// ============================================================================
+
+BOOST_AUTO_TEST_CASE(fuzz_matches_reference_oracle) {
+   using acc = transaction_dedup_test_access;
+   for (uint64_t seed : { 1ull, 7ull, 42ull, 1337ull, 9999ull }) {
+      transaction_dedup d;
+      dedup_oracle oracle;
+      uint64_t rng = seed;
+      uint64_t next_id = 0;             // monotonic -> records are always fresh (never tx_duplicate)
+      uint32_t now_sec = 0;
+      std::vector<int64_t> poppable;    // revisions of committed (reversible) block sessions
+
+      auto check = [&](const char* where) {
+         BOOST_REQUIRE_MESSAGE(acc::invariant_holds(d),
+            "map/index invariant broken (" << where << ") seed=" << seed);
+         BOOST_REQUIRE_MESSAGE(d.size() == oracle.m.size(),
+            "size mismatch (" << where << ") seed=" << seed << " got=" << d.size() << " exp=" << oracle.m.size());
+         BOOST_REQUIRE_MESSAGE(acc::index_order(d) == oracle.index_order(),
+            "serialization order diverged (" << where << ") seed=" << seed);
+      };
+
+      for (int blk = 0; blk < 250; ++blk) {
+         now_sec += 1 + static_cast<uint32_t>(rng_next(rng) % 4);
+
+         d.add_undo_session();                                         oracle.add_undo_session();   // block session
+         d.clear_expired(fc::time_point(fc::seconds(now_sec)));        oracle.clear_expired(fc::time_point(fc::seconds(now_sec)));
+         check("after clear");
+
+         int ntrx = static_cast<int>(rng_next(rng) % 9);
+         for (int t = 0; t < ntrx; ++t) {
+            d.add_undo_session();                                      oracle.add_undo_session();    // trx session
+            uint32_t e = now_sec + 1 + static_cast<uint32_t>(rng_next(rng) % 25);
+            auto id = make_id(++next_id);
+            d.record(id, fc::time_point_sec(e));                       oracle.record(id, fc::time_point_sec(e));
+            if (rng_next(rng) % 5 == 0) { d.undo();   oracle.undo(); }
+            else                        { d.squash(); oracle.squash(); }
+         }
+         check("after trx");
+
+         if (rng_next(rng) % 6 == 0) {
+            d.undo();                                                  oracle.undo();   // abort the block session
+            check("after abort");
+         } else {
+            // Commit: the block session simply remains on the stack (reversible until LIB advances).
+            poppable.push_back(d.revision());
+            check("after commit");
+
+            while (!poppable.empty() && rng_next(rng) % 4 == 0) {      // occasional fork-switch pops
+               d.undo();                                              oracle.undo();
+               poppable.pop_back();
+               check("after pop");
+            }
+            if (poppable.size() > 4 && rng_next(rng) % 3 == 0) {       // occasional LIB advance
+               int64_t lib = poppable[poppable.size() / 3];
+               d.commit(lib);                                         oracle.commit(lib);
+               poppable.erase(std::remove_if(poppable.begin(), poppable.end(),
+                              [lib](int64_t r){ return r <= lib; }), poppable.end());
+               check("after commit_to_lib");
+            }
+         }
+      }
+
+      // The accumulated state must round-trip through the dedup file (membership + revision stack)...
+      {
+         fc::temp_directory td;
+         auto path = td.path() / "fuzz_dedup.bin";
+         d.write_to_file(path);
+         transaction_dedup reloaded;
+         BOOST_REQUIRE(reloaded.read_from_file(path));
+         BOOST_REQUIRE_MESSAGE(acc::index_order(reloaded) == oracle.index_order(),
+            "file round trip diverged seed=" << seed);
+         BOOST_REQUIRE_EQUAL(acc::committed_revision_count(reloaded), poppable.size());
+      }
+      // ...and through a chain snapshot (membership only).
+      {
+         fc::mutable_variant_object storage;
+         auto writer = std::make_shared<variant_snapshot_writer>(storage);
+         d.add_to_snapshot(writer);
+         writer->finalize();
+         fc::variant snap(storage);
+         transaction_dedup reloaded;
+         reloaded.read_from_snapshot(std::make_shared<variant_snapshot_reader>(snap));
+         BOOST_REQUIRE_MESSAGE(acc::index_order(reloaded) == oracle.index_order(),
+            "snapshot round trip diverged seed=" << seed);
+      }
+   }
+}
+
+// ============================================================================
+// Database-driven undo: the dedup registered as a chainbase undo participant. Proves that
+// db.start_undo_session / undo / squash / commit drive the dedup's undo in lockstep, so the
+// controller can stop hand-pairing its own dedup undo calls with the database's.
+// ============================================================================
+
+BOOST_AUTO_TEST_CASE(driven_by_chainbase_database) {
+   using acc = transaction_dedup_test_access;
+   fc::temp_directory tmp_dir;
+   chainbase::database db(tmp_dir.path(), chainbase::database::read_write, 8 * 1024 * 1024, false,
+                          chainbase::pinnable_mapped_file::map_mode::heap);
+   transaction_dedup d;
+   db.add_undo_participant(std::make_unique<dedup_undo_index>(d));
+   BOOST_CHECK_EQUAL(db.revision(), 0);
+
+   // Block 1: the database opens the undo session (drives add_undo_session); the dedup records.
+   {
+      auto block = db.start_undo_session(true);
+      BOOST_CHECK_EQUAL(d.revision(), 1);
+      d.record(make_id(1), make_exp(100));
+      d.record(make_id(2), make_exp(100));
+      block.push();                              // keep the block
+   }
+   BOOST_CHECK(d.is_known(make_id(1)) && d.is_known(make_id(2)));
+   BOOST_CHECK_EQUAL(acc::committed_revision_count(d), 1u);
+
+   // Block 2, then a database undo (fork switch) must revert exactly block 2.
+   {
+      auto block = db.start_undo_session(true);
+      d.record(make_id(3), make_exp(100));
+      block.push();
+   }
+   BOOST_CHECK(d.is_known(make_id(3)));
+   BOOST_CHECK_EQUAL(db.revision(), 2);
+   db.undo();                                    // -> dedup.undo()
+   BOOST_CHECK(!d.is_known(make_id(3)));
+   BOOST_CHECK(d.is_known(make_id(1)) && d.is_known(make_id(2)));
+   BOOST_CHECK_EQUAL(acc::committed_revision_count(d), 1u);
+
+   // A failed transaction: a nested session undone by the database leaves no trace.
+   {
+      auto block = db.start_undo_session(true);
+      {
+         auto trx = db.start_undo_session(true);
+         d.record(make_id(4), make_exp(100));
+         BOOST_CHECK(d.is_known(make_id(4)));
+         trx.undo();                             // -> dedup.undo(): drops id 4
+      }
+      BOOST_CHECK(!d.is_known(make_id(4)));
+      d.record(make_id(5), make_exp(100));
+      block.push();
+   }
+   BOOST_CHECK(d.is_known(make_id(5)) && !d.is_known(make_id(4)));
+
+   // LIB advance makes everything irreversible; the undo stack drains, entries remain.
+   db.commit(db.revision());
+   BOOST_CHECK_EQUAL(acc::committed_revision_count(d), 0u);
+   BOOST_CHECK(acc::invariant_holds(d));
+   BOOST_CHECK(d.is_known(make_id(1)) && d.is_known(make_id(2)) && d.is_known(make_id(5)));
+   BOOST_CHECK_EQUAL(d.size(), 3u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Rebuilds the transaction dedup as a chainbase undo participant so the database drives its undo lifecycle in lockstep with the segment indices, instead of the controller hand-pairing every dedup undo call with the database's. That manual
lockstep was the root cause of the dedup desync bugs (fork-switch and restart).

- chaindb: database::add_undo_participant hook (abstract_index participant, revision-range validated like add_index).
- transaction_dedup: unified undo-session stack keyed by chainbase revision; dedup_undo_index adapter; undo stack persisted across clean restart.
- controller / transaction_context: register the participant; remove the manual lockstep sites.
- Data path stays on the heap (O(1) lookup; churn kept out of the shared segment).

Fixes the restart-persistence bug (a fork switch after a HEAD-mode restart was rejecting the canonical fork with tx_duplicate).

Tested: transaction_dedup_tests (incl. a chainbase-database-driven undo test and a randomized oracle fuzz), block/fork/restart/snapshot/replay suites, plugin_test, and the restart + snapshot integration tests. Full unit_test sweep clean except pre-existing locally-rebuilt-WASM reference mismatches.
