### PR TITLE
chain: uint128/int128 + checksum256 support in the BE key codec; fix batch_operator byoutepoch packing

### DIFF
--- a/libraries/chain/include/sysio/chain/database_utils.hpp
+++ b/libraries/chain/include/sysio/chain/database_utils.hpp
@@ -164,6 +164,13 @@ struct reader {
    uint32_t read_be32() { return read_be<uint32_t>(); }
    uint64_t read_be64() { return read_be<uint64_t>(); }
 
+   // Copy `n` raw bytes (already order-preserving, e.g. a checksum digest).
+   void read_bytes(char* out, size_t n) {
+      FC_ASSERT(remaining() >= n, "BE key underflow reading {} raw bytes", n);
+      std::memcpy(out, pos, n);
+      pos += n;
+   }
+
    // NUL-escape decoding: 0x00,0x01 = literal NUL byte, 0x00,0x00 = end of string.
    std::string read_nul_escaped_string() {
       std::string s;
@@ -201,6 +208,9 @@ struct writer {
    std::vector<char> buf;
 
    void write_u8(uint8_t v) { buf.push_back(static_cast<char>(v)); }
+
+   // Append `n` raw bytes verbatim (already order-preserving).
+   void write_bytes(const char* p, size_t n) { buf.insert(buf.end(), p, p + n); }
 
    void write_be16(uint16_t v) { write_be(v); }
 
@@ -257,6 +267,17 @@ inline fc::variant decode_field(reader& r, const std::string& type) {
       fc::to_variant(static_cast<fc::int128>(fc::to_uint128(hi, lo)), v);
       return v;
    }
+   if (type == "checksum256") {
+      // Raw 32 digest bytes in display order: fixed_bytes packs its words
+      // big-endian, so CDT's to_key emits the canonical byte sequence and
+      // memcmp order matches checksum256 ordering. Canonical hex spelling
+      // via fc::sha256's variant conversion.
+      fc::sha256 h;
+      r.read_bytes(h.data(), h.data_size());
+      fc::variant v;
+      fc::to_variant(h, v);
+      return v;
+   }
    if (type == "name")          return fc::variant(name(r.read_be64()).to_string());
    if (type == "bool")          return fc::variant(r.read_u8() != 0);
    if (type == "string")        return fc::variant(r.read_nul_escaped_string());
@@ -301,6 +322,12 @@ inline void encode_field(writer& w, const std::string& type, const fc::variant& 
       const auto u = static_cast<fc::uint128>(i);
       w.write_be64(static_cast<uint64_t>(u >> 64) ^ (uint64_t(1) << 63));
       w.write_be64(static_cast<uint64_t>(u));
+      return;
+   }
+   if (type == "checksum256") {
+      fc::sha256 h;
+      fc::from_variant(val, h);
+      w.write_bytes(h.data(), h.data_size());
       return;
    }
    if (type == "name")          { w.write_be64(name(val.as_string()).to_uint64_t()); return; }

--- a/libraries/chain/include/sysio/chain/database_utils.hpp
+++ b/libraries/chain/include/sysio/chain/database_utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sysio/chain/types.hpp>
+#include <fc/int128.hpp>
 #include <fc/io/raw.hpp>
 #include <fc/crypto/base64.hpp>
 #include <softfloat/softfloat.hpp>
@@ -240,6 +241,22 @@ inline fc::variant decode_field(reader& r, const std::string& type) {
    if (type == "int32")         return fc::variant(static_cast<int32_t>(r.read_be32() ^ 0x80000000u));
    if (type == "uint64")        return fc::variant(r.read_be64());
    if (type == "int64")         return fc::variant(static_cast<int64_t>(r.read_be64() ^ (uint64_t(1) << 63)));
+   if (type == "uint128") {
+      // 16-byte big-endian, high quadword first — mirrors the uint64 BE layout.
+      const uint64_t hi = r.read_be64();
+      const uint64_t lo = r.read_be64();
+      fc::variant v;
+      fc::to_variant(fc::to_uint128(hi, lo), v);
+      return v;
+   }
+   if (type == "int128") {
+      // Sign-flip the high quadword (same bias trick as int64) so signed values BE-sort.
+      const uint64_t hi = r.read_be64() ^ (uint64_t(1) << 63);
+      const uint64_t lo = r.read_be64();
+      fc::variant v;
+      fc::to_variant(static_cast<fc::int128>(fc::to_uint128(hi, lo)), v);
+      return v;
+   }
    if (type == "name")          return fc::variant(name(r.read_be64()).to_string());
    if (type == "bool")          return fc::variant(r.read_u8() != 0);
    if (type == "string")        return fc::variant(r.read_nul_escaped_string());
@@ -269,6 +286,23 @@ inline void encode_field(writer& w, const std::string& type, const fc::variant& 
    if (type == "int32")         { w.write_be32(static_cast<uint32_t>(static_cast<uint32_t>(val.as_int64()) ^ 0x80000000u)); return; }
    if (type == "uint64")        { w.write_be64(val.as_uint64()); return; }
    if (type == "int64")         { w.write_be64(static_cast<uint64_t>(val.as_int64()) ^ (uint64_t(1) << 63)); return; }
+   if (type == "uint128") {
+      // Accepts a native uint128 variant, a uint64 number, or a decimal/hex string
+      // (the JSON spelling for values past 2^64) via fc::from_variant.
+      fc::uint128 u = 0;
+      fc::from_variant(val, u);
+      w.write_be64(static_cast<uint64_t>(u >> 64));
+      w.write_be64(static_cast<uint64_t>(u));
+      return;
+   }
+   if (type == "int128") {
+      fc::int128 i = 0;
+      fc::from_variant(val, i);
+      const auto u = static_cast<fc::uint128>(i);
+      w.write_be64(static_cast<uint64_t>(u >> 64) ^ (uint64_t(1) << 63));
+      w.write_be64(static_cast<uint64_t>(u));
+      return;
+   }
    if (type == "name")          { w.write_be64(name(val.as_string()).to_uint64_t()); return; }
    if (type == "bool")          { w.write_u8(val.as_bool() ? 1 : 0); return; }
    if (type == "string")        { w.write_nul_escaped_string(val.as_string()); return; }

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -1,5 +1,6 @@
 #include <fc/log/logger.hpp>
 #include <fc/crypto/sha256.hpp>
+#include <fc/int128.hpp>
 #include <fc/io/json.hpp>
 #include <fc/variant_object.hpp>
 #include <boost/endian/conversion.hpp>
@@ -274,7 +275,12 @@ struct batch_operator_plugin::impl {
    /// given outpost + epoch by querying msgch::envelopes via the
    /// byoutepoch secondary index.
    bool has_delivered_envelope(uint64_t chain_code, uint32_t epoch_index) {
-      uint64_t key = (static_cast<uint64_t>(chain_code) << 32) | epoch_index;
+      // Canonical (outpost, epoch) packing per sysio.opp.common/opp_keys.hpp —
+      // chain_code (a slug_name, up to 48 bits) occupies bits 32-79, epoch bits 0-31.
+      // The byoutepoch index is uint128; serialize the bound as a decimal string so
+      // the JSON round-trip stays lossless past 2^64.
+      const fc::uint128 key =
+         (static_cast<fc::uint128>(chain_code) << 32) | static_cast<fc::uint128>(epoch_index);
       auto op_account = operator_account;
       // chain_plugin::get_table_rows forwards secondary-index bounds through
       // be_key_codec::encode_key, which unconditionally calls get_object() on
@@ -288,7 +294,7 @@ struct batch_operator_plugin::impl {
       p.code        = chain::name(msgch::account);
       p.scope       = msgch::account;
       p.table       = msgch::table_envelopes;
-      p.find        = std::format("{{\"{}\":{}}}", msgch::index_byoutepoch, key);
+      p.find        = std::format("{{\"{}\":\"{}\"}}", msgch::index_byoutepoch, fc::to_string(key));
       p.index_name  = msgch::index_byoutepoch;
       p.values_only = true;
       p.filter      = [op_account](const fc::variant& row) {

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -588,6 +588,51 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
       BOOST_CHECK_EQUAL(result.rows[2].get_object()["value"].get_object()["sec64"].as_uint64(), 7u);
    }
 
+   // (sec-3b) numobjs bysec2 (uint128) with a `find` bound — exercises
+   //          be_key_codec::encode_field("uint128", ...) on the decimal-string
+   //          JSON spelling. This is the exact shape batch_operator_plugin uses
+   //          for the msgch byoutepoch composite key; before uint128 codec
+   //          support it asserted "Unsupported BE key type: uint128".
+   {
+      chain_apis::read_only::get_table_rows_params p;
+      p.json = true;
+      p.code = "test"_n;
+      p.scope = "test";
+      p.table = "numobjs";
+      p.index_name = "bysec2";
+      p.find = R"({"bysec2":"5"})";
+      auto result = get_table_rows_full(plugin, p, fc::time_point::maximum());
+      BOOST_REQUIRE_EQUAL(result.rows.size(), 1u);
+      BOOST_CHECK_EQUAL(result.rows[0].get_object()["value"].get_object()["sec64"].as_uint64(), 5u);
+   }
+
+   // (sec-3c) numobjs bysec2 (uint128) pagination — next_key is produced by
+   //          be_key_codec::decode_field("uint128", ...) and fed back through
+   //          encode_field, covering the full decode/encode round-trip and the
+   //          BE ordering of the 16-byte key.
+   {
+      chain_apis::read_only::get_table_rows_params p;
+      p.json = true;
+      p.code = "test"_n;
+      p.scope = "test";
+      p.table = "numobjs";
+      p.index_name = "bysec2";
+      p.limit = 2;
+      auto page1 = get_table_rows_full(plugin, p, fc::time_point::maximum());
+      BOOST_REQUIRE_EQUAL(page1.rows.size(), 2u);
+      BOOST_REQUIRE_EQUAL(page1.more, true);
+      BOOST_REQUIRE(!page1.next_key.empty());
+      BOOST_CHECK_EQUAL(page1.rows[0].get_object()["value"].get_object()["sec64"].as_uint64(), 2u);
+      BOOST_CHECK_EQUAL(page1.rows[1].get_object()["value"].get_object()["sec64"].as_uint64(), 5u);
+
+      p.lower_bound = page1.next_key;
+      p.limit       = 50;
+      auto page2 = get_table_rows_full(plugin, p, fc::time_point::maximum());
+      BOOST_REQUIRE_EQUAL(page2.rows.size(), 1u);
+      BOOST_REQUIRE_EQUAL(page2.more, false);
+      BOOST_CHECK_EQUAL(page2.rows[0].get_object()["value"].get_object()["sec64"].as_uint64(), 7u);
+   }
+
    // (sec-4) hashobjs by name index "bysec1" (checksum256) — exercises the
    //         canonical-RecordType translation path that was the motivating
    //         abigen fix. All three rows must come back, ABI-decoded.

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -655,6 +655,62 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, validating_tester ) try {
       BOOST_CHECK(inputs.count("thirdinput"));
    }
 
+   // (sec-4b) hashobjs bysec1 (checksum256) with a `find` bound — exercises
+   //          be_key_codec::encode_field("checksum256", ...): the canonical
+   //          64-hex-char spelling maps to the raw 32 digest bytes (display
+   //          order; CDT to_key emits fixed_bytes' big-endian word packing).
+   //          Before checksum256 codec support this asserted
+   //          "Unsupported BE key type: checksum256".
+   {
+      chain_apis::read_only::get_table_rows_params p;
+      p.json = true;
+      p.code = "test"_n;
+      p.scope = "test";
+      p.table = "hashobjs";
+      p.index_name = "bysec1";
+      const auto second_hash = fc::sha256::hash("secondinput", 11).str();
+      p.find = std::string(R"({"bysec1":")") + second_hash + R"("})";
+      auto result = get_table_rows_full(plugin, p, fc::time_point::maximum());
+      BOOST_REQUIRE_EQUAL(result.rows.size(), 1u);
+      BOOST_CHECK_EQUAL(
+         result.rows[0].get_object()["value"].get_object()["hash_input"].as_string(),
+         "secondinput");
+   }
+
+   // (sec-4c) hashobjs bysec1 (checksum256) pagination — next_key is produced
+   //          by decode_field("checksum256") and fed back through encode_field
+   //          as lower_bound, covering the decode/encode round-trip. Row order
+   //          is hash-value order, so assert page sizes + full coverage rather
+   //          than a fixed sequence.
+   {
+      chain_apis::read_only::get_table_rows_params p;
+      p.json = true;
+      p.code = "test"_n;
+      p.scope = "test";
+      p.table = "hashobjs";
+      p.index_name = "bysec1";
+      p.limit = 2;
+      auto page1 = get_table_rows_full(plugin, p, fc::time_point::maximum());
+      BOOST_REQUIRE_EQUAL(page1.rows.size(), 2u);
+      BOOST_REQUIRE_EQUAL(page1.more, true);
+      BOOST_REQUIRE(!page1.next_key.empty());
+
+      p.lower_bound = page1.next_key;
+      p.limit       = 50;
+      auto page2 = get_table_rows_full(plugin, p, fc::time_point::maximum());
+      BOOST_REQUIRE_EQUAL(page2.rows.size(), 1u);
+      BOOST_REQUIRE_EQUAL(page2.more, false);
+
+      std::set<std::string> inputs;
+      for (auto* page : {&page1, &page2})
+         for (auto& row : page->rows)
+            inputs.insert(row.get_object()["value"].get_object()["hash_input"].as_string());
+      BOOST_CHECK_EQUAL(inputs.size(), 3u);
+      BOOST_CHECK(inputs.count("firstinput"));
+      BOOST_CHECK(inputs.count("secondinput"));
+      BOOST_CHECK(inputs.count("thirdinput"));
+   }
+
    // (sec-5) Invalid index name on multi_index — should throw, not silently
    //         return primary rows.
    {


### PR DESCRIPTION
## Problem

PR #386 widened the msgch `byoutepoch` composite key to **uint128** contract-side (`opp_keys.hpp`: chain_code bits 32-79, epoch bits 0-31), but the host side was never updated:

1. `be_key_codec::encode_field` / `decode_field` (`database_utils.hpp`) stop at 64-bit types — any `get_table_rows` bound or `next_key` on a uint128 KV index asserts **`Unsupported BE key type: uint128`**.
2. `batch_operator_plugin::has_delivered_envelope` still packs the pre-#386 lossy 64-bit `(chain_code << 32) | epoch` key.

Net effect on master — correctness and noise, **not** flow-fatal: `read_table_rows` catches the assert, logs `batch_operator: table read threw sysio.msgch::envelopes -- Assert Exception (10) false: Unsupported BE key type: uint128`, and returns an empty result. `has_delivered_envelope` therefore always answers "not delivered," so the dedup short-circuit is permanently non-functional — every relay poll emits the error line and re-attempts delivery, leaning on the contract's duplicate/late-delivery tolerance. Flows still pass without this fix for exactly that reason. What's actually broken:

1. The delivered-already dedup never works (error spam + redundant `deliver` traffic every poll).
2. Pre-#386, the same query ran with the lossy 64-bit packing — silently capable of cross-wiring outposts (the truncation #386 fixed contract-side, still present host-side until this PR).
3. Any JSON bound / `find` / `next_key` against a uint128 (or checksum256) kv index is broken RPC surface.

(Found while flow-verifying wire-tools-ts #7: the flow-run heartbeat treats `table read threw` plugin errors as a first-occurrence stop signal per the cluster-probing runbook, which is what halted those runs — the circulation itself survives this particular error.)

## Fix

- `database_utils.hpp`: add `uint128` / `int128` branches to `encode_field` and `decode_field` — 16-byte big-endian, high quadword first (BE order == numeric order for the unsigned key); `int128` uses the same high-bit sign bias as the existing `int64` handling; variant round-trip via `fc::uint128` (`to_variant` decimal string / `from_variant` accepting native, uint64, or decimal/hex string).
- `batch_operator_plugin.cpp`: pack the `byoutepoch` bound per `opp_keys.hpp` (uint128) and serialize it into the `find` JSON as a **decimal string**, so the round-trip stays lossless past 2^64.

## checksum256 (second commit)

The kv-key-type census surfaced the identical hole for **checksum256**: four live secondary indexes declare it (`authex links/bypubkey`, `msgch messages/bymsgid`, `roa nodeownerreg/bytrxid`, `system finkeys/byfinkey`), and any bound/`find`/`next_key` against them asserted `Unsupported BE key type: checksum256` — un-hit so far only because nothing host-side bound-queries them yet. Encoded as the raw 32 digest bytes in display order (fixed_bytes packs words big-endian, so CDT `to_key` emits the canonical sequence and memcmp order matches checksum256 ordering); JSON spelling via `fc::sha256`'s canonical variant conversions.

`uint256`/`int256` are deliberately not added: no contract can declare one (no native 256-bit integer in the CDT toolchain; `fc::uint256` also lacks variant conversions today) — checksum256 is the 256-bit key type in actual use. The full census of declared kv secondary key types is now covered: uint64 ×36, uint128 ×8, checksum256 ×4.

## Tests

`get_table_tests` gains four cases on the existing fixtures:
- **(sec-3b)** uint128 `find` bound on `numobjs/bysec2` — the exact query shape `batch_operator_plugin` uses; asserted before this fix.
- **(sec-3c)** uint128 pagination — `next_key` produced by `decode_field` fed back through `encode_field` as `lower_bound`, covering the full decode/encode round-trip and BE ordering.
- **(sec-4b)** checksum256 `find` bound on `hashobjs/bysec1` (bound computed as `sha256("secondinput")`).
- **(sec-4c)** checksum256 pagination round-tripping `next_key` through decode/encode.



## Test sweep

- `plugin_test` — green (`get_table_tests` incl. new cases)
- `contracts_unit_test -- --sys-vm` — green
- `test_fc` — green
- `unit_test -- --sys-vm` — 4 failures, **all pre-existing on stock master** (control-verified with this change stashed; the codec is referenced nowhere in `unittests/`): `api_part2_tests/crypto_tests` ("public key does not match") and `savanna_misc_tests/verify_block_compatibitity` (reference-id mismatch — the documented regenerate-reference-data case after #386 recompiled `sysio.msgch.wasm`).

## End-to-end verification

All 9 wire-tools-ts e2e flows pass with this fix applied (wire-tools-ts #7 verification sweep), with zero `table read threw` signatures in the cluster logs — the relay dedup short-circuit works and no redundant deliveries occur. Flows also pass **without** this fix (see Problem section — the error is caught and degrades to redundant delivery), so this is a correctness/noise fix for the relay and an unbreaking of the uint128/checksum256 RPC bound surface, not a circulation blocker.
