### PR TITLE
Stabilize Python integration tests on macOS

### DIFF
--- a/tests/nodeop_under_min_avail_ram.py
+++ b/tests/nodeop_under_min_avail_ram.py
@@ -108,24 +108,23 @@ try:
     action="store"
     numAmount=5000
     successfulStoreActions=0
+    # Safety ceiling for the RAM-pressure phase; when the guard works, all nodes exit well before this.
     maxStoreActions=80
     failedPushAttempts=0
+    # Each failed push can wait about 6 seconds, so this allows roughly a minute of transient shutdown churn.
     maxFailedPushAttempts=12
+    attemptedStoreActions=0
     lastFromIndex=0
 
-    def getLiveNodeIndexesOrFail(successfulStoreActions):
-        liveNodeIndexes=[i for i, node in enumerate(nodes) if node.verifyAlive()]
-        if successfulStoreActions>=maxStoreActions:
-            Utils.cmdError(
-                "Was able to send %d store actions without all nodes exiting" % (successfulStoreActions)
-            )
+    def getLiveNodeIndexesOrFail(sentStoreActions):
+        """Return live node indexes, failing only while live nodes remain past the pressure ceiling."""
+        liveNodeIndexes=[i for i, node in enumerate(nodes) if node.verifyAlive(silent=True)]
+        if liveNodeIndexes and sentStoreActions>=maxStoreActions:
+            Utils.cmdError("Was able to send %d store actions without all nodes exiting" % (sentStoreActions))
             errorExit("Failure - All Nodes should have died")
         return liveNodeIndexes
 
     while True:
-        liveNodeIndexes=getLiveNodeIndexesOrFail(successfulStoreActions)
-        if not liveNodeIndexes:
-            break
         numAmount+=1
         for fromIndex in range(namedAccounts.numAccounts):
             liveNodeIndexes=getLiveNodeIndexesOrFail(successfulStoreActions)
@@ -139,10 +138,11 @@ try:
             data="{\"from\":\"%s\",\"to\":\"%s\",\"num\":%d}" % (fromAccount.name, toAccount.name, numAmount)
             opts="--permission %s@active --permission %s@active --expiration 90 --payer %s" % (contract, fromAccount.name, fromAccount.name)
             try:
-                nodeIndex=liveNodeIndexes[successfulStoreActions % len(liveNodeIndexes)]
+                nodeIndex=liveNodeIndexes[attemptedStoreActions % len(liveNodeIndexes)]
+                attemptedStoreActions+=1
                 trans=nodes[nodeIndex].pushMessage(contract, action, data, opts)
                 if trans is None or not trans[0]:
-                    Print("Failed to push create action to sysio contract. sleep for 5 seconds")
+                    Print("Failed to push store action to sysio contract. sleep before retrying")
                     failedPushAttempts+=1
                     if failedPushAttempts>=maxFailedPushAttempts:
                         Utils.cmdError("Failed to push %d consecutive store actions" % (failedPushAttempts))
@@ -160,12 +160,13 @@ try:
                     Utils.cmdError("Failed to push %d consecutive store actions" % (failedPushAttempts))
                     errorExit("Failure - unable to keep applying RAM pressure to live nodes")
                 time.sleep(5)
+        if not liveNodeIndexes:
+            break
 
     #spread the actions to all accounts, to use each accounts tps bandwidth
     fromIndexStart=lastFromIndex+1 if lastFromIndex+1<namedAccounts.numAccounts else 0
 
-    # min and max are subjective, just assigned to make sure that many small changes in nodeop don't
-    # result in the test not correctly validating behavior
+    # The minimum is subjective, but catches changes that make nodeop exit before real RAM pressure is applied.
     if successfulStoreActions < 12:
         Utils.cmdError("Was able to send %d store actions which was too little" % (successfulStoreActions))
         errorExit("Incorrect number of store actions sent")
@@ -241,7 +242,7 @@ try:
             try:
                 trans=nodes[count % numNodes].pushMessage(contract, action, data, opts)
                 if trans is None or not trans[0]:
-                    Print("Failed to push create action to sysio contract. sleep for 60 seconds")
+                    Print("Failed to push store action to sysio contract. sleep for 60 seconds")
                     time.sleep(60)
                 time.sleep(1)
             except TypeError as ex:
@@ -300,7 +301,7 @@ try:
         try:
             trans=node.pushMessage(contract, action, data, opts)
             if trans is None or not trans[0]:
-                Print("Failed to push create action to sysio contract. sleep for 60 seconds")
+                Print("Failed to push store action to sysio contract. sleep for 60 seconds")
                 time.sleep(60)
                 continue
             time.sleep(1)

