### PR TITLE
fix(chain): dedup S-root merkle leaves to one per transaction per (contract, root)

### DIFF
--- a/libraries/chain/root_txn_identification.cpp
+++ b/libraries/chain/root_txn_identification.cpp
@@ -110,9 +110,21 @@ namespace sysio { namespace chain {
             if (root_contract_match.is_contract_match(contract) &&
                 root_contract_match.is_action_match(action)) {
                // We have a match, so we need to store the transaction id
-               // in the storage for this contract
+               // in the storage for this contract.
+               //
+               // A single transaction can carry several traces that match the same
+               // (contract, root): one per matching action plus one per
+               // require_recipient notification, which replicates act.account/act.name
+               // for every notified receiver. The S-root merkle commits to the set of
+               // transactions that touched the contract, so each transaction id must
+               // contribute exactly one leaf per (contract, root). All traces of a
+               // transaction are delivered in a single call and a transaction id is
+               // applied (with a receipt) at most once per block, so a duplicate can
+               // only ever be the most recently stored id.
                auto& contract_storage = this->storage[std::make_pair(contract, root_contract_match.root_name)];
-               contract_storage.push_back(action_trace.trx_id);
+               if (contract_storage.empty() || contract_storage.back() != action_trace.trx_id) {
+                  contract_storage.push_back(action_trace.trx_id);
+               }
                break;
             }
          }

--- a/unittests/test_s_root_extension.cpp
+++ b/unittests/test_s_root_extension.cpp
@@ -232,6 +232,74 @@ BOOST_AUTO_TEST_CASE(distinct_transactions_produce_one_leaf_each) {
    } FC_LOG_AND_RETHROW()
 }
 
+// A transaction that touches TWO watched (contract, root) pairs must contribute
+// one leaf to EACH pair's merkle — each contract's S-root commits to the set of
+// transactions that touched that contract. This pins why the dedup is a
+// per-bucket check rather than a per-transaction early-out: stopping at the
+// first matching trace (e.g. returning from process_action_traces after the
+// first record) would drop the transaction from every other matched contract's
+// root, making it unprovable against that contract.
+BOOST_AUTO_TEST_CASE(multi_contract_transaction_records_in_each_root) {
+   try {
+      contract_action_matches matches;
+      matches.push_back(contract_action_match("ra"_n, "tokena"_n, contract_action_match::match_type::exact));
+      matches[0].add_action("transfer"_n, contract_action_match::match_type::exact);
+      matches.push_back(contract_action_match("rb"_n, "tokenb"_n, contract_action_match::match_type::exact));
+      matches[1].add_action("transfer"_n, contract_action_match::match_type::exact);
+      tester chain(matches);
+
+      chain.create_accounts({"tokena"_n, "tokenb"_n, "alice"_n});
+      for (const auto& token : {"tokena"_n, "tokenb"_n}) {
+         chain.set_code(token, test_contracts::sysio_token_wasm());
+         chain.set_abi(token, test_contracts::sysio_token_abi());
+         // the token contract bills the currency stats row to the issuer account
+         chain.set_privileged(token);
+      }
+      chain.produce_block();
+
+      for (const auto& token : {"tokena"_n, "tokenb"_n}) {
+         chain.push_action(token, "create"_n, token, mvo()
+            ("issuer", name(config::system_account_name))
+            ("maximum_supply", core_from_string("1000000.0000")));
+         chain.push_action(token, "issue"_n, config::system_account_name, mvo()
+            ("to", name(config::system_account_name))
+            ("quantity", core_from_string("1000.0000"))
+            ("memo", ""));
+      }
+      chain.produce_block();
+
+      // ONE transaction carrying a matching transfer on each token contract.
+      signed_transaction trx;
+      for (const auto& token : {"tokena"_n, "tokenb"_n}) {
+         trx.actions.push_back(chain.get_action(token, "transfer"_n,
+            vector<permission_level>{{config::system_account_name, config::active_name}}, mvo()
+            ("from", name(config::system_account_name))
+            ("to", "alice"_n)
+            ("quantity", core_from_string("1.0000"))
+            ("memo", "")));
+      }
+      chain.set_transaction_headers(trx);
+      trx.sign(chain.get_private_key(config::system_account_name, "active"), chain.control->get_chain_id());
+      chain.push_transaction(trx);
+      auto block = chain.produce_block();
+
+      flat_multimap<uint16_t, block_header_extension> header_exts = block->validate_and_extract_header_extensions();
+      BOOST_REQUIRE_EQUAL(2u, header_exts.count(s_root_extension::extension_id()));
+      std::map<name, s_header> headers_by_contract;
+      for (const auto& ext : header_exts) {
+         if (ext.first != s_root_extension::extension_id())
+            continue;
+         const s_header header = std::get<s_root_extension>(ext.second).s_header_data;
+         headers_by_contract.emplace(header.contract_name, header);
+      }
+      BOOST_REQUIRE_EQUAL(2u, headers_by_contract.size());
+      const deque<digest_type> expected_leaves{trx.id()};
+      const auto expected_root = calculate_merkle(expected_leaves);
+      BOOST_CHECK_EQUAL(expected_root, headers_by_contract.at("tokena"_n).current_s_root);
+      BOOST_CHECK_EQUAL(expected_root, headers_by_contract.at("tokenb"_n).current_s_root);
+   } FC_LOG_AND_RETHROW()
+}
+
 // Direct unit tests for the validate_s_root_extensions_match helper extracted
 // from apply_block. Each test builds received/constructed extension vectors by
 // hand and verifies the helper accepts or rejects as expected.

