### PR TITLE
Stabilize nodeop integration tests

### DIFF
--- a/tests/nodeop_high_transaction_test.py
+++ b/tests/nodeop_high_transaction_test.py
@@ -3,6 +3,7 @@
 import signal
 import time
 import json
+import math
 
 from TestHarness import Cluster, Node, TestHelper, Utils, WalletMgr, CORE_SYMBOL
 from TestHarness.accounts import NamedAccounts
@@ -250,6 +251,7 @@ try:
             toAccount = accounts[toAccountIndex]
             node = nonProdNodes[accountIndex % nonProdNodeCount]
             trans = None
+            acceptedAt = None
             attempts = 0
             maxAttempts = maxTransactionAttempts if not args.send_duplicates else maxTransactionAttemptsNoSend  # for send_duplicates we are just constructing a transaction, so should never require a second attempt
             # can try up to maxAttempts times to send the transfer
@@ -260,6 +262,8 @@ try:
                     time.sleep(1)
                 expiration=None if args.send_duplicates else 90
                 trans=node.transferFunds(fromAccount, toAccount, transferAmount, "transfer round %d" % (round), exitOnError=False, reportStatus=False, sign=True, dontSend=args.send_duplicates, expiration=expiration)
+                if trans is not None and not args.send_duplicates:
+                    acceptedAt = time.perf_counter()
                 attempts += 1
 
             if args.send_duplicates:
@@ -273,6 +277,7 @@ try:
                         if repeatTrans is not None:
                             if trans is None and repeatTrans[0]:
                                 trans = repeatTrans[1]
+                                acceptedAt = time.perf_counter()
                                 transId = Node.getTransId(trans)
 
                             numAccepted += 1
@@ -280,8 +285,12 @@ try:
                     attempts += 1
 
             assert trans is not None, "ERROR: failed round: %d, fromAccount: %s, toAccount: %s" % (round, accountIndex, toAccountIndex)
+            assert acceptedAt is not None, "ERROR: no acceptance time recorded for round: %d, fromAccount: %s, toAccount: %s" % (round, accountIndex, toAccountIndex)
             transId = Node.getTransId(trans)
-            history.append(transId)
+            history.append({
+                "trans_id": transId,
+                "accepted_at": acceptedAt
+            })
 
     nextTime = time.perf_counter()
     Print("Sending transfers took %s sec" % (nextTime - startTransferTime))
@@ -296,9 +305,19 @@ try:
     newestBlockNumTransOrder = None
     lastBlockNum = None
     lastTransId = None
+    lastAcceptedAt = None
     transOrder = 0
     lastPassLIB = None
-    for transId in history:
+    def getAllowedBlockDelta(acceptedAt, lastAcceptedAt):
+        """Return the tolerated block drift for the active submission mode."""
+        if not args.send_duplicates:
+            return transBlocksBehind
+        acceptedDeltaBlocks = math.ceil(abs(acceptedAt - lastAcceptedAt) * blocksPerSec)
+        return transBlocksBehind + acceptedDeltaBlocks
+
+    for transRecord in history:
+        transId = transRecord["trans_id"]
+        acceptedAt = transRecord["accepted_at"]
         blockNum = None
         block = None
         transDesc = None
@@ -323,14 +342,17 @@ try:
             assert blockNum is not None, "ERROR: could not retrieve block num for block retrieved for transId: %s, block: %s" % (transId, json.dumps(block, indent=2))
 
         if lastBlockNum is not None:
-            if blockNum > lastBlockNum + transBlocksBehind or blockNum + transBlocksBehind < lastBlockNum:
+            allowedBlockDelta = getAllowedBlockDelta(acceptedAt, lastAcceptedAt)
+            if blockNum > lastBlockNum + allowedBlockDelta or blockNum + allowedBlockDelta < lastBlockNum:
                 transBlockOrderWeird.append({
                     "newer_trans_id" : transId,
                     "newer_trans_index" : transOrder,
                     "newer_bnum" : blockNum,
                     "last_trans_id" : lastTransId,
                     "last_trans_index" : transOrder - 1,
-                    "last_bnum" : lastBlockNum
+                    "last_bnum" : lastBlockNum,
+                    "accepted_delta_seconds" : acceptedAt - lastAcceptedAt,
+                    "allowed_block_delta" : allowedBlockDelta
                 })
                 if newestBlockNum > lastBlockNum:
                     last = transBlockOrderWeird[-1]
@@ -348,6 +370,7 @@ try:
             newestBlockNumTransOrder = transOrder
 
         lastTransId = transId
+        lastAcceptedAt = acceptedAt
         transOrder += 1
         lastBlockNum = blockNum
 
@@ -366,7 +389,8 @@ try:
         verboseOutput = "Delayed transaction information: [" if Utils.Debug else "Delayed transaction ids: ["
         verboseOutput = ", ".join([json.dumps(trans, indent=2) if Utils.Debug else trans["newer_trans_id"] for trans in transBlockOrderWeird])
         verboseOutput += "]"
