### PR TITLE
Pre-launch security hardening: non-contract fixes

### DIFF
--- a/libraries/chain/qc.cpp
+++ b/libraries/chain/qc.cpp
@@ -303,7 +303,12 @@ vote_result_t aggregating_qc_sig_t::add_weak_vote(size_t index, const bls_signat
       break;
 
    case state_t::weak_achieved:
-      if (weak_sum >= max_weak_sum_before_weak_final)
+      // Use strict '>' to match the unrestricted/restricted arm above. weak_final means a strong
+      // QC can no longer form; the max achievable strong sum is (sum - weak_sum), so strong is
+      // still possible while weak_sum == max_weak_sum_before_weak_final (== sum - threshold), where
+      // the achievable strong sum equals exactly the threshold. '>=' declared weak_final one
+      // weight-unit early.
+      if (weak_sum > max_weak_sum_before_weak_final)
          aggregating_state = state_t::weak_final;
       break;
 

--- a/libraries/chain/snapshot.cpp
+++ b/libraries/chain/snapshot.cpp
@@ -616,6 +616,11 @@ void threaded_snapshot_reader::set_section(const string& section_name) {
       if(entry.name == section_name) {
          cur_row = 0;
          num_rows = entry.row_count;
+         // An empty section carries no data bytes (writer invariant). Enforce it so a tampered
+         // row_count of 0 cannot hide a non-empty, hash-pinned data range from ever being read.
+         SYS_ASSERT(num_rows != 0 || entry.data_size == 0, snapshot_exception,
+                    "Snapshot section '{}' has row_count 0 but {} bytes of data; file may be tampered",
+                    section_name, entry.data_size);
          ds = fc::datastream<const char*>(mapped_snap_addr + entry.data_offset, entry.data_size);
          return;
       }
@@ -626,7 +631,16 @@ void threaded_snapshot_reader::set_section(const string& section_name) {
 
 bool threaded_snapshot_reader::read_row(detail::abstract_snapshot_row_reader& row_reader) {
    row_reader.provide(ds);
-   return ++cur_row < num_rows;
+   if (++cur_row < num_rows)
+      return true;
+   // Last row consumed. A section's data_size is covered by the integrity/root hash but its
+   // row_count is not, so require the section data to be exactly consumed: a tampered (decreased)
+   // row_count would otherwise silently drop the trailing rows while still matching the attested
+   // hash, loading a node with state that diverges from the canonical chain.
+   SYS_ASSERT(ds.remaining() == 0, snapshot_exception,
+              "Snapshot section row_count does not match section data ({} bytes unread); "
+              "file may be tampered", ds.remaining());
+   return false;
 }
 
 bool threaded_snapshot_reader::empty ( ) {

--- a/libraries/chain/snapshot.cpp
+++ b/libraries/chain/snapshot.cpp
@@ -631,16 +631,7 @@ void threaded_snapshot_reader::set_section(const string& section_name) {
 
 bool threaded_snapshot_reader::read_row(detail::abstract_snapshot_row_reader& row_reader) {
    row_reader.provide(ds);
-   if (++cur_row < num_rows)
-      return true;
-   // Last row consumed. A section's data_size is covered by the integrity/root hash but its
-   // row_count is not, so require the section data to be exactly consumed: a tampered (decreased)
-   // row_count would otherwise silently drop the trailing rows while still matching the attested
-   // hash, loading a node with state that diverges from the canonical chain.
-   SYS_ASSERT(ds.remaining() == 0, snapshot_exception,
-              "Snapshot section row_count does not match section data ({} bytes unread); "
-              "file may be tampered", ds.remaining());
-   return false;
+   return ++cur_row < num_rows;
 }
 
 bool threaded_snapshot_reader::empty ( ) {
@@ -648,6 +639,21 @@ bool threaded_snapshot_reader::empty ( ) {
 }
 
 void threaded_snapshot_reader::clear_section() {
+   // A section's data_size is covered by the integrity/root hash but its row_count (in the section
+   // index) is not. Enforce exact consumption of every selected section here — the universal
+   // teardown reached after read_section's callback for both loop readers (read until read_row
+   // returns false) and singleton readers (one read_row, return value ignored). Requiring
+   // cur_row == num_rows AND a fully-consumed datastream pins row_count to the hashed data in all
+   // cases: a row_count tampered down drops trailing rows (caught here or by a datastream overrun),
+   // and one tampered up leaves a singleton reader with cur_row < num_rows (which a per-read check
+   // in read_row would miss). num_rows == 0 means no section is active (e.g. return_to_header
+   // before any read), so skip. Checked before the madvise seekp(0) below, while ds is at the
+   // read position.
+   if(num_rows) {
+      SYS_ASSERT(cur_row == num_rows && ds.remaining() == 0, snapshot_exception,
+                 "Snapshot section not fully consumed (read {} of {} rows, {} bytes unread); "
+                 "file may be tampered", cur_row, num_rows, ds.remaining());
+   }
 #ifdef __linux__
    //this might work elsewhere, but unsure about alignment requirements on madvise() elsewhere
    if(num_rows) {

--- a/libraries/chain/webassembly/crypto.cpp
+++ b/libraries/chain/webassembly/crypto.cpp
@@ -342,7 +342,10 @@ namespace sysio::chain::webassembly {
    }
 
    int32_t interface::bls_g1_weighted_sum(span<const char> points, span<const char> scalars, const uint32_t n, span<char> result) const {
-      if(n == 0 || points.size() != n*96 ||  scalars.size() != n*32 ||  result.size() != 96)
+      // 64-bit size math: n*96 / n*32 in uint32_t would wrap modulo 2^32 and could match an
+      // undersized span, letting the i*96 / i*32 reads below run past the validated buffer.
+      const size_t sz = n;
+      if(n == 0 || points.size() != sz*96 ||  scalars.size() != sz*32 ||  result.size() != 96)
          return return_code::failure;
 
       // Use much efficient scale for the special case of n == 1.
@@ -377,7 +380,10 @@ namespace sysio::chain::webassembly {
    }
 
    int32_t interface::bls_g2_weighted_sum(span<const char> points, span<const char> scalars, const uint32_t n, span<char> result) const {
-      if(n == 0 || points.size() != n*192 ||  scalars.size() != n*32 ||  result.size() != 192)
+      // 64-bit size math: see bls_g1_weighted_sum — n*192 / n*32 in uint32_t can wrap and bypass
+      // the span-size guard, allowing the i*192 / i*32 reads below to run past the buffer.
+      const size_t sz = n;
+      if(n == 0 || points.size() != sz*192 ||  scalars.size() != sz*32 ||  result.size() != 192)
          return return_code::failure;
 
       // Use much efficient scale for the special case of n == 1.
@@ -412,7 +418,10 @@ namespace sysio::chain::webassembly {
    }
 
    int32_t interface::bls_pairing(span<const char> g1_points, span<const char> g2_points, const uint32_t n, span<char> result) const {
-      if(n == 0 || g1_points.size() != n*96 ||  g2_points.size() != n*192 ||  result.size() != 576)
+      // 64-bit size math: see bls_g1_weighted_sum — n*96 / n*192 in uint32_t can wrap and bypass
+      // the span-size guard, allowing the i*96 / i*192 reads below to run past the buffers.
+      const size_t sz = n;
+      if(n == 0 || g1_points.size() != sz*96 ||  g2_points.size() != sz*192 ||  result.size() != 576)
          return return_code::failure;
       std::vector<std::tuple<bls12_381::g1, bls12_381::g2>> v;
       v.reserve(n);

--- a/libraries/libfc/include/fc/network/message_buffer.hpp
+++ b/libraries/libfc/include/fc/network/message_buffer.hpp
@@ -157,6 +157,12 @@ namespace fc {
      *  start).
      */
     void advance_read_ptr(uint32_t bytes) {
+      // Advancing past the written data would push read_ind beyond write_ind and over-pop
+      // the buffer deque below (free()/pop_front() on an emptied deque is undefined behavior
+      // and underflows write_ind). Callers that derive the advance from untrusted, peer-supplied
+      // frame lengths must never exceed the buffered bytes; reject rather than corrupt the chain.
+      FC_ASSERT( bytes <= bytes_to_read(), "advance_read_ptr {} exceeds buffered bytes {}",
+                 bytes, bytes_to_read() );
       advance_index(read_ind, bytes);
       if (read_ind == write_ind) {
         reset();

--- a/libraries/libfc/src/crypto/sha3.cpp
+++ b/libraries/libfc/src/crypto/sha3.cpp
@@ -74,7 +74,7 @@ struct sha3_impl {
 		{
 			uint8_t *v;
 			// convert the buffer to little endian
-			for (std::size_t i; i < number_of_words; i++)
+			for (std::size_t i = 0; i < number_of_words; i++)
 			{
 				v = reinterpret_cast<uint8_t *>(words + i);
 				words[i] = ((uint64_t)v[0]) | (((uint64_t)v[1]) << 8) |
@@ -125,8 +125,10 @@ struct sha3_impl {
 		{
 			uint8_t *v;
 			uint64_t tmp;
-			// convert back to big endian
-			for (std::size_t i = 0; i < sizeof(words); i++)
+			// convert back to big endian. Iterate over the state's 64-bit lanes by element count;
+			// `sizeof(words)` is the byte size of the (over-allocated) union member, so using it as
+			// the element bound wrote far past the lane array.
+			for (std::size_t i = 0; i < number_of_words; i++)
 			{
 				v = (uint8_t *)(words + i);
 				tmp = words[i];

--- a/libraries/libfc/src/network/ethereum/ethereum_abi.cpp
+++ b/libraries/libfc/src/network/ethereum/ethereum_abi.cpp
@@ -421,6 +421,39 @@ size_t abi_head_size(const abi::component_type& component) {
    return 32;
 }
 
+namespace {
+   // ABI encodes every head slot, length prefix, and static value as a single 32-byte word.
+   constexpr size_t abi_word_size = 32;
+
+   // Overflow-safe bounds check for the half-open span [offset, offset + need) within an
+   // attacker-supplied buffer of `data_size` bytes. `offset + need` can wrap around on 64-bit when
+   // offset/need are decoded from untrusted ABI data, so the test is written with subtraction
+   // (offset <= data_size is established first).
+   void require_abi_span(size_t offset, size_t need, size_t data_size, const char* what) {
+      FC_ASSERT(offset <= data_size && data_size - offset >= need,
+                "Not enough data for {}: need {} bytes at offset {} (data_size {})",
+                what, need, offset, data_size);
+   }
+
+   // Reads the 32-byte big-endian ABI word at `at` and returns it as a size_t offset/length,
+   // rejecting values that cannot index the buffer. This bounds-checks the read of the word itself
+   // and prevents an out-of-range pointer/length — the >2^64 values std::stoull throws on, and the
+   // large-but-representable values that overflow when added to a base offset — from reaching the
+   // downstream pointer arithmetic that previously read out of bounds.
+   size_t read_abi_word_as_size(const uint8_t* data, size_t at, size_t data_size, const char* what) {
+      require_abi_span(at, abi_word_size, data_size, what);
+      const std::string dec = be_uint_to_decimal(data + at);
+      size_t value = 0;
+      try {
+         value = std::stoull(dec);
+      } catch (const std::out_of_range&) {
+         FC_THROW_EXCEPTION(fc::out_of_range_exception, "ABI {} exceeds representable range", what);
+      }
+      FC_ASSERT(value <= data_size, "ABI {} value {} exceeds data size {}", what, value, data_size);
+      return value;
+   }
+} // anonymous namespace
+
 /**
  * @brief Forward declaration for decode_value
  */
@@ -434,13 +467,17 @@ fc::variant decode_value(const abi::component_type& component, const uint8_t* da
  * @param offset Current offset in the data (will be advanced by 32)
  * @return Decoded value as fc::variant
  */
-fc::variant decode_static_value(const abi::component_type& component, const uint8_t* data, size_t& offset) {
+fc::variant decode_static_value(const abi::component_type& component, const uint8_t* data, size_t data_size,
+                                size_t& offset) {
    using dt = abi::data_type;
    const auto type = component.type;
 
-   FC_ASSERT(offset + 32 <= SIZE_MAX, "Offset overflow");
+   // A static value occupies one 32-byte word; bound the read against the actual buffer rather
+   // than the previous tautological `offset + 32 <= SIZE_MAX`, which never caught a short buffer
+   // and allowed a 32-byte out-of-bounds read.
+   require_abi_span(offset, abi_word_size, data_size, "static value");
    const uint8_t* value_data = data + offset;
-   offset += 32;
+   offset += abi_word_size;
 
    // Numeric types
    if (abi::is_data_type_numeric(type)) {
@@ -493,13 +530,11 @@ fc::variant decode_dynamic_data(const abi::component_type& component, const uint
    using dt = abi::data_type;
    const auto type = component.type;
 
-   // Read length (32 bytes)
-   FC_ASSERT(offset + 32 <= data_size, "Not enough data for dynamic length");
-   auto length_str = be_uint_to_decimal(data + offset);
-   offset += 32;
+   // Read length (32-byte word), bounded so a forged length cannot index past the buffer.
+   size_t length = read_abi_word_as_size(data, offset, data_size, "dynamic length");
+   offset += abi_word_size;
 
-   size_t length = std::stoull(length_str);
-   FC_ASSERT(offset + length <= data_size, "Not enough data for dynamic content");
+   require_abi_span(offset, length, data_size, "dynamic content");
 
    switch (type) {
    case dt::string: {
@@ -539,10 +574,13 @@ fc::variant decode_list(const abi::component_type& component, const uint8_t* dat
 
    // Read array length for dynamic arrays
    if (lc.is_dynamic_list()) {
-      FC_ASSERT(offset + 32 <= data_size, "Not enough data for array length");
-      auto length_str = be_uint_to_decimal(data + offset);
-      offset += 32;
-      array_length = std::stoull(length_str);
+      array_length = read_abi_word_as_size(data, offset, data_size, "array length");
+      offset += abi_word_size;
+      // Each element consumes at least one 32-byte word (a head offset slot for dynamic elements,
+      // or >=32 bytes of inline data for static ones), so the element count cannot exceed the
+      // remaining words. Bounds both the reserve() calls and the decode loops below.
+      FC_ASSERT(array_length <= (data_size - offset) / abi_word_size,
+                "ABI array length {} exceeds remaining data", array_length);
    } else {
       array_length = lc.size;
    }
@@ -563,10 +601,8 @@ fc::variant decode_list(const abi::component_type& component, const uint8_t* dat
       size_t base_offset = offset;
 
       for (size_t i = 0; i < array_length; ++i) {
-         FC_ASSERT(offset + 32 <= data_size, "Not enough data for array element offset");
-         auto offset_str = be_uint_to_decimal(data + offset);
-         offsets.push_back(base_offset + std::stoull(offset_str));
-         offset += 32;
+         offsets.push_back(base_offset + read_abi_word_as_size(data, offset, data_size, "array element offset"));
+         offset += abi_word_size;
       }
 
       // Decode elements from tail
@@ -610,12 +646,10 @@ fc::variant decode_tuple(const abi::component_type& component, const uint8_t* da
    // First pass: decode static fields and collect dynamic field offsets
    for (const auto& child : children) {
       if (child.is_dynamic()) {
-         // Read offset pointer (32 bytes)
-         FC_ASSERT(offset + 32 <= data_size, "Not enough data for tuple field offset");
-         auto offset_str = be_uint_to_decimal(data + offset);
-         size_t field_offset = base_offset + std::stoull(offset_str);
+         // Read offset pointer (32-byte word), bounded against the buffer.
+         size_t field_offset = base_offset + read_abi_word_as_size(data, offset, data_size, "tuple field offset");
          dynamic_fields.emplace_back(child.name, field_offset);
-         offset += 32;
+         offset += abi_word_size;
       } else {
          // Decode static field directly
          result[child.name] = decode_value(child, data, data_size, offset);
@@ -656,7 +690,7 @@ fc::variant decode_value(const abi::component_type& component, const uint8_t* da
       return decode_dynamic_data(component, data, data_size, offset);
    }
 
-   return decode_static_value(component, data, offset);
+   return decode_static_value(component, data, data_size, offset);
 }
 
 } // anonymous namespace
@@ -931,9 +965,7 @@ fc::variant contract_decode_data(const abi::contract& contract, const std::strin
       const auto& comp = components[0];
       // For dynamic or list components, we need to read the offset pointer first
       if (comp.is_dynamic() || comp.is_list()) {
-         FC_ASSERT(offset + 32 <= data_size, "Not enough data for parameter offset");
-         auto offset_str = be_uint_to_decimal(data + offset);
-         size_t actual_offset = offset + std::stoull(offset_str);
+         size_t actual_offset = offset + read_abi_word_as_size(data, offset, data_size, "parameter offset");
          return decode_value(comp, data, data_size, actual_offset);
       }
       return decode_value(comp, data, data_size, offset);
@@ -952,11 +984,9 @@ fc::variant contract_decode_data(const abi::contract& contract, const std::strin
    for (const auto& comp : components) {
 
       if (comp.is_dynamic()) {
-         // Dynamic component: read offset pointer (always 32 bytes)
-         FC_ASSERT(offset + 32 <= data_size, "Not enough data for parameter offset");
-         auto offset_str = be_uint_to_decimal(data + offset);
-         offsets.push_back(base_offset + std::stoull(offset_str));
-         offset += 32;
+         // Dynamic component: read offset pointer (always a 32-byte word), bounded against buffer.
+         offsets.push_back(base_offset + read_abi_word_as_size(data, offset, data_size, "parameter offset"));
+         offset += abi_word_size;
       } else {
          // Static component: inline data occupies its full encoded size
          // (e.g., a static tuple of 4 fields occupies 4 × 32 = 128 bytes)

--- a/libraries/libfc/test/network/ethereum/test_ethereum_client_and_rlp.cpp
+++ b/libraries/libfc/test/network/ethereum/test_ethereum_client_and_rlp.cpp
@@ -320,6 +320,46 @@ BOOST_AUTO_TEST_CASE(validate_contract_invoke_encode_decode) try {
 }
 FC_LOG_AND_RETHROW();
 
+// Malformed/adversarial ABI return data must be rejected with a clean fc::exception, never an
+// out-of-bounds read. These exercise the overflow-safe bounds checks in the decoder: a 256-bit
+// offset/length word that (a) exceeds 2^64, (b) is large-but-representable so that `base + offset`
+// previously wrapped size_t and bypassed the `offset + 32 <= data_size` check, or (c) declares more
+// array elements than the buffer can hold. See the pre-launch audit findings on ethereum_abi.cpp.
+BOOST_AUTO_TEST_CASE(decode_rejects_malicious_offsets_and_lengths) try {
+   auto abi_filename = fc::test::get_test_fixtures_path() / bfs::path(test_contract_abi_json_file_01);
+   auto contract_abis =
+      eth::abi::parse_contracts(fs::path(abi_filename.generic_string())) |
+      std::views::filter([&](auto& contract) { return contract.type == eth::abi::invoke_target_type::function; }) |
+      std::ranges::to<std::vector>();
+   BOOST_REQUIRE(contract_abis.size() >= 3);
+   // contract_abis[2] == submitOrders((address,uint256,bytes32)[]) — a single dynamic-array param.
+   const auto& orders_abi = contract_abis[2];
+   const std::string selector = "034918bd";
+
+   // (a) Parameter offset word > 2^64-1: previously std::stoull threw std::out_of_range (not an
+   //     fc::exception); now converted to a clean fc::out_of_range_exception.
+   {
+      const std::string encoded = selector + std::string(64, 'f');         // offset word = 2^256-1
+      BOOST_CHECK_THROW(eth::contract_decode_data(orders_abi, encoded, true), fc::exception);
+   }
+   // (b) Parameter offset word = 2^64-16: representable in uint64 and, added to the base offset,
+   //     used to wrap size_t so `offset + 32 <= data_size` passed and a wild pointer was read.
+   {
+      const std::string encoded = selector +
+         "000000000000000000000000000000000000000000000000fffffffffffffff0"; // 2^64-16
+      BOOST_CHECK_THROW(eth::contract_decode_data(orders_abi, encoded, true), fc::exception);
+   }
+   // (c) Valid array offset (0x20) but an element count (0x40) larger than the remaining buffer can
+   //     hold; the static-tuple element loop previously read 32 bytes per element past the buffer.
+   {
+      const std::string encoded = selector +
+         "0000000000000000000000000000000000000000000000000000000000000020"  // offset to array = 32
+         "0000000000000000000000000000000000000000000000000000000000000040"; // array length = 64
+      BOOST_CHECK_THROW(eth::contract_decode_data(orders_abi, encoded, true), fc::exception);
+   }
+}
+FC_LOG_AND_RETHROW();
+
 // BOOST_AUTO_TEST_CASE(can_encode_call_sig) try {
 //    auto encoded_call_sig = contract_invoke_encode(test_tx_01_sig, test_tx_01_sig_params);
 //    BOOST_CHECK(encoded_call_sig == test_tx_01_sig_encoded);

--- a/libraries/libfc/test/network/test_message_buffer.cpp
+++ b/libraries/libfc/test/network/test_message_buffer.cpp
@@ -305,6 +305,30 @@ BOOST_AUTO_TEST_CASE(message_buffer_read_peek_bounds_multi) {
    BOOST_CHECK_THROW(mbuff.read(&throw_away_buffer, 1), fc::out_of_range_exception);
 }
 
+// A read advance must never exceed the buffered bytes. The net_plugin early-dedup path computed
+// `message_length - header_bytes` from a peer-declared frame length; a frame shorter than the
+// already-consumed header underflowed that unsigned subtraction to ~4.29e9, over-popping the
+// buffer deque (undefined behavior). The bound in advance_read_ptr converts that into a catchable
+// exception (the net read loop then closes the offending peer).
+BOOST_AUTO_TEST_CASE(message_buffer_advance_read_ptr_bounds) {
+   using my_message_buffer_t = fc::message_buffer<1024>;
+   my_message_buffer_t mbuff;
+   unsigned char stuff[12] = { 0 };
+   memcpy(mbuff.write_ptr(), stuff, sizeof(stuff));
+   mbuff.advance_write_ptr(sizeof(stuff));            // 12 bytes available to read
+   BOOST_CHECK_EQUAL(mbuff.bytes_to_read(), 12u);
+
+   // Advancing more than the buffered bytes must throw rather than corrupt the chain.
+   BOOST_CHECK_THROW(mbuff.advance_read_ptr(13), fc::assert_exception);
+   // The exact unsigned-underflow value (5 - 33 as uint32_t == 4294967268) must also throw, not wrap.
+   BOOST_CHECK_THROW(mbuff.advance_read_ptr(static_cast<uint32_t>(5) - static_cast<uint32_t>(33)),
+                     fc::assert_exception);
+   // State is unchanged after the rejected advances; an in-bounds advance still works.
+   BOOST_CHECK_EQUAL(mbuff.bytes_to_read(), 12u);
+   mbuff.advance_read_ptr(12);
+   BOOST_CHECK_EQUAL(mbuff.bytes_to_read(), 0u);
+}
+
 BOOST_AUTO_TEST_CASE(message_buffer_datastream) {
    using my_message_buffer_t = fc::message_buffer<1024>;
    my_message_buffer_t mbuff;

--- a/plugins/net_plugin/src/net_plugin.cpp
+++ b/plugins/net_plugin/src/net_plugin.cpp
@@ -3262,6 +3262,17 @@ namespace sysio {
       fc::raw::unpack( ds, trx_id );
       const auto header_bytes = bytes_before - pending_message_buffer.bytes_to_read();
 
+      // A well-formed transaction_message frame contains at least which + trx_id. If the
+      // peer-declared message_length is shorter than the bytes just consumed, the id was read
+      // by spilling past this frame into pipelined bytes; closing here avoids underflowing the
+      // unsigned `message_length - header_bytes` advance below (which would corrupt the buffer).
+      if( header_bytes > message_length ) {
+         peer_wlog( p2p_trx_log, this, "transaction_message frame too short: length {} < header {} - closing",
+                    message_length, header_bytes );
+         close();
+         return true;
+      }
+
       if( my_impl->dispatcher.have_peer_txn( trx_id, *this ) ) {
          peer_dlog( p2p_trx_log, this, "got a duplicate transaction - dropping {}", trx_id );
          pending_message_buffer.advance_read_ptr( message_length - header_bytes );
@@ -3371,6 +3382,15 @@ namespace sysio {
       vote_id_type vote_id;
       fc::raw::unpack( ds, vote_id );
       const auto header_bytes = bytes_before - pending_message_buffer.bytes_to_read();
+
+      // See process_next_trx_message: a frame shorter than which + vote_id means the id was read
+      // from pipelined bytes past this frame; close rather than underflow the advance below.
+      if( header_bytes > message_length ) {
+         peer_wlog( vote_logger, this, "vote_message frame too short: length {} < header {} - closing",
+                    message_length, header_bytes );
+         close();
+         return true;
+      }
 
       if( my_impl->dispatcher.have_vote( vote_id ) ) {
          peer_dlog( vote_logger, this, "duplicate vote - dropping {}", vote_id );

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -1530,8 +1530,17 @@ struct underwriter_plugin::impl {
                  "receipt missing blockNumber for tx {}", req.id, tx_hash_hex);
             return false;
          }
-         const uint64_t rcpt_blk = std::stoull(
-            rcpt_obj["blockNumber"].as_string().substr(2), nullptr, 16);
+         const std::string blk_str = rcpt_obj["blockNumber"].as_string();
+         // Require a 0x-prefixed, non-empty hex body before substr(2)/stoull so a malformed
+         // blockNumber defers this uwreq rather than throwing std::out_of_range / invalid_argument.
+         if (blk_str.size() <= 2 || blk_str[0] != '0' ||
+             (blk_str[1] != 'x' && blk_str[1] != 'X')) {
+            ilog("underwriter: source-deposit verify deferred for uwreq {} — "
+                 "receipt blockNumber not 0x-prefixed hex ('{}') for tx {}",
+                 req.id, blk_str, tx_hash_hex);
+            return false;
+         }
+         const uint64_t rcpt_blk = std::stoull(blk_str.substr(2), nullptr, 16);
          const uint64_t head_blk =
             entry->client->get_block_number().convert_to<uint64_t>();
          if (head_blk < rcpt_blk ||
@@ -1550,6 +1559,14 @@ struct underwriter_plugin::impl {
       } catch (const fc::exception& e) {
          elog("underwriter: source-deposit verify failed for uwreq {} — "
               "RPC error: {}", req.id, e.to_detail_string());
+         bump_mismatch();
+         return false;
+      } catch (const std::exception& e) {
+         // std::stoul/std::stoull on a malformed or non-hex RPC field throw std::invalid_argument /
+         // std::out_of_range, which are NOT fc::exception; catch them here so one bad response fails
+         // just this uwreq instead of escaping and aborting the whole scan cycle for every request.
+         elog("underwriter: source-deposit verify failed for uwreq {} — "
+              "malformed RPC response: {}", req.id, e.what());
          bump_mismatch();
          return false;
       }
@@ -1735,10 +1752,50 @@ struct underwriter_plugin::impl {
                    !meta_obj["logMessages"].is_array()) {
                   continue;
                }
+               // Solana interleaves every invoked program's logs in meta.logMessages. Attribute each
+               // "Program log:" payload to the program currently executing by tracking the
+               // "Program <id> invoke" / "Program <id> success|failed" bracket lines, and trust the
+               // SwapDeposit marker ONLY when opp-outpost (sol_program_id) is the top-of-stack
+               // program. Without this, a forged "Program log:" emitted by any attacker program in a
+               // transaction that merely references sol_program_id would pass verification.
+               std::vector<std::string> program_stack;
                for (const auto& line_var : meta_obj["logMessages"].get_array()) {
                   if (!line_var.is_string()) continue;
                   const std::string line = line_var.as_string();
+
+                  // Maintain the invocation stack from the bracket lines (which are not log payloads).
+                  if (boost::algorithm::starts_with(line, "Program ") &&
+                      !boost::algorithm::starts_with(line, "Program log:") &&
+                      !boost::algorithm::starts_with(line, "Program data:") &&
+                      !boost::algorithm::starts_with(line, "Program return:")) {
+                     std::string_view rest{line};
+                     rest.remove_prefix(8);                  // strip "Program "
+                     const size_t sp1 = rest.find(' ');
+                     if (sp1 != std::string_view::npos) {
+                        const std::string_view prog = rest.substr(0, sp1);
+                        std::string_view after = rest.substr(sp1 + 1);
+                        const size_t sp2 = after.find(' ');
+                        const std::string_view verb =
+                           (sp2 == std::string_view::npos) ? after : after.substr(0, sp2);
+                        if (verb == "invoke") {
+                           program_stack.emplace_back(prog);
+                        } else if (verb.starts_with("success") || verb.starts_with("failed")) {
+                           if (!program_stack.empty()) program_stack.pop_back();
+                        }
+                        // "consumed", etc. — no stack change.
+                     }
+                     continue;
+                  }
+
                   if (!boost::algorithm::starts_with(line, marker_prefix)) {
+                     continue;
+                  }
+                  // Attribution: the marker is a "Program log:" payload of the top-of-stack program.
+                  if (program_stack.empty() || program_stack.back() != sol_program_id) {
+                     ilog("underwriter: ignoring SwapDeposit marker for uwreq {} in tx {} — not "
+                          "emitted by opp-outpost program {} (attributed to {})",
+                          req.id, sig_b58, sol_program_id,
+                          program_stack.empty() ? std::string{"<none>"} : program_stack.back());
                      continue;
                   }
                   // Parse the 64-char lowercase hex hash that follows

--- a/unittests/finality_misc_tests.cpp
+++ b/unittests/finality_misc_tests.cpp
@@ -293,6 +293,49 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
       BOOST_CHECK(qc.is_quorum_met());
    }
 
+   // weak_final is correctly terminal: once weak_sum > max_weak_sum_before_weak_final the remaining
+   // unvoted weight (weight_sum - weak_sum) is below the threshold, so a strong QC is genuinely
+   // unreachable and the state must stay weak_final even after every remaining finalizer votes
+   // strong. This is the complement of the weak_achieved-boundary case above (at weak_sum == max a
+   // strong QC IS still reachable); together they pin the exact semantics on both sides of the
+   // boundary. Correct under both '>' and '>=' — coverage of terminal behavior, not the off-by-one.
+   {
+      constexpr uint64_t quorum = 5;
+      constexpr uint64_t max_weak_sum_before_weak_final = 3; // weight_sum 8, threshold 5
+      aggregating_qc_sig_t qc(6, quorum, max_weak_sum_before_weak_final);
+
+      strong_vote(qc, digest, 0, 3); // strong_sum = 3
+      weak_vote(qc, digest, 1, 1);   // weak_sum = 1
+      weak_vote(qc, digest, 2, 1);   // weak_sum = 2 -> weak_achieved
+      weak_vote(qc, digest, 3, 1);   // weak_sum = 3 == max -> still weak_achieved
+      weak_vote(qc, digest, 4, 1);   // weak_sum = 4 > max  -> weak_final
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_final);
+
+      // All remaining weight (1) votes strong: strong_sum reaches 4 < quorum 5, so strong cannot
+      // form and the state stays weak_final (a strong vote into weak_final is a no-op).
+      strong_vote(qc, digest, 5, 1); // strong_sum = 4 (< quorum)
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_final);
+   }
+
+   // restricted-arm path to weak_final: weak votes that push weak_sum past max BEFORE quorum take
+   // the state unrestricted -> restricted (that arm already uses strict '>'), and reaching quorum
+   // from restricted goes straight to weak_final. Exercises the restricted intermediate state and
+   // the unrestricted/restricted boundary at weak_sum == max (which must NOT yet be restricted).
+   {
+      constexpr uint64_t quorum = 5;
+      constexpr uint64_t max_weak_sum_before_weak_final = 3; // weight_sum 8, threshold 5
+      aggregating_qc_sig_t qc(6, quorum, max_weak_sum_before_weak_final);
+
+      weak_vote(qc, digest, 0, 1);   // weak_sum = 1 (< quorum, < max)
+      weak_vote(qc, digest, 1, 1);   // weak_sum = 2
+      weak_vote(qc, digest, 2, 1);   // weak_sum = 3 == max: not > max, quorum not met -> unrestricted
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
+      weak_vote(qc, digest, 3, 1);   // weak_sum = 4 > max, quorum not met -> restricted
+      BOOST_CHECK_EQUAL(qc.state(), state_t::restricted);
+      weak_vote(qc, digest, 4, 1);   // weak_sum = 5 == quorum and > max -> weak_final
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_final);
+   }
+
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/finality_misc_tests.cpp
+++ b/unittests/finality_misc_tests.cpp
@@ -235,6 +235,64 @@ BOOST_AUTO_TEST_CASE(qc_state_transitions) try {
       }
    }
 
+   // -------------------------------------------------------------------------
+   //  weak_achieved-arm boundary at weak_sum == max_weak_sum_before_weak_final
+   // -------------------------------------------------------------------------
+   // weak_final means a strong QC can no longer form. The maximum still-achievable
+   // strong sum is (weight_sum - weak_sum), so at weak_sum == max_weak_sum_before_weak_final
+   // (== weight_sum - threshold) that maximum equals exactly the threshold: a strong QC is
+   // STILL reachable, and the state must remain weak_achieved (not weak_final). The
+   // add_weak_vote weak_achieved arm must therefore use strict '>' (matching the
+   // unrestricted/restricted arm), not '>='.
+   //
+   // The cases above all use max_weak_sum_before_weak_final == 1, where weak_achieved can
+   // only be entered once weak_sum >= 1 == max, so the weak vote that reaches the boundary
+   // is also the one that enters weak_achieved (via the '>' unrestricted arm) and the
+   // weak_achieved arm is never exercised AT the boundary. These cases use max == 3 so
+   // weak_achieved is entered (strong-assisted) while weak_sum < max, then a weak vote
+   // drives weak_sum to exactly max through the weak_achieved arm.
+   {
+      // weight_sum 8, threshold 5  ->  quorum 5, max_weak_sum_before_weak_final 3
+      constexpr uint64_t quorum = 5;
+      constexpr uint64_t max_weak_sum_before_weak_final = 3;
+      aggregating_qc_sig_t qc(6, quorum, max_weak_sum_before_weak_final);
+
+      strong_vote(qc, digest, 0, 3); // strong_sum = 3  (< quorum)
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
+
+      weak_vote(qc, digest, 1, 1);   // weak_sum = 1, weak+strong = 4  (< quorum)
+      BOOST_CHECK_EQUAL(qc.state(), state_t::unrestricted);
+
+      weak_vote(qc, digest, 2, 1);   // weak_sum = 2, weak+strong = 5  -> weak_achieved (weak_sum < max)
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_achieved);
+
+      weak_vote(qc, digest, 3, 1);   // weak_sum = 3 == max: strong still reachable -> stays weak_achieved
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_achieved); // would be weak_final with the '>=' off-by-one
+
+      weak_vote(qc, digest, 4, 1);   // weak_sum = 4 > max -> weak_final
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_final);
+   }
+
+   {
+      // From weak_sum == max the node must still be able to form a STRONG QC if the
+      // remaining (exactly-threshold) weight votes strong. The '>=' off-by-one would have
+      // latched weak_final at the boundary, so this strong vote could never upgrade it —
+      // needlessly downgrading the QC and delaying 2-chain finality.
+      constexpr uint64_t quorum = 5;
+      constexpr uint64_t max_weak_sum_before_weak_final = 3;
+      aggregating_qc_sig_t qc(6, quorum, max_weak_sum_before_weak_final);
+
+      strong_vote(qc, digest, 0, 3); // strong_sum = 3
+      weak_vote(qc, digest, 1, 1);   // weak_sum = 1
+      weak_vote(qc, digest, 2, 1);   // weak_sum = 2 -> weak_achieved
+      weak_vote(qc, digest, 3, 1);   // weak_sum = 3 == max -> stays weak_achieved (fixed)
+      BOOST_CHECK_EQUAL(qc.state(), state_t::weak_achieved);
+
+      strong_vote(qc, digest, 4, 2); // strong_sum = 5 == quorum -> strong
+      BOOST_CHECK_EQUAL(qc.state(), state_t::strong);
+      BOOST_CHECK(qc.is_quorum_met());
+   }
+
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -17,9 +17,16 @@
 #include <test_contracts.hpp>
 #include "test_wasts.hpp"
 
+#include <fc/filesystem.hpp>
+
 using namespace sysio;
 using namespace testing;
 using namespace chain;
+
+// Minimal reflected row type for the binary-snapshot section-consumption regression test
+// (threaded_snapshot_requires_full_section_consumption) in snapshot_part1_tests below.
+namespace snapshot_consume_test { struct row { uint64_t v = 0; }; }
+FC_REFLECT(snapshot_consume_test::row, (v))
 
 
 namespace {
@@ -132,6 +139,52 @@ namespace {
 // Split the tests into multiple parts which run approximately the same time
 // so that they can finish within CICD time limits
 BOOST_AUTO_TEST_SUITE(snapshot_part1_tests)
+
+// A binary (v1) snapshot section's row_count is stored in the section index, which is NOT covered
+// by the integrity/root hash; only the row data (data_size) is. clear_section must therefore reject
+// any selected section that is not consumed exactly. The case a per-read check in read_row cannot
+// catch is the singleton-reader shape — one read_row with the returned "more" ignored — against a
+// row_count tampered upward: the single read succeeds and the callback returns with cur_row <
+// num_rows. Writing a genuine 2-row section and then reading only one row reproduces exactly that
+// shape, so teardown must throw.
+BOOST_AUTO_TEST_CASE(threaded_snapshot_requires_full_section_consumption)
+{
+   fc::temp_directory tmp_dir;
+   const std::filesystem::path snap_path = tmp_dir.path() / "consume_test.bin";
+
+   {
+      threaded_snapshot_writer writer(snap_path);
+      writer.write_section("test_section", [](auto& s) {
+         s.add_row(snapshot_consume_test::row{1});
+         s.add_row(snapshot_consume_test::row{2});
+      });
+      writer.finalize();
+   }
+
+   // Full consumption of the 2-row section loads cleanly.
+   {
+      threaded_snapshot_reader reader(snap_path);
+      reader.validate();
+      reader.read_section("test_section", [](auto& s) {
+         snapshot_consume_test::row r;
+         BOOST_CHECK(s.read_row(r));    // row 1 -> more rows remain
+         BOOST_CHECK(!s.read_row(r));   // row 2 -> section exhausted
+      });
+   }
+
+   // Under-consumption (read 1 of 2, ignoring the "more" signal, exactly as a singleton reader does
+   // against an upward-tampered row_count) must be rejected at section teardown.
+   {
+      threaded_snapshot_reader reader(snap_path);
+      reader.validate();
+      BOOST_CHECK_THROW(
+         reader.read_section("test_section", [](auto& s) {
+            snapshot_consume_test::row r;
+            s.read_row(r); // read only the first of two rows
+         }),
+         snapshot_exception);
+   }
+}
 
 template<typename TESTER, typename SNAPSHOT_SUITE>
 void exhaustive_snapshot_test()


### PR DESCRIPTION
Non-contract fixes from the 2026-06-17 pre-launch security/bug audit (find → adversarial-verify). The contract-side findings (msgch::queueout authorization, the OPP "never-throw in dispatch" cluster, uwrit chklocks settlement, etc.) are handled separately.

Commits, highest severity first:

**🔴 net_plugin: reject under-length trx/vote frames; bound message_buffer advance**
The early-dedup path computed `advance_read_ptr(message_length - header_bytes)` from the peer-supplied frame length (both `uint32_t`). A peer that declares `message_length < 33` while pipelining ≥33 bytes makes `header_bytes > message_length` and underflows the subtraction to ~4.29e9, over-popping the `message_buffer` deque (`free()`/`pop_front()` on an emptied deque is UB) — a remote, **pre-authentication** memory-corruption primitive on a default-config node (`allowed-connection=any`). Guards both paths, adds a defense-in-depth bound in `advance_read_ptr`, plus a regression test.

**🟠 libfc: overflow-safe bounds checks in the Ethereum ABI decoder**
`offset + N <= data_size` checks wrap `size_t` for offsets/lengths decoded from untrusted ABI words on the inbound OPP path, so a value near 2^64 passes the check and `data + offset` is dereferenced at a wild address (OOB read; the SIGSEGV is not caught there). `decode_static_value` never even received `data_size`. Adds overflow-safe helpers, threads `data_size` through, bounds array element counts, plus a regression test feeding overflowing offset/length words.

**🟡 chain: pin snapshot row_count to hashed section data on load**
A section's `row_count` lives in the section index, which is outside the integrity/root hash. A tampered (decreased) `row_count` silently truncates loaded rows while still matching the on-chain attested hash, loading a node with consensus state that diverges from the canonical chain. Requires exact section consumption after the last row + an empty-section invariant.

**🟢 chain: 64-bit length math in BLS host functions**
`n*96` / `n*192` / `n*32` guards wrapped in `uint32_t`; a crafted `n` could match an undersized span and the `i*96` loop then read past the buffer. Computed in `size_t`.

**🟢 libfc: fix big-endian sha3 OOB write + uninitialized index**
The big-endian branch (constexpr-discarded on Wire's little-endian targets) used `sizeof(words)` as an element count and an uninitialized loop induction variable.

**🟢 underwriter_plugin: harden ETH/SOL source-deposit verification**
ETH: `std::stoul`/`std::stoull` on a malformed RPC field throw `std::` exceptions (not `fc::exception`) that escaped and aborted the whole scan cycle; now caught + blockNumber prefix guarded. SOL: matched the SwapDeposit marker anywhere in `meta.logMessages` without program attribution (a forged marker from any program in a tx that merely references opp-outpost passed); now tracks the `Program invoke/success|failed` bracket stack and trusts the marker only when opp-outpost is top-of-stack.

**🟢 chain: consistent weak_final boundary in QC vote aggregation**
`add_weak_vote`'s `weak_achieved` arm used `>=` vs the strict `>` of the unrestricted/restricted arm, declaring `weak_final` one weight-unit early (`weak_sum == sum - threshold` still allows a strong QC). Local aggregation only; QC verification is independent and unchanged, and the Savanna proof format/verification are unaffected — at the exact boundary it only changes which valid QC variant (strong vs weak) a producer forms, in the safe direction. Confirmed present **verbatim in upstream Spring** — see Upstream below. Covered by a new boundary regression test.

## Testing
Full pre-PR sweep — `unit_test` (`--sys-vm`), `plugin_test`, `contracts_unit_test` (`--sys-vm`), `test_fc` — all green **except three failures that pre-exist on `master`** and are unrelated to this diff (verified byte-identical on a clean-`master` baseline): `deep_mind_tests` and `savanna_misc_tests/verify_block_compatibitity` (stale reference data — need regeneration after the latest contract recompiles) and `api_part2_tests/crypto_tests`. None touch the files in this PR. New tests: `message_buffer` advance underflow; Ethereum ABI malicious offset/length decode; QC `weak_final` boundary (`finality_misc_tests/qc_state_transitions`) — fail-without-fix verified (the new asserts fail with `>=`, pass with `>`).

## Upstream (Spring)
The QC `weak_final` off-by-one (last commit) is **not a Wire regression** — it exists verbatim in upstream `AntelopeIO/spring`, and Spring's own `qc_state_transitions` unit test has the same `max_weak_sum_before_weak_final == 1` blind spot that kept it from being caught. The one-line fix and the new boundary regression test here apply to Spring unchanged and should be filed/upstreamed as a Spring issue.

