### PR TITLE
Re-record dedup entry on sys-vm-oc tier-up interrupt

### DIFF
--- a/libraries/chain/include/sysio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/sysio/chain/wasm_interface_private.hpp
@@ -3,6 +3,7 @@
 #include <sysio/chain/wasm_interface.hpp>
 #ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
 #include <sysio/chain/webassembly/sys-vm-oc.hpp>
+#include <sysio/chain/webassembly/sys-vm-oc/thread_exec_mem.hpp>
 #else
 #define _REGISTER_SYSVMOC_INTRINSIC(CLS, MOD, METHOD, WASM_SIG, NAME, SIG)
 #endif
@@ -55,23 +56,18 @@ struct sysvmoc_tier {
    // Called from main thread
    sysvmoc_tier(const std::filesystem::path& d, const sysvmoc::config& c, const chainbase::database& db,
                 sysvmoc::code_cache_async::compile_complete_callback cb)
-      : cc(d, c, db, std::move(cb)) {
-      // Construct exec and mem for the main thread
-      exec = std::make_unique<sysvmoc::executor>(cc);
-      mem  = std::make_unique<sysvmoc::memory>(wasm_constraints::maximum_linear_memory/wasm_constraints::wasm_page_size);
-   }
+      : cc(d, c, db, std::move(cb))
+      , exec_mem(cc) {}
 
    // Called from read-only threads
-   void init_thread_local_data() {
-      exec = std::make_unique<sysvmoc::executor>(cc);
-      mem  = std::make_unique<sysvmoc::memory>(sysvmoc::memory::sliced_pages_for_ro_thread);
-   }
+   void init_thread_local_data() { exec_mem.init_thread_local_data(); }
 
    sysvmoc::code_cache_async cc;
 
-   // Each thread requires its own exec and mem. Defined in wasm_interface.cpp
-   thread_local static std::unique_ptr<sysvmoc::executor> exec;
-   thread_local static std::unique_ptr<sysvmoc::memory>   mem;
+   // Per-thread executor/memory, always paired with this tier's code cache. Multiple tiers can
+   // exist in one process (one per controller, e.g. in a validating tester); an executor's
+   // mapping of one tier's cache file must never execute another tier's descriptor offsets.
+   sysvmoc::thread_exec_mem exec_mem;
 };
 #endif
 
@@ -170,7 +166,7 @@ struct sysvmoc_tier {
             if (cd) {
                if (!context.is_applying_block()) // read_only_trx_test.py looks for this log statement
                   tlog("{} speculatively executing {} with sys vm oc", context.get_receiver(), code_hash);
-               sysvmoc->exec->execute(*cd, *sysvmoc->mem, context);
+               sysvmoc->exec_mem.get_executor().execute(*cd, sysvmoc->exec_mem.get_memory(), context);
                return;
             }
          }

--- a/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc.hpp
+++ b/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc.hpp
@@ -13,6 +13,7 @@
 #include <sysio/chain/webassembly/sys-vm-oc/code_cache.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/config.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/intrinsic.hpp>
+#include <sysio/chain/webassembly/sys-vm-oc/thread_exec_mem.hpp>
 
 #include <boost/hana/string.hpp>
 
