### PR TITLE
test: deflake snapshot_attest_test & snapshot_api_test (regproducer/setrank race)

### DIFF
--- a/tests/snapshot_api_test.py
+++ b/tests/snapshot_api_test.py
@@ -123,8 +123,15 @@ try:
         }),
         f"--permission {producerA}@active")
     assert success, f"Failed to register producer {producerA}: {trans}"
+    regProducerTransId = node0.getTransId(trans)
 
-    assert node0.waitForHeadToAdvance(), "Head did not advance after regproducer"
+    # Wait for regproducer to be in a block before setrank reads the on-chain
+    # producers table. waitForHeadToAdvance() does not guarantee this specific
+    # transaction was applied -- with multiple producers a transaction pushed to
+    # node0 can be forwarded into a peer's block -- which would make setrank fail
+    # with "producer not found".
+    assert node0.waitForTransactionInBlock(regProducerTransId, timeout=60), \
+        "regproducer transaction did not make it into a block before setrank"
 
     success, trans = node0.pushMessage("sysio", "setrank",
         json.dumps({"producer": producerA, "rank": 1}),
@@ -137,14 +144,19 @@ try:
         json.dumps({"producer": producerA, "snap_account": snapProv1.name}),
         f"--permission {producerA}@active")
     assert success, f"Failed to register snapshot provider: {trans}"
+    regSnapProvTransId = node0.getTransId(trans)
 
     # Set attestation config: min_providers=1, threshold_pct=50 (single vote = quorum)
     success, trans = node0.pushMessage("sysio", "setsnpcfg",
         json.dumps({"min_providers": 1, "threshold_pct": 50}),
         "--permission sysio@active")
     assert success, f"Failed to set snapshot config: {trans}"
+    setCfgTransId = node0.getTransId(trans)
 
-    assert node0.waitForHeadToAdvance(), "Head did not advance after config"
+    # Ensure provider registration and config are applied in a block before the
+    # snapshot/attestation flow below depends on them.
+    assert node0.waitForTransactionsInBlock([regSnapProvTransId, setCfgTransId], timeout=60), \
+        "regsnapprov/setsnpcfg transactions did not make it into a block"
 
     # ===================================================================
     # Snapshot API endpoint tests

--- a/tests/snapshot_attest_test.py
+++ b/tests/snapshot_attest_test.py
@@ -152,16 +152,19 @@ try:
         json.dumps({"min_providers": 1, "threshold_pct": 50}),
         "--permission sysio@active")
     assert success, f"Failed to set snapshot config: {trans}"
-
-    assert node0.waitForHeadToAdvance(), "Head did not advance after config"
+    setCfgTransId = node0.getTransId(trans)
 
     # ---------------------------------------------------------------
     # Verify provider registration via table query
     # ---------------------------------------------------------------
-    # Ensure both regsnapprov registrations are in a block before reading the
-    # table, so the exact-count assertion below cannot race the registrations.
-    assert node0.waitForTransactionsInBlock(regSnapProvTransIds, timeout=60), \
-        "regsnapprov transactions did not make it into a block"
+    # Ensure both provider registrations and the attestation config are applied
+    # in a block before proceeding. The exact-count assertion below depends on
+    # the registrations, and Test 1's single votesnaphash depends on setsnpcfg
+    # making quorum == 1 — if the config is forwarded into a peer's block and not
+    # yet applied, the vote runs against the default config (2 providers @ 67%,
+    # quorum 2), creates no snaprecords entry, and the test fails.
+    assert node0.waitForTransactionsInBlock(regSnapProvTransIds + [setCfgTransId], timeout=60), \
+        "regsnapprov/setsnpcfg transactions did not make it into a block"
     Print("Verify snapshot providers registered")
     providers = node0.getTableRows("sysio", "sysio", "snapprovs")
     assert providers is not None, "Failed to read snapprovs table"

--- a/tests/snapshot_attest_test.py
+++ b/tests/snapshot_attest_test.py
@@ -85,6 +85,7 @@ try:
         walletMgr.importKey(account, ignWallet, ignoreDupKeyWarning=True)
 
     # Register producers via regproducer (required before setrank)
+    regProducerTransIds = []
     for name in [producerA, producerB]:
         account = cluster.defProducerAccounts[name]
         success, trans = node0.pushMessage("sysio", "regproducer",
@@ -96,9 +97,18 @@ try:
             }),
             f"--permission {name}@active")
         assert success, f"Failed to register producer {name}: {trans}"
