### PR TITLE
ci: harden workflow_dispatch overrides against shell injection (WSA-094)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -275,20 +275,44 @@ jobs:
         id: versions
         env:
           GH_TOKEN: ${{secrets.GH_TOKEN_DEV}}
+          # Untrusted workflow_dispatch overrides are passed as environment variables and are
+          # NEVER interpolated into the script body. GitHub expands ${{ }} before bash parses the
+          # script, so interpolating an override directly would let a value such as $(...) run as
+          # shell code in trusted CI that holds GH_TOKEN_DEV (WSA-094 / SEC-094). As env vars the
+          # values are inert data: bash does not re-evaluate command substitution found inside a
+          # variable's value. github.repository / github.sha are likewise read via env and quoted.
+          OVERRIDE_CDT: ${{ inputs.override-cdt }}
+          OVERRIDE_CDT_PRERELEASE: ${{ inputs.override-cdt-prerelease }}
+          OVERRIDE_SYS_SYSTEM_CONTRACTS: ${{ inputs.override-sys-system-contracts }}
+          REPO: ${{ github.repository }}
+          REF_SHA: ${{ github.sha }}
         run: |
-          DEFAULTS_JSON=$(curl -sSfL $(gh api https://api.github.com/repos/${{github.repository}}/contents/.cicd/defaults.json?ref=${{github.sha}} --jq .download_url))
-          echo cdt-target=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.target') >> $GITHUB_OUTPUT
-          echo cdt-prerelease=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.prerelease') >> $GITHUB_OUTPUT
-          echo wire-system-contracts-ref=$(echo "$DEFAULTS_JSON" | jq -r '.wiresystemcontracts.ref') >> $GITHUB_OUTPUT
+          # Defense in depth: reject ref/target overrides containing anything outside a conservative
+          # allowlist. This blocks every shell metacharacter and newline (so an override can never
+          # break out of $GITHUB_OUTPUT's "name=value" line either) while still accepting real values
+          # such as "4.1.0" and "release/4.0". The pattern is held in a variable so [[ =~ ]] treats it
+          # as a regex, and the candidate matched is only ever the variable's literal value.
+          ref_re='^[A-Za-z0-9._/+-]+$'
+          for ov in "$OVERRIDE_CDT" "$OVERRIDE_SYS_SYSTEM_CONTRACTS"; do
+            if [[ -n "$ov" && ! "$ov" =~ $ref_re ]]; then
+              echo "::error::Invalid override ref '$ov'; only [A-Za-z0-9._/+-] are allowed." >&2
+              exit 1
+            fi
+          done
 
-          if [[ "${{inputs.override-cdt}}" != "" ]]; then
-            echo cdt-target=${{inputs.override-cdt}} >> $GITHUB_OUTPUT
+          DEFAULTS_JSON=$(curl -sSfL "$(gh api "https://api.github.com/repos/${REPO}/contents/.cicd/defaults.json?ref=${REF_SHA}" --jq .download_url)")
+          echo "cdt-target=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.target')" >> "$GITHUB_OUTPUT"
+          echo "cdt-prerelease=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.prerelease')" >> "$GITHUB_OUTPUT"
+          echo "wire-system-contracts-ref=$(echo "$DEFAULTS_JSON" | jq -r '.wiresystemcontracts.ref')" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$OVERRIDE_CDT" ]]; then
+            echo "cdt-target=$OVERRIDE_CDT" >> "$GITHUB_OUTPUT"
           fi
-          if [[ "${{inputs.override-cdt-prerelease}}" == +(true|false) ]]; then
-            echo cdt-prerelease=${{inputs.override-cdt-prerelease}} >> $GITHUB_OUTPUT
+          if [[ "$OVERRIDE_CDT_PRERELEASE" == "true" || "$OVERRIDE_CDT_PRERELEASE" == "false" ]]; then
+            echo "cdt-prerelease=$OVERRIDE_CDT_PRERELEASE" >> "$GITHUB_OUTPUT"
           fi
-          if [[ "${{inputs.override-sys-system-contracts}}" != "" ]]; then
-            echo wire-system-contracts-ref=${{inputs.override-sys-system-contracts}} >> $GITHUB_OUTPUT
+          if [[ -n "$OVERRIDE_SYS_SYSTEM_CONTRACTS" ]]; then
+            echo "wire-system-contracts-ref=$OVERRIDE_SYS_SYSTEM_CONTRACTS" >> "$GITHUB_OUTPUT"
           fi
 
   all-passing:

--- a/.github/workflows/noop/performance_harness_run.yaml
+++ b/.github/workflows/noop/performance_harness_run.yaml
@@ -43,19 +43,42 @@ jobs:
     steps:
       - name: Setup Input Params
         id: overrides
+        env:
+          # Untrusted workflow_dispatch overrides are passed as environment variables and are NEVER
+          # interpolated into the script body. GitHub expands ${{ }} before bash parses the script,
+          # so interpolating an override directly would let a value such as $(...) run as shell code.
+          # As env vars the values are inert data: bash does not re-evaluate command substitution
+          # found inside a variable's value. Mirrors the hardened wire-sysio build.yaml (WSA-094).
+          OVERRIDE_TEST_PARAMS: ${{ inputs.override-test-params }}
+          OVERRIDE_SYSIO: ${{ inputs.override-sysio }}
+          OVERRIDE_SYSIO_PRERELEASE: ${{ inputs.override-sysio-prerelease }}
         run: |
-          echo test-params=findMax testBpOpMode >> $GITHUB_OUTPUT
-          echo sysio-target="DEFAULT" >> $GITHUB_OUTPUT
-          echo sysio-prerelease="false" >> $GITHUB_OUTPUT
+          # Defense in depth: reject overrides carrying shell metacharacters. The sysio target is a
+          # ref/version (single token); test params are a space-separated argv string, so it gets a
+          # wider allow-list that still blocks every shell metacharacter, glob, quote and newline.
+          ref_re='^[A-Za-z0-9._/+-]+$'
+          params_re='^[A-Za-z0-9 ._/=:,+-]*$'
+          if [[ -n "$OVERRIDE_SYSIO" && ! "$OVERRIDE_SYSIO" =~ $ref_re ]]; then
+            echo "::error::Invalid override-sysio '$OVERRIDE_SYSIO'; only [A-Za-z0-9._/+-] are allowed." >&2
+            exit 1
+          fi
+          if [[ -n "$OVERRIDE_TEST_PARAMS" && ! "$OVERRIDE_TEST_PARAMS" =~ $params_re ]]; then
+            echo "::error::Invalid override-test-params '$OVERRIDE_TEST_PARAMS'; shell metacharacters are not allowed." >&2
+            exit 1
+          fi
 
-          if [[ "${{inputs.override-test-params}}" != "" ]]; then
-            echo test-params=${{inputs.override-test-params}} >> $GITHUB_OUTPUT
+          echo "test-params=findMax testBpOpMode" >> "$GITHUB_OUTPUT"
+          echo "sysio-target=DEFAULT" >> "$GITHUB_OUTPUT"
+          echo "sysio-prerelease=false" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$OVERRIDE_TEST_PARAMS" ]]; then
+            echo "test-params=$OVERRIDE_TEST_PARAMS" >> "$GITHUB_OUTPUT"
           fi
-          if [[ "${{inputs.override-sysio}}" != "" ]]; then
-            echo sysio-target=${{inputs.override-sysio}} >> $GITHUB_OUTPUT
+          if [[ -n "$OVERRIDE_SYSIO" ]]; then
+            echo "sysio-target=$OVERRIDE_SYSIO" >> "$GITHUB_OUTPUT"
           fi
-          if [[ "${{inputs.override-sysio-prerelease}}" == +(true|false) ]]; then
-            echo sysio-prerelease=${{inputs.override-sysio-prerelease}} >> $GITHUB_OUTPUT
+          if [[ "$OVERRIDE_SYSIO_PRERELEASE" == "true" || "$OVERRIDE_SYSIO_PRERELEASE" == "false" ]]; then
+            echo "sysio-prerelease=$OVERRIDE_SYSIO_PRERELEASE" >> "$GITHUB_OUTPUT"
           fi
 
   platform-cache:
@@ -139,9 +162,14 @@ jobs:
           ./build/bin/nodeop --full-version
           ./build/bin/clio version full
       - name: Run Performance Test
+        env:
+          # test-params is allow-list validated at the `v` job (no shell metacharacters) and passed
+          # via env; left UNQUOTED below so it still word-splits into the script's argv, without
+          # ${{ }} ever being expanded into the shell as code.
+          TEST_PARAMS: ${{needs.v.outputs.test-params}}
         run: |
           cd build
-          ./tests/PerformanceHarnessScenarioRunner.py ${{needs.v.outputs.test-params}}
+          ./tests/PerformanceHarnessScenarioRunner.py $TEST_PARAMS
       - name: Prepare results
         id: prep-results
         run: |


### PR DESCRIPTION
## WSA-094 — workflow_dispatch override inputs shell-inject into trusted CI

### Problem
`workflow_dispatch` string inputs were interpolated as raw `${{ inputs.* }}` directly into Bash `run:` scripts. GitHub expands `${{ }}` **before** bash parses the script, so an override value like `$(...)` runs as shell code in trusted CI — which at that point holds `secrets.GH_TOKEN_DEV` (GHCR creds + version-resolution token). Exploitation requires workflow-dispatch capability (a collaborator or an Actions:write/`workflow`-scoped token), not a public PR.

### Fix
- **env-var indirection (primary):** untrusted inputs are passed via `env:` and referenced as quoted shell variables. Bash does not re-evaluate command substitution inside a variable's *value*, so `$(...)` is treated as data.
- **allow-list validation (defense in depth):** ref/target overrides must match `^[A-Za-z0-9._/+-]+$`; the perf-harness param string uses a wider no-metacharacter allow-list. This also closes a secondary `$GITHUB_OUTPUT` line-injection vector.
- Quoted `$GITHUB_OUTPUT` and the `gh api` URL; replaced the `+(true|false)` extglob test with an explicit `true`/`false` comparison.

### Files
- `.github/workflows/build.yaml` — the active *Discover Versions* job (the finding).
- `.github/workflows/noop/performance_harness_run.yaml` — same pattern in the inert (subdirectory) workflow + its unquoted `test-params` argv sink.

### Verification
YAML parses; a `$(...)` / `;` / `|` override is rejected by validation and does not execute even with validation bypassed (env-indirection); legitimate values (`4.1.0`, `release/4.0`, branch refs) pass; `test-params` still word-splits into separate argv under default IFS, preserving harness behavior.