--- a/unittests/test_s_root_extension.cpp
+++ b/unittests/test_s_root_extension.cpp
@@ -2,12 +2,17 @@
 #include <sysio/testing/tester.hpp>
 #include <sysio/chain/unapplied_transaction_queue.hpp>
 #include <sysio/chain/contract_types.hpp>
+#include <sysio/chain/merkle.hpp>
 #include <sysio/chain/s_root_extension.hpp>
+#include <fc/variant_object.hpp>
 
+#include <test_contracts.hpp>
 
 using namespace sysio;
 using namespace sysio::chain;
 using namespace sysio::testing;
+
+using mvo = fc::mutable_variant_object;
 
 BOOST_AUTO_TEST_SUITE(test_s_root_extension)
 
@@ -110,6 +115,120 @@ BOOST_AUTO_TEST_CASE(something_to_report) {
       BOOST_CHECK_EQUAL(brian_block->block_num(), crtd_s_header_multiple.previous_block_num);
       BOOST_CHECK(checksum256_type() != crtd_s_header_multiple.current_s_id);
       BOOST_CHECK(checksum256_type() != crtd_s_header_multiple.current_s_root);
+   } FC_LOG_AND_RETHROW()
+}
+
+namespace {
+
+// Extract the s_header from a block that must carry exactly one s_root_extension.
+s_header extract_single_s_header(const signed_block_ptr& block) {
+   flat_multimap<uint16_t, block_header_extension> header_exts = block->validate_and_extract_header_extensions();
+   BOOST_REQUIRE_EQUAL(1u, header_exts.count(s_root_extension::extension_id()));
+   auto itr = std::find_if(header_exts.begin(), header_exts.end(),
+      [](const auto& ext) { return ext.first == s_root_extension::extension_id(); });
+   BOOST_REQUIRE(itr != header_exts.end());
+   return std::get<s_root_extension>(itr->second).s_header_data;
+}
+
+} // namespace
+
+// The S-root merkle commits to the set of transactions that touched a matched
+// contract, so a transaction must contribute exactly one leaf per (contract, root)
+// no matter how many of its action traces match. A transfer notifying `from` and
+// `to` via require_recipient yields three matching traces (receiver = contract,
+// from, to) that all share one transaction id; before the dedup fix each trace
+// produced its own identical leaf.
+BOOST_AUTO_TEST_CASE(notification_produces_single_leaf) {
+   try {
+      contract_action_matches matches;
+      matches.push_back(contract_action_match("s"_n, "sysio.token"_n, contract_action_match::match_type::exact));
+      matches[0].add_action("transfer"_n, contract_action_match::match_type::exact);
+      tester chain(matches);
+
+      chain.create_accounts({"sysio.token"_n, "alice"_n});
+      chain.set_code("sysio.token"_n, test_contracts::sysio_token_wasm());
+      chain.set_abi("sysio.token"_n, test_contracts::sysio_token_abi());
+      // the token contract bills the currency stats row to the issuer account
+      chain.set_privileged("sysio.token"_n);
+      chain.produce_block();
+
+      // create/issue do not match the configured (sysio.token, transfer) pair, and
+      // issuing to the issuer avoids the contract's inline transfer on issue.
+      chain.push_action("sysio.token"_n, "create"_n, "sysio.token"_n, mvo()
+         ("issuer", name(config::system_account_name))
+         ("maximum_supply", core_from_string("1000000.0000")));
+      chain.push_action("sysio.token"_n, "issue"_n, config::system_account_name, mvo()
+         ("to", name(config::system_account_name))
+         ("quantity", core_from_string("1000.0000"))
+         ("memo", ""));
+      chain.produce_block();
+
+      auto trace = chain.push_action("sysio.token"_n, "transfer"_n, config::system_account_name, mvo()
+         ("from", name(config::system_account_name))
+         ("to", "alice"_n)
+         ("quantity", core_from_string("1.0000"))
+         ("memo", ""));
+      auto block = chain.produce_block();
+
+      const s_header header = extract_single_s_header(block);
+      BOOST_CHECK_EQUAL("sysio.token"_n, header.contract_name);
+      const deque<digest_type> expected_leaves{trace->id};
+      BOOST_CHECK_EQUAL(calculate_merkle(expected_leaves), header.current_s_root);
+   } FC_LOG_AND_RETHROW()
+}
+
+// Two matching actions in one transaction must also collapse to a single leaf.
+BOOST_AUTO_TEST_CASE(repeated_matching_actions_produce_single_leaf) {
+   try {
+      contract_action_matches matches;
+      matches.push_back(contract_action_match("s"_n, config::system_account_name, contract_action_match::match_type::exact));
+      matches[0].add_action("newaccount"_n, contract_action_match::match_type::exact);
+      tester chain(matches);
+      chain.produce_block();
+
+      // sysio.-prefixed accounts skip the tester's setalimits/ROA companion actions,
+      // leaving a transaction with exactly two matching newaccount actions.
+      signed_transaction trx;
+      chain.set_transaction_headers(trx);
+      for (const auto& account : {"sysio.aaa"_n, "sysio.bbb"_n}) {
+         trx.actions.emplace_back(vector<permission_level>{{config::system_account_name, config::active_name}},
+                                  newaccount{
+                                     .creator = config::system_account_name,
+                                     .name    = account,
+                                     .owner   = authority(chain.get_public_key(account, "owner")),
+                                     .active  = authority(chain.get_public_key(account, "active"))
+                                  });
+      }
+      chain.set_transaction_headers(trx);
+      trx.sign(chain.get_private_key(config::system_account_name, "active"), chain.control->get_chain_id());
+      auto trace = chain.push_transaction(trx);
+      auto block = chain.produce_block();
+
+      const s_header header = extract_single_s_header(block);
+      BOOST_CHECK_EQUAL(config::system_account_name, header.contract_name);
+      const deque<digest_type> expected_leaves{trace->id};
+      BOOST_CHECK_EQUAL(calculate_merkle(expected_leaves), header.current_s_root);
+   } FC_LOG_AND_RETHROW()
+}
+
+// Distinct transactions must keep one leaf each, in application order — the
+// dedup must only collapse traces of the same transaction, never across
+// transactions.
+BOOST_AUTO_TEST_CASE(distinct_transactions_produce_one_leaf_each) {
+   try {
+      contract_action_matches matches;
+      matches.push_back(contract_action_match("s"_n, config::system_account_name, contract_action_match::match_type::exact));
+      matches[0].add_action("newaccount"_n, contract_action_match::match_type::exact);
+      tester chain(matches);
+      chain.produce_block();
+
+      auto trace1 = chain.create_account("carol"_n);
+      auto trace2 = chain.create_account("dave"_n);
+      auto block = chain.produce_block();
+
+      const s_header header = extract_single_s_header(block);
+      const deque<digest_type> expected_leaves{trace1->id, trace2->id};
+      BOOST_CHECK_EQUAL(calculate_merkle(expected_leaves), header.current_s_root);
    } FC_LOG_AND_RETHROW()
 }
 