+        regProducerTransIds.append(node0.getTransId(trans))
         Print(f"Registered producer {name}")
 
-    assert node0.waitForHeadToAdvance(), "Head did not advance after regproducer"
+    # setrank reads the on-chain producers table and asserts "producer not found"
+    # if a registration is missing. pushMessage only confirms speculative
+    # execution, and waitForHeadToAdvance() does not guarantee these specific
+    # transactions were applied — with multiple producers a transaction pushed
+    # to node0 can be forwarded into a peer's block. Wait for both regproducer
+    # transactions to appear in a block so setrank speculatively executes
+    # against state that already contains the registrations.
+    assert node0.waitForTransactionsInBlock(regProducerTransIds, timeout=60), \
+        "regproducer transactions did not make it into a block before setrank"
 
     Print(f"Set rank for {producerA}")
     success, trans = node0.pushMessage("sysio", "setrank",
@@ -117,17 +127,20 @@ try:
     # ---------------------------------------------------------------
     # Register snapshot providers
     # ---------------------------------------------------------------
+    regSnapProvTransIds = []
     Print(f"Register snapshot provider {snapProv1.name} for {producerA}")
     success, trans = node0.pushMessage("sysio", "regsnapprov",
         json.dumps({"producer": producerA, "snap_account": snapProv1.name}),
         f"--permission {producerA}@active")
     assert success, f"Failed to register snapshot provider: {trans}"
+    regSnapProvTransIds.append(node0.getTransId(trans))
 
     Print(f"Register snapshot provider {snapProv2.name} for {producerB}")
     success, trans = node0.pushMessage("sysio", "regsnapprov",
         json.dumps({"producer": producerB, "snap_account": snapProv2.name}),
         f"--permission {producerB}@active")
     assert success, f"Failed to register snapshot provider: {trans}"
+    regSnapProvTransIds.append(node0.getTransId(trans))
 
     # ---------------------------------------------------------------
     # Set attestation config: min_providers=1, threshold_pct=50
@@ -145,6 +158,10 @@ try:
     # ---------------------------------------------------------------
     # Verify provider registration via table query
     # ---------------------------------------------------------------
+    # Ensure both regsnapprov registrations are in a block before reading the
+    # table, so the exact-count assertion below cannot race the registrations.
+    assert node0.waitForTransactionsInBlock(regSnapProvTransIds, timeout=60), \
+        "regsnapprov transactions did not make it into a block"
     Print("Verify snapshot providers registered")
     providers = node0.getTableRows("sysio", "sysio", "snapprovs")
     assert providers is not None, "Failed to read snapprovs table"


### PR DESCRIPTION
## Problem

`snapshot_attest_test` failed on the **ubuntu24** CI runner (passed on asan/ubsan/asserton/gcc) with:

```
Failed to set rank for defproducerb        # on-chain assert: "producer not found"
```

Root cause: `setrank` reads the on-chain `producers` table and asserts `"producer not found"` if a producer's `regproducer` has not yet been applied. Both tests followed `regproducer` with only `waitForHeadToAdvance()` (one block), which does **not** guarantee those specific transactions were applied — `pushMessage` only confirms speculative execution, and with multiple producing nodes a transaction pushed to node0 can be forwarded into a peer's block, racing the dependent `setrank`. The race is timing-sensitive, hence the single-runner flake.

`snapshot_api_test` has the identical pattern in its setup (latent), so it is fixed here too.

## Fix

Wait for the prerequisite transactions to appear in a block (via the existing `waitForTransactionsInBlock` / `waitForTransactionInBlock` harness helpers) before the dependent action/read:

- **`snapshot_attest_test`** — `regproducer` transactions before `setrank`; `regsnapprov` transactions before the `snapprovs` exact-count assertion.
- **`snapshot_api_test`** — `regproducer` transaction before `setrank`; `regsnapprov`/`setsnpcfg` before the snapshot-attestation flow that depends on them.

Test-harness (Python) only — no production code changes.

## Verification

Both tests run end-to-end locally against a freshly built `nodeop`:

- `snapshot_attest_test`: the previously-racing `Set rank for defproducerb` now passes; **Tests 1–5 PASS**.
- `snapshot_api_test`: **Tests 1–10 PASS**.
