### PR TITLE
SEC-12: Enforce deadlines in outpost JSON-RPC transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git and PR Review Follow-Ups
+
+- After addressing any PR review comment, re-read the full PR diff and commit list,
+  then update the PR description so it captures the complete current PR: all
+  material behavior changes, tests, validation, and reviewer-relevant notes. Do
+  not leave the description focused only on the latest follow-up commit.
+
 ## Code Quality Standards
 
 This is blockchain infrastructure code. **Prefer the best solution over the simplest one.** Correctness, robustness, and consensus safety always take priority over brevity or speed of implementation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Git and PR Review Follow-Ups
-
-- After addressing any PR review comment, re-read the full PR diff and commit list,
-  then update the PR description so it captures the complete current PR: all
-  material behavior changes, tests, validation, and reviewer-relevant notes. Do
-  not leave the description focused only on the latest follow-up commit.
-
 ## Code Quality Standards
 
 This is blockchain infrastructure code. **Prefer the best solution over the simplest one.** Correctness, robustness, and consensus safety always take priority over brevity or speed of implementation.

--- a/libraries/libfc/include/fc/network/json_rpc/json_rpc_client.hpp
+++ b/libraries/libfc/include/fc/network/json_rpc/json_rpc_client.hpp
@@ -80,8 +80,11 @@ private:
    // Perform HTTP POST with JSON payload; optionally parse JSON body.
    variant send_json(const variant& payload, bool expect_json_body = true);
 
-   /// Resolve the configured host and replace the cached endpoint set.
+   /// Resolve the configured host and replace the cached endpoint set without a per-RPC deadline.
    void refresh_resolved_endpoints();
+
+   /// Refresh stale cached endpoints using the active RPC deadline when one exists.
+   void refresh_resolved_endpoints_with_active_deadline();
 
    /// Mark cached endpoints stale after a connection failure.
    void mark_resolved_endpoints_stale();

--- a/libraries/libfc/include/fc/network/json_rpc/json_rpc_client.hpp
+++ b/libraries/libfc/include/fc/network/json_rpc/json_rpc_client.hpp
@@ -4,6 +4,7 @@
 #include <fc/variant_object.hpp>
 #include <fc/io/json.hpp>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
 
 #include <string>
 #include <variant>
@@ -65,13 +66,28 @@ public:
    static json_rpc_client create(const std::variant<std::string, fc::url>& source);
 
 private:
+   using tcp = boost::asio::ip::tcp;
+
    asio::io_context _io_ctx{};
    fc::url      _url;
+   std::string  _host;
+   std::string  _port;
    std::string  _user_agent;
    std::int64_t _next_id;
+   tcp::resolver::results_type _resolved_endpoints;
+   bool                        _resolved_endpoints_stale;
 
    // Perform HTTP POST with JSON payload; optionally parse JSON body.
    variant send_json(const variant& payload, bool expect_json_body = true);
+
+   /// Resolve the configured host and replace the cached endpoint set.
+   void refresh_resolved_endpoints();
+
+   /// Mark cached endpoints stale after a connection failure.
+   void mark_resolved_endpoints_stale();
+
+   /// Return cached endpoints, refreshing only after a previous connection failure.
+   const tcp::resolver::results_type& resolved_endpoints();
 
    static void validate_basic_response(const variant& response);
 };

--- a/libraries/libfc/include/fc/task/deadline.hpp
+++ b/libraries/libfc/include/fc/task/deadline.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <fc/time.hpp>
+
+#include <optional>
+
+namespace fc::task {
+
+namespace detail {
+   inline thread_local std::optional<fc::time_point> active_deadline;
+} // namespace detail
+
+/**
+ * Thread-local absolute deadline inherited by nested retry and transport calls.
+ *
+ * The scope stores the earliest active deadline so nested helpers cannot extend
+ * a caller's budget by installing a later one. This is intentionally
+ * thread-local: OPP relay workers execute one synchronous chain call stack per
+ * worker, while the shared chain clients may be referenced by other workers.
+ */
+class deadline_scope {
+public:
+   /**
+    * Begin a scoped deadline.
+    *
+    * @param deadline_abs Absolute wall-clock deadline that nested helpers must
+    *                     not exceed.
+    */
+   explicit deadline_scope(fc::time_point deadline_abs)
+      : _previous(detail::active_deadline) {
+      if (_previous && *_previous < deadline_abs) {
+         detail::active_deadline = *_previous;
+      } else {
+         detail::active_deadline = deadline_abs;
+      }
+   }
+
+   deadline_scope(const deadline_scope&) = delete;
+   deadline_scope& operator=(const deadline_scope&) = delete;
+
+   /**
+    * Restore the previously active deadline, if any.
+    */
+   ~deadline_scope() {
+      detail::active_deadline = _previous;
+   }
+
+private:
+   std::optional<fc::time_point> _previous;
+};
+
+/**
+ * Return the currently active thread-local deadline, if a caller installed one.
+ */
+inline std::optional<fc::time_point> current_deadline() {
+   return detail::active_deadline;
+}
+
+/**
+ * Clamp `deadline_abs` to the currently active scoped deadline.
+ *
+ * @param deadline_abs Local helper deadline.
+ * @return The earliest of `deadline_abs` and the active scoped deadline.
+ */
+inline fc::time_point clamp_to_current_deadline(fc::time_point deadline_abs) {
+   if (detail::active_deadline && *detail::active_deadline < deadline_abs) {
+      return *detail::active_deadline;
+   }
+   return deadline_abs;
+}
+
+} // namespace fc::task

--- a/libraries/libfc/include/fc/task/retry.hpp
+++ b/libraries/libfc/include/fc/task/retry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <fc/exception/exception.hpp>
+#include <fc/task/deadline.hpp>
 #include <fc/time.hpp>
 
 #include <algorithm>
