### PR TITLE
SEC-56: Bound state-history status request queues

### DIFF
--- a/libraries/state_history/include/sysio/state_history/status_request_queue.hpp
+++ b/libraries/state_history/include/sysio/state_history/status_request_queue.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <deque>
 #include <string_view>
 
 namespace sysio::state_history {
@@ -13,21 +12,52 @@ inline constexpr std::size_t max_status_request_queue_depth = 1024;
 inline constexpr std::string_view status_request_queue_limit_exceeded =
       "state history status request queue limit exceeded";
 
-/** Bounded FIFO for pending SHiP status requests. */
+/// SHiP status request protocol version.
+enum class status_request_version {
+   v0,
+   v1,
+};
+
+/** Counts pending SHiP status requests by protocol version for one queue drain. */
+struct pending_status_request_counts {
+   std::size_t v0 = 0; ///< Number of pending v0 status requests.
+   std::size_t v1 = 0; ///< Number of pending v1 status requests.
+
+   /// Returns the total number of pending status requests.
+   std::size_t size() const {
+      return v0 + v1;
+   }
+
+   /// Returns true when no status requests are pending.
+   bool empty() const {
+      return size() == 0;
+   }
+};
+
+/** Bounded counter queue for pending SHiP status requests. */
 class status_request_queue {
 public:
    /// Attempts to append one status request, returning false when the queue depth limit has been reached.
-   [[nodiscard]] bool try_append(bool is_v1_request) {
+   [[nodiscard]] bool try_append(status_request_version version) {
       if(requests.size() >= max_status_request_queue_depth)
          return false;
-      requests.emplace_back(is_v1_request);
+
+      switch(version) {
+      case status_request_version::v0:
+         ++requests.v0;
+         break;
+      case status_request_version::v1:
+         ++requests.v1;
+         break;
+      }
+
       return true;
    }
 
    /// Removes and returns all pending status requests while leaving the queue reusable.
-   std::deque<bool> pop_all() {
-      std::deque<bool> pending;
-      pending.swap(requests);
+   pending_status_request_counts pop_all() {
+      const pending_status_request_counts pending = requests;
+      requests = {};
       return pending;
    }
 
@@ -42,7 +72,7 @@ public:
    }
 
 private:
-   std::deque<bool> requests; ///< false for v0 requests, true for v1 requests.
+   pending_status_request_counts requests; ///< Counted pending requests since the last drain.
 };
 
 } // namespace sysio::state_history

--- a/libraries/state_history/include/sysio/state_history/status_request_queue.hpp
+++ b/libraries/state_history/include/sysio/state_history/status_request_queue.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <string_view>
+
+namespace sysio::state_history {
+
+/// Maximum status request queue depth before a SHiP session is closed.
+inline constexpr std::size_t max_status_request_queue_depth = 1024;
+
+/// Error text used when a SHiP client exceeds the per-session status request queue limit.
+inline constexpr std::string_view status_request_queue_limit_exceeded =
+      "state history status request queue limit exceeded";
+
+/** Bounded FIFO for pending SHiP status requests. */
+class status_request_queue {
+public:
+   /// Attempts to append one status request, returning false when the queue depth limit has been reached.
+   [[nodiscard]] bool try_append(bool is_v1_request) {
+      if(requests.size() >= max_status_request_queue_depth)
+         return false;
+      requests.emplace_back(is_v1_request);
+      return true;
+   }
+
+   /// Removes and returns all pending status requests while leaving the queue reusable.
+   std::deque<bool> pop_all() {
+      std::deque<bool> pending;
+      pending.swap(requests);
+      return pending;
+   }
+
+   /// Returns the number of queued status requests.
+   std::size_t size() const {
+      return requests.size();
+   }
+
+   /// Returns true when no status requests are queued.
+   bool empty() const {
+      return requests.empty();
+   }
+
+private:
+   std::deque<bool> requests; ///< false for v0 requests, true for v1 requests.
+};
+
+} // namespace sysio::state_history

--- a/plugins/state_history_plugin/include/sysio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/sysio/state_history_plugin/session.hpp
@@ -12,7 +12,6 @@
 #include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/beast/websocket.hpp>
-#include <deque>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -155,7 +154,10 @@ private:
                 */
                std::visit(chain::overloaded {
                   [&]<typename GetStatusRequestV0orV1, typename = std::enable_if_t<std::is_base_of_v<get_status_request_v0, GetStatusRequestV0orV1>>>(const GetStatusRequestV0orV1&) {
-                     if(!queued_status_requests.try_append(std::is_same_v<GetStatusRequestV0orV1, get_status_request_v1>))
+                     constexpr status_request_version request_version =
+                           std::is_same_v<GetStatusRequestV0orV1, get_status_request_v1> ? status_request_version::v1 :
+                                                                                             status_request_version::v0;
+                     if(!queued_status_requests.try_append(request_version))
                         throw std::runtime_error(std::string(status_request_queue_limit_exceeded));
                   },
                   [&]<typename GetBlocksRequestV0orV1, typename = std::enable_if_t<std::is_base_of_v<get_blocks_request_v0, GetBlocksRequestV0orV1>>>(const GetBlocksRequestV0orV1& gbr) {
@@ -236,8 +238,8 @@ private:
             if(!stream.is_open())
                break;
 
-            std::deque<bool>             status_requests;
-            std::optional<block_package> block_to_send;
+            pending_status_request_counts status_requests;
+            std::optional<block_package>  block_to_send;
 
             co_await boost::asio::co_spawn(app().get_io_context(), [&]() -> boost::asio::awaitable<void> {
                /**
@@ -277,7 +279,7 @@ private:
                   --send_credits;
                }
 
-               if(status_requests.size())
+               if(!status_requests.empty())
                   current_status_result = fill_current_status_result();
                co_return;
             }, boost::asio::use_awaitable);
@@ -288,13 +290,12 @@ private:
                continue;
             }
 
-            //send replies to all send status requests first
-            for(const bool status_request_is_v1 : status_requests) {
-               if(status_request_is_v1 == false) //v0 status request, gets a v0 status result
-                  co_await stream.async_write(boost::asio::buffer(fc::raw::pack(state_result((get_status_result_v0)current_status_result))));
-               else
-                  co_await stream.async_write(boost::asio::buffer(fc::raw::pack(state_result(current_status_result))));
-            }
+            // Send status responses first; a session uses one status version, so counted drains can write by batch.
+            for(std::size_t i = 0; i < status_requests.v0; ++i)
+               co_await stream.async_write(
+                     boost::asio::buffer(fc::raw::pack(state_result((get_status_result_v0)current_status_result))));
+            for(std::size_t i = 0; i < status_requests.v1; ++i)
+               co_await stream.async_write(boost::asio::buffer(fc::raw::pack(state_result(current_status_result))));
 
             //and then send the block
             if(block_to_send) {

--- a/plugins/state_history_plugin/include/sysio/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/sysio/state_history_plugin/session.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <sysio/state_history/log.hpp>
 #include <sysio/state_history/serialization.hpp>
+#include <sysio/state_history/status_request_queue.hpp>
 #include <sysio/state_history/types.hpp>
 
 #include <sysio/chain/types.hpp>
@@ -11,7 +12,10 @@
 #include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/beast/websocket.hpp>
+#include <deque>
 #include <memory>
+#include <stdexcept>
+#include <string>
 
 extern const char* const state_history_plugin_abi;
 
@@ -151,7 +155,8 @@ private:
                 */
                std::visit(chain::overloaded {
                   [&]<typename GetStatusRequestV0orV1, typename = std::enable_if_t<std::is_base_of_v<get_status_request_v0, GetStatusRequestV0orV1>>>(const GetStatusRequestV0orV1&) {
-                     queued_status_requests.emplace_back(std::is_same_v<GetStatusRequestV0orV1, get_status_request_v1>);
+                     if(!queued_status_requests.try_append(std::is_same_v<GetStatusRequestV0orV1, get_status_request_v1>))
+                        throw std::runtime_error(std::string(status_request_queue_limit_exceeded));
                   },
                   [&]<typename GetBlocksRequestV0orV1, typename = std::enable_if_t<std::is_base_of_v<get_blocks_request_v0, GetBlocksRequestV0orV1>>>(const GetBlocksRequestV0orV1& gbr) {
                      current_blocks_request_v1_finality.reset();
@@ -238,7 +243,7 @@ private:
                /**
                 * This lambda executes on the main thread; upon returning, the enclosing coroutine continues execution on the connection's strand
                 */
-               status_requests = std::move(queued_status_requests);
+               status_requests = queued_status_requests.pop_all();
 
                //decide what block -- if any -- to send out
                const chain::block_num_type latest_to_consider = current_blocks_request.irreversible_only ?
@@ -319,7 +324,7 @@ private:
    std::atomic_flag                  has_logged_exception;  //left as atomic_flag for useful test_and_set() interface
 
    ///these items must only ever be touched on the main thread
-   std::deque<bool>                  queued_status_requests;  //false for v0, true for v1
+   status_request_queue              queued_status_requests;
 
    get_blocks_request_v0             current_blocks_request;
    std::optional<bool>               current_blocks_request_v1_finality; //unset: current request is v0; set means v1; true/false is if finality requested

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -20,8 +20,6 @@
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/copy.hpp>
 
-#include <deque>
-
 using namespace sysio::chain;
 using namespace sysio::testing;
 using namespace std::literals;
@@ -68,28 +66,35 @@ std::vector<table_delta> create_deltas(const chainbase::database& db, bool full_
 
 BOOST_AUTO_TEST_SUITE(test_state_history)
 
-/// Verifies SHiP status requests are bounded, drained in FIFO order, and reusable after drain.
+/// Verifies SHiP status requests are bounded, drained by version count, and reusable after drain.
 BOOST_AUTO_TEST_CASE(status_request_queue_is_bounded)
 {
    sysio::state_history::status_request_queue queue;
+   std::size_t expected_v0 = 0;
+   std::size_t expected_v1 = 0;
 
    for(std::size_t i = 0; i < sysio::state_history::max_status_request_queue_depth; ++i) {
-      const bool is_v1_request = (i % 2) == 1;
-      BOOST_REQUIRE(queue.try_append(is_v1_request));
+      const sysio::state_history::status_request_version request_version =
+            (i % 2) == 1 ? sysio::state_history::status_request_version::v1 :
+                           sysio::state_history::status_request_version::v0;
+      BOOST_REQUIRE(queue.try_append(request_version));
+
+      if(request_version == sysio::state_history::status_request_version::v1)
+         ++expected_v1;
+      else
+         ++expected_v0;
    }
 
    BOOST_REQUIRE_EQUAL(queue.size(), sysio::state_history::max_status_request_queue_depth);
-   BOOST_CHECK(!queue.try_append(false));
+   BOOST_CHECK(!queue.try_append(sysio::state_history::status_request_version::v0));
 
-   const std::deque<bool> pending = queue.pop_all();
+   const sysio::state_history::pending_status_request_counts pending = queue.pop_all();
    BOOST_CHECK(queue.empty());
    BOOST_REQUIRE_EQUAL(pending.size(), sysio::state_history::max_status_request_queue_depth);
-   for(std::size_t i = 0; i < pending.size(); ++i) {
-      const bool expected_is_v1_request = (i % 2) == 1;
-      BOOST_CHECK_EQUAL(pending[i], expected_is_v1_request);
-   }
+   BOOST_CHECK_EQUAL(pending.v0, expected_v0);
+   BOOST_CHECK_EQUAL(pending.v1, expected_v1);
 
-   BOOST_CHECK(queue.try_append(true));
+   BOOST_CHECK(queue.try_append(sysio::state_history::status_request_version::v1));
    BOOST_REQUIRE_EQUAL(queue.size(), 1u);
 }
 

--- a/unittests/state_history_tests.cpp
+++ b/unittests/state_history_tests.cpp
@@ -6,6 +6,7 @@
 #include <sysio/state_history/abi.hpp>
 #include <sysio/state_history/create_deltas.hpp>
 #include <sysio/state_history/log_catalog.hpp>
+#include <sysio/state_history/status_request_queue.hpp>
 #include <sysio/state_history/trace_converter.hpp>
 #include <sysio/testing/tester.hpp>
 #include <fc/io/json.hpp>
@@ -18,6 +19,8 @@
 
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/copy.hpp>
+
+#include <deque>
 
 using namespace sysio::chain;
 using namespace sysio::testing;
@@ -64,6 +67,31 @@ std::vector<table_delta> create_deltas(const chainbase::database& db, bool full_
 }
 
 BOOST_AUTO_TEST_SUITE(test_state_history)
+
+/// Verifies SHiP status requests are bounded, drained in FIFO order, and reusable after drain.
+BOOST_AUTO_TEST_CASE(status_request_queue_is_bounded)
+{
+   sysio::state_history::status_request_queue queue;
+
+   for(std::size_t i = 0; i < sysio::state_history::max_status_request_queue_depth; ++i) {
+      const bool is_v1_request = (i % 2) == 1;
+      BOOST_REQUIRE(queue.try_append(is_v1_request));
+   }
+
+   BOOST_REQUIRE_EQUAL(queue.size(), sysio::state_history::max_status_request_queue_depth);
+   BOOST_CHECK(!queue.try_append(false));
+
+   const std::deque<bool> pending = queue.pop_all();
+   BOOST_CHECK(queue.empty());
+   BOOST_REQUIRE_EQUAL(pending.size(), sysio::state_history::max_status_request_queue_depth);
+   for(std::size_t i = 0; i < pending.size(); ++i) {
+      const bool expected_is_v1_request = (i % 2) == 1;
+      BOOST_CHECK_EQUAL(pending[i], expected_is_v1_request);
+   }
+
+   BOOST_CHECK(queue.try_append(true));
+   BOOST_REQUIRE_EQUAL(queue.size(), 1u);
+}
 
 class table_deltas_tester : public tester {
 public:


### PR DESCRIPTION
## Problem

SEC-56 / WSA-124 identified that each state-history WebSocket session could append every `get_status_request` into an unbounded per-session queue. A client that sent status requests faster than the write loop drained them could grow `queued_status_requests` without limit, consuming memory and forcing the node to serialize and send one status response per queued request.

That made the status endpoint vulnerable to request-queue amplification: the client did not need to request block data or hold many sessions open; one session could accumulate work and memory between write-loop drains.

## Solution

This PR adds a bounded `status_request_queue` utility for SHiP status requests:

- caps pending status requests at `max_status_request_queue_depth` (`1024`) per session queue drain window
- tracks pending v0/v1 status requests as counts, giving O(1) queue memory and avoiding per-request deque allocation
- preserves v0/v1 request identity with a typed `status_request_version` append API
- returns `false` from `try_append()` when the queue is full, with `[[nodiscard]]` so future call sites cannot accidentally ignore the security gate
- drains via `pop_all()` into `pending_status_request_counts`, leaving the queue reusable for later requests
- closes the session by throwing through the existing coroutine error path when a client exceeds the queue-depth cap

The cap is intentionally a queue-depth limit, not a lifetime counter: normal clients can continue sending status requests after the write loop drains pending work, while abusive bursts cannot grow memory without bound.

The counted drain intentionally does not retain interleaved v0/v1 ordering within one drain. That is safe for SHiP status responses because every response in a drain carries the same status snapshot, and a session uses one status protocol version.

## Tests

Latest validation after review follow-up:

- `ninja -C build/sec-56 -j6 unit_test`
- `./build/sec-56/unittests/unit_test --run_test=test_state_history/status_request_queue_is_bounded -- --sys-vm`
- `./build/sec-56/unittests/unit_test --run_test=test_state_history -- --sys-vm`
- `ninja -C build/sec-56 -j6 state_history_plugin nodeop`
- `ctest -j "$(nproc)" -R '^test_state_history_unit_test_' --output-on-failure --timeout 1000`
- `ctest -j "$(nproc)" -R '^ship_test$' --output-on-failure --timeout 1000`

Earlier broader validation on the initial patch before the review follow-up:

- `ninja -C build/sec-56 -j"$(nproc)"`
- `ctest -j "$(nproc)" -LE '(nonparallelizable_tests|long_running_tests|wasm_spec_tests)' --output-on-failure --timeout 1000`

That broad CTest sweep passed 320/326 tests. The six failures were local build/configuration checks unrelated to SEC-56:

- `native_overlay_unit_test_sys-vm-oc`, `native_overlay_unit_test_sys-vm`, `native_overlay_unit_test_sys-vm-jit`: this Debug worktree was configured without system contract native `.so` artifacts because CDT was unavailable
- `release-build-test`: expected failure for a Debug build
- `version-label-test`, `full-version-label-test`: local worktree reports version `unknown`

## Review

Addressed the optional reviewer suggestion to replace `std::deque<bool>` with counted v0/v1 pending requests. Also ran a read-only Claude review of the original patch; it found no correctness or behavioral regressions, and its hardening suggestions (`[[nodiscard]]` and clearer queue-depth naming) are included.