### PR TITLE
Fix SEC-40 Solana source deposit pagination

### DIFF
--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/solana_source_deposit_scanner.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/solana_source_deposit_scanner.hpp
@@ -10,8 +10,10 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <array>
+#include <compare>
 #include <cstring>
 #include <functional>
+#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -56,6 +58,107 @@ struct solana_source_deposit_page_scan_result {
 
 /// Fetches one decoded Solana transaction for the supplied base58 signature.
 using solana_transaction_fetcher = std::function<fc::variant(const std::string&)>;
+
+/// Cursor key for SOL source-deposit discovery. The uwreq id bounds the
+/// cursor to one depot request while the deposit id prevents accidental reuse
+/// if a stale entry survives across schema or replay changes.
+struct solana_source_deposit_scan_key {
+   uint64_t uwreq_id;
+   uint64_t deposit_id;
+   friend auto operator<=>(const solana_source_deposit_scan_key&,
+                           const solana_source_deposit_scan_key&) = default;
+};
+
+/// Persistent SOL signature scan progress for one pending UWREQ.
+struct solana_source_deposit_scan_cursor {
+   /// Signature cursor passed to `getSignaturesForAddress(before=...)`.
+   std::optional<std::string> before;
+   /// Number of pages inspected while walking this UWREQ's source deposit.
+   uint64_t pages_scanned = 0;
+   /// Number of signature-list entries inspected across scanned pages.
+   uint64_t signatures_scanned = 0;
+   /// True once verification found a terminal source-deposit failure.
+   bool terminal_failure = false;
+   /// First terminal failure reason, kept for later short-circuit logs.
+   std::string terminal_failure_reason;
+};
+
+/// Per-pending-UWREQ Solana scan state.
+using solana_source_deposit_scan_cursor_map =
+   std::map<solana_source_deposit_scan_key, solana_source_deposit_scan_cursor>;
+
+/// Result from recording a terminal SOL source-deposit verification failure.
+struct solana_source_deposit_terminal_failure_result {
+   /// Updated cursor state after recording the failure.
+   solana_source_deposit_scan_cursor cursor;
+   /// True only for the first terminal failure recorded for this UWREQ.
+   bool first_failure = false;
+};
+
+/// Returns the current SOL source-deposit scan cursor for `key`, creating one
+/// at the newest page when this is the first scan attempt for a UWREQ.
+inline solana_source_deposit_scan_cursor
+get_or_create_solana_source_deposit_scan_cursor(solana_source_deposit_scan_cursor_map& cursors,
+                                                const solana_source_deposit_scan_key& key) {
+   return cursors[key];
+}
+
+/// Returns terminal failure state for a SOL source-deposit scan, when present.
+inline std::optional<solana_source_deposit_scan_cursor>
+get_solana_source_deposit_terminal_failure(const solana_source_deposit_scan_cursor_map& cursors,
+                                           const solana_source_deposit_scan_key& key) {
+   const auto it = cursors.find(key);
+   if (it == cursors.end() || !it->second.terminal_failure) return std::nullopt;
+   return it->second;
+}
+
+/// Persists the next SOL source-deposit `before` cursor after a clean page
+/// that did not contain the target marker.
+inline solana_source_deposit_scan_cursor
+advance_solana_source_deposit_scan_cursor(solana_source_deposit_scan_cursor_map& cursors,
+                                          const solana_source_deposit_scan_key& key,
+                                          std::string before,
+                                          size_t signature_count) {
+   auto& cursor = cursors[key];
+   cursor.before = std::move(before);
+   cursor.pages_scanned++;
+   cursor.signatures_scanned += signature_count;
+   return cursor;
+}
+
+/// Records a terminal SOL source-deposit failure without allowing future scan
+/// cycles to re-walk the same pending UWREQ from the newest signature page.
+inline solana_source_deposit_terminal_failure_result
+record_solana_source_deposit_terminal_failure(solana_source_deposit_scan_cursor_map& cursors,
+                                              const solana_source_deposit_scan_key& key,
+                                              std::string reason,
+                                              size_t signature_count) {
+   auto& cursor = cursors[key];
+   const bool first_failure = !cursor.terminal_failure;
+   if (first_failure) {
+      cursor.pages_scanned++;
+      cursor.signatures_scanned += signature_count;
+      cursor.terminal_failure = true;
+      cursor.terminal_failure_reason = std::move(reason);
+   }
+   return {.cursor = cursor, .first_failure = first_failure};
+}
+
+/// Drops SOL source-deposit scan progress for a UWREQ once it matches or
+/// leaves the PENDING set.
+inline void erase_solana_source_deposit_scan_cursor(solana_source_deposit_scan_cursor_map& cursors,
+                                                    const solana_source_deposit_scan_key& key) {
+   cursors.erase(key);
+}
+
+/// Prunes SOL source-deposit scan state for UWREQs that are no longer pending.
+template<typename PendingUwreqIds>
+void prune_solana_source_deposit_scan_cursors(solana_source_deposit_scan_cursor_map& cursors,
+                                              const PendingUwreqIds& still_pending) {
+   std::erase_if(cursors, [&](const auto& entry) {
+      return !still_pending.contains(entry.first.uwreq_id);
+   });
+}
 
 /// Returns true when a Solana log line opens, closes, or otherwise describes
 /// an invocation frame rather than carrying a user `Program log:` payload.