### PR DESCRIPTION
## Problem

`root_txn_identification_impl::process_action_traces` records one merkle leaf per **matching action trace**, but the S-root merkle is meant to commit to the set of **transactions** that touched a matched contract. Two common patterns produce several matching traces for one transaction, all carrying the same `trx_id`:

- **`require_recipient` notifications** — every notified receiver gets its own action trace replicating `act.account`/`act.name`. A single matched token `transfer` yields 3 matching traces (receiver = contract, `from`, `to`).
- **Repeated matching actions** — a transaction carrying N matching actions yields N traces.

Each duplicate trace appended another identical leaf, so the per-contract S-root committed to a multiset: external settlement verifiers over-count transactions, and one transaction is provable at multiple leaf positions.

Found in the 2026-06-09 block-validation/trx-execution consensus review (finding #8); it was erroneously believed fixed by #391. Deterministic across nodes (producer and validator run the same code), so no chain-split risk — but the committed root is wrong for any external consumer. Wire-specific machinery; not present in Spring. Chain is pre-launch, so no produced-block compatibility concern.

## Fix

Dedup at insertion in `process_action_traces`: skip the append when the bucket's most recent id already equals `action_trace.trx_id`. All traces of a transaction are delivered in one applied-transaction signal and a transaction id is applied (with a receipt) at most once per block, so a duplicate can only ever be the most recently stored id — an O(1) back-check is exact, and merkle leaf order remains transaction application order.

## Tests (`test_s_root_extension`)

| Case | Asserts | Without fix |
|---|---|---|
| `notification_produces_single_leaf` | token transfer notifying `from`/`to` → exactly one leaf; `current_s_root == calculate_merkle({trx_id})` | **fails** (3 identical leaves) |
| `repeated_matching_actions_produce_single_leaf` | two matching `newaccount` actions in one trx → one leaf | **fails** (2 identical leaves) |
| `distinct_transactions_produce_one_leaf_each` | two separate matched trxs in one block → one leaf each, application order | passes (guards against over-dedup) |

Fail-without/pass-with verified locally; `forked_tests_savanna`, `snapshot_part1/2_tests`, `block_tests`, and the full `test_s_root_extension` suite are green with the fix.