### PR TITLE
Make cfile append-mode pwrite portable

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -544,9 +544,7 @@ namespace sysio { namespace chain {
          explicit basic_block_log(std::filesystem::path log_dir) { open(log_dir); }
 
          static void ensure_file_exists(fc::cfile& f) {
-            if (std::filesystem::exists(f.get_file_path()))
-               return;
-            f.open(fc::cfile::create_or_update_rw_mode);
+            f.open_existing_or_create_new();
             f.close();
          }
 

--- a/libraries/libfc/include/fc/io/cfile.hpp
+++ b/libraries/libfc/include/fc/io/cfile.hpp
@@ -44,7 +44,7 @@ public:
    /// Open an existing file for binary update without truncating or forcing appends.
    static constexpr auto update_rw_mode = "rb+";
    /// Create a new file for binary update, failing if the file already exists.
-   static constexpr auto create_new_rw_mode = "wbx+";
+   static constexpr auto create_new_rw_mode = "wb+x";
    /// Create or truncate a file for binary update.
    static constexpr auto truncate_rw_mode = "wb+";
    /// Open an existing file for binary reads.
@@ -98,12 +98,13 @@ public:
    ///         "ab+" - open for binary update - create if does not exist
    ///         "rb+" - open for binary update - file must exist
    void open( const char* mode ) {
-      _file.reset( FC_FOPEN( _file_path.generic_string().c_str(), mode ) );
-      if( !_file ) {
+      FILE* new_file = FC_FOPEN( _file_path.generic_string().c_str(), mode );
+      if( !new_file ) {
          const int open_errno = errno;
          throw std::ios_base::failure( "cfile unable to open: " +  _file_path.generic_string() + " in mode: " +
                                        std::string( mode ), std::error_code(open_errno, std::generic_category()) );
       }
+      _file.reset( new_file );
 #ifndef _WIN32
       struct stat st;
       _file_blk_size = 4096;

--- a/libraries/libfc/include/fc/io/cfile.hpp
+++ b/libraries/libfc/include/fc/io/cfile.hpp
@@ -48,6 +48,7 @@ public:
 
    cfile(cfile&& other)
      : _open(other._open)
+     , _append_mode(other._append_mode)
      , _file_path(std::move(other._file_path))
      , _file_blk_size(other._file_blk_size)
      , _file(std::move(other._file))
@@ -100,6 +101,7 @@ public:
       if( fstat(fileno(), &st) == 0 )
          _file_blk_size = st.st_blksize;
 #endif
+      _append_mode = mode_opens_for_append(mode);
       _open = true;
    }
 
@@ -191,11 +193,9 @@ public:
 
    /**
     * Positional write on the underlying file descriptor (POSIX pwrite), bypassing the FILE* buffer.
-    * Retries on EINTR and short writes until all n bytes are written.
-    * NOTE: on Linux, when the file is opened in an append mode (e.g. "ab+"), the kernel appends at
-    * EOF and IGNORES the offset argument (POSIX leaves this combination unspecified).  Callers
-    * holding an append-mode cfile must maintain offset == EOF themselves for the offset to be
-    * meaningful.
+    * Retries on EINTR and short writes until all n bytes are written.  When the file is opened in
+    * append mode (e.g. "ab+"), append at EOF on every supported POSIX platform; Linux does this for
+    * pwrite() on an O_APPEND fd, while BSD/macOS need write() to honor O_APPEND.
     * NOTE: bypasses stdio buffering entirely - interleaving with buffered write() requires explicit
     * flush() ordering by the caller.
     * @throws std::ios_base::failure on error; some bytes may already have been written in that case
@@ -205,7 +205,12 @@ public:
       const char* p         = d;
       size_t      remaining = n;
       while( remaining > 0 ) {
+#if !defined(__linux__)
+         const ssize_t r = _append_mode ? ::write( fd, p, remaining )
+                                        : ::pwrite( fd, p, remaining, static_cast<off_t>( offset ) );
+#else
          const ssize_t r = ::pwrite( fd, p, remaining, static_cast<off_t>( offset ) );
+#endif
          if( r > 0 ) {
             p         += r;
             offset    += static_cast<uint64_t>( r );
@@ -299,6 +304,7 @@ public:
    void close() {
       _file.reset();
       _open = false;
+      _append_mode = false;
    }
 
    boost::interprocess::mapping_handle_t get_mapping_handle() const {
@@ -311,13 +317,26 @@ public:
    friend void swap(cfile& lhs, cfile& rhs) {
       using std::swap;
       swap(lhs._open, rhs._open);
+      swap(lhs._append_mode, rhs._append_mode);
       swap(lhs._file_path, rhs._file_path);
       swap(lhs._file_blk_size, rhs._file_blk_size);
       swap(lhs._file, rhs._file);
    }
 
 private:
+   /**
+    * Return true when an fopen mode sets O_APPEND on the underlying file descriptor.
+    */
+   static bool mode_opens_for_append(const char* mode) {
+      for(; *mode != '\0'; ++mode) {
+         if(*mode == 'a')
+            return true;
+      }
+      return false;
+   }
+
    bool                  _open = false;
+   bool                  _append_mode = false;
    std::filesystem::path _file_path;
    size_t                _file_blk_size = 4096;
    detail::unique_file   _file;

--- a/libraries/libfc/include/fc/io/cfile.hpp
+++ b/libraries/libfc/include/fc/io/cfile.hpp
@@ -1,11 +1,13 @@
 #pragma once
 #include <fc/filesystem.hpp>
 #include <fc/io/datastream.hpp>
+#include <cassert>
 #include <cerrno>
 #include <cstdio>
 #include <ios>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <system_error>
 #include <unistd.h>
 
 #include <boost/interprocess/file_mapping.hpp>
@@ -37,9 +39,15 @@ class cfile_datastream;
 class cfile {
    friend class temp_cfile;
 public:
+   /// Open for binary update in append mode; callers must not use pwrite() with this mode.
    static constexpr auto create_or_update_rw_mode = "ab+";
+   /// Open an existing file for binary update without truncating or forcing appends.
    static constexpr auto update_rw_mode = "rb+";
+   /// Create a new file for binary update, failing if the file already exists.
+   static constexpr auto create_new_rw_mode = "wbx+";
+   /// Create or truncate a file for binary update.
    static constexpr auto truncate_rw_mode = "wb+";
+   /// Open an existing file for binary reads.
    static constexpr auto read_only_mode = "rb";
 
    cfile()
@@ -48,7 +56,6 @@ public:
 
    cfile(cfile&& other)
      : _open(other._open)
-     , _append_mode(other._append_mode)
      , _file_path(std::move(other._file_path))
      , _file_blk_size(other._file_blk_size)
      , _file(std::move(other._file))
@@ -93,7 +100,9 @@ public:
    void open( const char* mode ) {
       _file.reset( FC_FOPEN( _file_path.generic_string().c_str(), mode ) );
       if( !_file ) {
-         throw std::ios_base::failure( "cfile unable to open: " +  _file_path.generic_string() + " in mode: " + std::string( mode ) );
+         const int open_errno = errno;
+         throw std::ios_base::failure( "cfile unable to open: " +  _file_path.generic_string() + " in mode: " +
+                                       std::string( mode ), std::error_code(open_errno, std::generic_category()) );
       }
 #ifndef _WIN32
       struct stat st;
@@ -101,8 +110,41 @@ public:
       if( fstat(fileno(), &st) == 0 )
          _file_blk_size = st.st_blksize;
 #endif
-      _append_mode = mode_opens_for_append(mode);
       _open = true;
+   }
+
+   /**
+    * Open an existing file for binary update without truncating it, or exclusively create a new one.
+    * Use this only when existing contents must be preserved; use truncate_rw_mode for complete rewrites.
+    *
+    * @return true when an existing file was opened, false when a new file was created
+    */
+   bool open_existing_or_create_new() {
+      try {
+         open(update_rw_mode);
+         return true;
+      } catch (const std::ios_base::failure& e) {
+         if (e.code().value() != ENOENT)
+            throw;
+      }
+
+      try {
+         open(create_new_rw_mode);
+         return false;
+      } catch (const std::ios_base::failure& e) {
+         if (e.code().value() == EEXIST) {
+            open(update_rw_mode);
+            return true;
+         }
+
+         // Some libc implementations can create the file, then fail later inside fopen().  If that
+         // leaves a zero-byte placeholder, remove it so the next open can create a valid file.
+         std::error_code ec;
+         const auto size = std::filesystem::file_size(_file_path, ec);
+         if (!ec && size == 0)
+            std::filesystem::remove(_file_path, ec);
+         throw;
+      }
    }
 
    size_t tellp() const {
@@ -193,24 +235,20 @@ public:
 
    /**
     * Positional write on the underlying file descriptor (POSIX pwrite), bypassing the FILE* buffer.
-    * Retries on EINTR and short writes until all n bytes are written.  When the file is opened in
-    * append mode (e.g. "ab+"), append at EOF on every supported POSIX platform; Linux does this for
-    * pwrite() on an O_APPEND fd, while BSD/macOS need write() to honor O_APPEND.
+    * Retries on EINTR and short writes until all n bytes are written.  The offset is always honored;
+    * callers must not use this API on a file descriptor opened with O_APPEND.
     * NOTE: bypasses stdio buffering entirely - interleaving with buffered write() requires explicit
     * flush() ordering by the caller.
     * @throws std::ios_base::failure on error; some bytes may already have been written in that case
     */
    void pwrite( const char* d, size_t n, uint64_t offset ) {
       const int fd = fileno();
+      assert((::fcntl(fd, F_GETFL) & O_APPEND) == 0 &&
+             "cfile::pwrite is positional; not valid on an O_APPEND file");
       const char* p         = d;
       size_t      remaining = n;
       while( remaining > 0 ) {
-#if !defined(__linux__)
-         const ssize_t r = _append_mode ? ::write( fd, p, remaining )
-                                        : ::pwrite( fd, p, remaining, static_cast<off_t>( offset ) );
-#else
          const ssize_t r = ::pwrite( fd, p, remaining, static_cast<off_t>( offset ) );
-#endif
          if( r > 0 ) {
             p         += r;
             offset    += static_cast<uint64_t>( r );
@@ -304,7 +342,6 @@ public:
    void close() {
       _file.reset();
       _open = false;
-      _append_mode = false;
    }
 
    boost::interprocess::mapping_handle_t get_mapping_handle() const {
@@ -317,26 +354,13 @@ public:
    friend void swap(cfile& lhs, cfile& rhs) {
       using std::swap;
       swap(lhs._open, rhs._open);
-      swap(lhs._append_mode, rhs._append_mode);
       swap(lhs._file_path, rhs._file_path);
       swap(lhs._file_blk_size, rhs._file_blk_size);
       swap(lhs._file, rhs._file);
    }
 
 private:
-   /**
-    * Return true when an fopen mode sets O_APPEND on the underlying file descriptor.
-    */
-   static bool mode_opens_for_append(const char* mode) {
-      for(; *mode != '\0'; ++mode) {
-         if(*mode == 'a')
-            return true;
-      }
-      return false;
-   }
-
    bool                  _open = false;
-   bool                  _append_mode = false;
    std::filesystem::path _file_path;
    size_t                _file_blk_size = 4096;
    detail::unique_file   _file;

--- a/libraries/libfc/test/io/test_cfile.cpp
+++ b/libraries/libfc/test/io/test_cfile.cpp
@@ -2,6 +2,8 @@
 
 #include <fc/io/cfile.hpp>
 
+#include <cerrno>
+
 using namespace fc;
 
 BOOST_AUTO_TEST_SUITE(cfile_test_suite)
@@ -14,6 +16,22 @@ BOOST_AUTO_TEST_SUITE(cfile_test_suite)
       t.open( "ab+" );
       BOOST_CHECK( t.is_open() );
       BOOST_CHECK( std::filesystem::exists( tempdir.path() / "test") );
+
+      cfile exclusive;
+      exclusive.set_file_path( tempdir.path() / "exclusive" );
+      exclusive.open( cfile::create_new_rw_mode );
+      BOOST_CHECK( exclusive.is_open() );
+      exclusive.close();
+      BOOST_CHECK_EXCEPTION( exclusive.open( cfile::create_new_rw_mode ), std::ios_base::failure,
+                             [](const std::ios_base::failure& e) { return e.code().value() == EEXIST; } );
+
+      cfile open_or_create;
+      open_or_create.set_file_path( tempdir.path() / "open_or_create" );
+      BOOST_CHECK( !open_or_create.open_existing_or_create_new() );
+      BOOST_CHECK( open_or_create.is_open() );
+      open_or_create.close();
+      BOOST_CHECK( open_or_create.open_existing_or_create_new() );
+      open_or_create.close();
 
       t.open( "rb+" );
       BOOST_CHECK( t.is_open() );
@@ -54,7 +72,11 @@ BOOST_AUTO_TEST_SUITE(cfile_test_suite)
 
       t.close();
       std::filesystem::remove_all( t.get_file_path() );
+      std::filesystem::remove_all( exclusive.get_file_path() );
+      std::filesystem::remove_all( open_or_create.get_file_path() );
       BOOST_CHECK( !std::filesystem::exists( tempdir.path() / "test") );
+      BOOST_CHECK( !std::filesystem::exists( tempdir.path() / "exclusive") );
+      BOOST_CHECK( !std::filesystem::exists( tempdir.path() / "open_or_create") );
    }
 
    BOOST_AUTO_TEST_CASE(test_positional_io)
@@ -87,14 +109,8 @@ BOOST_AUTO_TEST_SUITE(cfile_test_suite)
       // Reading past EOF throws (short read).
       BOOST_CHECK_THROW( t.pread( &v[0], 6, 4 ), std::ios_base::failure );
 
-      // pwrite on an append-mode cfile appends at EOF regardless of the offset argument.
-      t.close();
-      t.open( cfile::create_or_update_rw_mode );
-      t.pwrite( "gh", 2, 0 );
-      std::vector<char> w(8);
-      t.pread( &w[0], 8, 0 );
-      BOOST_CHECK_EQUAL( std::string( w.begin(), w.end() ), "abXYefgh" );
-
+      // pwrite() rejects O_APPEND descriptors via assert(); this suite avoids an aborting death
+      // test because there is no local Boost.Test pattern for native assert death checks.
       t.close();
       std::filesystem::remove_all( t.get_file_path() );
    }

--- a/libraries/libfc/test/io/test_cfile.cpp
+++ b/libraries/libfc/test/io/test_cfile.cpp
@@ -87,8 +87,7 @@ BOOST_AUTO_TEST_SUITE(cfile_test_suite)
       // Reading past EOF throws (short read).
       BOOST_CHECK_THROW( t.pread( &v[0], 6, 4 ), std::ios_base::failure );
 
-      // pwrite on an append-mode fd: Linux appends at EOF regardless of the offset argument -
-      // the documented caveat that callers holding append-mode cfiles rely on.
+      // pwrite on an append-mode cfile appends at EOF regardless of the offset argument.
       t.close();
       t.open( cfile::create_or_update_rw_mode );
       t.pwrite( "gh", 2, 0 );

--- a/plugins/trace_api_plugin/src/abi_log.cpp
+++ b/plugins/trace_api_plugin/src/abi_log.cpp
@@ -24,6 +24,30 @@ constexpr uint64_t record_trailer_size = sizeof(uint32_t);
 constexpr uint64_t journal_record_len_size = sizeof(uint32_t);
 constexpr uint64_t journal_record_crc_size = sizeof(uint32_t);
 
+constexpr uint64_t file_header_offset = 0;
+
+/**
+ * Read an fc::raw-packed fixed-size header through cfile's positional API.
+ */
+template<typename T>
+T pread_packed_header(const fc::cfile& file) {
+   std::vector<char> data(sizeof(T));
+   file.pread(data.data(), data.size(), file_header_offset);
+   fc::datastream<const char*> ds(data.data(), data.size());
+   T value;
+   fc::raw::unpack(ds, value);
+   return value;
+}
+
+/**
+ * Write an fc::raw-packed fixed-size header through cfile's positional API.
+ */
+template<typename T>
+void pwrite_packed_header(fc::cfile& file, const T& value) {
+   auto data = fc::raw::pack(value);
+   file.pwrite(data.data(), data.size(), file_header_offset);
+}
+
 } // namespace
 
 uint32_t abi_log::compute_record_crc(const record_header& hdr, const char* blob, uint64_t blob_size) {
@@ -36,35 +60,25 @@ uint32_t abi_log::compute_record_crc(const record_header& hdr, const char* blob,
 
 abi_log::abi_log(const std::filesystem::path& path, size_t journal_compaction_threshold_bytes)
    : _journal_compaction_threshold(journal_compaction_threshold_bytes) {
-   const bool existed = std::filesystem::exists(path);
    _cfile.set_file_path(path);
+   bool existed = false;
    try {
-      _cfile.open(fc::cfile::create_or_update_rw_mode);
+      existed = _cfile.open_existing_or_create_new();
    } catch (...) {
       fc_wlog(_log, "trace_api: abi_log failed to open {}", path.generic_string());
-      // Best-effort clean-up: a failed open on some libc versions leaves a zero-byte
-      // file behind, which would look like a valid-but-header-less log on the next
-      // start and fail an unpack inside the existing-file branch.
-      std::error_code ec;
-      if (!existed)
-         std::filesystem::remove(path, ec);
       return;
    }
 
    if (!existed) {
-      // Fresh file: write header, no records yet.  "ab+" mode always writes at
-      // EOF, so the seek below is advisory for the position indicator; the
-      // write lands at offset 0 by construction (file is freshly opened, EOF = 0).
-      abi_log_header hdr;
-      auto data = fc::raw::pack(hdr);
+      // Fresh file: write the header positionally, with no stdio buffering mixed into later pread()
+      // and pwrite() calls.
       try {
-         _cfile.write(data.data(), data.size());
-         _cfile.flush();
+         pwrite_packed_header(_cfile, abi_log_header{});
       } catch (...) {
          fc_wlog(_log, "trace_api: abi_log failed to write header to {}", path.generic_string());
          return;
       }
-      _end_offset = data.size();
+      _end_offset = sizeof(abi_log_header);
       _valid = true;
       init_journal(derive_journal_path(path));
       return;
@@ -72,10 +86,7 @@ abi_log::abi_log(const std::filesystem::path& path, size_t journal_compaction_th
 
    // Existing file: validate header, scan records, populate index, truncate any bad tail.
    try {
-      _cfile.seek(0);
-      auto ds = _cfile.create_datastream();
-      abi_log_header hdr;
-      fc::raw::unpack(ds, hdr);
+      abi_log_header hdr = pread_packed_header<abi_log_header>(_cfile);
       if (hdr.magic != abi_log_header::magic_value) {
          fc_wlog(_log, "trace_api: abi_log {} has wrong magic {:#x}, ignoring",
               path.generic_string(), hdr.magic);
@@ -100,8 +111,7 @@ uint64_t abi_log::recover_from_disk(const std::filesystem::path& path) {
    const uint64_t header_size = sizeof(abi_log_header);
    const uint64_t file_size = std::filesystem::file_size(path);
 
-   // pread correctness: the only buffered (FILE*) write on this cfile is the fresh-file header in
-   // the constructor, which flushes immediately; appends use raw-fd pwrite.  Never introduce
+   // pread correctness: all writes on this cfile go through raw-fd pwrite.  Never introduce
    // unflushed buffered writes on this cfile or pread may see stale data.
    uint64_t offset = header_size;
    while (offset < file_size) {
@@ -202,9 +212,8 @@ bool abi_log::append(chain::name account, uint64_t global_seq, std::vector<char>
    {
       std::lock_guard<std::mutex> lock(_append_mtx);
       try {
-         // NOTE: the cfile is opened with fopen("ab+"), so cfile::pwrite appends at EOF regardless
-         // of the offset argument.  That is exactly what we want: "file ends at
-         // _end_offset" is a maintained invariant (restored below on failure), so EOF == _end_offset.
+         // "_end_offset is EOF" is a maintained invariant (restored below on failure), so this
+         // positional write appends without relying on O_APPEND.
          _cfile.pwrite(record.data(), record.size(), _end_offset);
       } catch (const std::exception& e) {
          fc_wlog(_log, "trace_api: abi_log append of {} bytes at offset {} failed: {}; truncating torn tail",
@@ -547,13 +556,9 @@ std::vector<char> abi_log::frame_journal_record(const std::vector<char>& body) {
 }
 
 bool abi_log::write_journal_header() {
-   abi_journal_header hdr;
-   auto data = fc::raw::pack(hdr);
    try {
-      // "ab+" appends at EOF regardless of position, so on a fresh or just-truncated file the
-      // header lands at offset 0 by construction (matching the main log's fresh-file write).
-      _journal_cfile.write(data.data(), data.size());
-      _journal_cfile.flush();
+      // Positional header write keeps the journal on the same raw-fd I/O path as journal records.
+      pwrite_packed_header(_journal_cfile, abi_journal_header{});
    } catch (...) {
       fc_wlog(_log, "trace_api: abi_log journal failed to write header to {}",
               _journal_path.generic_string());
@@ -572,7 +577,7 @@ bool abi_log::journal_append(const std::vector<char>& body) {
    auto rec = frame_journal_record(body);
    std::lock_guard<std::mutex> lock(_journal_mtx);
    try {
-      // Like the main log, append-mode cfile::pwrite lands at EOF == _journal_end_offset.
+      // Like the main log, _journal_end_offset is maintained as EOF and used as the pwrite offset.
       _journal_cfile.pwrite(rec.data(), rec.size(), _journal_end_offset);
    } catch (const std::exception& e) {
       fc_wlog(_log, "trace_api: abi_log journal append of {} bytes at offset {} failed: {}; truncating torn tail",
@@ -758,7 +763,7 @@ void abi_log::compact_journal() {
       _journal_cfile.close();
       std::filesystem::rename(tmp, _journal_path); // atomic on POSIX
       _journal_cfile.set_file_path(_journal_path);
-      _journal_cfile.open(fc::cfile::create_or_update_rw_mode);
+      _journal_cfile.open(fc::cfile::update_rw_mode);
       _journal_end_offset = std::filesystem::file_size(_journal_path);
       _journal_enabled = true;
    } catch (const std::exception& e) {
@@ -772,16 +777,13 @@ void abi_log::compact_journal() {
 
 void abi_log::init_journal(const std::filesystem::path& journal_path) {
    _journal_path = journal_path;
-   const bool existed = std::filesystem::exists(journal_path);
    _journal_cfile.set_file_path(journal_path);
+   bool existed = false;
    try {
-      _journal_cfile.open(fc::cfile::create_or_update_rw_mode);
+      existed = _journal_cfile.open_existing_or_create_new();
    } catch (...) {
       fc_wlog(_log, "trace_api: abi_log journal failed to open {}; reversible ABI records will not "
                     "survive a restart", journal_path.generic_string());
-      std::error_code ec;
-      if (!existed)
-         std::filesystem::remove(journal_path, ec);
       _journal_enabled = false;
       return;
    }
@@ -799,10 +801,7 @@ void abi_log::init_journal(const std::filesystem::path& journal_path) {
    // Existing journal: validate the header.
    bool header_ok = false;
    try {
-      _journal_cfile.seek(0);
-      auto ds = _journal_cfile.create_datastream();
-      abi_journal_header hdr;
-      fc::raw::unpack(ds, hdr);
+      abi_journal_header hdr = pread_packed_header<abi_journal_header>(_journal_cfile);
       header_ok = (hdr.magic == abi_journal_header::magic_value &&
                    hdr.version == abi_journal_header::current_version);
       if (!header_ok)

--- a/plugins/trace_api_plugin/src/abi_log.cpp
+++ b/plugins/trace_api_plugin/src/abi_log.cpp
@@ -202,8 +202,8 @@ bool abi_log::append(chain::name account, uint64_t global_seq, std::vector<char>
    {
       std::lock_guard<std::mutex> lock(_append_mtx);
       try {
-         // NOTE: the fd comes from fopen("ab+") and carries O_APPEND, so on Linux this pwrite appends
-         // at EOF regardless of the offset argument.  That is exactly what we want: "file ends at
+         // NOTE: the cfile is opened with fopen("ab+"), so cfile::pwrite appends at EOF regardless
+         // of the offset argument.  That is exactly what we want: "file ends at
          // _end_offset" is a maintained invariant (restored below on failure), so EOF == _end_offset.
          _cfile.pwrite(record.data(), record.size(), _end_offset);
       } catch (const std::exception& e) {
@@ -572,7 +572,7 @@ bool abi_log::journal_append(const std::vector<char>& body) {
    auto rec = frame_journal_record(body);
    std::lock_guard<std::mutex> lock(_journal_mtx);
    try {
-      // Like the main log, the fd carries O_APPEND, so this pwrite lands at EOF == _journal_end_offset.
+      // Like the main log, append-mode cfile::pwrite lands at EOF == _journal_end_offset.
       _journal_cfile.pwrite(rec.data(), rec.size(), _journal_end_offset);
    } catch (const std::exception& e) {
       fc_wlog(_log, "trace_api: abi_log journal append of {} bytes at offset {} failed: {}; truncating torn tail",

--- a/plugins/trace_api_plugin/src/abi_log.cpp
+++ b/plugins/trace_api_plugin/src/abi_log.cpp
@@ -7,8 +7,10 @@
 
 #include <magic_enum/magic_enum.hpp>
 
+#include <cassert>
 #include <cstring>
 #include <stdexcept>
+#include <type_traits>
 
 namespace sysio::trace_api {
 
@@ -27,10 +29,11 @@ constexpr uint64_t journal_record_crc_size = sizeof(uint32_t);
 constexpr uint64_t file_header_offset = 0;
 
 /**
- * Read an fc::raw-packed fixed-size header through cfile's positional API.
+ * Read an fc::raw-packed fixed-size POD header through cfile's positional API.
  */
 template<typename T>
 T pread_packed_header(const fc::cfile& file) {
+   static_assert(std::is_trivially_copyable_v<T>);
    std::vector<char> data(sizeof(T));
    file.pread(data.data(), data.size(), file_header_offset);
    fc::datastream<const char*> ds(data.data(), data.size());
@@ -40,11 +43,13 @@ T pread_packed_header(const fc::cfile& file) {
 }
 
 /**
- * Write an fc::raw-packed fixed-size header through cfile's positional API.
+ * Write an fc::raw-packed fixed-size POD header through cfile's positional API.
  */
 template<typename T>
 void pwrite_packed_header(fc::cfile& file, const T& value) {
+   static_assert(std::is_trivially_copyable_v<T>);
    auto data = fc::raw::pack(value);
+   assert(data.size() == sizeof(T));
    file.pwrite(data.data(), data.size(), file_header_offset);
 }
 


### PR DESCRIPTION
## Summary

Keep `fc::cfile::pwrite()` as a positional write on every platform and update trace ABI logging to append through explicit offsets instead of `O_APPEND` semantics.

## What changed

- Documented `cfile` open modes and added `create_new_rw_mode` plus `open_existing_or_create_new()` for non-truncating open-or-create flows.
- Preserved `errno` in `cfile::open()` failures so callers can distinguish `ENOENT` / `EEXIST` and recover zero-byte placeholders from rare partial-create failures.
- Added a debug assertion that rejects `cfile::pwrite()` on `O_APPEND` descriptors.
- Updated `abi_log` main and journal files to use non-append read/write modes, positional header I/O, and positional record appends via maintained EOF offsets.
- Updated `block_log::ensure_file_exists()` to use `open_existing_or_create_new()` instead of a separate existence check plus `"ab+"` open.
- Updated `test_cfile` coverage for exclusive create, open-or-create return values, positional I/O, and the intentionally untested aborting assert precondition.

## Why

`pwrite()` with `O_APPEND` is not portable: Linux appends despite the explicit offset, while macOS/BSD honor the offset. Keeping `cfile::pwrite()` purely positional avoids an API that silently discards its offset, and `abi_log` already maintains EOF offsets for crash recovery and index correctness.

## Testing

- `git diff --check`
- Standalone `clang++` check that `std::ios_base::failure(..., std::error_code)` preserves `EEXIST`

Not run: targeted CMake build/tests. Local configure did not complete because vcpkg dependency setup entered Boost retrieval/build and no usable compile database or Ninja build tree was available.

## Notes

Remaining `create_or_update_rw_mode` (`"ab+"`) call sites in `trx_id_index.cpp`, `store_provider.cpp`, `block_log.cpp`, and `persistence_util.hpp` do not call `pwrite()` today, so they are unaffected by the new debug assert. The `cfile` mode and `pwrite()` API comments now document that `"ab+"` must not be mixed with positional writes.