-        Utils.Print("ERROR: There are %d transactions delayed more than %d seconds.  %s" % (len(transBlockOrderWeird), args.transaction_time_delta, verboseOutput))
+        toleranceKind = "accepted-time-adjusted" if args.send_duplicates else "fixed"
+        Utils.Print("ERROR: There are %d transactions outside the %s %d second tolerance.  %s" % (len(transBlockOrderWeird), toleranceKind, args.transaction_time_delta, verboseOutput))
         delayedReportError = True
 
     testSuccessful = not delayedReportError

--- a/tests/nodeop_late_block_test.py
+++ b/tests/nodeop_late_block_test.py
@@ -26,6 +26,10 @@ errorExit=Utils.errorExit
 args=TestHelper.parse_args({"-d","--keep-logs","--dump-error-details","-v","--leave-running","--unshared"})
 pnodes=4
 total_nodes=pnodes + 1
+canonicalConvergenceTimeout=90
+expectedIProducerBlocks=9
+forkSwitchLogTimeout=30
+producerSlotBlockCount=12
 delay=args.d
 debug=args.v
 dumpErrorDetails=args.dump_error_details
@@ -57,42 +61,93 @@ try:
     cluster.waitOnClusterSync(blockAdvancing=5)
 
     node3 = cluster.getNode(3)
+    node2 = cluster.getNode(2)
     node4 = cluster.getNode(4) # bridge between 2 & 3
+
+    def firstBlockForProducer(node, producer, blockNum):
+        """Return the first contiguous block produced by producer ending at blockNum."""
+        firstBlockNum = blockNum
+        while firstBlockNum > 1:
+            previousBlock = node.getBlock(firstBlockNum - 1, silentErrors=True, exitOnError=False)
+            if previousBlock is None or previousBlock["producer"] != producer:
+                break
+            firstBlockNum -= 1
+        return firstBlockNum
+
+    def getProducerBlockIds(node, producer, firstBlockNum, maxBlocks):
+        """Return contiguous producer block numbers and IDs starting at firstBlockNum."""
+        blocks = []
+        for blockNum in range(firstBlockNum, firstBlockNum + maxBlocks):
+            block = node.getBlock(blockNum, silentErrors=True, exitOnError=False)
+            if block is None:
+                return None
+            if block["producer"] != producer:
+                break
+            blocks.append({"block_num": blockNum, "id": block["id"]})
+        return blocks
 
     Print("Wait for producer before j")
     node3.waitForAnyProducer("defproducerh", exitOnError=True)
     node3.waitForAnyProducer("defproduceri", exitOnError=True)
     iProdBlockNum = node3.getHeadBlockNum()
+    firstIProdBlockNum = firstBlockForProducer(node3, "defproduceri", iProdBlockNum)
 
     node4.kill(signal.SIGTERM)
     assert not node4.verifyAlive(), "Node4 did not shutdown"
 
     Print("Wait until Node_03 is well into its isolated fork (defproducerl)")
     node3.waitForProducer("defproducerl", exitOnError=True)
+    isolatedForkInfo = node3.getInfo(exitOnError=True)
+    isolatedForkHeadId = isolatedForkInfo["head_block_id"]
+    isolatedForkHeadNum = isolatedForkInfo["head_block_num"]
+    def collectCanonicalIProducerBlocks():
+        """Return canonical defproduceri blocks once node_02 has the whole verification window."""
+        blocks = getProducerBlockIds(node2, "defproduceri", firstIProdBlockNum, producerSlotBlockCount)
+        if blocks is None or len(blocks) < expectedIProducerBlocks:
+            return None
+        return blocks[:expectedIProducerBlocks]
+    canonicalIProducerBlocks = Utils.waitForObj(collectCanonicalIProducerBlocks, timeout=forkSwitchLogTimeout)
+    assert canonicalIProducerBlocks, \
+        f"Expected at least {expectedIProducerBlocks} canonical defproduceri blocks from block {firstIProdBlockNum}"
 
     Print("Relaunch bridge to reconnect Node_02 and Node_03")
     node4.relaunch()
 
-    Print("Verify Node_03 fork switches even though it is producing")
-    node3.waitForProducer("defproduceri", exitOnError=True)
+    Print("Verify Node_03 converges from its isolated fork back to Node_02's canonical branch")
+    def node3ConvergedToCanonicalBranch():
+        """Return true when node_03 has adopted node_02's canonical block at the fork height."""
+        info = node3.getInfo(silentErrors=True, exitOnError=False)
+        if info is None or info["head_block_id"] == isolatedForkHeadId:
+            return False
+
+        node3Block = node3.getBlock(isolatedForkHeadNum, silentErrors=True, exitOnError=False)
+        node2Block = node2.getBlock(isolatedForkHeadNum, silentErrors=True, exitOnError=False)
+        return node3Block is not None \
+            and node2Block is not None \
+            and node3Block["id"] == node2Block["id"] \
+            and node3Block["id"] != isolatedForkHeadId
+
+    assert Utils.waitForBool(node3ConvergedToCanonicalBranch, timeout=canonicalConvergenceTimeout), \
+        f"Expected node_03 to leave isolated fork head #{isolatedForkHeadNum} {isolatedForkHeadId} " \
+        "and converge to node_02's canonical branch at that height"
 
     Print("Verify fork switch - poll for log entry in case sync is still settling")
     # The fork switch log may reference any of node_03's producers (j, k, or l) depending
     # on exactly when the bridge reconnects and blocks propagate.
     def findForkSwitch():