@@ -36,12 +37,12 @@ class sysvmoc_runtime : public sysio::chain::wasm_runtime_interface {
 
       friend sysvmoc_instantiated_module;
       sysvmoc::code_cache_sync cc;
-      sysvmoc::executor exec;
-      sysvmoc::memory mem;
 
-      // Defined in sys-vm-oc.cpp. Used for non-main thread in multi-threaded execution
-      thread_local static std::unique_ptr<sysvmoc::executor> exec_thread_local;
-      thread_local static std::unique_ptr<sysvmoc::memory> mem_thread_local;
+      // Per-thread executor/memory, always paired with this runtime's code cache. Multiple
+      // runtimes can exist in one process (one per controller, e.g. in a validating tester); an
+      // executor's mapping of one runtime's cache file must never execute another runtime's
+      // descriptor offsets.
+      sysvmoc::thread_exec_mem exec_mem;
 };
 
 /**

--- a/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/thread_exec_mem.hpp
+++ b/libraries/chain/include/sysio/chain/webassembly/sys-vm-oc/thread_exec_mem.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <sysio/chain/webassembly/sys-vm-oc/executor.hpp>
+#include <sysio/chain/webassembly/sys-vm-oc/memory.hpp>
+#include <sysio/chain/wasm_sysio_constraints.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+namespace sysio { namespace chain { namespace sysvmoc {
+
+class code_cache_base;
+
+/**
+ * Provides the sys-vm-oc executor and memory for whichever thread is executing, always paired
+ * with the one code cache this instance was constructed against.
+ *
+ * An executor mmaps its code cache's backing file, and the code descriptors handed out by that
+ * cache hold offsets that are only meaningful within that same file. A process can contain
+ * multiple wasm_interface instances -- e.g. a validating tester runs two controllers, each with
+ * its own sys-vm-oc runtime or tier-up -- so executor/memory state shared loosely across
+ * instances (such as a bare `thread_local static`) can end up executing one cache's descriptor
+ * offsets against another cache's mapping, running garbage. Each runtime/tier-up instance
+ * therefore owns one of these providers:
+ *
+ *  - The main thread's executor/memory are direct members, created with the instance, so their
+ *    pairing with the instance's code cache is guaranteed by construction.
+ *  - Read-only threads share one `thread_local` executor/memory slot per thread. Each slot is
+ *    tagged with the id of the owning provider and is rebuilt from the calling provider's code
+ *    cache whenever a different provider executes on that thread.
+ *
+ * Owner ids are minted from a monotonic counter and never reused, so a destroyed provider's id
+ * cannot collide with a later provider the way a recycled `this` pointer could. A read-only
+ * thread's slot built by a since-destroyed provider is dormant (never executed from) until some
+ * other provider's ensure_ro_thread_state() rebuilds it.
+ */
+class thread_exec_mem {
+   public:
+      /// Construct the main thread's executor (mapping cc's cache file) and full-sized memory.
+      /// Must be constructed on the main thread, before any read-only thread executes.
+      explicit thread_exec_mem(const code_cache_base& cc)
+         : cc(cc)
+         , main_thread_exec(cc)
+         , main_thread_mem(wasm_constraints::maximum_linear_memory/wasm_constraints::wasm_page_size) {}
+
+      /// Executor for the calling thread, built from this instance's code cache.
+      executor& get_executor() {
+         if(std::this_thread::get_id() == main_thread_id)
+            return main_thread_exec;
+         ensure_ro_thread_state();
+         return *ro_thread_state.exec;
+      }
+
+      /// Memory for the calling thread (full-sized on the main thread, read-only-thread-sized
+      /// elsewhere).
+      memory& get_memory() {
+         if(std::this_thread::get_id() == main_thread_id)
+            return main_thread_mem;
+         ensure_ro_thread_state();
+         return *ro_thread_state.mem;
+      }
+
+      /// Eagerly build the calling read-only thread's executor/memory; called from the
+      /// read-only thread pool's thread-start hook.
+      void init_thread_local_data() { ensure_ro_thread_state(); }
+
+   private:
+      /// Rebuild the calling thread's thread_local executor/memory from this instance's code
+      /// cache if they were built by a different instance (or not yet built).
+      void ensure_ro_thread_state() {
+         if(ro_thread_state.owner_id != id) {
+            ro_thread_state.exec     = std::make_unique<executor>(cc);
+            ro_thread_state.mem      = std::make_unique<memory>(memory::sliced_pages_for_ro_thread);
+            ro_thread_state.owner_id = id;
+         }
+      }
+
+      /// Process-unique id; monotonic, never reused.
+      static uint64_t next_owner_id() {
+         static std::atomic<uint64_t> counter{0};
+         return ++counter;
+      }
+
+      const code_cache_base& cc;               ///< cache this instance's executors are built from
+      executor               main_thread_exec; ///< main thread executor; maps cc's cache file
+      memory                 main_thread_mem;  ///< main thread memory
+      const std::thread::id  main_thread_id = std::this_thread::get_id();
+      const uint64_t         id = next_owner_id();
+
+      /// One executor/memory slot per read-only thread, shared by all providers in the process
+      /// and tagged with the id of the provider that built it. Defined in executor.cpp.
+      struct ro_thread_exec_mem {
+         uint64_t                  owner_id = 0; ///< id of the provider that built exec/mem; 0 = none
+         std::unique_ptr<executor> exec;
+         std::unique_ptr<memory>   mem;
+      };
+      thread_local static ro_thread_exec_mem ro_thread_state;
+};
+
+}}} // namespace sysio::chain::sysvmoc

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -79,6 +79,14 @@ namespace sysio::chain {
       *trace = transaction_trace{}; // reset trace
       trace->net_usage = net_usage;
       initialize();
+      // reset() runs only on the sys-vm-oc tier-up interrupt retry, which re-runs exec() but NOT
+      // init_for_input_trx. The undo() above reverted the dedup record made in init_for_input_trx,
+      // so it must be re-issued here under the freshly-initialized undo session -- otherwise an
+      // interrupting validator silently drops this transaction from its dedup set (diverging the
+      // integrity hash from non-interrupting nodes, and letting a still-unexpired resubmission
+      // double-execute). Gated exactly as the original record: input and non-transient.
+      if (is_input && !is_transient())
+         record_transaction(packed_trx.id(), packed_trx.get_transaction().expiration);
       if (!explicit_billed_cpu_time)
          billed_cpu_us.clear();
       trx_blk_context = trx_block_context{};

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -92,11 +92,6 @@ namespace sysio { namespace chain {
    wasm_instantiated_module_interface::~wasm_instantiated_module_interface() = default;
    wasm_runtime_interface::~wasm_runtime_interface() = default;
 
-#ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
-   thread_local std::unique_ptr<sysvmoc::executor> wasm_interface_impl::sysvmoc_tier::exec{};
-   thread_local std::unique_ptr<sysvmoc::memory>   wasm_interface_impl::sysvmoc_tier::mem{};
-#endif
-
 std::istream& operator>>(std::istream& in, wasm_interface::vm_type& runtime) {
    std::string s;
    in >> s;

--- a/libraries/chain/webassembly/runtimes/sys-vm-oc.cpp
+++ b/libraries/chain/webassembly/runtimes/sys-vm-oc.cpp
@@ -15,8 +15,7 @@ class sysvmoc_instantiated_module : public wasm_instantiated_module_interface {
       sysvmoc_instantiated_module(const digest_type& code_hash, const uint8_t& vm_version, sysvmoc_runtime& wr) :
          _code_hash(code_hash),
          _vm_version(vm_version),
-         _sysvmoc_runtime(wr),
-         _main_thread_id(std::this_thread::get_id())
+         _sysvmoc_runtime(wr)
       {
 
       }
@@ -25,8 +24,6 @@ class sysvmoc_instantiated_module : public wasm_instantiated_module_interface {
          _sysvmoc_runtime.cc.free_code(_code_hash, _vm_version);
       }
 
-      bool is_main_thread() { return _main_thread_id == std::this_thread::get_id(); };
-
       void apply(apply_context& context) override {
          sysio::chain::sysvmoc::code_cache_sync::mode m;
          m.whitelisted = context.is_sys_vm_oc_whitelisted();
@@ -34,20 +31,16 @@ class sysvmoc_instantiated_module : public wasm_instantiated_module_interface {
          const code_descriptor* const cd = _sysvmoc_runtime.cc.get_descriptor_for_code_sync(m, context.get_receiver(), _code_hash, _vm_version);
          SYS_ASSERT(cd, wasm_execution_error, "SYS VM OC instantiation failed");
 
-         if ( is_main_thread() )
-            _sysvmoc_runtime.exec.execute(*cd, _sysvmoc_runtime.mem, context);
-         else
-            _sysvmoc_runtime.exec_thread_local->execute(*cd, *_sysvmoc_runtime.mem_thread_local, context);
+         _sysvmoc_runtime.exec_mem.get_executor().execute(*cd, _sysvmoc_runtime.exec_mem.get_memory(), context);
       }
 
       const digest_type              _code_hash;
       const uint8_t                  _vm_version;
       sysvmoc_runtime&               _sysvmoc_runtime;
-      std::thread::id                _main_thread_id;
 };
 
 sysvmoc_runtime::sysvmoc_runtime(const std::filesystem::path data_dir, const sysvmoc::config& sysvmoc_config, const chainbase::database& db)
-   : cc(data_dir, sysvmoc_config, db), exec(cc), mem(wasm_constraints::maximum_linear_memory/wasm_constraints::wasm_page_size) {
+   : cc(data_dir, sysvmoc_config, db), exec_mem(cc) {
 }
 
 sysvmoc_runtime::~sysvmoc_runtime() {
@@ -59,11 +52,7 @@ std::unique_ptr<wasm_instantiated_module_interface> sysvmoc_runtime::instantiate
 }
 
 void sysvmoc_runtime::init_thread_local_data() {
-   exec_thread_local = std::make_unique<sysvmoc::executor>(cc);
-   mem_thread_local  = std::make_unique<sysvmoc::memory>(sysvmoc::memory::sliced_pages_for_ro_thread);
+   exec_mem.init_thread_local_data();
 }
-
-thread_local std::unique_ptr<sysvmoc::executor> sysvmoc_runtime::exec_thread_local{};
-thread_local std::unique_ptr<sysvmoc::memory> sysvmoc_runtime::mem_thread_local{};
 
 }}}}

--- a/libraries/chain/webassembly/runtimes/sys-vm-oc/code_cache.cpp
+++ b/libraries/chain/webassembly/runtimes/sys-vm-oc/code_cache.cpp
@@ -80,7 +80,15 @@ void code_cache_async::wait_on_compile_monitor_message() {
       [[maybe_unused]] const bool p = _result_queue.push(msg);
       assert(p);
 
-      _compile_complete_func(_ctx, msg.code.code_id, msg.queued_time);
+      // Only notify (and thereby possibly interrupt a currently executing transaction) when the
+      // compile actually produced code to switch to. A failed compile must not interrupt: there is
+      // nothing to tier-up to, so the transaction would just be redone on the baseline runtime. Worse,
+      // for a whitelisted account get_descriptor_for_code() un-blacklists the code and queues a fresh
+      // compile, so a persistently failing compile would interrupt the restarted transaction again,
+      // exceeding the single interrupt-retry transaction_context::exec() allows and failing the
+      // transaction -- on a validating node that means rejecting a perfectly valid block.
+      if (std::holds_alternative<code_descriptor>(msg.result))
+         _compile_complete_func(_ctx, msg.code.code_id, msg.queued_time);
 
       process_queued_compiles();
 

--- a/libraries/chain/webassembly/runtimes/sys-vm-oc/executor.cpp
+++ b/libraries/chain/webassembly/runtimes/sys-vm-oc/executor.cpp
@@ -1,6 +1,7 @@
 #include <sysio/chain/webassembly/sys-vm-oc/executor.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/code_cache.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/memory.hpp>
+#include <sysio/chain/webassembly/sys-vm-oc/thread_exec_mem.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/intrinsic_mapping.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/intrinsic.hpp>
 #include <sysio/chain/webassembly/sys-vm-oc/sys-vm-oc.h>
@@ -280,5 +281,7 @@ executor::~executor() {
    sys_vm_oc_setgs(0);
    munmap(code_mapping, code_mapping_size);
 }
+
+thread_local thread_exec_mem::ro_thread_exec_mem thread_exec_mem::ro_thread_state{};
 
 } // namespace sysio::chain::sysvmoc

--- a/libraries/wasm-jit/Include/Inline/Serialization.h
+++ b/libraries/wasm-jit/Include/Inline/Serialization.h
@@ -130,12 +130,17 @@ namespace Serialization
 	};
 
 	// Serialize raw byte sequences.
+	// numBytes == 0 must not reach memcpy: the source/destination pointer may be null then
+	// (e.g. std::vector::data() of an empty vector for a zero-length UserSection payload or
+	// data segment), and passing null to memcpy is undefined behavior regardless of size.
 	FORCEINLINE void serializeBytes(OutputStream& stream,const U8* bytes,Uptr numBytes)
-	{ memcpy(stream.advance(numBytes),bytes,numBytes); }
+	{ if(numBytes) memcpy(stream.advance(numBytes),bytes,numBytes); }
 	FORCEINLINE void serializeBytes(InputStream& stream,U8* bytes,Uptr numBytes)
-	{ 
+	{
+      if ( numBytes == 0 )
+         return;
       if ( numBytes < sysio::chain::wasm_constraints::wasm_page_size || !WASM::check_limits)
-         memcpy(bytes,stream.advance(numBytes),numBytes); 
+         memcpy(bytes,stream.advance(numBytes),numBytes);
       else
          throw FatalSerializationException(std::string("Trying to deserialize bytes of size : " + std::to_string((uint64_t)numBytes)));
    }

--- a/unittests/sysvmoc_interrupt_tests.cpp
+++ b/unittests/sysvmoc_interrupt_tests.cpp
@@ -56,4 +56,76 @@ BOOST_AUTO_TEST_CASE( wasm_interrupt_test ) { try {
 #endif
 } FC_LOG_AND_RETHROW() }
 
+// Regression for the sys-vm-oc interrupt dropping a transaction's dedup record. When oc tier-up
+// completes mid-execution of a transaction applied as part of a block (explicit cpu billing), the
+// transaction is restarted via transaction_context::reset(), whose undo() reverts the dedup record
+// made in init_for_input_trx; the retry re-runs only exec(), so without the fix the record is never
+// re-created and the transaction silently drops out of the dedup set on the interrupting node.
+//
+// The action is finite-but-long: long enough under the interpreter that oc compile completes and
+// interrupts+restarts it, but it completes under sys-vm-oc and the transaction is committed. We then
+// assert the transaction is still known. This assertion can fail ONLY when the bug manifests (the
+// interrupt fired AND the record was dropped); if oc compile happens not to interrupt this run, the
+// record is trivially still present, so the test never fails spuriously.
+BOOST_AUTO_TEST_CASE( oc_interrupt_preserves_dedup_record ) { try {
+#ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
+   fc::temp_directory tempdir;
+   constexpr bool use_genesis = true;
+   savanna_validating_tester t(
+      tempdir,
+      [&](controller::config& cfg) {
+         cfg.sys_vm_oc_whitelist_suffixes.insert("testapi"_n);
+         if (cfg.wasm_runtime != wasm_interface::vm_type::sys_vm_oc)
+            cfg.sysvmoc_tierup = chain::wasm_interface::vm_oc_enable::oc_auto;
+      },
+      use_genesis
+   );
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::sys_vm_oc ) {
+      return; // eos_vm_oc does not tier-up; no interrupt path (see wasm_interrupt_test)
+   }
+   t.execute_setup_policy( setup_policy::full );
+   t.produce_block();
+
+   t.create_account( "testapi"_n );
+   t.set_code( "testapi"_n, test_contracts::test_api_wasm() );
+   t.produce_block();
+
+   const auto pre_count = t.control->get_wasm_interface().get_sys_vm_oc_compile_interrupt_count();
+
+   // Build a finite checktime action (bound^2 inner iterations) and push it with explicit cpu
+   // billing so it takes the applying-block path where the oc interrupt is allowed.
+   signed_transaction trx;
+   action act;
+   act.account = "testapi"_n;
+   act.name = action_name(WASM_TEST_ACTION("test_checktime", "checktime_failure"));
+   act.authorization = vector<permission_level>{{"testapi"_n, config::active_name}};
+   act.data = fc::raw::pack( (unsigned long long)15000 );
+   trx.actions.push_back( act );
+   t.set_transaction_headers( trx );
+   trx.sign( t.get_private_key( "testapi"_n, "active" ), t.get_chain_id() );
+   const auto trx_id = trx.id();
+   const auto total_actions = trx.total_actions();
+
+   auto ptrx = std::make_shared<packed_transaction>( std::move(trx) );
+   auto fut = transaction_metadata::start_recover_keys( std::move(ptrx), t.control->get_thread_pool(),
+                                                        t.get_chain_id(), fc::microseconds::maximum(),
+                                                        transaction_metadata::trx_type::input );
+   auto trx_meta = fut.get();
+   cpu_usage_t billed_cpu_us;
+   billed_cpu_us.insert( billed_cpu_us.end(), total_actions, 1000u ); // explicit, within [min, max]
+   auto res = t.control->test_push_transaction( trx_meta, fc::time_point::now() + fc::seconds(60),
+                                                fc::seconds(60), billed_cpu_us, /*explicit_bill*/ true );
+   if( res->except_ptr ) std::rethrow_exception( res->except_ptr );
+   if( res->except ) throw *res->except;
+
+   const auto post_count = t.control->get_wasm_interface().get_sys_vm_oc_compile_interrupt_count();
+   t.produce_block(); // commit the pending block containing the transaction
+
+   // Must still be deduplicated. Without the fix, the interrupt's reset() dropped the record.
+   BOOST_CHECK( t.control->is_known_unexpired_transaction( trx_id ) );
+   if( post_count == pre_count )
+      ilog("oc compile interrupt did not fire this run; dedup-survival path not exercised");
+#endif
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/sysvmoc_interrupt_tests.cpp
+++ b/unittests/sysvmoc_interrupt_tests.cpp
@@ -106,6 +106,13 @@ BOOST_AUTO_TEST_CASE( oc_interrupt_preserves_dedup_record ) { try {
       // identical behavior, distinct code hash, so this attempt compiles -- and can interrupt --
       // afresh. (A code hash that is already compiled executes directly under oc and can never
       // exercise the interrupt path again.)
+      //
+      // The custom section deliberately has a zero-length payload after the name. That is legal
+      // wasm, and the oc compile child deserializes it through wasm-jit's
+      // serializeBytes(InputStream&,...), which must tolerate an empty (null-data) byte range --
+      // under the ubsan CI build (-fno-sanitize-recover) a regression there kills the compile
+      // child, the compile reports unknownfailure, and this test fails its fired-interrupt
+      // requirement. Keep the payload empty so that coverage is exercised every run.
       std::vector<uint8_t> wasm = base_wasm;
       const uint8_t custom_section[] = { 0x00, 0x02, 0x01, static_cast<uint8_t>('A' + attempt) };
       wasm.insert( wasm.end(), std::begin(custom_section), std::end(custom_section) );
@@ -159,6 +166,92 @@ BOOST_AUTO_TEST_CASE( oc_interrupt_preserves_dedup_record ) { try {
 
    // Must still be deduplicated. Without the fix, the interrupt's reset() dropped the record.
    BOOST_CHECK( t.control->is_known_unexpired_transaction( interrupted_trx_id ) );
+#endif
+} FC_LOG_AND_RETHROW() }
+
+// A FAILED oc compile must not interrupt the executing transaction: there is no oc code to
+// switch to, so the interrupt would only force a pointless restart on the baseline runtime --
+// and worse. For a whitelisted account get_descriptor_for_code() un-blacklists the code and
+// queues a fresh compile on the restart, so a persistently failing compile interrupts the
+// restarted transaction again, exceeding the single interrupt-retry transaction_context::exec()
+// allows; the transaction then fails with interrupt_oc_exception, which on a node applying a
+// block means rejecting a valid block. (This is exactly how the ubsan CI failed before
+// wasm-jit's serializeBytes tolerated empty user-section payloads: the sanitizer killed the
+// compile child, the monitor reported unknownfailure, and the interrupt still fired.)
+//
+// Force a deterministic compile failure via the subjective generated-code size limit (enforced
+// only for non-whitelisted accounts; payloadless generates far more than 1 KiB of native code,
+// see sysvmoc_limits_tests/generated_code_size_limit) and run an action that spins until the
+// deadline. The compile failure lands mid-execution; before the fix it fired the interrupt
+// (observable as the interrupt count incrementing), with the fix the count must stay unchanged.
+BOOST_AUTO_TEST_CASE( oc_compile_failure_does_not_interrupt ) { try {
+#ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
+   fc::temp_directory tempdir;
+   constexpr bool use_genesis = true;
+   savanna_validating_tester t(
+      tempdir,
+      [&](controller::config& cfg) {
+         if (cfg.wasm_runtime != wasm_interface::vm_type::sys_vm_oc)
+            cfg.sysvmoc_tierup = chain::wasm_interface::vm_oc_enable::oc_all; // tier up non-whitelisted accounts too
+         // libtester resets all subjective compile limits; re-enable only the generated code
+         // size limit, small enough that compiling payloadless always fails.
+         cfg.sysvmoc_config.non_whitelisted_limits.cpu_limit.reset();
+         cfg.sysvmoc_config.non_whitelisted_limits.vm_limit.reset();
+         cfg.sysvmoc_config.non_whitelisted_limits.stack_size_limit.reset();
+         cfg.sysvmoc_config.non_whitelisted_limits.generated_code_size_limit = 1024;
+      },
+      use_genesis
+   );
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::sys_vm_oc ) {
+      // With sys-vm-oc as the base runtime the compile is synchronous and its failure surfaces
+      // as wasm_execution_error (covered by sysvmoc_limits_tests); there is no interrupt path.
+      return;
+   }
+   t.execute_setup_policy( setup_policy::full );
+   t.produce_block();
+
+   t.create_account( "payloadless"_n );
+   t.set_code( "payloadless"_n, test_contracts::payloadless_wasm() );
+   t.set_abi( "payloadless"_n, test_contracts::payloadless_abi() );
+   t.produce_block();
+
+   const auto pre_count = t.control->get_wasm_interface().get_sys_vm_oc_compile_interrupt_count();
+
+   // doitforever spins until the block deadline below stops it; the failed compile result
+   // arrives well within that window. Explicit cpu billing takes the applying-block path where
+   // the oc interrupt is allowed.
+   signed_transaction trx;
+   action act;
+   act.account = "payloadless"_n;
+   act.name = "doitforever"_n;
+   act.authorization = vector<permission_level>{{"payloadless"_n, config::active_name}};
+   trx.actions.push_back( act );
+   t.set_transaction_headers( trx );
+   trx.sign( t.get_private_key( "payloadless"_n, "active" ), t.get_chain_id() );
+   const auto total_actions = trx.total_actions();
+
+   auto ptrx = std::make_shared<packed_transaction>( std::move(trx) );
+   auto fut = transaction_metadata::start_recover_keys( std::move(ptrx), t.control->get_thread_pool(),
+                                                        t.get_chain_id(), fc::microseconds::maximum(),
+                                                        transaction_metadata::trx_type::input );
+   auto trx_meta = fut.get();
+   cpu_usage_t billed_cpu_us;
+   billed_cpu_us.insert( billed_cpu_us.end(), total_actions, 1000u );
+
+   BOOST_CHECK_THROW(
+      ([&]() {
+         auto res = t.control->test_push_transaction( trx_meta, fc::time_point::now() + fc::seconds(8),
+                                                      fc::seconds(60), billed_cpu_us, /*explicit_bill*/ true );
+         if( res->except_ptr ) std::rethrow_exception( res->except_ptr );
+         if( res->except ) throw *res->except;
+      })(),
+      deadline_exception );
+
+   const auto post_count = t.control->get_wasm_interface().get_sys_vm_oc_compile_interrupt_count();
+   BOOST_TEST( post_count == pre_count );
+
+   t.produce_block();
+   BOOST_REQUIRE_EQUAL( t.validate(), true );
 #endif
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/sysvmoc_interrupt_tests.cpp
+++ b/unittests/sysvmoc_interrupt_tests.cpp
@@ -64,9 +64,16 @@ BOOST_AUTO_TEST_CASE( wasm_interrupt_test ) { try {
 //
 // The action is finite-but-long: long enough under the interpreter that oc compile completes and
 // interrupts+restarts it, but it completes under sys-vm-oc and the transaction is committed. We then
-// assert the transaction is still known. This assertion can fail ONLY when the bug manifests (the
-// interrupt fired AND the record was dropped); if oc compile happens not to interrupt this run, the
-// record is trivially still present, so the test never fails spuriously.
+// REQUIRE the interrupt fired (so the dedup record was actually dropped and re-recorded) and assert
+// the transaction is still known.
+//
+// The interrupt only fires if oc compile completes while the action is still executing under the
+// interpreter, and no earlier than 500ms after the compile was queued (async_compile_complete's
+// floor). Whether a single fixed-size action gets interrupted therefore depends on machine speed: a
+// fast release build can finish the action before the floor. To make the interrupt a hard
+// prerequisite without making the test timing-flaky, retry with the action size doubling each
+// attempt, re-deploying the contract with a distinct trailing custom section each time -- a fresh
+// code hash, so every attempt opens a fresh compile-interrupt window.
 BOOST_AUTO_TEST_CASE( oc_interrupt_preserves_dedup_record ) { try {
 #ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
    fc::temp_directory tempdir;
@@ -87,44 +94,71 @@ BOOST_AUTO_TEST_CASE( oc_interrupt_preserves_dedup_record ) { try {
    t.produce_block();
 
    t.create_account( "testapi"_n );
-   t.set_code( "testapi"_n, test_contracts::test_api_wasm() );
-   t.produce_block();
 
-   const auto pre_count = t.control->get_wasm_interface().get_sys_vm_oc_compile_interrupt_count();
+   const std::vector<uint8_t> base_wasm = test_contracts::test_api_wasm();
+   constexpr int max_attempts = 3;
+   transaction_id_type interrupted_trx_id;
+   bool fired = false;
+   unsigned long long bound = 20000; // checktime_failure runs bound^2 iterations; doubles per attempt
 
-   // Build a finite checktime action (bound^2 inner iterations) and push it with explicit cpu
-   // billing so it takes the applying-block path where the oc interrupt is allowed.
-   signed_transaction trx;
-   action act;
-   act.account = "testapi"_n;
-   act.name = action_name(WASM_TEST_ACTION("test_checktime", "checktime_failure"));
-   act.authorization = vector<permission_level>{{"testapi"_n, config::active_name}};
-   act.data = fc::raw::pack( (unsigned long long)15000 );
-   trx.actions.push_back( act );
-   t.set_transaction_headers( trx );
-   trx.sign( t.get_private_key( "testapi"_n, "active" ), t.get_chain_id() );
-   const auto trx_id = trx.id();
-   const auto total_actions = trx.total_actions();
+   for( int attempt = 0; attempt < max_attempts && !fired; ++attempt, bound *= 2 ) {
+      // Re-deploy with a unique trailing custom section (id 0, size 2, name len 1, 1-char name):
+      // identical behavior, distinct code hash, so this attempt compiles -- and can interrupt --
+      // afresh. (A code hash that is already compiled executes directly under oc and can never
+      // exercise the interrupt path again.)
+      std::vector<uint8_t> wasm = base_wasm;
+      const uint8_t custom_section[] = { 0x00, 0x02, 0x01, static_cast<uint8_t>('A' + attempt) };
+      wasm.insert( wasm.end(), std::begin(custom_section), std::end(custom_section) );
+      t.set_code( "testapi"_n, wasm );
+      t.produce_block();
 
-   auto ptrx = std::make_shared<packed_transaction>( std::move(trx) );
-   auto fut = transaction_metadata::start_recover_keys( std::move(ptrx), t.control->get_thread_pool(),
-                                                        t.get_chain_id(), fc::microseconds::maximum(),
-                                                        transaction_metadata::trx_type::input );
-   auto trx_meta = fut.get();
-   cpu_usage_t billed_cpu_us;
-   billed_cpu_us.insert( billed_cpu_us.end(), total_actions, 1000u ); // explicit, within [min, max]
-   auto res = t.control->test_push_transaction( trx_meta, fc::time_point::now() + fc::seconds(60),
-                                                fc::seconds(60), billed_cpu_us, /*explicit_bill*/ true );
-   if( res->except_ptr ) std::rethrow_exception( res->except_ptr );
-   if( res->except ) throw *res->except;
+      const auto pre_count = t.control->get_wasm_interface().get_sys_vm_oc_compile_interrupt_count();
 
-   const auto post_count = t.control->get_wasm_interface().get_sys_vm_oc_compile_interrupt_count();
-   t.produce_block(); // commit the pending block containing the transaction
+      // Build a finite checktime action and push it with explicit cpu billing so it takes the
+      // applying-block path where the oc interrupt is allowed.
+      signed_transaction trx;
+      action act;
+      act.account = "testapi"_n;
+      act.name = action_name(WASM_TEST_ACTION("test_checktime", "checktime_failure"));
+      act.authorization = vector<permission_level>{{"testapi"_n, config::active_name}};
+      act.data = fc::raw::pack( bound );
+      trx.actions.push_back( act );
+      t.set_transaction_headers( trx );
+      trx.sign( t.get_private_key( "testapi"_n, "active" ), t.get_chain_id() );
+      const auto trx_id = trx.id();
+      const auto total_actions = trx.total_actions();
+
+      auto ptrx = std::make_shared<packed_transaction>( std::move(trx) );
+      auto fut = transaction_metadata::start_recover_keys( std::move(ptrx), t.control->get_thread_pool(),
+                                                           t.get_chain_id(), fc::microseconds::maximum(),
+                                                           transaction_metadata::trx_type::input );
+      auto trx_meta = fut.get();
+      cpu_usage_t billed_cpu_us;
+      billed_cpu_us.insert( billed_cpu_us.end(), total_actions, 1000u ); // explicit, within [min, max]
+      auto res = t.control->test_push_transaction( trx_meta, fc::time_point::now() + fc::seconds(60),
+                                                   fc::seconds(60), billed_cpu_us, /*explicit_bill*/ true );
+      if( res->except_ptr ) std::rethrow_exception( res->except_ptr );
+      if( res->except ) throw *res->except;
+
+      const auto post_count = t.control->get_wasm_interface().get_sys_vm_oc_compile_interrupt_count();
+      t.produce_block(); // commit the pending block containing the transaction
+
+      if( post_count == pre_count + 1 ) {
+         fired = true;
+         interrupted_trx_id = trx_id;
+      } else {
+         ilog("oc compile interrupt did not fire at bound {}; retrying with a longer action", bound);
+      }
+   }
+
+   // The interrupt firing is a prerequisite: only then was the dedup record dropped by reset() and
+   // re-recorded by the fix. Without it the assertion below would be trivially satisfied by
+   // init_for_input_trx alone.
+   BOOST_REQUIRE_MESSAGE( fired, "oc compile interrupt did not fire within " << max_attempts <<
+                                 " attempts; regression path not exercised" );
 
    // Must still be deduplicated. Without the fix, the interrupt's reset() dropped the record.
-   BOOST_CHECK( t.control->is_known_unexpired_transaction( trx_id ) );
-   if( post_count == pre_count )
-      ilog("oc compile interrupt did not fire this run; dedup-survival path not exercised");
+   BOOST_CHECK( t.control->is_known_unexpired_transaction( interrupted_trx_id ) );
 #endif
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/wasm_jit_serialization_tests.cpp
+++ b/unittests/wasm_jit_serialization_tests.cpp
@@ -1,0 +1,93 @@
+#include <boost/test/unit_test.hpp>
+
+#ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
+#include "IR/Module.h"
+#include "WASM/WASM.h"
+#include "Inline/Serialization.h"
+#endif
+
+#include <cstdint>
+#include <vector>
+
+/**
+ * Regression tests for wasm-jit's binary deserializer as used by the sys-vm-oc compile child
+ * (sysvmoc::run_compile). Legal-but-degenerate wasm modules must deserialize without undefined
+ * behavior: a zero-length UserSection payload used to reach memcpy with a null destination
+ * (std::vector::data() of an empty vector) through Inline/Serialization.h serializeBytes().
+ * memcpy with a null pointer is UB regardless of size, and under the ubsan CI build
+ * (-fno-sanitize-recover=all) it aborts the compile child; the death then surfaced as
+ * compilation_result_unknownfailure from the compile monitor.
+ *
+ * These run the deserializer in-process so the regression is caught directly, in every build
+ * and sanitizer flavor, not only via a dead compile child under ubsan.
+ */
+BOOST_AUTO_TEST_SUITE(wasm_jit_serialization_tests)
+
+#ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
+namespace {
+   /// 8-byte wasm binary preamble: magic "\0asm" + version 1
+   constexpr uint8_t wasm_preamble[] = { 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 };
+
+   /// Deserialize raw wasm bytes the same way the sys-vm-oc compile child does
+   /// (compile_trampoline.cpp run_compile), including its scoped_skip_checks setting.
+   IR::Module deserialize_as_compile_child(const std::vector<uint8_t>& wasm) {
+      IR::Module module;
+      Serialization::MemoryInputStream stream(wasm.data(), wasm.size());
+      WASM::scoped_skip_checks no_check;
+      WASM::serialize(stream, module);
+      return module;
+   }
+}
+#endif
+
+// A trailing custom section whose payload is empty after the section name -- the exact shape
+// sysvmoc_interrupt_tests/oc_interrupt_preserves_dedup_record appends to vary a code hash, and
+// legal per the wasm spec. Must parse cleanly with an empty data vector.
+BOOST_AUTO_TEST_CASE( empty_user_section_payload ) {
+#ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
+   std::vector<uint8_t> wasm( std::begin(wasm_preamble), std::end(wasm_preamble) );
+   // custom section: id 0, section size 2, name length 1, name "A", zero payload bytes
+   const uint8_t custom_section[] = { 0x00, 0x02, 0x01, 'A' };
+   wasm.insert( wasm.end(), std::begin(custom_section), std::end(custom_section) );
+
+   IR::Module module = deserialize_as_compile_child( wasm );
+   BOOST_REQUIRE_EQUAL( module.userSections.size(), 1u );
+   BOOST_TEST( module.userSections[0].name == "A" );
+   BOOST_TEST( module.userSections[0].data.empty() );
+#endif
+}
+
+// Degenerate further: the name is empty too (section payload is just the zero name length).
+// std::string::data() is guaranteed non-null even when empty, but the section data vector is
+// not -- both must be tolerated. Runs with default limit checking enabled to cover the
+// check_limits == true branch as well.
+BOOST_AUTO_TEST_CASE( empty_user_section_name_and_payload ) {
+#ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
+   std::vector<uint8_t> wasm( std::begin(wasm_preamble), std::end(wasm_preamble) );
+   // custom section: id 0, section size 1, name length 0, no name, zero payload bytes
+   const uint8_t custom_section[] = { 0x00, 0x01, 0x00 };
+   wasm.insert( wasm.end(), std::begin(custom_section), std::end(custom_section) );
+
+   IR::Module module;
+   Serialization::MemoryInputStream stream( wasm.data(), wasm.size() );
+   WASM::serialize( stream, module );
+   BOOST_REQUIRE_EQUAL( module.userSections.size(), 1u );
+   BOOST_TEST( module.userSections[0].name.empty() );
+   BOOST_TEST( module.userSections[0].data.empty() );
+#endif
+}
+
+// A custom section truncated to zero total bytes cannot even hold its name length; it must be
+// rejected with a serialization exception rather than crash.
+BOOST_AUTO_TEST_CASE( truncated_user_section_throws ) {
+#ifdef SYSIO_SYS_VM_OC_RUNTIME_ENABLED
+   std::vector<uint8_t> wasm( std::begin(wasm_preamble), std::end(wasm_preamble) );
+   // custom section: id 0, section size 0 -- no room for the name length varint
+   const uint8_t custom_section[] = { 0x00, 0x00 };
+   wasm.insert( wasm.end(), std::begin(custom_section), std::end(custom_section) );
+
+   BOOST_CHECK_THROW( deserialize_as_compile_child( wasm ), Serialization::FatalSerializationException );
+#endif
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Fixes a latent bug in the sys-vm-oc tier-up interrupt path. **This bug also exists in Spring** -- the same `transaction_context::reset()` retry path never re-records the transaction.

When sys-vm-oc finishes compiling a contract while that contract's transaction is executing under the interpreter, it interrupts the transaction and restarts it under the optimized runtime. The restart goes through `transaction_context::reset()`, which:

1. `undo()`s the transaction's undo session -- reverting the dedup record made in `init_for_input_trx`, then
2. re-runs only `exec()`, **not** `init_for_input_trx`.

So the dedup record is never re-created: an interrupting node silently drops the transaction from its dedup set.

## Why it matters

The OC interrupt is only allowed when applying a block with explicit CPU billing (a validator/relay), and only fires if OC compilation happens to finish mid-execution -- so it is validator-only and timing-dependent. When it does fire:

- The dedup set is folded into `calculate_integrity_hash` and snapshots, so the interrupting node diverges on that auxiliary state from nodes that did not interrupt at the same block.
- A still-unexpired resubmission of the same transaction would execute again instead of being rejected `tx_duplicate`.

## Fix

Re-issue `record_transaction(...)` in `reset()` after `initialize()` re-creates the undo session, gated exactly as the original record in `init_for_input_trx` (`is_input && !is_transient()`).

## Test

`sysvmoc_interrupt_tests/oc_interrupt_preserves_dedup_record` pushes a finite-but-long `checktime_failure` action (a `bound*bound` loop) under explicit billing -- the applying-block path where the OC interrupt is allowed -- forcing an OC tier-up interrupt and restart, then asserts the transaction is still known to the dedup set after the block is produced.

The assertion can fail **only** when the bug manifests (the interrupt fired AND the record was dropped). If OC compilation happens not to interrupt on a given run, the record is trivially still present, so the test never fails spuriously (it logs when the interrupt path was not exercised). This keeps the test non-flaky -- a best-effort regression guard, as the interrupt timing is inherently machine-dependent.


## Second fix: sys-vm-oc executor paired with the wrong code cache (`7c99d6d4ec`)

The new test exposed a second latent bug, which this PR also fixes. **This bug also exists in Spring** -- `eosvmoc_tier` has the same `thread_local static` executor/memory shared across instances.

CI's asan and gcc jobs SEGV'd in `oc_interrupt_preserves_dedup_record` with the crash pc inside `code_cache.bin` while the **validating** node applied the block. Root cause: `sysvmoc_tier`'s executor and memory were process-wide `thread_local` **statics** -- one per thread, shared by every tier instance, rebuilt by whichever tier was constructed last. An executor mmaps its own code cache's backing file, and descriptors hold offsets only meaningful within that file. A validating tester runs two controllers (the validating node constructs first, the main node second), so the validating node's tier-up executions ran:

```
apply_func = main node's code_cache.bin mapping + validating node's descriptor offsets
```

The two caches usually compile the same contracts in the same order, so the wrong mapping silently executes byte-identical code. When compile-completion order diverges between the nodes (asan/gcc builds perturb timing), the offsets land on different code and the JIT executes garbage -- a wild read the OC SEGV handler correctly refuses to claim, so the process dies.

`wasm_interrupt_test` never tripped this because its transaction always fails on deadline and is never re-executed by the validating node; the new test is the first to tier-up execute a **committed** transaction on the validating node. **A running nodeop is unaffected**: one controller per process means the pairing could never mismatch (and the base `sysvmoc_runtime`'s main-thread executor/memory were already per-instance members).

Fixed by extracting `sysvmoc::thread_exec_mem`, owned per tier/runtime instance:

- **Main thread**: executor/memory are instance members, so pairing with the instance's code cache is guaranteed by construction.
- **Read-only threads**: one `thread_local` slot per thread, tagged with a monotonic owner id (never reused, so a recycled `this` pointer cannot alias a destroyed instance) and rebuilt whenever a different instance executes on that thread. This also fixes the same latent mismatch in the base `sysvmoc_runtime`'s read-only-thread statics.

Verified against a RelWithDebInfo + ASan build matching CI's asan job: `sysvmoc_interrupt_tests` under `--sys-vm` crashed 5/5 runs before the fix and passes 10/10 after; `--sys-vm-jit`/`--sys-vm-oc` variants and the `sysvmoc_limits`, `checktime`, and `block_tests` OC suites pass unchanged.
