### PR TITLE
Fix compiler warnings in wire-sysio

### DIFF
--- a/contracts/tests/emissions_tests.cpp
+++ b/contracts/tests/emissions_tests.cpp
@@ -212,7 +212,8 @@ static constexpr uint16_t GOV_BPS                = 1000;
 // lazily via sysio.dclaim::onreward -> sysio.system::fundclaim, not paid at
 // payepoch -- so it doesn't appear in t5state.total_distributed until the
 // underlying fundclaim transfer happens.
-static constexpr uint16_t IMPLICIT_CAPITAL_BPS   = 10000 - COMPUTE_BPS - CAPEX_BPS - GOV_BPS;
+// The implicit capital reserve at these defaults is
+// 10000 - COMPUTE_BPS - CAPEX_BPS - GOV_BPS = 3000 bps.
 static constexpr uint16_t PRODUCER_BPS           = 7000;
 
 // Performance-based pay constants (keep in sync with emissions.cpp)

--- a/contracts/tests/sysio.msgch_tests.cpp
+++ b/contracts/tests/sysio.msgch_tests.cpp
@@ -330,7 +330,6 @@ using fc::slug_name_literals::operator""_s;
 /// tests register one EVM-class chain via `register_outpost(...)` which uses
 /// the spelling `"ETH"`. ETH_OUTPOST_ID is the slug_name's packed value.
 constexpr uint64_t ETH_OUTPOST_ID = "ETH"_s.value;
-constexpr uint64_t SOL_OUTPOST_ID = "SOL"_s.value;
 
 } // anonymous namespace
 

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -68,7 +68,7 @@ namespace sysio { namespace chain { namespace webassembly {
       for (const auto& p : candidate.proposer_schedule.producers) {
          SYS_ASSERT(context.is_account(p.producer_name), wasm_execution_error,
                     "producer schedule includes a nonexisting account");
-         std::visit([&p](const auto& a) {
+         std::visit([](const auto& a) {
             for (const auto& kw : a.keys) {
                SYS_ASSERT(kw.key.contains_type(key_type::k1, key_type::r1), unactivated_key_type,
                           "Unactivated key type used in proposed producer schedule");

--- a/libraries/libfc/test/variant/test_variant_assign.cpp
+++ b/libraries/libfc/test/variant/test_variant_assign.cpp
@@ -24,7 +24,8 @@ BOOST_AUTO_TEST_CASE(self_assign_copy) {
 
 BOOST_AUTO_TEST_CASE(self_assign_move) {
    variant v{std::string{"y"}};
-   v = std::move(v);
+   variant& same = v;
+   v = std::move(same);
    BOOST_CHECK(v.is_string());
    BOOST_CHECK_EQUAL(v.get_string(), "y");
 }

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -383,7 +383,7 @@ struct batch_operator_plugin::impl {
       is_active = sysio::depot::opreg_status::compute_is_active(status, was_active);
 
       if (was_active && !is_active) {
-         elog("batch_operator: own status flipped to {} — halting relay loop", ("s", status));
+         elog("batch_operator: own status flipped to {} — halting relay loop", status);
       } else if (!was_active && is_active) {
          ilog("batch_operator: own status flipped to ACTIVE — resuming relay loop");
       }


### PR DESCRIPTION
## Summary

Clean up compiler warnings reported by the ubuntu24 GitHub Actions build.

## What changed

- Avoid Clang's self-move warning in the `variant` self-move assignment test while preserving coverage of assigning through an alias.
- Remove an unused lambda capture in producer schedule validation.
- Pass the batch operator status string directly to the error log instead of using an accidental comma expression.
- Remove unused constants from contract tests while keeping the relevant value documented.

## Why

The referenced CI job completed successfully but emitted source warnings in these files. Removing them keeps Release builds cleaner and makes future warnings easier to spot.

## Testing

- `git diff --check`

Not run locally: full `wire-sysio` build/test suite.
