### PR TITLE
fix(tests): isolate bridge-topology shape file per test process

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -378,9 +378,17 @@ class Cluster(object):
         if topo=="bridge":
             shapeFilePrefix="shape_bridge"
             shapeFile=shapeFilePrefix+".json"
+            # Keep the shape file inside this cluster's per-process log directory. nodeopLogPath is
+            # uniquified by PID, so every test gets its own copy. Writing the bare relative filename
+            # instead would land it in the shared CWD ($BUILD_DIR); two "bridge" topology tests running
+            # concurrently (e.g. nodeop_snapshot_forked_test and nodeop_short_fork_take_over_test) would
+            # then read and write the same ./shape_bridge.json, racing and corrupting it. The reader
+            # (make_custom() in launcher.py) would observe a partially/doubly written document and fail
+            # with json.decoder.JSONDecodeError: "Extra data".
+            shapeFilePath=nodeopLogPath / shapeFile
             cmdArrForOutput=copy.deepcopy(argsArr)
             cmdArrForOutput.append("--output")
-            cmdArrForOutput.append(str(nodeopLogPath / shapeFile))
+            cmdArrForOutput.append(str(shapeFilePath))
             cmdArrForOutput.append("--shape")
             cmdArrForOutput.append("line")
             s=" ".join(cmdArrForOutput)
@@ -388,8 +396,8 @@ class Cluster(object):
             bridgeLauncher.define_network()
             bridgeLauncher.generate()
 
-            Utils.Print(f"opening {topo} shape file: {nodeopLogPath / shapeFile}")
-            f = open(nodeopLogPath / shapeFile, "r")
+            Utils.Print(f"opening {topo} shape file: {shapeFilePath}")
+            f = open(shapeFilePath, "r")
             shapeFileJsonStr = f.read()
             f.close()
             shapeFileObject = json.loads(shapeFileJsonStr)
@@ -468,12 +476,12 @@ class Cluster(object):
             connectGroup(producerGroup1, producerNodes, bridgeNodes)
             connectGroup(producerGroup2, producerNodes, bridgeNodes)
 
-            f=open(shapeFile,"w")
+            f=open(shapeFilePath,"w")
             f.write(json.dumps(shapeFileObject, indent=4, sort_keys=True))
             f.close()
 
             argsArr.append("--shape")
-            argsArr.append(shapeFile)
+            argsArr.append(str(shapeFilePath))
         else:
             argsArr.append("--shape")
             argsArr.append(topo)


### PR DESCRIPTION
## Problem

Flaky CI failures in the sharded NP/LR test run, e.g. [run 28247855204](https://github.com/Wire-Network/wire-sysio/actions/runs/28247855204/job/83691538579) where **two** tests failed:

- `nodeop_snapshot_forked_test`
- `nodeop_short_fork_take_over_test`

Both died in ~0.2s during cluster setup with:

```
json.decoder.JSONDecodeError: Extra data: line 117 column 2 (char 6380)
  at TestHarness/launcher.py:501  topo = json.load(source)   # make_custom()
```

Only the `ubuntu24` matrix leg failed; `ubsan`/`gcc`/`asserton`/`asan` passed — the timing-dependent signature of a race.

## Root cause

In `Cluster.py`, the `topo="bridge"` launch path writes a shape file twice. The *initial* shape is written to the per-process, PID-isolated log dir (`nodeopLogPath`), but the *modified* shape was written with a **bare relative filename**:

```python
f = open(shapeFile, "w")          # -> ./shape_bridge.json in the shared CWD ($BUILD_DIR)
...
argsArr.append("--shape"); argsArr.append(shapeFile)   # relative path handed to the launcher
```

There are three `topo="bridge"` tests. When two of them run concurrently (here, both started at the same second), they write and read the same `$BUILD_DIR/shape_bridge.json`. One reads it mid-write and `json.load` sees a complete document followed by trailing bytes → `Extra data`.

This also explains why the uploaded `shape_bridge.json` artifact looks clean: that's the *per-test* copy under `TestLogs/…`; the corrupted *shared* copy lived in `$BUILD_DIR` and was never uploaded. The `oc-compile` core dump in the same artifact is unrelated — these tests aborted in Python setup before any `nodeop` launched.

## Fix

Write the modified shape file into the cluster's per-process log directory (`nodeopLogPath`, uniquified by PID) — the same location already used for the initial write/read-back — and pass that absolute path to `--shape`. Each test gets its own copy; the shared-file race surface is gone.

