### PR TITLE
producer_plugin: floor the speculative-retry CPU cap

### DIFF
--- a/plugins/producer_plugin/src/producer_plugin.cpp
+++ b/plugins/producer_plugin/src/producer_plugin.cpp
@@ -810,6 +810,14 @@ public:
    unapplied_transaction_queue                       _unapplied_transactions;
    alignas(hardware_destructive_interference_sz)
    std::atomic<int32_t>                              _max_transaction_time_ms; // modified by app thread, read by net_plugin thread pool
+   // Floor for the speculative-retry CPU cap applied in push_transaction(). That cap is normally
+   // 2x the transaction's previously measured wall-clock cost, which guards against "producer bombs"
+   // (transactions that speculate cheaply but consume large CPU when produced into a block). For very
+   // cheap transactions, however, 2x prev_elapsed can fall below the run-to-run wall-clock variance of
+   // re-execution during fork catch-up or node load, dropping a valid forked-out transaction (the only
+   // copy on this node, never rebroadcast) instead of re-applying it. Flooring the cap lets cheap
+   // transactions absorb that variance while still bounding the CPU a bomb can consume before rejection.
+   static constexpr fc::microseconds                 _speculative_retry_min_cpu_cap{5000}; // 5 ms
    alignas(hardware_destructive_interference_sz)
    std::atomic<uint32_t>                             _received_block{0};       // modified by net_plugin thread pool
    implicit_production_pause_vote_tracker            _implicit_pause_vote_tracker;
@@ -2831,8 +2839,11 @@ producer_plugin_impl::push_result producer_plugin_impl::push_transaction(const f
 
       // elapsed can be set on failure, but prev_succeeded indicates a real cost
       // measurement -- only then is 2x prev_elapsed a sound cap on this retry.
+      // Floor the cap at _speculative_retry_min_cpu_cap: for very cheap trxs, 2x prev_elapsed is below
+      // the wall-clock variance of re-execution during fork catch-up / node load and would otherwise
+      // drop a valid forked-out trx; the floor still bounds the CPU a producer bomb can consume.
       if (trx->prev_succeeded) {
-         max_trx_time = std::min(max_trx_time, prev_elapsed * 2);
+         max_trx_time = std::min(max_trx_time, std::max(prev_elapsed * 2, _speculative_retry_min_cpu_cap));
       }
    }
 


### PR DESCRIPTION
## Summary

Floors the producer's speculative-retry CPU cap so valid forked-out transactions are not dropped during fork catch-up. This fixes intermittent failures of the `trx_finality_status_forked_test` NP test.

## Failing tests / CI

The same test fails intermittently, and the failing build config varies run-to-run (which is the signature of a timing flake, not a config-specific bug):

- **`trx_finality_status_forked_test`** — `NP Tests (ubsan)`, master, run [27701210214](https://github.com/Wire-Network/wire-sysio/actions/runs/27701210214/job/81941039355)
- **`trx_finality_status_forked_test`** — `NP Tests (gcc)`, run [27702644464](https://github.com/Wire-Network/wire-sysio/actions/runs/27702644464/job/81951983280) (that run's ubsan NP job passed)

In both, the test asserts at line 222 that the forked-out transaction reaches `IN_BLOCK`/`IRREVERSIBLE`; instead it ends in `FAILED` (expired), with the status sequence `LOCALLY_APPLIED -> IN_BLOCK -> FORKED_OUT -> FAILED` and `block_number` frozen at the pre-fork block.

## Root cause

When a transaction has previously succeeded, `producer_plugin_impl::push_transaction` caps the retry budget at `2 * prev_elapsed` (its last measured wall-clock cost). This guards against "producer bombs" — transactions that execute cheaply during speculation but consume large CPU when produced into a block.

For a trivial transaction (a token transfer, ~100µs) that cap is only ~200–330µs. During fork catch-up the same transaction's wall-clock re-execution can legitimately exceed 2× its calm baseline purely from scheduling/load variance (observed **292µs on gcc**, **887µs on ubsan**). When it does, `transaction_context` throws `tx_cpu_usage_exceeded` (reason `speculative_executed_adjusted_max_transaction_time`). That code is not in `exception_is_exhausted()`, so `handle_push_result` marks the push failed and `process_unapplied_trxs` **erases** the transaction from the unapplied queue. Forked-out transactions are the only copy on the node and are never rebroadcast, so the transaction is lost and eventually expires.

## Fix

Floor the cap at a small constant (`_speculative_retry_min_cpu_cap`, 5ms):

```cpp
max_trx_time = std::min(max_trx_time, std::max(prev_elapsed * 2, _speculative_retry_min_cpu_cap));
```

This only relaxes the cap for sub-2.5ms transactions — exactly where 2× falls into the wall-clock noise band. **Drop-on-overshoot is unchanged**, so the anti-bomb protection is preserved: a bomb is still rejected, now after consuming at most ~5ms once (no retry, no escalation). 5ms is 2.5% of the default 200ms block CPU budget and gives ~6× headroom over the worst re-execution observed.

