### PR TITLE
Fix performance harness log directory race

### DIFF
--- a/tests/PerformanceHarness/performance_test.py
+++ b/tests/PerformanceHarness/performance_test.py
@@ -103,7 +103,7 @@ class PerformanceTest:
         self.testsStart = datetime.now(UTC)
 
         self.loggingConfig = PerformanceTest.LoggingConfig(logDirBase=Path(self.ptConfig.logDirRoot)/f"PHSRLogs",
-                                                           logDirTimestamp=f"{self.testsStart.strftime('%Y-%m-%d_%H-%M-%S')}")
+                                                           logDirTimestamp=f"{self.testsStart.strftime('%Y-%m-%d_%H-%M-%S-%f')}-{os.getpid()}")
 
     def performPtbBinarySearch(self, clusterConfig: PerformanceTestBasic.ClusterConfig, logDirRoot: Path, delReport: bool, quiet: bool, delPerfLogs: bool, saveState: bool) -> TpsTestResult.PerfTestSearchResults:
         floor = self.ptConfig.minTpsToTest
@@ -314,10 +314,10 @@ class PerformanceTest:
     def testDirsSetup(self):
         try:
             def createArtifactsDir(path):
+                """Create a performance artifact directory without failing if a parallel test wins the race."""
                 print(f"Checking if test artifacts dir exists: {path}")
-                if not Path(path).is_dir():
-                    print(f"Creating test artifacts dir: {path}")
-                    os.mkdir(f"{path}")
+                print(f"Creating test artifacts dir: {path}")
+                Path(path).mkdir(parents=True, exist_ok=True)
 
             createArtifactsDir(self.loggingConfig.logDirBase)
             createArtifactsDir(self.loggingConfig.logDirPath)


### PR DESCRIPTION
## Summary

Fix a race in the performance harness artifact directory setup when multiple performance CTest jobs start in the same second.

## What changed

- Include microseconds and the process ID in `PerformanceTest` top-level log directory names.
- Create performance artifact directories with `Path.mkdir(parents=True, exist_ok=True)` so setup remains safe if another process creates a parent directory first.

## Why

The sharded NP/LR CTest run can start `performance_test_bp` and `performance_test_api` together. They previously shared a `PHSRLogs/<second-resolution timestamp>` directory, allowing one test's cleanup/setup path to remove or skip directories needed by the other. This caused failures such as a missing `pluginThreadOptRunLogs/chainThreadResults.txt`.

Observed in the failed UBSan job from run 27840130511:
https://github.com/Wire-Network/wire-sysio/actions/runs/27840130511/job/82397129698

The failing `performance_test_bp` log showed:

```text
FileNotFoundError: [Errno 2] No such file or directory:
'PHSRLogs/2026-06-19_17-55-07/pluginThreadOptRunLogs/chainThreadResults.txt'
```

## Testing

- `PYTHONPYCACHEPREFIX=/private/tmp/wire-pycache python3 -m py_compile tests/PerformanceHarness/performance_test.py`