+        """Return the log line number for node_03 switching away from one of its fork producers."""
         return node3.findInLog("switching forks .* defproducer[jkl]")
-    switchForkLineNum = Utils.waitForBool(findForkSwitch, timeout=30)
+    switchForkLineNum = Utils.waitForObj(findForkSwitch, timeout=forkSwitchLogTimeout)
     assert switchForkLineNum, "Expected to find 'switching forks' from a node_03 producer in node_03 log"
 
     # Verify the lockout-detection optimization fired: when the bridge reconnects, node_03
-    # is still inside its producing slot, and the rest of the network's blocks (carrying a
-    # strong QC for a block on the canonical branch) reach node_03's fork database. The
-    # producer plugin's in_producing_mode early-return should fall through and apply blocks
-    # immediately rather than waiting for the slot to end. Without this optimization,
-    # node_03 would orphan its entire round.
+    # is still inside its producing slot, and the rest of the network's blocks reach node_03's
+    # fork database. The producer plugin should apply blocks immediately rather than waiting
+    # for the slot to end. The block-ID assertion above verifies the externally visible result.
     def findApplyDuringProducing():
+        """Return the log line number for the lockout fast-path diagnostic."""
         return node3.findInLog("applying blocks while producing: head's branch is locked out")
-    applyDuringProducingLine = Utils.waitForBool(findApplyDuringProducing, timeout=30)
+    applyDuringProducingLine = Utils.waitForObj(findApplyDuringProducing, timeout=forkSwitchLogTimeout)
     assert applyDuringProducingLine, \
         "Expected node_03 to apply blocks mid-slot upon detecting strong-QC lockout of its isolated fork"
 
@@ -101,9 +156,12 @@ try:
 
     # verify the LIB blocks of defproduceri made it into the canonical chain
     # defproducerk has produced at least one block, but possibly more by time of relaunch, so verify only some of the round
-    for i in range(9):
-        defprod=node3.getBlockProducerByNum(iProdBlockNum + i)
-        assert defprod == "defproduceri", f"expected defproduceri for block {iProdBlockNum + i}, instead: {defprod}"
+    for canonicalBlock in canonicalIProducerBlocks:
+        block = node3.getBlock(canonicalBlock["block_num"], exitOnError=True)
+        assert block["id"] == canonicalBlock["id"], \
+            f"expected canonical defproduceri block {canonicalBlock['id']} at block {canonicalBlock['block_num']}, instead: {block['id']}"
+        assert block["producer"] == "defproduceri", \
+            f"expected defproduceri for block {canonicalBlock['block_num']}, instead: {block['producer']}"
 
     # verify that defproducerk or defproducerl blocks made it into the canonical chain
     # It can take a while to resolve the fork, but should have at least one block from node_03's


### PR DESCRIPTION
## Summary
Stabilizes two timing-sensitive nodeop integration checks that can fail despite valid chain recovery or transaction ordering.

## What changed
### `nodeop_late_block_test`
- Captures `node_02`'s canonical `defproduceri` block IDs before reconnecting the isolated branch.
- Waits for `node_03` to leave its isolated fork and converge to `node_02`'s canonical block at the isolated fork height.
- Keeps the fork-switch and lockout fast-path log assertions, but now pairs them with an observable chain-state transition instead of relying on the log line alone.
- Verifies `node_03` adopted the exact canonical `defproduceri` blocks from `node_02`, not just blocks with the expected producer name.

### `nodeop_repeat_transaction_lr_test`
- Records the acceptance time for the first successful push of each duplicate transaction.
- Stores transaction history as transaction ID plus acceptance timestamp so validation can account for real spacing between accepted duplicate submissions.
- Uses an accepted-time-adjusted block-order tolerance only when `--send-duplicates` is active.
- Preserves the fixed block-order tolerance for the normal non-duplicate `nodeop_high_transaction_lr_test` path.
- Adds acceptance-delta and allowed-block-delta details to the delayed-transaction failure payload for easier diagnosis.

## Why
The previous checks could fail on valid timing variation or lean too heavily on a single diagnostic log line. The tests now assert the observable state transition while retaining the lockout fast-path log check for regression coverage.

## Testing
- `python3 -m py_compile tests/nodeop_high_transaction_test.py tests/nodeop_late_block_test.py`
- `./tests/nodeop_late_block_test.py -v --keep-logs --dump-error-details`
- `./tests/nodeop_high_transaction_test.py -v -p 4 -n 8 --num-transactions 1000 --max-transactions-per-second 500 --send-duplicates --keep-logs --dump-error-details`

## Notes
Timing-sensitive integration coverage still carries some CI variance risk, but both adjusted paths passed locally and the non-duplicate high-transaction path keeps the fixed tolerance behavior.
- Failed CI run investigated: [GitHub Actions job](https://github.com/Wire-Network/wire-sysio/actions/runs/28180620140/job/83468942497?pr=356).