@@ -71,10 +72,18 @@ template <typename T>
 T retry_until(std::string_view                          op_label,
               const retry_options&                      opts,
               const std::function<std::optional<T>()>&  attempt) {
-   const auto deadline_abs = fc::time_point::now() + opts.total_timeout;
+   const auto start_time   = fc::time_point::now();
+   const auto deadline_abs = fc::task::clamp_to_current_deadline(start_time + opts.total_timeout);
+   const auto budget       = std::max(fc::microseconds(), deadline_abs - start_time);
    auto       backoff      = opts.initial_backoff;
 
    while (true) {
+      if (fc::time_point::now() >= deadline_abs) {
+         FC_THROW_EXCEPTION(fc::timeout_exception,
+                            "{}: deadline exceeded after {}ms",
+                            std::string(op_label),
+                            budget.count() / 1000);
+      }
       if (auto out = attempt(); out.has_value()) {
          return std::move(*out);
       }
@@ -83,7 +92,7 @@ T retry_until(std::string_view                          op_label,
          FC_THROW_EXCEPTION(fc::timeout_exception,
                             "{}: deadline exceeded after {}ms",
                             std::string(op_label),
-                            opts.total_timeout.count() / 1000);
+                            budget.count() / 1000);
       }
       const auto remaining = deadline_abs - now;
       const auto sleep_for_us = std::min(backoff, remaining);

--- a/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
+++ b/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
@@ -1,25 +1,271 @@
 // Implementation file for JSON-RPC client
 #include <fc/network/json_rpc/json_rpc_client.hpp>
+#include <fc/task/deadline.hpp>
 
 #include <boost/asio.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/ssl.hpp>
 #include <boost/beast/version.hpp>
+#include <boost/system/system_error.hpp>
 
-#include <format>
+#include <chrono>
+#include <functional>
 #include <ranges>
-#include <gsl-lite/gsl-lite.hpp>
-
-#define HTTP_VERSION 11
+#include <string_view>
+#include <utility>
 
 namespace fc::network::json_rpc {
 
-using namespace std::literals;
 namespace beast = boost::beast;
 namespace http = beast::http;
 namespace asio = boost::asio;
 using tcp = asio::ip::tcp;
+
+namespace {
+
+constexpr int HTTP_VERSION = 11;
+
+constexpr std::string_view HTTP_SCHEME        = "http";
+constexpr std::string_view HTTPS_SCHEME       = "https";
+constexpr std::string_view DEFAULT_HTTP_PATH  = "/";
+constexpr std::string_view OP_RESOLVE         = "JSON-RPC resolve";
+constexpr std::string_view OP_CONNECT         = "JSON-RPC connect";
+constexpr std::string_view OP_TLS_SNI         = "JSON-RPC TLS SNI";
+constexpr std::string_view OP_TLS_HANDSHAKE   = "JSON-RPC TLS handshake";
+constexpr std::string_view OP_TLS_SHUTDOWN    = "JSON-RPC TLS shutdown";
+constexpr std::string_view OP_HTTP_WRITE      = "JSON-RPC HTTP write";
+constexpr std::string_view OP_HTTP_READ       = "JSON-RPC HTTP read";
+
+/// Return the explicit URL port or the scheme's default JSON-RPC transport port.
+std::string default_port_for(const fc::url& url, std::string_view scheme) {
+   return std::to_string(url.port().value_or(scheme == HTTPS_SCHEME ? 443 : 80));
+}
+
+/// Return the caller-scoped transport deadline, treating maximum as unbounded.
+std::optional<fc::time_point> active_transport_deadline() {
+   auto deadline = fc::task::current_deadline();
+   if (deadline && *deadline < fc::time_point::maximum()) {
+      return deadline;
+   }
+   return std::nullopt;
+}
+
+/// Throw the fc timeout type expected by retry and batch-job callers.
+void throw_transport_timeout(std::string_view op_label) {
+   FC_THROW_EXCEPTION(fc::timeout_exception, "{} timed out", std::string(op_label));
+}
+
+/// Compute remaining time for an async operation or throw if the budget expired.
+std::chrono::microseconds remaining_until(fc::time_point deadline_abs,
+                                          std::string_view op_label) {
+   const auto now = fc::time_point::now();
+   if (now >= deadline_abs) {
+      throw_transport_timeout(op_label);
+   }
+   return std::chrono::microseconds((deadline_abs - now).count());
+}
+
+/// Identify timeout error codes returned by Beast/Asio cancellation paths.
+bool is_timeout_error(const boost::system::error_code& ec) {
+   return ec == beast::error::timeout ||
+          ec == asio::error::timed_out ||
+          ec == boost::system::errc::make_error_code(boost::system::errc::timed_out);
+}
+
+/// Convert a low-level transport error into an fc exception.
+void throw_transport_error(const boost::system::error_code& ec,
+                           std::string_view op_label) {
+   if (is_timeout_error(ec)) {
+      throw_transport_timeout(op_label);
+   }
+   FC_THROW("{} failed: {}", std::string(op_label), ec.message());
+}
+
+using async_complete_fn = std::function<void(const boost::system::error_code&)>;
+
+/// Run one async operation synchronously, cancelling it when the deadline expires.
+template <typename StartFn, typename CancelFn>
+void run_async_op(asio::io_context& ioc,
+                  const std::optional<fc::time_point>& deadline_abs,
+                  std::string_view op_label,
+                  StartFn&& start,
+                  CancelFn&& cancel) {
+   boost::system::error_code op_ec;
+   bool                      op_done    = false;
+   bool                      timer_done = !deadline_abs;
+   bool                      timed_out  = false;
+
+   ioc.restart();
+   std::optional<asio::steady_timer> timer;
+   if (deadline_abs) {
+      timer.emplace(ioc);
+      timer->expires_after(remaining_until(*deadline_abs, op_label));
+      timer->async_wait([&](const boost::system::error_code& ec) {
+         timer_done = true;
+         if (!ec && !op_done) {
+            timed_out = true;
+            cancel();
+         }
+      });
+   }
+
+   start([&](const boost::system::error_code& ec) {
+      op_done = true;
+      op_ec   = ec;
+      if (timer) {
+         timer->cancel();
+      }
+   });
+
+   while (!(op_done && timer_done)) {
+      ioc.run_one();
+   }
+
+   if (timed_out) {
+      throw_transport_timeout(op_label);
+   }
+   if (op_ec) {
+      throw_transport_error(op_ec, op_label);
+   }
+}
+
+/// Resolve DNS under the same deadline budget as the following HTTP operation.
+tcp::resolver::results_type resolve_with_deadline(asio::io_context& ioc,
+                                                  const std::string& host,
+                                                  const std::string& port,
+                                                  const std::optional<fc::time_point>& deadline_abs) {
+   tcp::resolver resolver{ioc};
+   tcp::resolver::results_type results;
+
+   run_async_op(ioc, deadline_abs, OP_RESOLVE,
+      [&](const async_complete_fn& complete) {
+         resolver.async_resolve(host, port,
+            [&, complete](const boost::system::error_code& ec, tcp::resolver::results_type resolved) {
+               if (!ec) {
+                  results = std::move(resolved);
+               }
+               complete(ec);
+            });
+      },
+      [&] { resolver.cancel(); });
+   return results;
+}
+
+/// Convert the public HTTP verb enum into the Boost.Beast request verb.
+http::verb to_beast_verb(http_verb v) {
+   switch (v) {
+      case http_verb::GET:     return http::verb::get;
+      case http_verb::PUT:     return http::verb::put;
+      case http_verb::POST:    return http::verb::post;
+      case http_verb::DELETE_: return http::verb::delete_;
+   }
+   FC_THROW("Unknown http_verb value: {}", static_cast<int>(v));
+}
+
+/// Execute a single HTTP/HTTPS request and return the raw Beast response.
+http::response<http::string_body> send_request(asio::io_context& ioc,
+                                               const fc::url& url,
+                                               http::request<http::string_body>& req) {
+   const auto scheme = url.proto();
+   FC_ASSERT(scheme == HTTP_SCHEME || scheme == HTTPS_SCHEME, "Unsupported URL scheme: {}", scheme);
+   FC_ASSERT(url.host(), "JSON-RPC URL is missing host");
+
+   const auto host = *url.host();
+   const auto port = default_port_for(url, scheme);
+   const auto deadline_abs = active_transport_deadline();
+   const auto dest = resolve_with_deadline(ioc, host, port, deadline_abs);
+
+   beast::flat_buffer                buffer;
+   http::response<http::string_body> res;
+
+   if (scheme == HTTPS_SCHEME) {
+      asio::ssl::context ctx{asio::ssl::context::tlsv12_client};
+      beast::ssl_stream<beast::tcp_stream> stream(ioc, ctx);
+
+      if (!SSL_set_tlsext_host_name(stream.native_handle(), host.c_str())) {
+         auto ec = beast::error_code(static_cast<int>(::ERR_get_error()),
+                                     asio::error::get_ssl_category());
+         throw_transport_error(ec, OP_TLS_SNI);
+      }
+
+      run_async_op(ioc, deadline_abs, OP_CONNECT,
+         [&](const async_complete_fn& complete) {
+            beast::get_lowest_layer(stream).async_connect(dest,
+               [complete](const boost::system::error_code& ec, const tcp::endpoint&) {
+                  complete(ec);
+               });
+         },
+         [&] { beast::get_lowest_layer(stream).close(); });
+      run_async_op(ioc, deadline_abs, OP_TLS_HANDSHAKE,
+         [&](const async_complete_fn& complete) {
+            stream.async_handshake(asio::ssl::stream_base::client, complete);
+         },
+         [&] { beast::get_lowest_layer(stream).close(); });
+      run_async_op(ioc, deadline_abs, OP_HTTP_WRITE,
+         [&](const async_complete_fn& complete) {
+            http::async_write(stream, req,
+               [complete](const boost::system::error_code& ec, std::size_t) {
+                  complete(ec);
+               });
+         },
+         [&] { beast::get_lowest_layer(stream).close(); });
+      run_async_op(ioc, deadline_abs, OP_HTTP_READ,
+         [&](const async_complete_fn& complete) {
+            http::async_read(stream, buffer, res,
+               [complete](const boost::system::error_code& ec, std::size_t) {
+                  complete(ec);
+               });
+         },
+         [&] { beast::get_lowest_layer(stream).close(); });
+
+      try {
+         run_async_op(ioc, deadline_abs, OP_TLS_SHUTDOWN,
+            [&](const async_complete_fn& complete) {
+               stream.async_shutdown(complete);
+            },
+            [&] { beast::get_lowest_layer(stream).close(); });
+      } catch (const fc::exception&) {
+         // The response has already been read; shutdown only needs to be bounded.
+      }
+      beast::get_lowest_layer(stream).close();
+   } else {
+      beast::tcp_stream stream{ioc};
+
+      run_async_op(ioc, deadline_abs, OP_CONNECT,
+         [&](const async_complete_fn& complete) {
+            stream.async_connect(dest,
+               [complete](const boost::system::error_code& ec, const tcp::endpoint&) {
+                  complete(ec);
+               });
+         },
+         [&] { stream.close(); });
+      run_async_op(ioc, deadline_abs, OP_HTTP_WRITE,
+         [&](const async_complete_fn& complete) {
+            http::async_write(stream, req,
+               [complete](const boost::system::error_code& ec, std::size_t) {
+                  complete(ec);
+               });
+         },
+         [&] { stream.close(); });
+      run_async_op(ioc, deadline_abs, OP_HTTP_READ,
+         [&](const async_complete_fn& complete) {
+            http::async_read(stream, buffer, res,
+               [complete](const boost::system::error_code& ec, std::size_t) {
+                  complete(ec);
+               });
+         },
+         [&] { stream.close(); });
+
+      beast::error_code ec;
+      stream.socket().shutdown(tcp::socket::shutdown_both, ec);
+      stream.close();
+   }
+
+   return res;
+}
+
+} // namespace
 
 // json_rpc_error
 json_rpc_error::json_rpc_error(const std::string& message) : json_rpc_error(0, message, {}) {}
@@ -155,22 +401,10 @@ fc::variant json_rpc_client::call_batch(const std::vector<fc::variant>& requests
 }
 
 variant json_rpc_client::send_json(const variant& payload, bool expect_json_body) {
-   auto& ioc  = _io_ctx;
    auto  body = fc::json::to_string(payload, fc::json::yield_function_t{});
 
-   auto        scheme = _url.proto();
    auto        host   = _url.host().value();
-   auto        port   = std::to_string(_url.port().value_or(scheme == "https" ? 443 : 80));
-   std::string path   = _url.path().value_or("/");
-
-   asio::ssl::context ctx{asio::ssl::context::tlsv12_client};
-   tcp::resolver      resolver{_io_ctx};
-
-   // Resolve and connect
-   auto dest = resolver.resolve(
-      host,
-      port);
-
+   std::string path   = _url.path().value_or(std::string(DEFAULT_HTTP_PATH));
 
    // Build HTTP request
    http::request<http::string_body> req{http::verb::post, path, HTTP_VERSION};
@@ -179,57 +413,7 @@ variant json_rpc_client::send_json(const variant& payload, bool expect_json_body
    req.set(http::field::content_type, "application/json");
    req.body() = body;
    req.prepare_payload();
-   beast::flat_buffer                buffer;
-   http::response<http::string_body> res;
-   if (scheme == "https") {
-      // ---------------- HTTPS ----------------
-
-      beast::ssl_stream<beast::tcp_stream> stream(ioc, ctx);
-
-      // SNI required for most servers
-      if (!SSL_set_tlsext_host_name(stream.native_handle(), host.c_str())) {
-         throw beast::system_error(
-            beast::error_code(static_cast<int>(::ERR_get_error()),
-                              asio::error::get_ssl_category()));
-      }
-
-      beast::get_lowest_layer(stream).connect(dest);
-      stream.handshake(asio::ssl::stream_base::client);
-
-      http::write(stream, req);
-
-
-      http::read(stream, buffer, res);
-
-      // Shutdown TLS
-      beast::error_code ec;
-      stream.shutdown(ec);
-
-
-   } else if (scheme == "http") {
-      beast::tcp_stream stream{_io_ctx};
-
-      auto stream_cleaner = gsl_lite::finally([&stream] {
-         stream.close();
-         // stream.socket().shutdown(tcp::socket::shutdown_both);
-      });
-
-      stream.connect(dest);
-      // Send request
-      http::write(stream, req);
-
-      // Receive response
-      http::read(stream, buffer, res);
-
-      // Gracefully close the socket
-      beast::error_code ec;
-      stream.socket().shutdown(tcp::socket::shutdown_both, ec);
-
-
-   } else {
-      throw std::runtime_error("Unsupported URL scheme: " + scheme);
-   }
-   // ignore ec on shutdown
+   auto res = send_request(_io_ctx, _url, req);
 
    // Check HTTP status
    if (res.result() != http::status::ok) {
@@ -257,33 +441,11 @@ variant json_rpc_client::send_json(const variant& payload, bool expect_json_body
 //  wrap in JSON-RPC envelope or validate JSON-RPC response structure.
 // -----------------------------------------------------------------------
 
-namespace {
-   http::verb to_beast_verb(http_verb v) {
-      switch (v) {
-         case http_verb::GET:     return http::verb::get;
-         case http_verb::PUT:     return http::verb::put;
-         case http_verb::POST:    return http::verb::post;
-         case http_verb::DELETE_: return http::verb::delete_;
-      }
-      FC_THROW("Unknown http_verb value: {}", static_cast<int>(v));
-   }
-} // anonymous namespace
-
 std::string json_rpc_client::send_http(http_verb verb, const std::string& path,
                                        const std::string& body,
                                        const std::string& content_type) {
-   auto& ioc = _io_ctx;
-
-   auto scheme = _url.proto();
-   auto host   = _url.host().value();
-   auto port   = std::to_string(_url.port().value_or(scheme == "https" ? 443 : 80));
-
-   asio::ssl::context ctx{asio::ssl::context::tlsv12_client};
-   tcp::resolver      resolver{_io_ctx};
-   auto               dest = resolver.resolve(host, port);
-
    http::request<http::string_body> req{to_beast_verb(verb), path, HTTP_VERSION};
-   req.set(http::field::host, host);
+   req.set(http::field::host, _url.host().value());
    req.set(http::field::user_agent, _user_agent);
    if (!body.empty()) {
       req.set(http::field::content_type, content_type);
@@ -291,33 +453,7 @@ std::string json_rpc_client::send_http(http_verb verb, const std::string& path,
    }
    req.prepare_payload();
 
-   beast::flat_buffer                buffer;
-   http::response<http::string_body> res;
-
-   if (scheme == "https") {
-      beast::ssl_stream<beast::tcp_stream> stream(ioc, ctx);
-      if (!SSL_set_tlsext_host_name(stream.native_handle(), host.c_str())) {
-         throw beast::system_error(
-            beast::error_code(static_cast<int>(::ERR_get_error()),
-                              asio::error::get_ssl_category()));
-      }
-      beast::get_lowest_layer(stream).connect(dest);
-      stream.handshake(asio::ssl::stream_base::client);
-      http::write(stream, req);
-      http::read(stream, buffer, res);
-      beast::error_code ec;
-      stream.shutdown(ec);
-   } else if (scheme == "http") {
-      beast::tcp_stream stream{_io_ctx};
-      auto stream_cleaner = gsl_lite::finally([&stream] { stream.close(); });
-      stream.connect(dest);
-      http::write(stream, req);
-      http::read(stream, buffer, res);
-      beast::error_code ec;
-      stream.socket().shutdown(tcp::socket::shutdown_both, ec);
-   } else {
-      throw std::runtime_error("Unsupported URL scheme: " + scheme);
-   }
+   auto res = send_request(_io_ctx, _url, req);
 
    if (res.result() != http::status::ok) {
       FC_THROW("HTTP {} {} failed ({}): {}",

--- a/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
+++ b/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
@@ -48,6 +48,8 @@ std::optional<fc::time_point> active_transport_deadline() {
    if (deadline && *deadline < fc::time_point::maximum()) {
       return deadline;
    }
+   // Preserve legacy behavior for generic callers; outpost paths install a
+   // deadline_scope before entering retry and JSON-RPC transport code.
    return std::nullopt;
 }
 
@@ -130,25 +132,16 @@ void run_async_op(asio::io_context& ioc,
    }
 }
 
-/// Resolve DNS under the same deadline budget as the following HTTP operation.
-tcp::resolver::results_type resolve_with_deadline(asio::io_context& ioc,
-                                                  const std::string& host,
-                                                  const std::string& port,
-                                                  const std::optional<fc::time_point>& deadline_abs) {
+/// Resolve DNS for the long-lived client cache outside the per-RPC transport deadline.
+tcp::resolver::results_type resolve_endpoints(asio::io_context& ioc,
+                                              const std::string& host,
+                                              const std::string& port) {
    tcp::resolver resolver{ioc};
-   tcp::resolver::results_type results;
-
-   run_async_op(ioc, deadline_abs, OP_RESOLVE,
-      [&](const async_complete_fn& complete) {
-         resolver.async_resolve(host, port,
-            [&, complete](const boost::system::error_code& ec, tcp::resolver::results_type resolved) {
-               if (!ec) {
-                  results = std::move(resolved);
-               }
-               complete(ec);
-            });
-      },
-      [&] { resolver.cancel(); });
+   boost::system::error_code ec;
+   auto results = resolver.resolve(host, port, ec);
+   if (ec) {
+      throw_transport_error(ec, OP_RESOLVE);
+   }
    return results;
 }
 
@@ -163,18 +156,40 @@ http::verb to_beast_verb(http_verb v) {
    FC_THROW("Unknown http_verb value: {}", static_cast<int>(v));
 }
 
+/// Run a connection attempt and mark cached endpoints stale if the peer set fails.
+template <typename StartFn, typename CancelFn, typename MarkStaleFn>
+void connect_with_deadline(asio::io_context& ioc,
+                           const std::optional<fc::time_point>& deadline_abs,
+                           StartFn&& start,
+                           CancelFn&& cancel,
+                           MarkStaleFn&& mark_stale) {
+   try {
+      run_async_op(ioc,
+                   deadline_abs,
+                   OP_CONNECT,
+                   std::forward<StartFn>(start),
+                   std::forward<CancelFn>(cancel));
+   } catch (const fc::timeout_exception&) {
+      throw;
+   } catch (const fc::exception&) {
+      mark_stale();
+      throw;
+   }
+}
+
 /// Execute a single HTTP/HTTPS request and return the raw Beast response.
+template <typename MarkStaleFn>
 http::response<http::string_body> send_request(asio::io_context& ioc,
                                                const fc::url& url,
-                                               http::request<http::string_body>& req) {
+                                               const tcp::resolver::results_type& dest,
+                                               http::request<http::string_body>& req,
+                                               MarkStaleFn&& mark_stale) {
    const auto scheme = url.proto();
    FC_ASSERT(scheme == HTTP_SCHEME || scheme == HTTPS_SCHEME, "Unsupported URL scheme: {}", scheme);
    FC_ASSERT(url.host(), "JSON-RPC URL is missing host");
 
    const auto host = *url.host();
-   const auto port = default_port_for(url, scheme);
    const auto deadline_abs = active_transport_deadline();
-   const auto dest = resolve_with_deadline(ioc, host, port, deadline_abs);
 
    beast::flat_buffer                buffer;
    http::response<http::string_body> res;
@@ -189,14 +204,15 @@ http::response<http::string_body> send_request(asio::io_context& ioc,
          throw_transport_error(ec, OP_TLS_SNI);
       }
 
-      run_async_op(ioc, deadline_abs, OP_CONNECT,
+      connect_with_deadline(ioc, deadline_abs,
          [&](const async_complete_fn& complete) {
             beast::get_lowest_layer(stream).async_connect(dest,
                [complete](const boost::system::error_code& ec, const tcp::endpoint&) {
                   complete(ec);
                });
          },
-         [&] { beast::get_lowest_layer(stream).close(); });
+         [&] { beast::get_lowest_layer(stream).close(); },
+         mark_stale);
       run_async_op(ioc, deadline_abs, OP_TLS_HANDSHAKE,
          [&](const async_complete_fn& complete) {
             stream.async_handshake(asio::ssl::stream_base::client, complete);
@@ -232,14 +248,15 @@ http::response<http::string_body> send_request(asio::io_context& ioc,
    } else {
       beast::tcp_stream stream{ioc};
 
-      run_async_op(ioc, deadline_abs, OP_CONNECT,
+      connect_with_deadline(ioc, deadline_abs,
          [&](const async_complete_fn& complete) {
             stream.async_connect(dest,
                [complete](const boost::system::error_code& ec, const tcp::endpoint&) {
                   complete(ec);
                });
          },
-         [&] { stream.close(); });
+         [&] { stream.close(); },
+         mark_stale);
       run_async_op(ioc, deadline_abs, OP_HTTP_WRITE,
          [&](const async_complete_fn& complete) {
             http::async_write(stream, req,
@@ -300,8 +317,36 @@ json_rpc_client json_rpc_client::create(const std::variant<std::string, fc::url>
 json_rpc_client::json_rpc_client(fc::url                           url,
                                  const std::optional<std::string>& user_agent)
    : _url(std::move(url))
+     , _host()
+     , _port()
      , _user_agent(user_agent.value_or(BOOST_BEAST_VERSION_STRING))
-     , _next_id(1) {}
+     , _next_id(1)
+     , _resolved_endpoints()
+     , _resolved_endpoints_stale(false) {
+   const auto scheme = _url.proto();
+   FC_ASSERT(scheme == HTTP_SCHEME || scheme == HTTPS_SCHEME, "Unsupported URL scheme: {}", scheme);
+   FC_ASSERT(_url.host(), "JSON-RPC URL is missing host");
+
+   _host = *_url.host();
+   _port = default_port_for(_url, scheme);
+   refresh_resolved_endpoints();
+}
+
+void json_rpc_client::refresh_resolved_endpoints() {
+   _resolved_endpoints = resolve_endpoints(_io_ctx, _host, _port);
+   _resolved_endpoints_stale = false;
+}
+
+void json_rpc_client::mark_resolved_endpoints_stale() {
+   _resolved_endpoints_stale = true;
+}
+
+const json_rpc_client::tcp::resolver::results_type& json_rpc_client::resolved_endpoints() {
+   if (_resolved_endpoints_stale || _resolved_endpoints.empty()) {
+      refresh_resolved_endpoints();
+   }
+   return _resolved_endpoints;
+}
 
 variant json_rpc_client::call(const std::string& method, const fc::variant& params) {
    const auto id = _next_id++;
@@ -403,17 +448,18 @@ fc::variant json_rpc_client::call_batch(const std::vector<fc::variant>& requests
 variant json_rpc_client::send_json(const variant& payload, bool expect_json_body) {
    auto  body = fc::json::to_string(payload, fc::json::yield_function_t{});
 
-   auto        host   = _url.host().value();
    std::string path   = _url.path().value_or(std::string(DEFAULT_HTTP_PATH));
 
    // Build HTTP request
    http::request<http::string_body> req{http::verb::post, path, HTTP_VERSION};
-   req.set(http::field::host, host);
+   req.set(http::field::host, _host);
    req.set(http::field::user_agent, _user_agent);
    req.set(http::field::content_type, "application/json");
    req.body() = body;
    req.prepare_payload();
-   auto res = send_request(_io_ctx, _url, req);
+   auto res = send_request(_io_ctx, _url, resolved_endpoints(), req, [this] {
+      mark_resolved_endpoints_stale();
+   });
 
    // Check HTTP status
    if (res.result() != http::status::ok) {
@@ -445,7 +491,7 @@ std::string json_rpc_client::send_http(http_verb verb, const std::string& path,
                                        const std::string& body,
                                        const std::string& content_type) {
    http::request<http::string_body> req{to_beast_verb(verb), path, HTTP_VERSION};
-   req.set(http::field::host, _url.host().value());
+   req.set(http::field::host, _host);
    req.set(http::field::user_agent, _user_agent);
    if (!body.empty()) {
       req.set(http::field::content_type, content_type);
@@ -453,7 +499,9 @@ std::string json_rpc_client::send_http(http_verb verb, const std::string& path,
    }
    req.prepare_payload();
 
-   auto res = send_request(_io_ctx, _url, req);
+   auto res = send_request(_io_ctx, _url, resolved_endpoints(), req, [this] {
+      mark_resolved_endpoints_stale();
+   });
 
    if (res.result() != http::status::ok) {
       FC_THROW("HTTP {} {} failed ({}): {}",

--- a/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
+++ b/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
@@ -10,6 +10,7 @@
 #include <boost/system/system_error.hpp>
 
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <ranges>
 #include <string_view>
@@ -36,6 +37,7 @@ constexpr std::string_view OP_TLS_HANDSHAKE   = "JSON-RPC TLS handshake";
 constexpr std::string_view OP_TLS_SHUTDOWN    = "JSON-RPC TLS shutdown";
 constexpr std::string_view OP_HTTP_WRITE      = "JSON-RPC HTTP write";
 constexpr std::string_view OP_HTTP_READ       = "JSON-RPC HTTP read";
+constexpr std::uint64_t    MAX_RESPONSE_BODY_BYTES = 1ULL * 1024ULL * 1024ULL;
 
 /// Return the explicit URL port or the scheme's default JSON-RPC transport port.
 std::string default_port_for(const fc::url& url, std::string_view scheme) {
@@ -75,11 +77,21 @@ bool is_timeout_error(const boost::system::error_code& ec) {
           ec == boost::system::errc::make_error_code(boost::system::errc::timed_out);
 }
 
+/// Identify Beast parser admission failures for oversized response bodies.
+bool is_body_limit_error(const boost::system::error_code& ec) {
+   return ec == http::error::body_limit;
+}
+
 /// Convert a low-level transport error into an fc exception.
 void throw_transport_error(const boost::system::error_code& ec,
                            std::string_view op_label) {
    if (is_timeout_error(ec)) {
       throw_transport_timeout(op_label);
+   }
+   if (is_body_limit_error(ec)) {
+      FC_THROW("{} exceeded {} byte response body limit",
+               std::string(op_label),
+               MAX_RESPONSE_BODY_BYTES);
    }
    FC_THROW("{} failed: {}", std::string(op_label), ec.message());
 }
@@ -177,6 +189,29 @@ void connect_with_deadline(asio::io_context& ioc,
    }
 }
 
+/// Read an HTTP response through a parser with a fixed response body limit.
+template <typename Stream, typename CancelFn>
+http::response<http::string_body> read_response_with_deadline(
+   asio::io_context& ioc,
+   const std::optional<fc::time_point>& deadline_abs,
+   Stream& stream,
+   beast::flat_buffer& buffer,
+   CancelFn&& cancel) {
+   http::response_parser<http::string_body> parser;
+   parser.body_limit(MAX_RESPONSE_BODY_BYTES);
+
+   run_async_op(ioc, deadline_abs, OP_HTTP_READ,
+      [&](const async_complete_fn& complete) {
+         http::async_read(stream, buffer, parser,
+            [complete](const boost::system::error_code& ec, std::size_t) {
+               complete(ec);
+            });
+      },
+      std::forward<CancelFn>(cancel));
+
+   return parser.release();
+}
+
 /// Execute a single HTTP/HTTPS request and return the raw Beast response.
 template <typename MarkStaleFn>
 http::response<http::string_body> send_request(asio::io_context& ioc,
@@ -226,13 +261,7 @@ http::response<http::string_body> send_request(asio::io_context& ioc,
                });
          },
          [&] { beast::get_lowest_layer(stream).close(); });
-      run_async_op(ioc, deadline_abs, OP_HTTP_READ,
-         [&](const async_complete_fn& complete) {
-            http::async_read(stream, buffer, res,
-               [complete](const boost::system::error_code& ec, std::size_t) {
-                  complete(ec);
-               });
-         },
+      res = read_response_with_deadline(ioc, deadline_abs, stream, buffer,
          [&] { beast::get_lowest_layer(stream).close(); });
 
       try {
@@ -265,13 +294,7 @@ http::response<http::string_body> send_request(asio::io_context& ioc,
                });
          },
          [&] { stream.close(); });
-      run_async_op(ioc, deadline_abs, OP_HTTP_READ,
-         [&](const async_complete_fn& complete) {
-            http::async_read(stream, buffer, res,
-               [complete](const boost::system::error_code& ec, std::size_t) {
-                  complete(ec);
-               });
-         },
+      res = read_response_with_deadline(ioc, deadline_abs, stream, buffer,
          [&] { stream.close(); });
 
       beast::error_code ec;

--- a/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
+++ b/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
@@ -144,16 +144,26 @@ void run_async_op(asio::io_context& ioc,
    }
 }
 
-/// Resolve DNS for the long-lived client cache outside the per-RPC transport deadline.
+/// Resolve DNS for the long-lived client cache, optionally bounded by an RPC deadline.
 tcp::resolver::results_type resolve_endpoints(asio::io_context& ioc,
                                               const std::string& host,
-                                              const std::string& port) {
+                                              const std::string& port,
+                                              const std::optional<fc::time_point>& deadline_abs) {
    tcp::resolver resolver{ioc};
-   boost::system::error_code ec;
-   auto results = resolver.resolve(host, port, ec);
-   if (ec) {
-      throw_transport_error(ec, OP_RESOLVE);
-   }
+   tcp::resolver::results_type results;
+
+   run_async_op(ioc, deadline_abs, OP_RESOLVE,
+      [&](const async_complete_fn& complete) {
+         resolver.async_resolve(host, port,
+            [&results, complete](const boost::system::error_code& ec, tcp::resolver::results_type resolved) {
+               if (!ec) {
+                  results = std::move(resolved);
+               }
+               complete(ec);
+            });
+      },
+      [&] { resolver.cancel(); });
+
    return results;
 }
 
@@ -356,7 +366,12 @@ json_rpc_client::json_rpc_client(fc::url                           url,
 }
 
 void json_rpc_client::refresh_resolved_endpoints() {
-   _resolved_endpoints = resolve_endpoints(_io_ctx, _host, _port);
+   _resolved_endpoints = resolve_endpoints(_io_ctx, _host, _port, std::nullopt);
+   _resolved_endpoints_stale = false;
+}
+
+void json_rpc_client::refresh_resolved_endpoints_with_active_deadline() {
+   _resolved_endpoints = resolve_endpoints(_io_ctx, _host, _port, active_transport_deadline());
    _resolved_endpoints_stale = false;
 }
 
@@ -366,7 +381,7 @@ void json_rpc_client::mark_resolved_endpoints_stale() {
 
 const json_rpc_client::tcp::resolver::results_type& json_rpc_client::resolved_endpoints() {
    if (_resolved_endpoints_stale || _resolved_endpoints.empty()) {
-      refresh_resolved_endpoints();
+      refresh_resolved_endpoints_with_active_deadline();
    }
    return _resolved_endpoints;
 }

--- a/libraries/libfc/test/CMakeLists.txt
+++ b/libraries/libfc/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable( test_fc
         io/test_raw.cpp
         io/test_tracked_storage.cpp
         network/ethereum/test_ethereum_client_and_rlp.cpp
+        network/test_json_rpc_client.cpp
         network/solana/test_solana_client.cpp
         network/test_message_buffer.cpp
         scoped_exit/test_scoped_exit.cpp

--- a/libraries/libfc/test/network/test_json_rpc_client.cpp
+++ b/libraries/libfc/test/network/test_json_rpc_client.cpp
@@ -11,14 +11,18 @@
 
 #include <atomic>
 #include <chrono>
+#include <sstream>
 #include <string>
 #include <thread>
+#include <utility>
 
 using namespace std::chrono_literals;
 
 namespace {
 
 using tcp = boost::asio::ip::tcp;
+
+constexpr size_t OVERSIZED_RESPONSE_BODY_BYTES = 2 * 1024 * 1024;
 
 /**
  * HTTP endpoint that reads one request and deliberately withholds the response.
@@ -91,6 +95,93 @@ private:
    std::thread             _worker;
 };
 
+/**
+ * HTTP endpoint that replies to one request with a caller-supplied response body.
+ */
+class fixed_response_http_server {
+public:
+   /**
+    * Start listening on a loopback port and launch the response worker.
+    */
+   explicit fixed_response_http_server(std::string response_body)
+      : _acceptor(_io, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0))
+      , _port(_acceptor.local_endpoint().port())
+      , _response_body(std::move(response_body))
+      , _worker([this] { serve(); }) {}
+
+   fixed_response_http_server(const fixed_response_http_server&) = delete;
+   fixed_response_http_server& operator=(const fixed_response_http_server&) = delete;
+
+   /**
+    * Stop the worker if the client failed before accepting the response.
+    */
+   ~fixed_response_http_server() {
+      boost::system::error_code ec;
+      _acceptor.close(ec);
+      unblock_accept();
+      if (_worker.joinable()) {
+         _worker.join();
+      }
+   }
+
+   /**
+    * Return the TCP port assigned by the OS.
+    */
+   uint16_t port() const { return _port; }
+
+private:
+   /**
+    * Connect once to the listening socket so a blocked accept can observe shutdown.
+    */
+   void unblock_accept() {
+      boost::asio::io_context io;
+      tcp::socket socket(io);
+      boost::system::error_code ec;
+      socket.connect(tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), _port), ec);
+   }
+
+   /**
+    * Accept a single client, consume its request header, and write the response.
+    */
+   void serve() {
+      boost::system::error_code ec;
+      tcp::socket socket(_io);
+      _acceptor.accept(socket, ec);
+      if (ec) {
+         return;
+      }
+
+      boost::asio::streambuf request;
+      boost::asio::read_until(socket, request, "\r\n\r\n", ec);
+      if (ec) {
+         return;
+      }
+
+      std::ostringstream response;
+      response << "HTTP/1.1 200 OK\r\n"
+               << "Content-Type: application/json\r\n"
+               << "Content-Length: " << _response_body.size() << "\r\n"
+               << "Connection: close\r\n\r\n"
+               << _response_body;
+      const auto response_text = response.str();
+      boost::asio::write(socket, boost::asio::buffer(response_text), ec);
+      socket.close(ec);
+   }
+
+   boost::asio::io_context _io;
+   tcp::acceptor           _acceptor;
+   uint16_t                _port;
+   std::string             _response_body;
+   std::thread             _worker;
+};
+
+/**
+ * Return true when the exception came from the transport response body limit.
+ */
+bool is_response_body_limit_error(const fc::exception& e) {
+   return e.to_detail_string().find("response body limit") != std::string::npos;
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_SUITE(json_rpc_client_tests)
@@ -112,6 +203,31 @@ BOOST_AUTO_TEST_CASE(call_times_out_when_http_response_hangs) {
    const auto elapsed = fc::time_point::now() - start;
 
    BOOST_CHECK_LT(elapsed.count(), 1500 * 1000);
+}
+
+/// A peer that completes HTTP 200 with an oversized body must be rejected by
+/// the transport parser before JSON parsing or outpost envelope decoding.
+BOOST_AUTO_TEST_CASE(call_rejects_oversized_response_body) {
+   fixed_response_http_server server(std::string(OVERSIZED_RESPONSE_BODY_BYTES, 'x'));
+   fc::network::json_rpc::json_rpc_client client(
+      fc::url("http://127.0.0.1:" + std::to_string(server.port())));
+
+   BOOST_CHECK_EXCEPTION(
+      client.call("wire_body_limit_probe"),
+      fc::exception,
+      is_response_body_limit_error);
+}
+
+/// The raw HTTP helper shares the same bounded transport path as JSON-RPC calls.
+BOOST_AUTO_TEST_CASE(send_http_rejects_oversized_response_body) {
+   fixed_response_http_server server(std::string(OVERSIZED_RESPONSE_BODY_BYTES, 'x'));
+   fc::network::json_rpc::json_rpc_client client(
+      fc::url("http://127.0.0.1:" + std::to_string(server.port())));
+
+   BOOST_CHECK_EXCEPTION(
+      client.send_http(fc::network::json_rpc::http_verb::GET, "/"),
+      fc::exception,
+      is_response_body_limit_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libraries/libfc/test/network/test_json_rpc_client.cpp
+++ b/libraries/libfc/test/network/test_json_rpc_client.cpp
@@ -25,6 +25,18 @@ using tcp = boost::asio::ip::tcp;
 constexpr size_t OVERSIZED_RESPONSE_BODY_BYTES = 2 * 1024 * 1024;
 
 /**
+ * Return a loopback port that has no listener after this function returns.
+ */
+uint16_t closed_loopback_port() {
+   boost::asio::io_context io;
+   tcp::acceptor acceptor(io, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0));
+   const auto port = acceptor.local_endpoint().port();
+   boost::system::error_code ec;
+   acceptor.close(ec);
+   return port;
+}
+
+/**
  * HTTP endpoint that reads one request and deliberately withholds the response.
  */
 class hanging_http_server {
@@ -182,6 +194,13 @@ bool is_response_body_limit_error(const fc::exception& e) {
    return e.to_detail_string().find("response body limit") != std::string::npos;
 }
 
+/**
+ * Return true when the exception came from bounded DNS refresh.
+ */
+bool is_resolve_timeout_error(const fc::exception& e) {
+   return e.to_detail_string().find("JSON-RPC resolve timed out") != std::string::npos;
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_SUITE(json_rpc_client_tests)
@@ -203,6 +222,22 @@ BOOST_AUTO_TEST_CASE(call_times_out_when_http_response_hangs) {
    const auto elapsed = fc::time_point::now() - start;
 
    BOOST_CHECK_LT(elapsed.count(), 1500 * 1000);
+}
+
+/// Refreshing stale cached endpoints must observe the active RPC deadline.
+BOOST_AUTO_TEST_CASE(stale_endpoint_refresh_respects_expired_deadline) {
+   fc::network::json_rpc::json_rpc_client client(
+      fc::url("http://127.0.0.1:" + std::to_string(closed_loopback_port())));
+
+   BOOST_CHECK_THROW(client.call("wire_stale_cache_probe"), fc::exception);
+
+   BOOST_CHECK_EXCEPTION(
+      [&] {
+         fc::task::deadline_scope deadline(fc::time_point::now() - fc::milliseconds(1));
+         client.call("wire_stale_cache_probe");
+      }(),
+      fc::timeout_exception,
+      is_resolve_timeout_error);
 }
 
 /// A peer that completes HTTP 200 with an oversized body must be rejected by

--- a/libraries/libfc/test/network/test_json_rpc_client.cpp
+++ b/libraries/libfc/test/network/test_json_rpc_client.cpp
@@ -1,0 +1,117 @@
+/**
+ * @file test_json_rpc_client.cpp
+ * @brief Regression tests for deadline-bound JSON-RPC transport calls.
+ */
+
+#include <fc/network/json_rpc/json_rpc_client.hpp>
+#include <fc/task/deadline.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+using tcp = boost::asio::ip::tcp;
+
+/**
+ * HTTP endpoint that reads one request and deliberately withholds the response.
+ */
+class hanging_http_server {
+public:
+   /**
+    * Start listening on a loopback port and launch the accept worker.
+    */
+   hanging_http_server()
+      : _acceptor(_io, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0))
+      , _port(_acceptor.local_endpoint().port())
+      , _worker([this] { serve(); }) {}
+
+   hanging_http_server(const hanging_http_server&) = delete;
+   hanging_http_server& operator=(const hanging_http_server&) = delete;
+
+   /**
+    * Stop the worker without waiting for the client's read timeout.
+    */
+   ~hanging_http_server() {
+      _stop = true;
+      boost::system::error_code ec;
+      _acceptor.close(ec);
+      unblock_accept();
+      if (_worker.joinable()) {
+         _worker.join();
+      }
+   }
+
+   /**
+    * Return the TCP port assigned by the OS.
+    */
+   uint16_t port() const { return _port; }
+
+private:
+   /**
+    * Connect once to the listening socket so a blocked accept can observe shutdown.
+    */
+   void unblock_accept() {
+      boost::asio::io_context io;
+      tcp::socket socket(io);
+      boost::system::error_code ec;
+      socket.connect(tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), _port), ec);
+   }
+
+   /**
+    * Accept a single client, consume the request header, and then hang.
+    */
+   void serve() {
+      boost::system::error_code ec;
+      tcp::socket socket(_io);
+      _acceptor.accept(socket, ec);
+      if (ec) {
+         return;
+      }
+
+      boost::asio::streambuf request;
+      boost::asio::read_until(socket, request, "\r\n\r\n", ec);
+      while (!_stop.load()) {
+         std::this_thread::sleep_for(10ms);
+      }
+      socket.close(ec);
+   }
+
+   boost::asio::io_context _io;
+   tcp::acceptor           _acceptor;
+   uint16_t                _port;
+   std::atomic_bool        _stop{false};
+   std::thread             _worker;
+};
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(json_rpc_client_tests)
+
+/// A peer that accepts the TCP request but withholds the HTTP response must
+/// release the caller within the active RPC deadline.
+BOOST_AUTO_TEST_CASE(call_times_out_when_http_response_hangs) {
+   hanging_http_server server;
+   fc::network::json_rpc::json_rpc_client client(
+      fc::url("http://127.0.0.1:" + std::to_string(server.port())));
+
+   const auto start = fc::time_point::now();
+   BOOST_CHECK_THROW(
+      [&] {
+         fc::task::deadline_scope deadline(fc::time_point::now() + fc::milliseconds(200));
+         client.call("wire_deadline_probe");
+      }(),
+      fc::timeout_exception);
+   const auto elapsed = fc::time_point::now() - start;
+
+   BOOST_CHECK_LT(elapsed.count(), 1500 * 1000);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libraries/libfc/test/task/test_retry.cpp
+++ b/libraries/libfc/test/task/test_retry.cpp
@@ -66,6 +66,25 @@ BOOST_AUTO_TEST_CASE(throws_timeout_on_deadline_expiry) {
    BOOST_CHECK_GE(elapsed.count(), 90 * 1000); // at least 90ms — some tolerance
 }
 
+/// A caller-installed deadline scope must cap a retry loop even when the
+/// retry options carry a larger timeout budget.
+BOOST_AUTO_TEST_CASE(deadline_scope_clamps_total_timeout) {
+   auto opts = fast_opts();
+   opts.total_timeout = fc::seconds(5);
+
+   const auto start = fc::time_point::now();
+   BOOST_CHECK_THROW(
+      [&] {
+         fc::task::deadline_scope deadline(fc::time_point::now() + fc::milliseconds(100));
+         retry_until<int>("scoped-deadline", opts,
+            []() -> std::optional<int> { return std::nullopt; });
+      }(),
+      fc::timeout_exception);
+   const auto elapsed = fc::time_point::now() - start;
+
+   BOOST_CHECK_LT(elapsed.count(), 1000 * 1000);
+}
+
 // A fatal exception thrown from inside the predicate must propagate out
 // unchanged — retry_until does not swallow or retry on a throw.
 BOOST_AUTO_TEST_CASE(propagates_predicate_exception) {

--- a/libraries/libfc/test/task/test_retry.cpp
+++ b/libraries/libfc/test/task/test_retry.cpp
@@ -85,6 +85,22 @@ BOOST_AUTO_TEST_CASE(deadline_scope_clamps_total_timeout) {
    BOOST_CHECK_LT(elapsed.count(), 1000 * 1000);
 }
 
+/// An already-expired caller scope must fail fast instead of invoking the
+/// predicate after the caller's budget has been exhausted.
+BOOST_AUTO_TEST_CASE(expired_deadline_scope_skips_first_attempt) {
+   int calls = 0;
+
+   BOOST_CHECK_THROW(
+      [&] {
+         fc::task::deadline_scope deadline(fc::time_point::now() - fc::milliseconds(1));
+         retry_until<int>("expired-scope", fast_opts(),
+            [&]() -> std::optional<int> { ++calls; return 1; });
+      }(),
+      fc::timeout_exception);
+
+   BOOST_CHECK_EQUAL(calls, 0);
+}
+
 // A fatal exception thrown from inside the predicate must propagate out
 // unchanged — retry_until does not swallow or retry on a throw.
 BOOST_AUTO_TEST_CASE(propagates_predicate_exception) {

--- a/plugins/outpost_client_plugin/include/sysio/outpost_client/outpost_client.hpp
+++ b/plugins/outpost_client_plugin/include/sysio/outpost_client/outpost_client.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <format>
 #include <memory>
@@ -12,6 +13,11 @@
 #include <sysio/opp/opp.hpp>
 
 namespace sysio {
+
+/// Cross-chain hard cap for a serialized OPP envelope accepted from an outpost.
+/// This mirrors the Solana program's `MAX_ENVELOPE_BYTES` and the e2e-supported
+/// WIRE / Ethereum / Solana envelope boundary.
+inline constexpr size_t OPP_MAX_ENVELOPE_BYTES = 65'536;
 
 /**
  * @brief Chain-agnostic facade for OPP delivery on a single external outpost.

--- a/plugins/outpost_ethereum_client_plugin/src/outpost_ethereum_client.cpp
+++ b/plugins/outpost_ethereum_client_plugin/src/outpost_ethereum_client.cpp
@@ -5,6 +5,7 @@
 #include <fc/io/json.hpp>
 #include <fc/log/logger.hpp>
 #include <fc/network/ethereum/ethereum_abi.hpp>
+#include <fc/task/deadline.hpp>
 
 #include <sysio/opp/opp.hpp>
 #include <sysio/opp/opp.pb.h>
@@ -67,6 +68,7 @@ std::string outpost_ethereum_client::deliver_outbound_envelope(
    const std::vector<char>& envelope_bytes,
    fc::microseconds         deadline) {
    const auto deadline_abs = fc::time_point::now() + deadline;
+   fc::task::deadline_scope rpc_deadline(deadline_abs);
 
    throw_if_past_deadline(deadline_abs, OP_DELIVER_OUTBOUND);
    FC_ASSERT(_opp_inbound_client,
@@ -86,6 +88,8 @@ std::vector<char> outpost_ethereum_client::read_inbound_envelope(
    uint32_t         epoch_index,
    fc::microseconds deadline) {
    const auto deadline_abs = fc::time_point::now() + deadline;
+   fc::task::deadline_scope rpc_deadline(deadline_abs);
+
    throw_if_past_deadline(deadline_abs, OP_READ_INBOUND);
    FC_ASSERT(_opp_client,
              "outpost_ethereum_client[{}]: read_inbound_envelope requires an OPP "
@@ -210,6 +214,8 @@ std::string outpost_ethereum_client::uw_commit(
    const std::vector<char>& uic_bytes,
    fc::microseconds         deadline) {
    const auto deadline_abs = fc::time_point::now() + deadline;
+   fc::task::deadline_scope rpc_deadline(deadline_abs);
+
    throw_if_past_deadline(deadline_abs, OP_UW_COMMIT);
 
    FC_ASSERT(_operator_registry_client,

--- a/plugins/outpost_ethereum_client_plugin/src/outpost_ethereum_client.cpp
+++ b/plugins/outpost_ethereum_client_plugin/src/outpost_ethereum_client.cpp
@@ -20,6 +20,16 @@ namespace eth = fc::network::ethereum;
 constexpr std::string_view OP_DELIVER_OUTBOUND = "deliver_outbound_envelope";
 constexpr std::string_view OP_READ_INBOUND     = "read_inbound_envelope";
 constexpr std::string_view OP_UW_COMMIT        = "uw_commit";
+constexpr size_t EVM_ABI_WORD_BYTES            = 32;
+constexpr size_t HEX_PREFIX_CHARS              = 2;
+constexpr size_t HEX_CHARS_PER_BYTE            = 2;
+constexpr size_t MAX_ENVELOPE_HEX_CHARS =
+   HEX_PREFIX_CHARS + OPP_MAX_ENVELOPE_BYTES * HEX_CHARS_PER_BYTE;
+constexpr size_t MAX_LATEST_OUTBOUND_RPC_BYTES =
+   EVM_ABI_WORD_BYTES * 3 +
+   ((OPP_MAX_ENVELOPE_BYTES + EVM_ABI_WORD_BYTES - 1) / EVM_ABI_WORD_BYTES) * EVM_ABI_WORD_BYTES;
+constexpr size_t MAX_LATEST_OUTBOUND_RPC_HEX_CHARS =
+   HEX_PREFIX_CHARS + MAX_LATEST_OUTBOUND_RPC_BYTES * HEX_CHARS_PER_BYTE;
 
 } // namespace
 
@@ -131,6 +141,12 @@ std::vector<char> outpost_ethereum_client::read_inbound_envelope(
            to_string());
       return {};
    }
+   if (raw_hex.size() > MAX_LATEST_OUTBOUND_RPC_HEX_CHARS) {
+      wlog("outpost_ethereum_client[{}]: getLatestOutboundEnvelope raw hex "
+           "({} chars) exceeds ABI envelope cap of {} chars",
+           to_string(), raw_hex.size(), MAX_LATEST_OUTBOUND_RPC_HEX_CHARS);
+      return {};
+   }
 
    const auto decoded = eth::contract_decode_data(abi, raw_hex);
    dlog("outpost_ethereum_client[{}]: getLatestOutboundEnvelope decoded={}",
@@ -185,8 +201,20 @@ std::vector<char> outpost_ethereum_client::read_inbound_envelope(
       return {};
    }
    const std::string hex_data = data_var.as_string();
+   if (hex_data.size() > MAX_ENVELOPE_HEX_CHARS) {
+      wlog("outpost_ethereum_client[{}]: latestOutboundEnvelope data_ "
+           "({} chars) exceeds envelope cap of {} chars",
+           to_string(), hex_data.size(), MAX_ENVELOPE_HEX_CHARS);
+      return {};
+   }
    const auto raw = fc::crypto::ethereum::hex_to_bytes(hex_data);
    if (raw.empty()) return {};
+   if (raw.size() > OPP_MAX_ENVELOPE_BYTES) {
+      wlog("outpost_ethereum_client[{}]: latestOutboundEnvelope raw "
+           "envelope ({} bytes) exceeds cap of {} bytes",
+           to_string(), raw.size(), OPP_MAX_ENVELOPE_BYTES);
+      return {};
+   }
 
    sysio::opp::Envelope envelope;
    if (!envelope.ParseFromArray(raw.data(), static_cast<int>(raw.size()))) {

--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
@@ -17,12 +17,9 @@ namespace sysio {
 
 /// Hard cap on the assembled OPP envelope. Mirrors the Solana program's
 /// `MAX_ENVELOPE_BYTES` (`programs/opp-outpost/src/state/envelope_chunks.rs`).
-/// 64 KiB is the e2e-supported max across WIRE / Ethereum / Solana — the
-/// binding constraint is Solana's 256 KB BPF heap divided by the ~3.3×
-/// envelope-size peak heap usage during the finalising chunk's
-/// `Envelope::decode` + `keccak::hash` + assembled-buffer + clone. Kept in
-/// sync by hand because there's no shared C++/Rust constant header.
-inline constexpr size_t SOLANA_MAX_ENVELOPE_BYTES = 65'536;
+/// The shared C++ boundary lives on `outpost_client` because Ethereum inbound
+/// reads must reject the same envelope size before hex decoding.
+inline constexpr size_t SOLANA_MAX_ENVELOPE_BYTES = OPP_MAX_ENVELOPE_BYTES;
 
 /// Per-`epoch_in` chunk payload limit. Mirrors `MAX_CHUNK_BYTES` on the
 /// Solana side. Solana's tx-packet MTU is 1 232 B raw. Tx overhead at the

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
@@ -9,6 +9,7 @@
 #include <fc/crypto/sha256.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/log/logger.hpp>
+#include <fc/task/deadline.hpp>
 #include <fc/variant_object.hpp>
 
 #include <sysio/opp/opp.hpp>
@@ -319,6 +320,7 @@ std::string outpost_solana_client::deliver_outbound_envelope(
    const std::vector<char>& envelope_bytes,
    fc::microseconds         deadline) {
    const auto deadline_abs = fc::time_point::now() + deadline;
+   fc::task::deadline_scope rpc_deadline(deadline_abs);
 
    const size_t total = envelope_bytes.size();
    FC_ASSERT(total > 0,
@@ -480,6 +482,8 @@ std::vector<char> outpost_solana_client::read_inbound_envelope(
    uint32_t         epoch_index,
    fc::microseconds deadline) {
    const auto deadline_abs = fc::time_point::now() + deadline;
+   fc::task::deadline_scope rpc_deadline(deadline_abs);
+
    throw_if_past_deadline(deadline_abs, OP_READ_LATEST);
 
    // Single RPC: fetch the `latest_outbound_envelope` PDA. The Solana
@@ -573,6 +577,8 @@ std::string outpost_solana_client::uw_commit(
    const std::vector<char>& uic_bytes,
    fc::microseconds         deadline) {
    const auto deadline_abs = fc::time_point::now() + deadline;
+   fc::task::deadline_scope rpc_deadline(deadline_abs);
+
    throw_if_past_deadline(deadline_abs, OP_UW_COMMIT);
 
    // `commit_underwrite(uic_bytes: bytes)` — opaque relay. The typed

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
@@ -541,6 +541,12 @@ std::vector<char> outpost_solana_client::read_inbound_envelope(
    }
 
    const uint32_t data_len = read_u32_le(buf, LATEST_VEC_LEN_OFF);
+   if (data_len > SOLANA_MAX_ENVELOPE_BYTES) {
+      wlog("outpost_solana_client[{}]: latest_outbound_envelope data length "
+           "{} exceeds envelope cap of {} bytes",
+           to_string(), data_len, SOLANA_MAX_ENVELOPE_BYTES);
+      return {};
+   }
    if (LATEST_DATA_OFF + data_len > buf.size()) {
       wlog("outpost_solana_client[{}]: latest_outbound_envelope data length "
            "{} exceeds account size {}",


### PR DESCRIPTION
## Summary
- Addresses SEC-12 by carrying one scoped `fc::task` deadline through the outpost retry stack and JSON-RPC transport, so relay workers do not wait past their RPC budget on hung peers.
- Reworks JSON-RPC HTTP/HTTPS transport to run DNS refresh, connect, TLS handshake/shutdown, request write, and response read through deadline-aware async operations with cancellation.
- Caches resolved endpoints outside the steady-state per-RPC path, marks the cache stale after connect failures, and bounds stale-cache DNS refreshes by the active `deadline_scope`.
- Includes SEC-95 / WSA-213 hardening on the same transport path: JSON-RPC responses now use a Beast parser with a 1 MiB body cap before JSON parsing, covering both JSON-RPC calls and raw `send_http`.
- Adds a shared 64 KiB OPP envelope cap and enforces it before Ethereum hex decoding, Solana account-data copying, and protobuf envelope parsing.

## Tests
- Added JSON-RPC transport regressions for:
  - a peer that accepts the request but never sends an HTTP response,
  - stale endpoint refresh under an already-expired deadline,
  - oversized HTTP 200 response bodies for `call`,
  - oversized HTTP 200 response bodies for `send_http`.
- Added retry/deadline coverage for clamped total timeout behavior and expired-scope first-attempt semantics.
- Reused existing Ethereum and Solana outpost plugin tests to cover the affected clients after the shared envelope cap changes.

## Validation
- `git diff --check`
- `cmake --build build/sec-12-release --target test_fc -- -j6`
- `./build/sec-12-release/libraries/libfc/test/test_fc --run_test=json_rpc_client_tests --catch_system_errors=no --log_level=test_suite`
- `./build/sec-12-release/libraries/libfc/test/test_fc --run_test=retry_until_tests --catch_system_errors=no --log_level=test_suite`
- `./build/sec-12-release/libraries/libfc/test/test_fc --catch_system_errors=no`
- `cmake --build build/sec-12-release --target outpost_ethereum_client_plugin outpost_solana_client_plugin test_outpost_ethereum_client_plugin test_outpost_solana_client_plugin -- -j6`
- `./build/sec-12-release/plugins/outpost_ethereum_client_plugin/test_outpost_ethereum_client_plugin --catch_system_errors=no`
- `./build/sec-12-release/plugins/outpost_solana_client_plugin/test_outpost_solana_client_plugin --catch_system_errors=no`

## Notes
- Initial client construction still resolves synchronously and fails fast before per-RPC deadline handling begins.
- Connect timeouts continue to preserve the cached endpoint set; non-timeout connect failures mark it stale for the next call.