### PR TITLE
SEC-41: Stop exposing npm token during OPP PR installs

### DIFF
--- a/.github/workflows/opp-bundles.yaml
+++ b/.github/workflows/opp-bundles.yaml
@@ -38,9 +38,9 @@ jobs:
           package_json_file: libraries/opp/tools/package.json
 
       - name: Install deps
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          # PR validation must not expose the npm publish token to dependency
+          # install lifecycle scripts; publishing is scoped to the push-only step.
           cd ./libraries/opp/tools
           pnpm install
         

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -105,7 +105,7 @@ cmake_workspace_build(
     pre_build_steps = [
         "npm i -g @protobuf-ts/plugin",
         "pnpm i -g @protobuf-ts/plugin",
-        "( cd libraries/opp/tools && pnpm install --force --no-frozen-lockfile && pnpm --filter 'proto*' dist )",
+        "( cd libraries/opp/tools && pnpm install --force --no-frozen-lockfile && pnpm --filter './proto*' dist )",
     ],
     tags = [
         "cpp",

--- a/libraries/opp/tools/scripts/generate-opp-bundles.fish
+++ b/libraries/opp/tools/scripts/generate-opp-bundles.fish
@@ -29,7 +29,9 @@ end
 # --- Setup & build tools ---
 pushd $tools_root
 pnpm install; or exit 1
-pnpm --filter "proto*" dist; or exit 1
+# Match the workspace package directories so scoped npm package names do not
+# bypass the OPP tool build on pnpm 10.
+pnpm --filter "./proto*" dist; or exit 1
 cd protoc-gen-solidity && pnpm link --global && cd ..; or exit 1
 cd protoc-gen-solana && pnpm link --global && cd ..; or exit 1
 cd protobuf-bundler && pnpm link --global && cd ..; or exit 1


### PR DESCRIPTION
## Summary

- stop exposing `secrets.NPM_TOKEN` to the OPP dependency install step used by pull-request validation
- keep the npm publish token scoped to the push-only publish step
- fix the OPP tooling pnpm filter from `proto*` to `./proto*` so pnpm 10 builds the actual workspace package directories before global linking

## Validation

- `CI=true pnpm install` from `libraries/opp/tools`
- `CI=true fish ./libraries/opp/tools/scripts/generate-opp-bundles.fish`
- confirmed `build/opp/{typescript,solidity,solana}` generation succeeds
- `git diff --check`
- YAML parse check: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/opp-bundles.yaml")); print("yaml ok")'`

## Notes

This keeps OPP bundle generation behavior intact for the platform e2e chain while removing the pre-merge npm-token exposure described by SEC-41 / WSA-092.

Follow-up for the mirrored local dev bootstrap script: Wire-Network/wire-devcontainer#2 updates `scripts/wire-local-setup.bash` to use the same `./proto*` pnpm path selector.