--- a/tests/nodeop_under_min_avail_ram.py
+++ b/tests/nodeop_under_min_avail_ram.py
@@ -107,13 +107,30 @@ try:
     Print("push create action to %s contract" % (contract))
     action="store"
     numAmount=5000
-    keepProcessing=True
-    count=0
-    while keepProcessing:
+    successfulStoreActions=0
+    maxStoreActions=80
+    failedPushAttempts=0
+    maxFailedPushAttempts=12
+    lastFromIndex=0
+
+    def getLiveNodeIndexesOrFail(successfulStoreActions):
+        liveNodeIndexes=[i for i, node in enumerate(nodes) if node.verifyAlive()]
+        if successfulStoreActions>=maxStoreActions:
+            Utils.cmdError(
+                "Was able to send %d store actions without all nodes exiting" % (successfulStoreActions)
+            )
+            errorExit("Failure - All Nodes should have died")
+        return liveNodeIndexes
+
+    while True:
+        liveNodeIndexes=getLiveNodeIndexesOrFail(successfulStoreActions)
+        if not liveNodeIndexes:
+            break
         numAmount+=1
-        timeOutCount=0
         for fromIndex in range(namedAccounts.numAccounts):
-            count+=1
+            liveNodeIndexes=getLiveNodeIndexesOrFail(successfulStoreActions)
+            if not liveNodeIndexes:
+                break
             toIndex=fromIndex+1
             if toIndex==namedAccounts.numAccounts:
                 toIndex=0
@@ -122,32 +139,35 @@ try:
             data="{\"from\":\"%s\",\"to\":\"%s\",\"num\":%d}" % (fromAccount.name, toAccount.name, numAmount)
             opts="--permission %s@active --permission %s@active --expiration 90 --payer %s" % (contract, fromAccount.name, fromAccount.name)
             try:
-                trans=nodes[count % numNodes].pushMessage(contract, action, data, opts)
+                nodeIndex=liveNodeIndexes[successfulStoreActions % len(liveNodeIndexes)]
+                trans=nodes[nodeIndex].pushMessage(contract, action, data, opts)
                 if trans is None or not trans[0]:
-                    timeOutCount+=1
-                    if timeOutCount>=3:
-                        Print("Failed to push create action to sysio contract for %d consecutive times, looks like nodeop already exited." % (timeOutCount))
-                        keepProcessing=False
-                        break
-
                     Print("Failed to push create action to sysio contract. sleep for 5 seconds")
-                    count-=1 # failed attempt shouldn't be counted
+                    failedPushAttempts+=1
+                    if failedPushAttempts>=maxFailedPushAttempts:
+                        Utils.cmdError("Failed to push %d consecutive store actions" % (failedPushAttempts))
+                        errorExit("Failure - unable to keep applying RAM pressure to live nodes")
                     time.sleep(5)
                 else:
-                    timeOutCount=0
+                    successfulStoreActions+=1
+                    failedPushAttempts=0
+                    lastFromIndex=fromIndex
                 time.sleep(1)
             except TypeError as ex:
-                keepProcessing=False
-                break
+                Print("Failed to send %s action, nodeop may have exited" % (action))
+                failedPushAttempts+=1
+                if failedPushAttempts>=maxFailedPushAttempts:
+                    Utils.cmdError("Failed to push %d consecutive store actions" % (failedPushAttempts))
+                    errorExit("Failure - unable to keep applying RAM pressure to live nodes")
+                time.sleep(5)
 
     #spread the actions to all accounts, to use each accounts tps bandwidth
-    fromIndexStart=fromIndex+1 if fromIndex+1<namedAccounts.numAccounts else 0
+    fromIndexStart=lastFromIndex+1 if lastFromIndex+1<namedAccounts.numAccounts else 0
 
     # min and max are subjective, just assigned to make sure that many small changes in nodeop don't
     # result in the test not correctly validating behavior
-    if count < 12 or count > 24:
-        strMsg="little" if count < 25 else "much"
-        Utils.cmdError("Was able to send %d store actions which was too %s" % (count, strMsg))
+    if successfulStoreActions < 12:
+        Utils.cmdError("Was able to send %d store actions which was too little" % (successfulStoreActions))
         errorExit("Incorrect number of store actions sent")
 
     # Make sure all the nodes are shutdown (may take a little while for this to happen, so making multiple passes)

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -70,7 +70,11 @@ testAccountName = "test"
 userAccountName = "user"
 payloadlessAccountName = "payloadless"
 infiniteAccountName = "infinite"