--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/solana_source_deposit_scanner.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/solana_source_deposit_scanner.hpp
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <sysio/underwriter_plugin/source_deposit_constants.hpp>
+
+#include <fc/crypto/keccak256.hpp>
+#include <fc/crypto/hex.hpp>
+#include <fc/exception/exception.hpp>
+#include <fc/variant.hpp>
+
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <array>
+#include <cstring>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace sysio::underwriter {
+
+/// Result categories for scanning one Solana `getSignaturesForAddress` page
+/// for an authenticated `SwapDeposit` source-deposit marker.
+enum class solana_source_deposit_page_status {
+   matched,
+   not_found,
+   deferred,
+   hard_mismatch
+};
+
+/// Inputs shared by every transaction inspected in one signature page.
+struct solana_source_deposit_page_scan_config {
+   /// Deployed opp-outpost program id resolved from the loaded Anchor IDL.
+   std::string_view sol_program_id;
+   /// Full log prefix ending immediately before the 64-character hash field.
+   std::string_view marker_prefix;
+   /// Expected correlation hash recomputed from the depot UWREQ row.
+   const fc::crypto::keccak256& recomputed_hash;
+};
+
+/// Outcome details from scanning a single Solana signature page.
+struct solana_source_deposit_page_scan_result {
+   solana_source_deposit_page_status status = solana_source_deposit_page_status::not_found;
+   /// Matching transaction signature when `status == matched`.
+   std::string matched_signature;
+   /// Last valid signature in the page. Use as the next `before` cursor only
+   /// when `status == not_found` and `page_exhausted == false`.
+   std::optional<std::string> next_before;
+   /// True when the page had fewer results than the RPC page limit, so there
+   /// is no older page to request for this address history.
+   bool page_exhausted = false;
+   /// Human-readable reason for hard mismatches or deferred scans.
+   std::string reason;
+};
+
+/// Fetches one decoded Solana transaction for the supplied base58 signature.
+using solana_transaction_fetcher = std::function<fc::variant(const std::string&)>;
+
+/// Returns true when a Solana log line opens, closes, or otherwise describes
+/// an invocation frame rather than carrying a user `Program log:` payload.
+inline bool is_solana_program_frame_line(const std::string& line) {
+   return boost::algorithm::starts_with(line, "Program ") &&
+          !boost::algorithm::starts_with(line, "Program log:") &&
+          !boost::algorithm::starts_with(line, "Program data:") &&
+          !boost::algorithm::starts_with(line, "Program return:");
+}
+
+/// Updates the executing-program stack from one Solana runtime frame line.
+inline void update_solana_program_stack(const std::string& line,
+                                        std::vector<std::string>& program_stack) {
+   std::string_view rest{line};
+   rest.remove_prefix(8); // strip "Program "
+   const size_t sp1 = rest.find(' ');
+   if (sp1 == std::string_view::npos) return;
+
+   const std::string_view prog = rest.substr(0, sp1);
+   std::string_view after = rest.substr(sp1 + 1);
+   const size_t sp2 = after.find(' ');
+   const std::string_view verb = (sp2 == std::string_view::npos) ? after : after.substr(0, sp2);
+   if (verb == "invoke") {
+      program_stack.emplace_back(prog);
+   } else if (verb.starts_with("success") || verb.starts_with("failed")) {
+      if (!program_stack.empty()) program_stack.pop_back();
+   }
+}
+
+/// Decodes one lower-case hex digit from the canonical marker hash.
+inline std::optional<uint8_t> decode_lowercase_hex_digit(char c) {
+   if (c >= '0' && c <= '9') return static_cast<uint8_t>(c - '0');
+   if (c >= 'a' && c <= 'f') return static_cast<uint8_t>(c - 'a' + 10);
+   return std::nullopt;
+}
+
+/// Parses the 64-character lower-case hex hash suffix emitted by
+/// `opp-outpost::request_swap` after the canonical marker prefix.
+inline std::optional<std::array<uint8_t, 32>> parse_solana_swap_deposit_hash(std::string_view hash_hex) {
+   if (hash_hex.size() != 64) return std::nullopt;
+
+   std::array<uint8_t, 32> parsed{};
+   for (size_t i = 0; i < parsed.size(); ++i) {
+      const auto high = decode_lowercase_hex_digit(hash_hex[i * 2]);
+      const auto low = decode_lowercase_hex_digit(hash_hex[i * 2 + 1]);
+      if (!high || !low) return std::nullopt;
+      parsed[i] = static_cast<uint8_t>((*high << 4) | *low);
+   }
+   return parsed;
+}
+
+/// Scans one page of Solana program signatures for a source-deposit marker.
+///
+/// The function is deliberately free of plugin state: production code supplies
+/// the RPC-backed transaction fetcher, and unit tests supply an in-memory
+/// fetcher. Pagination is page-at-a-time; callers persist `next_before` only
+/// after a clean `not_found` result so transient transaction fetch failures
+/// cannot advance past an uninspected candidate.
+inline solana_source_deposit_page_scan_result
+scan_solana_source_deposit_signature_page(const std::vector<fc::variant>& sigs,
+                                          const solana_transaction_fetcher& get_transaction,
+                                          const solana_source_deposit_page_scan_config& config) {
+   solana_source_deposit_page_scan_result result;
+   result.page_exhausted = sigs.size() < SOL_SIGNATURE_SCAN_PAGE_SIZE;
+   bool saw_uninspected_candidate = false;
+   std::string deferred_reason;
+
+   for (const auto& sig_var : sigs) {
+      if (!sig_var.is_object()) continue;
+      const auto sig_obj = sig_var.get_object();
+      if (!sig_obj.contains("signature") || !sig_obj["signature"].is_string()) continue;
+      const std::string sig_b58 = sig_obj["signature"].as_string();
+      result.next_before = sig_b58;
+
+      // Skip failed txs at the listing level. They cannot have emitted the
+      // successful source-deposit marker.
+      if (sig_obj.contains("err") && !sig_obj["err"].is_null()) {
+         continue;
+      }
+
+      fc::variant tx;
+      try {
+         tx = get_transaction(sig_b58);
+      } catch (const fc::exception& e) {
+         saw_uninspected_candidate = true;
+         if (deferred_reason.empty()) {
+            deferred_reason = "getTransaction(" + sig_b58 + ") RPC error: " + e.to_detail_string();
+         }
+         continue;
+      }
+      if (tx.is_null() || !tx.is_object()) continue;
+      const auto tx_obj = tx.get_object();
+      if (!tx_obj.contains("meta") || !tx_obj["meta"].is_object()) continue;
+      const auto meta_obj = tx_obj["meta"].get_object();
+      if (meta_obj.contains("err") && !meta_obj["err"].is_null()) continue;
+      if (!meta_obj.contains("logMessages") || !meta_obj["logMessages"].is_array()) continue;
+
+      std::vector<std::string> program_stack;
+      for (const auto& line_var : meta_obj["logMessages"].get_array()) {
+         if (!line_var.is_string()) continue;
+         const std::string line = line_var.as_string();
+
+         if (is_solana_program_frame_line(line)) {
+            update_solana_program_stack(line, program_stack);
+            continue;
+         }
+
+         if (!boost::algorithm::starts_with(line, config.marker_prefix)) {
+            continue;
+         }
+
+         // Attribute "Program log:" to the program currently executing.
+         if (program_stack.empty() || program_stack.back() != config.sol_program_id) {
+            continue;
+         }
+
+         const auto hash_hex = std::string_view{line}.substr(config.marker_prefix.size());
+         const auto on_chain_hash = parse_solana_swap_deposit_hash(hash_hex);
+         if (!on_chain_hash) {
+            result.status = solana_source_deposit_page_status::hard_mismatch;
+            result.next_before.reset();
+            result.reason = "marker hash is malformed";
+            return result;
+         }
+
+         if (std::memcmp(config.recomputed_hash.data(), on_chain_hash->data(), on_chain_hash->size()) != 0) {
+            const std::string want_hex =
+               fc::to_hex(reinterpret_cast<const char*>(config.recomputed_hash.data()), 32);
+            result.status = solana_source_deposit_page_status::hard_mismatch;
+            result.next_before.reset();
+            result.reason = "SwapDeposit hash mismatch: recomputed=" + want_hex +
+                            " on-chain=" + std::string{hash_hex};
+            return result;
+         }
+
+         std::string conf_status;
+         if (sig_obj.contains("confirmationStatus") && sig_obj["confirmationStatus"].is_string()) {
+            conf_status = sig_obj["confirmationStatus"].as_string();
+         }
+         if (conf_status != "finalized") {
+            result.status = solana_source_deposit_page_status::deferred;
+            result.next_before.reset();
+            result.reason = "matching tx is not finalized";
+            return result;
+         }
+
+         result.status = solana_source_deposit_page_status::matched;
+         result.matched_signature = sig_b58;
+         result.next_before.reset();
+         return result;
+      }
+   }
+
+   if (saw_uninspected_candidate) {
+      result.status = solana_source_deposit_page_status::deferred;
+      result.next_before.reset();
+      result.reason = std::move(deferred_reason);
+   }
+
+   return result;
+}
+
+} // namespace sysio::underwriter

--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_constants.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_constants.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 #include <string_view>
 
 #include <fc/network/solana/solana_types.hpp>
@@ -35,5 +36,12 @@ inline constexpr uint64_t ETH_MIN_CONFIRMATIONS = 12;
 /// reorgs become a real concern) is one edit.
 inline constexpr auto SOL_COMMITMENT =
    fc::network::solana::commitment_t::confirmed;
+
+/// SOL: maximum page size accepted by Solana JSON-RPC
+/// `getSignaturesForAddress`. The underwriter walks one page per retry
+/// callback and persists the `before` cursor between outer scan cycles so
+/// unrelated newer program traffic cannot keep an older valid source deposit
+/// outside the verifier's search window forever.
+inline constexpr size_t SOL_SIGNATURE_SCAN_PAGE_SIZE = 1000;
 
 } // namespace sysio::underwriter

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -19,6 +19,7 @@
 #include <sysio/signature_provider_manager_plugin/signature_provider_manager_plugin.hpp>
 #include <sysio/underwriter_plugin/underwriter_plugin.hpp>
 #include <sysio/underwriter_plugin/source_deposit_constants.hpp>
+#include <sysio/underwriter_plugin/solana_source_deposit_scanner.hpp>
 #include <sysio/depot/opreg_status.hpp>
 #include <sysio/opp/opp.hpp>
 #include <sysio/opp/types/types.pb.h>
@@ -27,6 +28,7 @@
 #include <mutex>
 
 #include <algorithm>
+#include <map>
 #include <numeric>
 #include <set>
 #include <tuple>
