### PR TITLE
test: de-flake snapshot_api bootstrap wait and read_only_trx setup setcode

### DIFF
--- a/tests/snapshot_api_test.py
+++ b/tests/snapshot_api_test.py
@@ -39,6 +39,26 @@ from TestHarness.TestHelper import AppArgs
 Print=Utils.Print
 errorExit=Utils.errorExit
 
+def waitForAttestationRecord(node, blockNum, timeout=90):
+    """Poll a node's sysio.snaprecords table until the attestation for ``blockNum`` appears.
+
+    A snapshot is created first and attested afterwards, so the votesnaphash transaction
+    lands in a block *after* the snapshot height. A node that bootstraps from that snapshot
+    therefore does not have the attestation in its loaded state -- it must sync forward past
+    the attestation block before the record becomes visible.
+
+    A single ``waitForLibToAdvance`` only guarantees one finality round (a few blocks), which
+    can fall far short of the attestation block when bootstrapping from an older snapshot
+    while the chain head is already many blocks ahead. Poll for the record itself instead so
+    the wait tracks the actual condition under test rather than a proxy that races it.
+
+    Returns True once the record is found, False on timeout.
+    """
+    def recordPresent():
+        records = node.getTableRows("sysio", "sysio", "snaprecords")
+        return records is not None and any(r["value"]["block_num"] == blockNum for r in records)
+    return Utils.waitForBool(recordPresent, timeout=timeout, sleepTime=1)
+
 appArgs = AppArgs()
 args=TestHelper.parse_args({"--dump-error-details","--keep-logs","-v","--leave-running","--unshared"},
                             applicationSpecificArgs=appArgs)
@@ -420,15 +440,11 @@ try:
         chainArg=f"--delete-all-blocks --snapshot-endpoint {endpointUrl}")
     assert isRelaunchSuccess, "Failed to relaunch bootstrap node from snapshot endpoint"
 
-    Print("Wait for bootstrap node to sync")
-    assert bootstrapNode.waitForLibToAdvance(timeout=60), \
-        "LIB did not advance on bootstrap node"
-
-    # Verify attestation records accessible on bootstrap node
-    records = bootstrapNode.getTableRows("sysio", "sysio", "snaprecords")
-    assert records is not None, "Failed to read snaprecords on bootstrap node"
-    found = any(r["value"]["block_num"] == snap2BlockNum for r in records)
-    assert found, f"Attestation for block {snap2BlockNum} not found on bootstrap node"
+    # The attestation is in blocks after the snapshot height, so wait for the bootstrap
+    # node to sync forward until the record is visible (not just one LIB advance).
+    Print("Wait for bootstrap node to sync past the attestation block")
+    assert waitForAttestationRecord(bootstrapNode, snap2BlockNum), \
+        f"Attestation for block {snap2BlockNum} not found on bootstrap node"
 
     Print("Test 8 PASSED")
 
@@ -464,12 +480,12 @@ try:
         addSwapFlags={"--snapshot-endpoint": endpointUrlWithBlock})
     assert isRelaunchSuccess, "Failed to relaunch with specific block number"
 
-    assert bootstrapNode.waitForLibToAdvance(timeout=60), \
-        "LIB did not advance on bootstrap node with specific block"
-
-    records = bootstrapNode.getTableRows("sysio", "sysio", "snaprecords")
-    found = any(r["value"]["block_num"] == snapBlockNum for r in records)
-    assert found, f"First snapshot attestation not found after specific-block bootstrap"
+    # Bootstrapped from the FIRST (older) snapshot, so the attestation block is many
+    # blocks ahead of the loaded state -- a single LIB advance is not enough. Poll for
+    # the record until the node syncs forward to it.
+    Print("Wait for bootstrap node to sync past the attestation block")
+    assert waitForAttestationRecord(bootstrapNode, snapBlockNum), \
+        "First snapshot attestation not found after specific-block bootstrap"
 
     Print("Test 9 PASSED")
 

--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -107,7 +107,16 @@ void test_trxs_common(std::vector<const char*>& specific_args) {
                   "-p", "sysio", "-e", // actual arguments follow
                   "--data-dir", temp_dir_str.c_str(),
                   "--config-dir", temp_dir_str.c_str(),
-                  "--max-transaction-time=100",
+                  // -1 == no wall-clock cap on write transactions. The setup step below deploys the
+                  // sysio.bios contract via setcode, a write transaction. Under heavy CI parallelism
+                  // (this binary runs alongside ~1800 wasm_spec_tests saturating every core) the
+                  // setcode is repeatedly descheduled: it bills ~0 cpu yet its wall-clock checktime
+                  // can run hundreds of ms, tripping a tight --max-transaction-time and failing the
+                  // run with tx_cpu_usage_exceeded. This test exercises read-only execution, not
+                  // write-trx cpu enforcement, so the cap only adds flake. The setup is still bounded
+                  // by push_input_trx's 5s future wait, and read-only transactions remain bounded by
+                  // read-only-read-window-time-us (effective ~390000us after the 10000us margin).
+                  "--max-transaction-time=-1",
                   "--abi-serializer-max-time-ms=999",
                   "--read-only-write-window-time-us=100000",
                   "--read-only-read-window-time-us=400000"


### PR DESCRIPTION
Two unrelated CI test flakes surfaced on the PR #396 merge-with-master run. Both are in tests **outside** that PR's diff (they arrived on master via the snapshot-endpoint feature, #246/#248). No product code changes here — test-only.

## 1. `snapshot_api_test` Test 9 — under-waited the bootstrap sync (NP, ubuntu24)
A snapshot is created first and attested afterwards, so the `votesnaphash` transaction lands in a block well after the snapshot height. Test 9 bootstraps the node from the **first (older)** snapshot, then asserted the attestation record existed after a single `waitForLibToAdvance`. One finality round (a few blocks) does not close the gap between an old snapshot and the much-later attestation block, so the record simply hadn't been replayed yet (observed: node at lib ~196, attestation recorded at block ~209).

**Fix:** replace the single LIB advance + immediate table read in Tests 8 and 9 with `waitForAttestationRecord()`, which polls `sysio.snaprecords` until the record surfaces as the node syncs forward. The wait now tracks the actual condition under test instead of a proxy that races it.

## 2. `read_only_trxs/with_3_read_only_threads_no_tierup` — setup setcode tripped the wall-clock cap (gcc)
The suite's setup deploys `sysio.bios` via `setcode` (a write transaction) under `--max-transaction-time=100ms`. Running alongside ~1800 concurrent `wasm_spec_tests` saturating every core, the setcode bills ~0 cpu yet its wall-clock `checktime` ran 398ms, tripping `tx_cpu_usage_exceeded`.

**Fix:** set `--max-transaction-time=-1`. The suite exercises read-only execution, not write-trx cpu enforcement. Setup is still bounded by `push_input_trx`'s 5s future wait, and read-only transactions remain bounded by `read-only-read-window-time-us` (effective ~390000us after the 10000us margin), so their enforcement is unchanged.