-max_trx_time = args.read_only_read_window_time_us - 60000 # should be less than read-only-read-window-time-us and less than block time
+READ_WINDOW_ASSERTION_MARGIN_US = 60000
+if args.read_only_read_window_time_us <= READ_WINDOW_ASSERTION_MARGIN_US:
+    errorExit("--read-only-read-window-time-us must be greater than %d" % (READ_WINDOW_ASSERTION_MARGIN_US))
+# Keep the fallback assertion threshold below the read window.
+max_trx_time = args.read_only_read_window_time_us - READ_WINDOW_ASSERTION_MARGIN_US
 
 def getCodeHash(node, account):
     # Example get code result: code hash: 67d0598c72e2521a1d588161dad20bbe9f8547beb5ce6d14f3abd550ab27d3dc

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -23,6 +23,7 @@ errorExit=Utils.errorExit
 
 appArgs=AppArgs()
 appArgs.add(flag="--read-only-threads", type=int, help="number of read-only threads", default=0)
+appArgs.add(flag="--read-only-read-window-time-us", type=int, help="read-only read window in microseconds", default=750000)
 appArgs.add(flag="--num-test-runs", type=int, help="number of times to run the tests", default=1)
 appArgs.add(flag="--sys-vm-oc-enable", type=str, help="specify sys-vm-oc-enable option", default=Utils.SysVmOcEnableAuto)
 appArgs.add(flag="--wasm-runtime", type=str, help="if wanting sys-vm-oc, must use 'sys-vm-oc-forced'",
@@ -69,7 +70,7 @@ testAccountName = "test"
 userAccountName = "user"
 payloadlessAccountName = "payloadless"
 infiniteAccountName = "infinite"
-max_trx_time = 450000 # should be less than read-only-read-window-time-us and less than block time
+max_trx_time = args.read_only_read_window_time_us - 60000 # should be less than read-only-read-window-time-us and less than block time
 
 def getCodeHash(node, account):
     # Example get code result: code hash: 67d0598c72e2521a1d588161dad20bbe9f8547beb5ce6d14f3abd550ab27d3dc
@@ -111,7 +112,8 @@ def startCluster():
     specificExtraNodeopArgs[pnodes]+=" --read-only-write-window-time-us "
     specificExtraNodeopArgs[pnodes]+=" 10000 "
     specificExtraNodeopArgs[pnodes]+=" --read-only-read-window-time-us "
-    specificExtraNodeopArgs[pnodes]+=" 510000 "
+    specificExtraNodeopArgs[pnodes]+=str(args.read_only_read_window_time_us)
+    specificExtraNodeopArgs[pnodes]+=" "
     specificExtraNodeopArgs[pnodes]+=" --read-only-threads "
     specificExtraNodeopArgs[pnodes]+=str(args.read_only_threads)
     if Utils.shouldSkipBecauseSysVmOcUnavailable(args.sys_vm_oc_enable, args.wasm_runtime):


### PR DESCRIPTION
## Summary

Stabilize the Python integration tests that were failing or flaky on macOS CI.

## What changed

- Keep `nodeop_under_min_avail_ram.py` applying RAM pressure to producer nodes that are still alive until all guarded nodes exit.
- Add bounded failure handling so the RAM-pressure loop fails clearly if live nodes stop accepting actions.
- Rotate RAM-pressure attempts across the current live-node set, even when a push fails, so one alive-but-not-accepting node does not monopolize retries.
- Treat an empty live-node set as success before enforcing the RAM-pressure safety ceiling.
- Reduce noisy hot-path liveness polling and update stale `store` action log wording.
- Make `read_only_trx_test.py` default `--read-only-read-window-time-us` to `750000`, derive `max_trx_time` from that setting, and reject read windows that are too small for the assertion margin.

## Why

The RAM guard test could stop applying pressure after one node exited, leaving another producer alive long enough to fail the "all nodes should have died" assertion. The revised loop targets only live nodes and continues until the live set is empty.

The old `12-24` action band applied to the previous behavior, which effectively tested how quickly the first node died. The updated test intentionally keeps a lower-bound check for "nodes exited too early" and uses `maxStoreActions=80` as a safety ceiling for "guard never fired while nodes are still alive." That wider ceiling is not meant to preserve the old tight sensitivity check; it reflects that the test now drives all guarded nodes to exit.

The read-only transaction test also needed a larger default read window for slower CI hosts, with an explicit guard so manual runs cannot accidentally choose a window that makes the fallback elapsed-time assertion meaningless.

## Testing

- `python3 -m py_compile tests/read_only_trx_test.py tests/nodeop_under_min_avail_ram.py`
- `git diff --check`
- `ctest -R "^nodeop_under_min_avail_ram_lr_test$" --output-on-failure --timeout 1500` from `build/macos-arm64-jit-release` before the review follow-up commit; passed in 282.23 sec.

## Notes

Review follow-up was added as a separate commit, `3a0cbf8afa`, so reviewers can inspect the delta since the original review. This branch is based on `origin/master` and includes only Python integration test changes.
