### PR TITLE
Fix launcher option replacement guard

### DIFF
--- a/tests/TestHarness/launcher.py
+++ b/tests/TestHarness/launcher.py
@@ -16,6 +16,10 @@ from .accounts import createAccountKeys
 
 block_dir = 'blocks'
 
+def _is_command_option(token):
+    """Return whether a command-line token is an option name rather than an option value."""
+    return token.startswith('--')
+
 class EnhancedEncoder(json.JSONEncoder):
     def default(self, o):
         if is_dataclass(o):
@@ -575,7 +579,7 @@ class cluster_generator:
                 if '-' in arg and arg not in repeatable:
                     if arg in sysdcmd:
                         i = sysdcmd.index(arg)
-                        if sysdcmd[i+1] != '-':
+                        if i + 1 < len(sysdcmd) and not _is_command_option(sysdcmd[i+1]):
                             sysdcmd.pop(i+1)
                         sysdcmd.pop(i)
             sysdcmd.extend(specificList)


### PR DESCRIPTION
Summary

Fix TestHarness launcher option replacement when an option is followed by another option instead of a value.

What changed

- Add `_is_command_option()` to identify command-line option tokens.
- Guard option-value removal with a bounds check and only remove the next token when it is actually a value.

Why

The port-sharded test changes in PR #369 rely on overriding generated nodeop arguments. The existing replacement logic can treat the following `--option` as a value and remove it, or read past the end of the command list.

Testing

- `python3 -m py_compile tests/TestHarness/launcher.py`
- `git diff --check`

Notes

- This PR is stacked on PR #369: https://github.com/Wire-Network/wire-sysio/pull/369
