### PR TITLE
Opp-bundler: fix protoc-gen-ts resolution and propagate publish failures

### DIFF
--- a/libraries/opp/tools/package.json
+++ b/libraries/opp/tools/package.json
@@ -24,7 +24,8 @@
   "resolutions": {
     "lodash": "4.17.21",
     "prettier": "3.8.1",
-    "typescript": "6.0.2"
+    "typescript": "6.0.2",
+    "@protobuf-ts/plugin>typescript": "3.9.10"
   },
   "packageManager": "pnpm@10.32.1",
   "engines": {

--- a/libraries/opp/tools/protobuf-bundler/src/commands/bundle.ts
+++ b/libraries/opp/tools/protobuf-bundler/src/commands/bundle.ts
@@ -84,6 +84,10 @@ export async function bundleCommand(args: BundleArgs): Promise<void> {
   } catch (err: any) {
     skipCleanup = true
     log.error(`Bundle failed: ${err.message}`, err)
+    // Re-throw so the failure propagates to `main().catch` → process.exit(1).
+    // Without this the CLI exits 0 on a failed generate/publish and CI reports
+    // a green run even though no package was produced or published.
+    throw err
   } finally {
     if (!skipCleanup) {
       try {

--- a/libraries/opp/tools/protobuf-bundler/src/steps/generateTypescript.ts
+++ b/libraries/opp/tools/protobuf-bundler/src/steps/generateTypescript.ts
@@ -3,7 +3,7 @@ import Fs from "node:fs"
 import Path from "node:path"
 import { log } from "../util/logger.js"
 import { renderTemplate } from "../util/templates.js"
-import { resolvePluginBin, findProtoRoot } from "./runProtoc.js"
+import { resolvePluginBin, resolveProtocBin, findProtoRoot } from "./runProtoc.js"
 import { Target, TemplatePath, TemplateFile } from "../constants.js"
 
 export interface GenerateTypescriptOptions {
@@ -61,10 +61,11 @@ export async function generateTypescript(
     ...relativeProtos
   ]
 
-  log.info("Running protoc for TypeScript: npx protoc %s", args.join(" "))
+  const protocBin = resolveProtocBin()
+  log.info("Running protoc for TypeScript: %s %s", protocBin, args.join(" "))
 
   try {
-    execFileSync("npx", ["protoc", ...args], {
+    execFileSync(protocBin, args, {
       stdio: ["pipe", "pipe", "inherit"]
     })
   } catch (err: any) {

--- a/libraries/opp/tools/protobuf-bundler/src/steps/runProtoc.ts
+++ b/libraries/opp/tools/protobuf-bundler/src/steps/runProtoc.ts
@@ -126,6 +126,29 @@ export function resolvePluginBin(name: string, npmPkg: string): string {
 }
 
 /**
+ * Resolve the `protoc` compiler binary CWD-independently.
+ *
+ * The bundler depends on a pinned `protoc` (see package.json) that pnpm places
+ * in its own `node_modules/.bin`. Invoking bare `npx protoc` from the consumer
+ * repo root (the bundler's runtime CWD — see generate-opp-bundles.fish) does NOT
+ * find that pinned binary; npx instead downloads the LATEST `protoc` from the
+ * registry, which can be a major version ahead of what the `protoc-gen-*`
+ * plugins support and make code generation fail. Resolving from the bundler's
+ * own install tree pins the compatible version; the system PATH is the
+ * last-resort fallback.
+ *
+ * @return Absolute path to a `protoc` binary.
+ */
+export function resolveProtocBin(): string {
+  const fromInstall = resolveFromBundlerInstall("protoc")
+  if (fromInstall) {
+    log.debug("Resolved protoc from bundler install: %s", fromInstall)
+    return fromInstall
+  }
+  return resolveFromPathOrBin("protoc", "protoc")
+}
+
+/**
  * Determine the best --proto_path root. Proto files use import paths
  * relative to a root directory. If the cloned content has a "proto/" or
  * "protos/" subdirectory, that is likely the import root.
@@ -167,10 +190,11 @@ export async function runProtoc(opts: RunProtocOptions): Promise<string[]> {
     ...relativeProtos
   ]
 
-  log.info("Running: npx protoc %s", args.join(" "))
+  const protocBin = resolveProtocBin()
+  log.info("Running: %s %s", protocBin, args.join(" "))
 
   try {
-    execFileSync("npx", ["protoc", ...args], {
+    execFileSync(protocBin, args, {
       stdio: ["pipe", "pipe", "inherit"]
     })
   } catch (err: any) {

--- a/libraries/opp/tools/protobuf-bundler/src/steps/runProtoc.ts
+++ b/libraries/opp/tools/protobuf-bundler/src/steps/runProtoc.ts
@@ -58,12 +58,48 @@ function resolveFromPathOrBin(name: string, npmPkg: string): string {
 }
 
 /**
+ * Resolve a protoc plugin binary from the bundler's OWN install tree.
+ *
+ * The bundler runs with its CWD set to the consumer repo root (see
+ * `generate-opp-bundles.fish`, which `cd`s to the repo before invoking the
+ * globally-linked CLI). Plugin binaries that live only in the bundler's own
+ * dependency tree — notably `protoc-gen-ts` from `@protobuf-ts/plugin`, which
+ * (unlike the workspace `protoc-gen-solana`/`protoc-gen-solidity`) is never
+ * `pnpm link --global`'d onto the system PATH — are therefore invisible to the
+ * CWD-relative and PATH lookups below. Anchoring on `__dirname` and walking up
+ * to the nearest `node_modules/.bin/<name>` finds them regardless of CWD.
+ *
+ * @param name Plugin executable name, e.g. `protoc-gen-ts`.
+ * @return Absolute path to the binary, or `undefined` when not found.
+ */
+function resolveFromBundlerInstall(name: string): string | undefined {
+  let dir = __dirname
+  for (;;) {
+    const candidate = Path.join(dir, "node_modules", ".bin", name)
+    if (Fs.existsSync(candidate)) return Path.resolve(candidate)
+    const parent = Path.dirname(dir)
+    if (parent === dir) return undefined
+    dir = parent
+  }
+}
+
+/**
  * Resolve a plugin binary. Search order:
- *   1. pkg binary inside the installed npm package (dist/bin/<name>)
- *   2. System PATH
- *   3. node_modules/.bin wrapper (fallback)
+ *   1. the bundler's own install tree, anchored on __dirname (CWD-independent)
+ *   2. pkg binary inside the installed npm package (dist/bin/<name>)
+ *   3. System PATH
+ *   4. node_modules/.bin wrapper (fallback)
  */
 export function resolvePluginBin(name: string, npmPkg: string): string {
+  // (1) Prefer the bundler's own install tree. This is CWD-independent and the
+  // only reliable way to find dependency-provided plugins (e.g. protoc-gen-ts)
+  // when the CWD is the consumer repo root rather than the bundler package dir.
+  const fromInstall = resolveFromBundlerInstall(name)
+  if (fromInstall) {
+    log.debug("Found pkg binary in bundler install: %s", fromInstall)
+    return fromInstall
+  }
+
   const pkgBinCandidates = [
     Path.join("node_modules", ".bin", name),
     Path.join("node_modules", npmPkg, "dist", "bin", name),


### PR DESCRIPTION
The OPP model packages (@wireio/opp-solidity-models, @wireio/opp-typescript-models) have not been republished since 2026-05-27, predating the entire DEX precision feature, despite multiple merges touching libraries/opp/proto. The opp-bundles workflow reported success on every run while publishing nothing.

There are four causes in wire-protobuf-bundler, the last three exposed in sequence as each preceding one is fixed:

- protoc-gen-ts could not be resolved. generate-opp-bundles.fish runs the globally-linked CLI from the repo root, so the bundler's CWD-relative node_modules/.bin lookups missed. protoc-gen-solana/-solidity are linked onto the global PATH and survived; @protobuf-ts/plugin's protoc-gen-ts is not, so the typescript target threw and the solidity target never ran.

- bundleCommand logged the failure but did not rethrow, so the process exited 0 and CI reported green even though no package was generated or published.

- protoc was invoked as bare `npx protoc`, which from the repo-root CWD ignores the pinned protoc@^34 and downloads the latest protoc instead.

- @protobuf-ts/plugin@2.11.1 (the latest published) targets the TypeScript 3.9 factory API, but the tools workspace pins typescript@6.0.2 globally via package.json "resolutions", which pnpm forces onto the plugin as well, crashing protoc-gen-ts (ts.createTypeReferenceNode was removed in 5.0; the createInterfaceDeclaration signature changed in 4.8).

Changes: resolvePluginBin and a new resolveProtocBin resolve plugin and protoc binaries from the bundler's own install tree first, anchored on __dirname and walking up to the nearest node_modules/.bin/<name>, independent of the working directory. bundleCommand re-throws after logging so a failed generate/publish exits non-zero. A scoped resolution "@protobuf-ts/plugin>typescript": "3.9.10" (the plugin's declared range, and the version the known-good install resolves) keeps the plugin on a compatible compiler while the bundler itself keeps typescript@6.

With these, wire-protobuf-bundler generates all three targets (solana, typescript, solidity) from a clean install; verified locally and in the PR's opp-bundles run. The PR run validates generation without publishing (publish is gated on push to master); on merge it republishes the synchronized 1.0.28 models carrying source_token_precision and NodeOwnerTier.