### PR TITLE
Clean up successful Python test logs

### DIFF
--- a/tests/interrupt_read_only_trx_test.py
+++ b/tests/interrupt_read_only_trx_test.py
@@ -68,6 +68,7 @@ def startCluster():
     global total_nodes
     global producerNode
     global apiNode
+    global testSuccessful
 
     TestHelper.printSystemInfo("BEGIN")
     cluster.setWalletMgr(walletMgr)
@@ -86,6 +87,7 @@ def startCluster():
     specificExtraNodeopArgs[pnodes]+=str(args.read_only_threads)
     if Utils.shouldSkipBecauseSysVmOcUnavailable(args.sys_vm_oc_enable, args.wasm_runtime):
         Print("sys-vm-oc is unavailable on this platform. Skip the test")
+        testSuccessful = True
         exit(0) # Do not fail the test
     if ocSupported:
         specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "

--- a/tests/read_only_trx_test.py
+++ b/tests/read_only_trx_test.py
@@ -89,6 +89,7 @@ def startCluster():
     global total_nodes
     global producerNode
     global apiNode
+    global testSuccessful
 
     TestHelper.printSystemInfo("BEGIN")
     cluster.setWalletMgr(walletMgr)
@@ -122,6 +123,7 @@ def startCluster():
     specificExtraNodeopArgs[pnodes]+=str(args.read_only_threads)
     if Utils.shouldSkipBecauseSysVmOcUnavailable(args.sys_vm_oc_enable, args.wasm_runtime):
         Print("sys-vm-oc is unavailable on this platform. Skip the test")
+        testSuccessful = True
         exit(0) # Do not fail the test
     if ocSupported:
         specificExtraNodeopArgs[pnodes]+=" --sys-vm-oc-enable "

--- a/tests/resource_monitor_plugin_test.py
+++ b/tests/resource_monitor_plugin_test.py
@@ -63,7 +63,13 @@ logging="""{
 }"""
 
 def cleanDirectories():
+    """Remove resource monitor staging directories created by this test."""
     os.path.exists(stagingDir) and shutil.rmtree(stagingDir)
+
+def cleanTestLogDirectory():
+    """Remove this test's harness log directory after a successful run."""
+    if not args.keep_logs:
+        shutil.rmtree(Utils.DataPath, ignore_errors=True)
 
 def prepareDirectories():
     # Prepare own directories so we don't depend on others to make sure
@@ -220,6 +226,8 @@ try:
 finally:
     if debug: Print("Cleanup in finally block.")
     cleanDirectories()
+    if testSuccessful:
+        cleanTestLogDirectory()
 
 exitCode = 0 if testSuccessful else 1
 if debug: Print("Exiting test, exit value %d." % (exitCode))


### PR DESCRIPTION
Summary

- Clean up successful Python test harness log directories that previously remained after passing or skipped tests.

What changed

- Mark sys-vm-oc unavailable read-only test skips as successful before exiting so harness cleanup removes their TestLogs directories.
- Remove the resource monitor test harness log directory after successful runs when --keep-logs is not set.

Why

- These tests could pass from CTest’s perspective while leaving only subprocess_results.log behind under TestLogs.
- Successful runs should not preserve per-test harness logs unless explicitly requested.

Testing

- python3 -m py_compile tests/read_only_trx_test.py tests/interrupt_read_only_trx_test.py tests/resource_monitor_plugin_test.py
- ctest -R "(read-only-trx-parallel-if-sys-vm-oc-test|interrupt-read-only-trx-parallel-if-sys-vm-oc-test)"
- ctest -R "^resource_monitor_plugin_test$"