@@ -75,8 +77,8 @@ struct uw_request {
    /// so the underwriter cannot collude with a stale on-chain
    /// `SwapDeposit` whose terms differ from the depot's UWREQ.
    uint32_t                 variance_tolerance_bps{};
-   /// Source-chain identifier. ETH = 8-byte big-endian `SwapDeposit.id`
-   /// (the outpost-local monotonic counter); SOL = 64-byte signature.
+   /// Source-chain identifier. ETH and SOL both use the 8-byte big-endian
+   /// `SwapDeposit.id` minted by their source outpost's monotonic counter.
    /// Populated by `createuwreq` from `SwapRequest.source_tx_id`. The
    /// underwriter's source-deposit verifier interprets the bytes
    /// per-chain.
@@ -170,10 +172,11 @@ struct underwriter_plugin::impl {
    uint64_t     commits_failed_count          = 0;
    uint64_t     uwreqs_seen_pending_count     = 0;
 
-   // Protects `confirmed_commits` and the diagnostic counters from
-   // concurrent access between the cron-callback (single-threaded) and
-   // the HTTP handler threads. The cron callback takes the lock around
-   // mutations; the HTTP handlers take it around reads.
+   // Protects `confirmed_commits`, `sol_source_deposit_scan_cursors`, and
+   // the diagnostic counters from concurrent access between the
+   // cron-callback (single-threaded) and the HTTP handler threads. The cron
+   // callback takes the lock around mutations; the HTTP handlers take it
+   // around reads.
    mutable std::mutex                stats_mutex;
 
    // Credit lines (read from sysio.opreg::operators each cycle)
@@ -233,6 +236,59 @@ struct underwriter_plugin::impl {
       friend auto operator<=>(const commit_key&, const commit_key&) = default;
    };
    std::set<commit_key>              confirmed_commits;
+
+   /// Cursor key for SOL source-deposit discovery. The uwreq id bounds the
+   /// cursor to one depot request while the deposit id prevents accidental
+   /// reuse if a stale entry survives across schema or replay changes.
+   struct sol_source_deposit_scan_key {
+      uint64_t uwreq_id;
+      uint64_t deposit_id;
+      friend auto operator<=>(const sol_source_deposit_scan_key&,
+                              const sol_source_deposit_scan_key&) = default;
+   };
+
+   /// Persistent SOL signature scan progress for one pending UWREQ.
+   struct sol_source_deposit_scan_cursor {
+      std::optional<std::string> before;
+      uint64_t pages_scanned = 0;
+      uint64_t signatures_scanned = 0;
+   };
+
+   /// Per-pending-UWREQ Solana scan cursors. Persisting `before` across
+   /// retry attempts and outer scan cycles prevents unrelated newer
+   /// opp-outpost traffic from keeping a valid source deposit forever
+   /// outside the newest-page window.
+   std::map<sol_source_deposit_scan_key, sol_source_deposit_scan_cursor>
+      sol_source_deposit_scan_cursors;
+
+   /// Returns the current SOL source-deposit scan cursor for `key`, creating
+   /// one at the newest page when this is the first scan attempt for a UWREQ.
+   sol_source_deposit_scan_cursor get_or_create_sol_source_deposit_scan_cursor(
+      const sol_source_deposit_scan_key& key) {
+      std::lock_guard lk{stats_mutex};
+      return sol_source_deposit_scan_cursors[key];
+   }
+
+   /// Persists the next SOL source-deposit `before` cursor after a clean page
+   /// that did not contain the target marker.
+   sol_source_deposit_scan_cursor advance_sol_source_deposit_scan_cursor(
+      const sol_source_deposit_scan_key& key,
+      std::string                        before,
+      size_t                             signature_count) {
+      std::lock_guard lk{stats_mutex};
+      auto& cursor = sol_source_deposit_scan_cursors[key];
+      cursor.before = std::move(before);
+      cursor.pages_scanned++;
+      cursor.signatures_scanned += signature_count;
+      return cursor;
+   }
+
+   /// Drops SOL source-deposit scan progress for a UWREQ once it either
+   /// matches, fails hard, or leaves the PENDING set.
+   void erase_sol_source_deposit_scan_cursor(const sol_source_deposit_scan_key& key) {
+      std::lock_guard lk{stats_mutex};
+      sol_source_deposit_scan_cursors.erase(key);
+   }
 
    // -----------------------------------------------------------------------
    //  Table read helper
@@ -603,10 +659,10 @@ struct underwriter_plugin::impl {
       // Step 4: Scan sysio.uwrit::uwreqs for PENDING requests
       auto requests = scan_pending_requests();
 
-      // Step 4b: prune `confirmed_commits` of entries whose uwreq is no
-      // longer PENDING — the depot has resolved (won/lost/expired) those
-      // races, so the local set should not grow unbounded. This is the
-      // same pass that already reads the PENDING set, so it's free.
+      // Step 4b: prune local per-uwreq state whose uwreq is no longer
+      // PENDING — the depot has resolved (won/lost/expired) those races, so
+      // the local sets should not grow unbounded. This is the same pass that
+      // already reads the PENDING set, so it's free.
       {
          std::unordered_set<uint64_t> still_pending;
          still_pending.reserve(requests.size());
@@ -614,6 +670,9 @@ struct underwriter_plugin::impl {
          std::lock_guard lk{stats_mutex};
          std::erase_if(confirmed_commits, [&](const commit_key& k) {
             return !still_pending.contains(k.uwreq_id);
+         });
+         std::erase_if(sol_source_deposit_scan_cursors, [&](const auto& entry) {
+            return !still_pending.contains(entry.first.uwreq_id);
          });
          uwreqs_seen_pending_count = requests.size();
       }
@@ -1316,10 +1375,11 @@ struct underwriter_plugin::impl {
 
    /// Before committing collateral, independently verify the source-chain
    /// deposit that funded this swap. `req.source_tx_id` is the chain-native
-   /// transaction id captured at swap-emit time (ETH: 32-byte tx hash;
-   /// SOL: 64-byte signature). The verify path fetches that tx, confirms
-   /// it succeeded against the configured source contract / program, and
-   /// cross-references every argument we can decode against the uwreq:
+   /// deposit id captured at swap-emit time (ETH/SOL: 8-byte monotonic
+   /// `SwapDeposit.id`). The verify path locates the source-chain event or
+   /// log for that id, confirms the transaction succeeded against the
+   /// configured source contract / program, and cross-references every
+   /// argument we can decode against the uwreq:
    ///
    ///   * `depositor`   — `tx.from` (ETH) / fee-payer (SOL) must match `req.depositor`.
    ///   * source contract — `tx.to` (ETH) / program-id (SOL) must match the configured address.
@@ -1621,14 +1681,17 @@ struct underwriter_plugin::impl {
    ///   2. `fc::task::retry_until` with
    ///      `SOL_SWAP_DEPOSIT_POLL_INTERVAL` (15s) /
    ///      `SOL_SWAP_DEPOSIT_TOTAL_TIMEOUT` (120s, both in
-   ///      `outpost_solana_client_plugin.hpp`) drives the scan loop:
+   ///      `outpost_solana_client_plugin.hpp`) drives the paginated scan:
    ///        a. `getSignaturesForAddress(sol_program_id,
-   ///           limit=SOL_SCAN_LIMIT)` — enumerate recent program
-   ///           sigs.
+   ///           before=<persisted cursor>, limit=SOL_SIGNATURE_SCAN_PAGE_SIZE)`
+   ///           enumerates the next older page of program sigs.
    ///        b. For each sig, `getTransaction(sig)`; inspect
    ///           `meta.err` (skip failed tx) and
    ///           `meta.logMessages[]` for the canonical marker:
    ///           `Program log: opp_outpost: SwapDeposit id=<id> hash=<64hex>`.
+   ///        c. Persist the next `before` cursor only after a clean page with
+   ///           no match; unfinalized matches and transient tx fetch failures
+   ///           retry the same page.
    ///   3. On match, parse the 32-byte on-chain hash from the log.
    ///   4. Recompute the same hash from the UWREQ row's flat fields
    ///      (depositor[32] + 7×u64 BE + u32 BE = 92 packed bytes).
@@ -1641,10 +1704,10 @@ struct underwriter_plugin::impl {
    ///
    /// `false` returns:
    ///   - hard mismatch (counter bumped) on bad size, hash divergence,
-   ///     or tx-level execution error;
+   ///     malformed marker hash, or full-history exhaustion without a marker;
    ///   - deferred retry (no counter bump) on `retry_until` deadline
-   ///     reached without a matching log — the outer poll loop
-   ///     reattempts on its next tick.
+   ///     reached without a matching finalized log — the outer poll loop
+   ///     reattempts on its next tick from the persisted cursor.
    bool verify_source_deposit_sol(const uw_request& req) {
       auto entry = sol_plug->get_client(sol_client_id);
       if (!entry || !entry->client) {
@@ -1723,15 +1786,15 @@ struct underwriter_plugin::impl {
 
       // ── (2) + (3) retry-loop until matched or budget expires ───────────
       // `bool hard_mismatch` distinguishes "found and known-bad" (hash
-      // divergence / tx error) from "not yet found" (deferred). The
-      // retry-callback returns:
-      //   - Some(true)               → success, exit retry_until
-      //   - Some(false) hard_mismatch → fail-fast, exit retry_until
-      //   - None                     → deferred, sleep + retry
+      // divergence / malformed marker / exhausted history) from "not yet
+      // found" (deferred). The retry-callback returns:
+      //   - Some(true)                 -> success, exit retry_until
+      //   - Some(false) hard_mismatch  -> fail-fast, exit retry_until
+      //   - None                       -> deferred, sleep + retry
       // Outer `try { retry_until } catch (timeout_exception)` maps the
-      // deadline-without-match case to deferred-no-mismatch-bump,
-      // matching the ETH verify's semantics.
-      constexpr size_t SOL_SCAN_LIMIT = 50;   // per-iteration sig batch
+      // deadline-without-match case to deferred-no-mismatch-bump, while the
+      // cursor survives for the next outer scan tick.
+      const sol_source_deposit_scan_key scan_key{req.id, deposit_id};
       bool        hard_mismatch_seen = false;
       std::string matched_sig;
 
@@ -1744,166 +1807,106 @@ struct underwriter_plugin::impl {
 
          std::function<std::optional<bool>()> attempt =
          [&]() -> std::optional<bool> {
+            const auto cursor = get_or_create_sol_source_deposit_scan_cursor(scan_key);
             std::vector<fc::variant> sigs;
             try {
                sigs = entry->client->get_signatures_for_address(
-                  sol_program_id, std::nullopt, std::nullopt, SOL_SCAN_LIMIT);
+                  sol_program_id,
+                  cursor.before,
+                  std::nullopt,
+                  underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE);
             } catch (const fc::exception& e) {
                ilog("underwriter: source-deposit verify deferred for uwreq {} — "
-                    "getSignaturesForAddress({}) RPC error: {}",
-                    req.id, sol_program_id, e.to_detail_string());
+                    "getSignaturesForAddress({}, before={}) RPC error: {}",
+                    req.id,
+                    sol_program_id,
+                    cursor.before.value_or("<newest>"),
+                    e.to_detail_string());
                return std::nullopt;
             }
 
-            for (const auto& sig_var : sigs) {
-               if (!sig_var.is_object()) continue;
-               const auto sig_obj = sig_var.get_object();
-               if (!sig_obj.contains("signature") ||
-                   !sig_obj["signature"].is_string()) continue;
-               const std::string sig_b58 = sig_obj["signature"].as_string();
+            const underwriter::solana_source_deposit_page_scan_config scan_config{
+               .sol_program_id = sol_program_id,
+               .marker_prefix = marker_prefix,
+               .recomputed_hash = recomputed_hash,
+            };
+            const auto scan_result = underwriter::scan_solana_source_deposit_signature_page(
+               sigs,
+               [&](const std::string& sig_b58) {
+                  return entry->client->get_transaction(sig_b58, underwriter::SOL_COMMITMENT);
+               },
+               scan_config);
 
-               // Skip failed txs at the listing level — sigs with an `err`
-               // field carry execution failures and can't have emitted our
-               // marker line successfully.
-               if (sig_obj.contains("err") && !sig_obj["err"].is_null()) {
-                  continue;
-               }
-
-               fc::variant tx;
-               try {
-                  tx = entry->client->get_transaction(
-                     sig_b58, underwriter::SOL_COMMITMENT);
-               } catch (const fc::exception& e) {
-                  // Transient — move on; the next iteration may succeed.
-                  continue;
-               }
-               if (tx.is_null() || !tx.is_object()) continue;
-               const auto tx_obj = tx.get_object();
-               if (!tx_obj.contains("meta") || !tx_obj["meta"].is_object()) {
-                  continue;
-               }
-               const auto meta_obj = tx_obj["meta"].get_object();
-               // Skip failed txs again at the tx level for completeness.
-               if (meta_obj.contains("err") && !meta_obj["err"].is_null()) {
-                  continue;
-               }
-               if (!meta_obj.contains("logMessages") ||
-                   !meta_obj["logMessages"].is_array()) {
-                  continue;
-               }
-               // Solana interleaves every invoked program's logs in meta.logMessages. Attribute each
-               // "Program log:" payload to the program currently executing by tracking the
-               // "Program <id> invoke" / "Program <id> success|failed" bracket lines, and trust the
-               // SwapDeposit marker ONLY when opp-outpost (sol_program_id) is the top-of-stack
-               // program. Without this, a forged "Program log:" emitted by any attacker program in a
-               // transaction that merely references sol_program_id would pass verification.
-               std::vector<std::string> program_stack;
-               for (const auto& line_var : meta_obj["logMessages"].get_array()) {
-                  if (!line_var.is_string()) continue;
-                  const std::string line = line_var.as_string();
-
-                  // Maintain the invocation stack from the bracket lines (which are not log payloads).
-                  if (boost::algorithm::starts_with(line, "Program ") &&
-                      !boost::algorithm::starts_with(line, "Program log:") &&
-                      !boost::algorithm::starts_with(line, "Program data:") &&
-                      !boost::algorithm::starts_with(line, "Program return:")) {
-                     std::string_view rest{line};
-                     rest.remove_prefix(8);                  // strip "Program "
-                     const size_t sp1 = rest.find(' ');
-                     if (sp1 != std::string_view::npos) {
-                        const std::string_view prog = rest.substr(0, sp1);
-                        std::string_view after = rest.substr(sp1 + 1);
-                        const size_t sp2 = after.find(' ');
-                        const std::string_view verb =
-                           (sp2 == std::string_view::npos) ? after : after.substr(0, sp2);
-                        if (verb == "invoke") {
-                           program_stack.emplace_back(prog);
-                        } else if (verb.starts_with("success") || verb.starts_with("failed")) {
-                           if (!program_stack.empty()) program_stack.pop_back();
-                        }
-                        // "consumed", etc. — no stack change.
-                     }
-                     continue;
-                  }
-
-                  if (!boost::algorithm::starts_with(line, marker_prefix)) {
-                     continue;
-                  }
-                  // Attribution: the marker is a "Program log:" payload of the top-of-stack program.
-                  if (program_stack.empty() || program_stack.back() != sol_program_id) {
-                     ilog("underwriter: ignoring SwapDeposit marker for uwreq {} in tx {} — not "
-                          "emitted by opp-outpost program {} (attributed to {})",
-                          req.id, sig_b58, sol_program_id,
-                          program_stack.empty() ? std::string{"<none>"} : program_stack.back());
-                     continue;
-                  }
-                  // Parse the 64-char lowercase hex hash that follows
-                  // `marker_prefix`. Format MUST match the producer's
-                  // `format!("{:02x}", b)` per-byte spelling.
-                  const auto hash_hex = std::string_view{line}
-                                          .substr(marker_prefix.size());
-                  if (hash_hex.size() != 64) {
-                     elog("underwriter: source-deposit verify failed for "
-                          "uwreq {} — marker found in tx {} but hash field "
-                          "has wrong size ({} chars; expected 64)",
-                          req.id, sig_b58, hash_hex.size());
-                     hard_mismatch_seen = true;
-                     bump_mismatch();
-                     return std::optional<bool>(false);
-                  }
-                  std::array<uint8_t, 32> on_chain_hash{};
-                  bool parse_ok = true;
-                  for (size_t i = 0; i < 32 && parse_ok; ++i) {
-                     try {
-                        on_chain_hash[i] = static_cast<uint8_t>(std::stoul(
-                           std::string{hash_hex.substr(i * 2, 2)},
-                           nullptr, 16));
-                     } catch (...) {
-                        parse_ok = false;
-                     }
-                  }
-                  if (!parse_ok) {
-                     elog("underwriter: source-deposit verify failed for "
-                          "uwreq {} — marker found in tx {} but hash field "
-                          "is not lowercase hex: {}",
-                          req.id, sig_b58, std::string(hash_hex));
-                     hard_mismatch_seen = true;
-                     bump_mismatch();
-                     return std::optional<bool>(false);
-                  }
-                  if (std::memcmp(recomputed_hash.data(),
-                                   on_chain_hash.data(), 32) != 0) {
-                     const std::string got_hex(hash_hex);
-                     const std::string want_hex = fc::to_hex(
-                        reinterpret_cast<const char*>(recomputed_hash.data()),
-                        32);
-                     elog("underwriter: source-deposit verify failed for "
-                          "uwreq {} — SwapDeposit hash mismatch "
-                          "(deposit_id={} tx={}): on-chain={} recomputed={}",
-                          req.id, deposit_id, sig_b58, got_hex, want_hex);
-                     hard_mismatch_seen = true;
-                     bump_mismatch();
-                     return std::optional<bool>(false);
-                  }
-
-                  // ── (5) Confirmation gate — must be finalized ──────────
-                  std::string conf_status;
-                  if (sig_obj.contains("confirmationStatus") &&
-                      sig_obj["confirmationStatus"].is_string()) {
-                     conf_status = sig_obj["confirmationStatus"].as_string();
-                  }
-                  if (conf_status != "finalized") {
-                     ilog("underwriter: source-deposit verify deferred for "
-                          "uwreq {} — matching tx {} not yet finalized "
-                          "(confirmationStatus={})",
-                          req.id, sig_b58, conf_status);
-                     return std::nullopt;
-                  }
-
-                  matched_sig = sig_b58;
+            using page_status = underwriter::solana_source_deposit_page_status;
+            switch (scan_result.status) {
+               case page_status::matched:
+                  matched_sig = scan_result.matched_signature;
+                  erase_sol_source_deposit_scan_cursor(scan_key);
                   return std::optional<bool>(true);
-               }
+               case page_status::hard_mismatch:
+                  elog("underwriter: source-deposit verify failed for uwreq {} — "
+                       "{} (deposit_id={}, program={}, before={})",
+                       req.id,
+                       scan_result.reason,
+                       deposit_id,
+                       sol_program_id,
+                       cursor.before.value_or("<newest>"));
+                  hard_mismatch_seen = true;
+                  erase_sol_source_deposit_scan_cursor(scan_key);
+                  bump_mismatch();
+                  return std::optional<bool>(false);
+               case page_status::deferred:
+                  ilog("underwriter: source-deposit verify deferred for uwreq {} — "
+                       "{} (deposit_id={}, program={}, before={})",
+                       req.id,
+                       scan_result.reason,
+                       deposit_id,
+                       sol_program_id,
+                       cursor.before.value_or("<newest>"));
+                  return std::nullopt;
+               case page_status::not_found:
+                  break;
             }
+
+            if (scan_result.page_exhausted) {
+               elog("underwriter: source-deposit verify failed for uwreq {} — "
+                    "exhausted Solana program signature history without SwapDeposit log "
+                    "(deposit_id={}, program={}, before={}, page_size={})",
+                    req.id,
+                    deposit_id,
+                    sol_program_id,
+                    cursor.before.value_or("<newest>"),
+                    sigs.size());
+               hard_mismatch_seen = true;
+               erase_sol_source_deposit_scan_cursor(scan_key);
+               bump_mismatch();
+               return std::optional<bool>(false);
+            }
+
+            if (!scan_result.next_before) {
+               ilog("underwriter: source-deposit verify deferred for uwreq {} — "
+                    "signature page produced no usable pagination cursor "
+                    "(deposit_id={}, program={}, before={}, page_size={})",
+                    req.id,
+                    deposit_id,
+                    sol_program_id,
+                    cursor.before.value_or("<newest>"),
+                    sigs.size());
+               return std::nullopt;
+            }
+
+            const auto advanced = advance_sol_source_deposit_scan_cursor(
+               scan_key, *scan_result.next_before, sigs.size());
+            ilog("underwriter: source-deposit verify paginated for uwreq {} — "
+                 "no SwapDeposit log in page (deposit_id={}, program={}, "
+                 "before={}, next_before={}, pages_scanned={}, signatures_scanned={})",
+                 req.id,
+                 deposit_id,
+                 sol_program_id,
+                 cursor.before.value_or("<newest>"),
+                 *scan_result.next_before,
+                 advanced.pages_scanned,
+                 advanced.signatures_scanned);
             return std::nullopt;   // not found this iteration; sleep + retry
          };
 
@@ -1930,11 +1933,12 @@ struct underwriter_plugin::impl {
          }
          ilog("underwriter: source-deposit verify deferred for uwreq {} — "
               "no SwapDeposit log line for deposit_id={} after {}s "
-              "(program={}, scan-interval={}s, will retry on next outer tick)",
+              "(program={}, scan-interval={}s, page-size={}, will retry from persisted cursor)",
               req.id, deposit_id,
               SOL_SWAP_DEPOSIT_TOTAL_TIMEOUT.count() / 1'000'000,
               sol_program_id,
-              SOL_SWAP_DEPOSIT_POLL_INTERVAL.count() / 1'000'000);
+              SOL_SWAP_DEPOSIT_POLL_INTERVAL.count() / 1'000'000,
+              underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE);
          return false;
       } catch (const fc::exception& e) {
          elog("underwriter: source-deposit verify failed for uwreq {} — "
@@ -2113,6 +2117,7 @@ struct underwriter_plugin::impl {
          ("commits_failed",                 commits_failed_count)
          ("source_deposit_mismatch",        source_deposit_mismatch_count)
          ("outstanding_commit_count",       confirmed_commits.size())
+         ("sol_source_deposit_cursor_count", sol_source_deposit_scan_cursors.size())
       );
    }
 

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -237,57 +237,63 @@ struct underwriter_plugin::impl {
    };
    std::set<commit_key>              confirmed_commits;
 
-   /// Cursor key for SOL source-deposit discovery. The uwreq id bounds the
-   /// cursor to one depot request while the deposit id prevents accidental
-   /// reuse if a stale entry survives across schema or replay changes.
-   struct sol_source_deposit_scan_key {
-      uint64_t uwreq_id;
-      uint64_t deposit_id;
-      friend auto operator<=>(const sol_source_deposit_scan_key&,
-                              const sol_source_deposit_scan_key&) = default;
-   };
-
-   /// Persistent SOL signature scan progress for one pending UWREQ.
-   struct sol_source_deposit_scan_cursor {
-      std::optional<std::string> before;
-      uint64_t pages_scanned = 0;
-      uint64_t signatures_scanned = 0;
-   };
-
    /// Per-pending-UWREQ Solana scan cursors. Persisting `before` across
    /// retry attempts and outer scan cycles prevents unrelated newer
    /// opp-outpost traffic from keeping a valid source deposit forever
-   /// outside the newest-page window.
-   std::map<sol_source_deposit_scan_key, sol_source_deposit_scan_cursor>
-      sol_source_deposit_scan_cursors;
+   /// outside the newest-page window. Terminal negative entries remain until
+   /// the UWREQ leaves PENDING so failed scans do not re-walk full history or
+   /// re-bump mismatch counters every outer scan cycle.
+   underwriter::solana_source_deposit_scan_cursor_map sol_source_deposit_scan_cursors;
 
    /// Returns the current SOL source-deposit scan cursor for `key`, creating
    /// one at the newest page when this is the first scan attempt for a UWREQ.
-   sol_source_deposit_scan_cursor get_or_create_sol_source_deposit_scan_cursor(
-      const sol_source_deposit_scan_key& key) {
+   underwriter::solana_source_deposit_scan_cursor get_or_create_sol_source_deposit_scan_cursor(
+      const underwriter::solana_source_deposit_scan_key& key) {
       std::lock_guard lk{stats_mutex};
-      return sol_source_deposit_scan_cursors[key];
+      return underwriter::get_or_create_solana_source_deposit_scan_cursor(
+         sol_source_deposit_scan_cursors, key);
+   }
+
+   /// Returns a terminal SOL source-deposit failure for `key`, when one has
+   /// already been recorded while the UWREQ remains PENDING.
+   std::optional<underwriter::solana_source_deposit_scan_cursor>
+   get_sol_source_deposit_terminal_failure(
+      const underwriter::solana_source_deposit_scan_key& key) const {
+      std::lock_guard lk{stats_mutex};
+      return underwriter::get_solana_source_deposit_terminal_failure(
+         sol_source_deposit_scan_cursors, key);
    }
 
    /// Persists the next SOL source-deposit `before` cursor after a clean page
    /// that did not contain the target marker.
-   sol_source_deposit_scan_cursor advance_sol_source_deposit_scan_cursor(
-      const sol_source_deposit_scan_key& key,
+   underwriter::solana_source_deposit_scan_cursor advance_sol_source_deposit_scan_cursor(
+      const underwriter::solana_source_deposit_scan_key& key,
       std::string                        before,
       size_t                             signature_count) {
       std::lock_guard lk{stats_mutex};
-      auto& cursor = sol_source_deposit_scan_cursors[key];
-      cursor.before = std::move(before);
-      cursor.pages_scanned++;
-      cursor.signatures_scanned += signature_count;
-      return cursor;
+      return underwriter::advance_solana_source_deposit_scan_cursor(
+         sol_source_deposit_scan_cursors, key, std::move(before), signature_count);
+   }
+
+   /// Records a terminal SOL source-deposit failure while keeping the scan
+   /// state until the UWREQ leaves PENDING.
+   underwriter::solana_source_deposit_terminal_failure_result
+   record_sol_source_deposit_terminal_failure(
+      const underwriter::solana_source_deposit_scan_key& key,
+      std::string reason,
+      size_t signature_count) {
+      std::lock_guard lk{stats_mutex};
+      return underwriter::record_solana_source_deposit_terminal_failure(
+         sol_source_deposit_scan_cursors, key, std::move(reason), signature_count);
    }
 
    /// Drops SOL source-deposit scan progress for a UWREQ once it either
-   /// matches, fails hard, or leaves the PENDING set.
-   void erase_sol_source_deposit_scan_cursor(const sol_source_deposit_scan_key& key) {
+   /// matches or leaves the PENDING set.
+   void erase_sol_source_deposit_scan_cursor(
+      const underwriter::solana_source_deposit_scan_key& key) {
       std::lock_guard lk{stats_mutex};
-      sol_source_deposit_scan_cursors.erase(key);
+      underwriter::erase_solana_source_deposit_scan_cursor(
+         sol_source_deposit_scan_cursors, key);
    }
 
    // -----------------------------------------------------------------------
@@ -671,9 +677,8 @@ struct underwriter_plugin::impl {
          std::erase_if(confirmed_commits, [&](const commit_key& k) {
             return !still_pending.contains(k.uwreq_id);
          });
-         std::erase_if(sol_source_deposit_scan_cursors, [&](const auto& entry) {
-            return !still_pending.contains(entry.first.uwreq_id);
-         });
+         underwriter::prune_solana_source_deposit_scan_cursors(
+            sol_source_deposit_scan_cursors, still_pending);
          uwreqs_seen_pending_count = requests.size();
       }
 
@@ -1703,8 +1708,10 @@ struct underwriter_plugin::impl {
    ///      not yet finalized → deferred retry (no mismatch bump).
    ///
    /// `false` returns:
-   ///   - hard mismatch (counter bumped) on bad size, hash divergence,
-   ///     malformed marker hash, or full-history exhaustion without a marker;
+   ///   - hard mismatch on bad size;
+   ///   - terminal source-deposit failure (counter bumped once per pending
+   ///     UWREQ) on hash divergence, malformed marker hash, or full-history
+   ///     exhaustion without a marker;
    ///   - deferred retry (no counter bump) on `retry_until` deadline
    ///     reached without a matching finalized log — the outer poll loop
    ///     reattempts on its next tick from the persisted cursor.
@@ -1787,14 +1794,28 @@ struct underwriter_plugin::impl {
       // ── (2) + (3) retry-loop until matched or budget expires ───────────
       // `bool hard_mismatch` distinguishes "found and known-bad" (hash
       // divergence / malformed marker / exhausted history) from "not yet
-      // found" (deferred). The retry-callback returns:
+      // found" (deferred). Terminal SOL failures are cached until the UWREQ
+      // leaves PENDING so later scan cycles do not re-walk full history.
+      // The retry-callback returns:
       //   - Some(true)                 -> success, exit retry_until
       //   - Some(false) hard_mismatch  -> fail-fast, exit retry_until
       //   - None                       -> deferred, sleep + retry
       // Outer `try { retry_until } catch (timeout_exception)` maps the
       // deadline-without-match case to deferred-no-mismatch-bump, while the
       // cursor survives for the next outer scan tick.
-      const sol_source_deposit_scan_key scan_key{req.id, deposit_id};
+      const underwriter::solana_source_deposit_scan_key scan_key{req.id, deposit_id};
+      if (const auto terminal = get_sol_source_deposit_terminal_failure(scan_key)) {
+         ilog("underwriter: source-deposit verify skipped for uwreq {} — "
+              "previous terminal SOL verification failure: {} "
+              "(deposit_id={}, pages_scanned={}, signatures_scanned={})",
+              req.id,
+              terminal->terminal_failure_reason,
+              deposit_id,
+              terminal->pages_scanned,
+              terminal->signatures_scanned);
+         return false;
+      }
+
       bool        hard_mismatch_seen = false;
       std::string matched_sig;
 
@@ -1852,8 +1873,11 @@ struct underwriter_plugin::impl {
                        sol_program_id,
                        cursor.before.value_or("<newest>"));
                   hard_mismatch_seen = true;
-                  erase_sol_source_deposit_scan_cursor(scan_key);
-                  bump_mismatch();
+                  {
+                     const auto terminal = record_sol_source_deposit_terminal_failure(
+                        scan_key, scan_result.reason, sigs.size());
+                     if (terminal.first_failure) bump_mismatch();
+                  }
                   return std::optional<bool>(false);
                case page_status::deferred:
                   ilog("underwriter: source-deposit verify deferred for uwreq {} — "
@@ -1869,17 +1893,22 @@ struct underwriter_plugin::impl {
             }
 
             if (scan_result.page_exhausted) {
+               const std::string reason =
+                  "exhausted Solana program signature history without SwapDeposit log";
                elog("underwriter: source-deposit verify failed for uwreq {} — "
-                    "exhausted Solana program signature history without SwapDeposit log "
-                    "(deposit_id={}, program={}, before={}, page_size={})",
+                    "{} (deposit_id={}, program={}, before={}, page_size={})",
                     req.id,
+                    reason,
                     deposit_id,
                     sol_program_id,
                     cursor.before.value_or("<newest>"),
                     sigs.size());
                hard_mismatch_seen = true;
-               erase_sol_source_deposit_scan_cursor(scan_key);
-               bump_mismatch();
+               {
+                  const auto terminal = record_sol_source_deposit_terminal_failure(
+                     scan_key, reason, sigs.size());
+                  if (terminal.first_failure) bump_mismatch();
+               }
                return std::optional<bool>(false);
             }
 
@@ -2099,6 +2128,15 @@ struct underwriter_plugin::impl {
    // the nodeop HTTP port.
    fc::variant build_stats_response() {
       std::lock_guard lk{stats_mutex};
+      size_t active_sol_source_deposit_cursor_count = 0;
+      size_t sol_source_deposit_terminal_failure_count = 0;
+      for (const auto& entry : sol_source_deposit_scan_cursors) {
+         if (entry.second.terminal_failure) {
+            sol_source_deposit_terminal_failure_count++;
+         } else {
+            active_sol_source_deposit_cursor_count++;
+         }
+      }
       return fc::variant(fc::mutable_variant_object()
          ("underwriter_account",            underwriter_account.to_string())
          ("enabled",                        enabled)
@@ -2117,7 +2155,8 @@ struct underwriter_plugin::impl {
          ("commits_failed",                 commits_failed_count)
          ("source_deposit_mismatch",        source_deposit_mismatch_count)
          ("outstanding_commit_count",       confirmed_commits.size())
-         ("sol_source_deposit_cursor_count", sol_source_deposit_scan_cursors.size())
+         ("sol_source_deposit_cursor_count", active_sol_source_deposit_cursor_count)
+         ("sol_source_deposit_terminal_failure_count", sol_source_deposit_terminal_failure_count)
       );
    }
 

--- a/plugins/underwriter_plugin/test/test_underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/test/test_underwriter_plugin.cpp
@@ -1,11 +1,111 @@
 #include <boost/test/unit_test.hpp>
 
-#include <set>
+#include <fc/crypto/keccak256.hpp>
+#include <fc/crypto/hex.hpp>
+#include <fc/variant_object.hpp>
 
+#include <set>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <sysio/underwriter_plugin/solana_source_deposit_scanner.hpp>
 #include <sysio/underwriter_plugin/underwriter_plugin.hpp>
 
 using namespace std::literals;
 using namespace sysio::underwriter_defaults;
+
+namespace {
+
+/// Program id used by the scanner tests to model the configured opp-outpost.
+const std::string test_sol_program_id = "OppOutpost11111111111111111111111111111111";
+
+/// Program id used by the scanner tests to model an attacker-controlled CPI caller.
+const std::string attacker_program_id = "Attacker111111111111111111111111111111111";
+
+/// Returns a deterministic expected correlation hash for test markers.
+fc::crypto::keccak256 test_expected_hash() {
+   return fc::crypto::keccak256::hash(std::string{"sec-40-source-deposit"});
+}
+
+/// Hex-encodes a 32-byte keccak hash the same way the Solana outpost log does.
+std::string hash_hex(const fc::crypto::keccak256& hash) {
+   return fc::to_hex(reinterpret_cast<const char*>(hash.data()), 32);
+}
+
+/// Builds the canonical SwapDeposit marker prefix for a deposit id.
+std::string marker_prefix(uint64_t deposit_id) {
+   return "Program log: opp_outpost: SwapDeposit id=" + std::to_string(deposit_id) + " hash=";
+}
+
+/// Builds one `getSignaturesForAddress` response entry.
+fc::variant signature_entry(const std::string& sig,
+                            const std::string& confirmation_status = "finalized",
+                            bool failed = false) {
+   fc::mutable_variant_object obj;
+   obj("signature", sig);
+   obj("confirmationStatus", confirmation_status);
+   if (failed) {
+      obj("err", "failed");
+   } else {
+      obj("err", fc::variant());
+   }
+   return fc::variant(obj);
+}
+
+/// Builds one `getTransaction` response with the supplied runtime log lines.
+fc::variant transaction_with_logs(const std::vector<std::string>& logs, bool failed = false) {
+   fc::variants log_variants;
+   log_variants.reserve(logs.size());
+   for (const auto& line : logs) {
+      log_variants.emplace_back(line);
+   }
+
+   fc::mutable_variant_object meta;
+   if (failed) {
+      meta("err", "failed");
+   } else {
+      meta("err", fc::variant());
+   }
+   meta("logMessages", log_variants);
+
+   return fc::variant(fc::mutable_variant_object()("meta", meta));
+}
+
+/// Builds runtime logs where `program_id` is the current executing program.
+std::vector<std::string> program_logs(const std::string& program_id,
+                                      const std::vector<std::string>& payloads) {
+   std::vector<std::string> logs;
+   logs.reserve(payloads.size() + 2);
+   logs.push_back("Program " + program_id + " invoke [1]");
+   logs.insert(logs.end(), payloads.begin(), payloads.end());
+   logs.push_back("Program " + program_id + " success");
+   return logs;
+}
+
+/// Runs the Solana source-deposit page scanner against in-memory transactions.
+sysio::underwriter::solana_source_deposit_page_scan_result
+scan_test_page(const std::vector<fc::variant>& sigs,
+               const std::map<std::string, fc::variant>& tx_by_sig,
+               const fc::crypto::keccak256& expected_hash,
+               uint64_t deposit_id,
+               size_t* fetch_count = nullptr) {
+   const auto prefix = marker_prefix(deposit_id);
+   const sysio::underwriter::solana_source_deposit_page_scan_config config{
+      .sol_program_id = test_sol_program_id,
+      .marker_prefix = prefix,
+      .recomputed_hash = expected_hash,
+   };
+   return sysio::underwriter::scan_solana_source_deposit_signature_page(
+      sigs,
+      [&](const std::string& sig) {
+         if (fetch_count) ++*fetch_count;
+         return tx_by_sig.at(sig);
+      },
+      config);
+}
+
+} // namespace
 
 BOOST_AUTO_TEST_SUITE(underwriter_plugin_tests)
 
@@ -115,6 +215,205 @@ BOOST_AUTO_TEST_CASE(knapsack_fallback_threshold_is_documented) try {
 // integration coverage via curl in the flow tests.
 BOOST_AUTO_TEST_CASE(http_endpoints_registered_at_startup) try {
    BOOST_CHECK(true);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_finds_match_after_legacy_window) try {
+   const uint64_t deposit_id = 7;
+   const auto expected_hash = test_expected_hash();
+   const auto marker = marker_prefix(deposit_id) + hash_hex(expected_hash);
+
+   std::vector<fc::variant> sigs;
+   std::map<std::string, fc::variant> tx_by_sig;
+   for (size_t i = 0; i < 51; ++i) {
+      const std::string sig = "noise-" + std::to_string(i);
+      sigs.push_back(signature_entry(sig));
+      tx_by_sig.emplace(sig, transaction_with_logs(program_logs(test_sol_program_id, {"Program log: unrelated"})));
+   }
+
+   const std::string target_sig = "target-source-deposit";
+   sigs.push_back(signature_entry(target_sig));
+   tx_by_sig.emplace(target_sig, transaction_with_logs(program_logs(test_sol_program_id, {marker})));
+
+   size_t fetch_count = 0;
+   const auto result = scan_test_page(sigs, tx_by_sig, expected_hash, deposit_id, &fetch_count);
+
+   BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::matched);
+   BOOST_CHECK_EQUAL(result.matched_signature, target_sig);
+   BOOST_CHECK_EQUAL(fetch_count, 52);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_returns_next_before_for_full_clean_page) try {
+   const uint64_t deposit_id = 8;
+   const auto expected_hash = test_expected_hash();
+
+   std::vector<fc::variant> sigs;
+   std::map<std::string, fc::variant> tx_by_sig;
+   for (size_t i = 0; i < sysio::underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE; ++i) {
+      const std::string sig = "full-page-" + std::to_string(i);
+      sigs.push_back(signature_entry(sig));
+      tx_by_sig.emplace(sig, transaction_with_logs(program_logs(test_sol_program_id, {"Program log: unrelated"})));
+   }
+
+   const auto result = scan_test_page(sigs, tx_by_sig, expected_hash, deposit_id);
+
+   BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::not_found);
+   BOOST_REQUIRE(result.next_before);
+   BOOST_CHECK_EQUAL(*result.next_before, "full-page-999");
+   BOOST_CHECK(!result.page_exhausted);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_ignores_forged_marker_from_wrong_program) try {
+   const uint64_t deposit_id = 9;
+   const auto expected_hash = test_expected_hash();
+   const auto marker = marker_prefix(deposit_id) + hash_hex(expected_hash);
+   const std::string sig = "forged-marker";
+
+   const std::vector<fc::variant> sigs{signature_entry(sig)};
+   const std::map<std::string, fc::variant> tx_by_sig{
+      {sig, transaction_with_logs(program_logs(attacker_program_id, {marker}))},
+   };
+
+   const auto result = scan_test_page(sigs, tx_by_sig, expected_hash, deposit_id);
+
+   BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::not_found);
+   BOOST_REQUIRE(result.next_before);
+   BOOST_CHECK_EQUAL(*result.next_before, sig);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_defers_unfinalized_match_without_cursor_advance) try {
+   const uint64_t deposit_id = 10;
+   const auto expected_hash = test_expected_hash();
+   const auto marker = marker_prefix(deposit_id) + hash_hex(expected_hash);
+   const std::string sig = "unfinalized-marker";
+
+   const std::vector<fc::variant> sigs{signature_entry(sig, "confirmed")};
+   const std::map<std::string, fc::variant> tx_by_sig{
+      {sig, transaction_with_logs(program_logs(test_sol_program_id, {marker}))},
+   };
+
+   const auto result = scan_test_page(sigs, tx_by_sig, expected_hash, deposit_id);
+
+   BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::deferred);
+   BOOST_CHECK(!result.next_before);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_continues_after_fetch_error_to_find_match) try {
+   const uint64_t deposit_id = 11;
+   const auto expected_hash = test_expected_hash();
+   const auto marker = marker_prefix(deposit_id) + hash_hex(expected_hash);
+   const std::string error_sig = "transient-fetch-error";
+   const std::string target_sig = "target-after-fetch-error";
+   const std::vector<fc::variant> sigs{signature_entry(error_sig), signature_entry(target_sig)};
+   const std::map<std::string, fc::variant> tx_by_sig{
+      {target_sig, transaction_with_logs(program_logs(test_sol_program_id, {marker}))},
+   };
+   const auto prefix = marker_prefix(deposit_id);
+   const sysio::underwriter::solana_source_deposit_page_scan_config config{
+      .sol_program_id = test_sol_program_id,
+      .marker_prefix = prefix,
+      .recomputed_hash = expected_hash,
+   };
+
+   const auto result = sysio::underwriter::scan_solana_source_deposit_signature_page(
+      sigs,
+      [&](const std::string& sig) -> fc::variant {
+         if (sig == error_sig) {
+            FC_THROW_EXCEPTION(fc::exception, "transient fetch failure");
+         }
+         return tx_by_sig.at(sig);
+      },
+      config);
+
+   BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::matched);
+   BOOST_CHECK_EQUAL(result.matched_signature, target_sig);
+   BOOST_CHECK(!result.next_before);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_defers_fetch_error_without_cursor_advance) try {
+   const uint64_t deposit_id = 12;
+   const auto expected_hash = test_expected_hash();
+   const std::string error_sig = "transient-fetch-error";
+   const std::string clean_sig = "clean-after-fetch-error";
+   const std::vector<fc::variant> sigs{signature_entry(error_sig), signature_entry(clean_sig)};
+   const std::map<std::string, fc::variant> tx_by_sig{
+      {clean_sig, transaction_with_logs(program_logs(test_sol_program_id, {"Program log: unrelated"}))},
+   };
+   const auto prefix = marker_prefix(deposit_id);
+   const sysio::underwriter::solana_source_deposit_page_scan_config config{
+      .sol_program_id = test_sol_program_id,
+      .marker_prefix = prefix,
+      .recomputed_hash = expected_hash,
+   };
+
+   const auto result = sysio::underwriter::scan_solana_source_deposit_signature_page(
+      sigs,
+      [&](const std::string& sig) -> fc::variant {
+         if (sig == error_sig) {
+            FC_THROW_EXCEPTION(fc::exception, "transient fetch failure");
+         }
+         return tx_by_sig.at(sig);
+      },
+      config);
+
+   BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::deferred);
+   BOOST_CHECK(!result.next_before);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_hard_fails_malformed_marker_hash) try {
+   const uint64_t deposit_id = 13;
+   const auto expected_hash = test_expected_hash();
+   const auto marker = marker_prefix(deposit_id) + "abc";
+   const std::string sig = "malformed-marker";
+
+   const std::vector<fc::variant> sigs{signature_entry(sig)};
+   const std::map<std::string, fc::variant> tx_by_sig{
+      {sig, transaction_with_logs(program_logs(test_sol_program_id, {marker}))},
+   };
+
+   const auto result = scan_test_page(sigs, tx_by_sig, expected_hash, deposit_id);
+
+   BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::hard_mismatch);
+   BOOST_CHECK(!result.next_before);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_hard_fails_partial_hex_parse) try {
+   const uint64_t deposit_id = 14;
+   const fc::crypto::keccak256 expected_zero_hash;
+   std::string malformed_zero_hash;
+   malformed_zero_hash.reserve(64);
+   for (size_t i = 0; i < 32; ++i) {
+      malformed_zero_hash += "0g";
+   }
+   const auto marker = marker_prefix(deposit_id) + malformed_zero_hash;
+   const std::string sig = "partial-hex-marker";
+
+   const std::vector<fc::variant> sigs{signature_entry(sig)};
+   const std::map<std::string, fc::variant> tx_by_sig{
+      {sig, transaction_with_logs(program_logs(test_sol_program_id, {marker}))},
+   };
+
+   const auto result = scan_test_page(sigs, tx_by_sig, expected_zero_hash, deposit_id);
+
+   BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::hard_mismatch);
+   BOOST_CHECK(!result.next_before);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_skips_failed_listing_transactions) try {
+   const uint64_t deposit_id = 15;
+   const auto expected_hash = test_expected_hash();
+   const auto marker = marker_prefix(deposit_id) + hash_hex(expected_hash);
+   const std::string sig = "failed-listing";
+
+   const std::vector<fc::variant> sigs{signature_entry(sig, "finalized", true)};
+   const std::map<std::string, fc::variant> tx_by_sig{
+      {sig, transaction_with_logs(program_logs(test_sol_program_id, {marker}))},
+   };
+
+   size_t fetch_count = 0;
+   const auto result = scan_test_page(sigs, tx_by_sig, expected_hash, deposit_id, &fetch_count);
+
+   BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::not_found);
+   BOOST_CHECK_EQUAL(fetch_count, 0);
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/plugins/underwriter_plugin/test/test_underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/test/test_underwriter_plugin.cpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <sysio/underwriter_plugin/solana_source_deposit_scanner.hpp>
@@ -215,6 +216,86 @@ BOOST_AUTO_TEST_CASE(knapsack_fallback_threshold_is_documented) try {
 // integration coverage via curl in the flow tests.
 BOOST_AUTO_TEST_CASE(http_endpoints_registered_at_startup) try {
    BOOST_CHECK(true);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_state_advances_across_pages) try {
+   sysio::underwriter::solana_source_deposit_scan_cursor_map cursors;
+   const sysio::underwriter::solana_source_deposit_scan_key key{
+      .uwreq_id = 42,
+      .deposit_id = 7,
+   };
+
+   const auto initial =
+      sysio::underwriter::get_or_create_solana_source_deposit_scan_cursor(cursors, key);
+   BOOST_CHECK(!initial.before);
+   BOOST_CHECK_EQUAL(initial.pages_scanned, 0);
+   BOOST_CHECK_EQUAL(initial.signatures_scanned, 0);
+
+   const auto first_page = sysio::underwriter::advance_solana_source_deposit_scan_cursor(
+      cursors, key, "page-0-last-signature", sysio::underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE);
+   BOOST_REQUIRE(first_page.before);
+   BOOST_CHECK_EQUAL(*first_page.before, "page-0-last-signature");
+   BOOST_CHECK_EQUAL(first_page.pages_scanned, 1);
+   BOOST_CHECK_EQUAL(first_page.signatures_scanned, sysio::underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE);
+
+   const auto second_page = sysio::underwriter::advance_solana_source_deposit_scan_cursor(
+      cursors, key, "page-1-last-signature", sysio::underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE);
+   BOOST_REQUIRE(second_page.before);
+   BOOST_CHECK_EQUAL(*second_page.before, "page-1-last-signature");
+   BOOST_CHECK_EQUAL(second_page.pages_scanned, 2);
+   BOOST_CHECK_EQUAL(second_page.signatures_scanned, sysio::underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE * 2);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_state_records_terminal_failure_once) try {
+   sysio::underwriter::solana_source_deposit_scan_cursor_map cursors;
+   const sysio::underwriter::solana_source_deposit_scan_key key{
+      .uwreq_id = 43,
+      .deposit_id = 8,
+   };
+
+   sysio::underwriter::advance_solana_source_deposit_scan_cursor(
+      cursors, key, "page-0-last-signature", sysio::underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE);
+   const auto first = sysio::underwriter::record_solana_source_deposit_terminal_failure(
+      cursors, key, "exhausted history", 17);
+   BOOST_CHECK(first.first_failure);
+   BOOST_CHECK(first.cursor.terminal_failure);
+   BOOST_CHECK_EQUAL(first.cursor.terminal_failure_reason, "exhausted history");
+   BOOST_CHECK_EQUAL(first.cursor.pages_scanned, 2);
+   BOOST_CHECK_EQUAL(first.cursor.signatures_scanned, sysio::underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE + 17);
+
+   const auto terminal =
+      sysio::underwriter::get_solana_source_deposit_terminal_failure(cursors, key);
+   BOOST_REQUIRE(terminal);
+   BOOST_CHECK_EQUAL(terminal->terminal_failure_reason, "exhausted history");
+
+   const auto repeated = sysio::underwriter::record_solana_source_deposit_terminal_failure(
+      cursors, key, "second failure should not replace first", 99);
+   BOOST_CHECK(!repeated.first_failure);
+   BOOST_CHECK_EQUAL(repeated.cursor.terminal_failure_reason, "exhausted history");
+   BOOST_CHECK_EQUAL(repeated.cursor.pages_scanned, 2);
+   BOOST_CHECK_EQUAL(repeated.cursor.signatures_scanned, sysio::underwriter::SOL_SIGNATURE_SCAN_PAGE_SIZE + 17);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_state_prunes_resolved_uwreqs) try {
+   sysio::underwriter::solana_source_deposit_scan_cursor_map cursors;
+   const sysio::underwriter::solana_source_deposit_scan_key pending_key{
+      .uwreq_id = 44,
+      .deposit_id = 9,
+   };
+   const sysio::underwriter::solana_source_deposit_scan_key resolved_key{
+      .uwreq_id = 45,
+      .deposit_id = 10,
+   };
+   sysio::underwriter::advance_solana_source_deposit_scan_cursor(
+      cursors, pending_key, "pending-last-signature", 3);
+   sysio::underwriter::record_solana_source_deposit_terminal_failure(
+      cursors, resolved_key, "resolved terminal failure", 5);
+
+   const std::unordered_set<uint64_t> still_pending{pending_key.uwreq_id};
+   sysio::underwriter::prune_solana_source_deposit_scan_cursors(cursors, still_pending);
+
+   BOOST_CHECK(cursors.contains(pending_key));
+   BOOST_CHECK(!cursors.contains(resolved_key));
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_finds_match_after_legacy_window) try {


### PR DESCRIPTION
## Summary
- Replaces the fixed latest-50 Solana signature scan with persisted per-UWREQ pagination using Solana `before` cursors and 1000-signature pages.
- Extracts the Solana page scanner into a pure helper that preserves program-log attribution, finalized gating, source-deposit hash verification, malformed-marker failure, and transient-fetch retry behavior.
- Adds terminal negative scan state for hard SOL verification failures so pending UWREQs do not repeatedly re-walk full program history or re-bump mismatch counters after exhaustion or a bad marker.
- Prunes Solana scan state with the pending-UWREQ lifecycle, clears it on match, and exposes separate active cursor / terminal failure counts in underwriter stats.
- Adds focused scanner and state tests for legacy-window starvation, multi-page cursor advancement, terminal failure caching, pending-state pruning, forged markers, unfinalized matches, fetch errors, malformed hashes, partial hex parsing, and failed listing transactions.

## Review Follow-Up
- Addressed the review finding about hard-fail amplification by caching terminal SOL verification failures until the UWREQ leaves `PENDING`.
- Addressed the review test-gap finding by extracting/test-covering the stateful cursor lifecycle helpers used by `verify_source_deposit_sol`.
- Left JSON-RPC batching/consecutive-page latency as performance follow-up scope; this PR preserves the conservative one-page-per-retry behavior while removing the starvation and repeated full-history re-walks.

## Validation
- `export NUM_JOBS="$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)"`
- `git diff --check`
- `cmake -B build/sec-40-release -S . -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON -DBUILD_OPP_BUNDLES=OFF -DCMAKE_TOOLCHAIN_FILE="$PWD/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-linux-release -DVCPKG_HOST_TRIPLET=x64-linux-release -DVCPKG_OVERLAY_TRIPLETS="$PWD/.github/vcpkg-triplets"`
- `cmake --build build/sec-40-release --target test_underwriter_plugin -- -j"$NUM_JOBS"`
- `ctest --test-dir build/sec-40-release -j"$NUM_JOBS" -R '^test_underwriter_plugin$' --output-on-failure`
- `cmake --build build/sec-40-release -- -j"$NUM_JOBS"`
- `ctest --test-dir build/sec-40-release -j"$NUM_JOBS" -LE "(nonparallelizable_tests|long_running_tests|wasm_spec_tests)" -E "^(version-label-test|full-version-label-test)$" --output-on-failure --timeout 1000` (324/324 passed)

Version-label note: `version-label-test` and `full-version-label-test` still fail in this local build because `APPBASE_ENABLE_AUTO_VERSION:BOOL=OFF` and `nodeop --version` / `--full-version` print `unknown`.
