### PR TITLE
fix(tests): retry the ship_streamer jumbo transaction under CPU contention

### DIFF
--- a/tests/ship_streamer_test.py
+++ b/tests/ship_streamer_test.py
@@ -130,8 +130,22 @@ try:
                      "data": "",
                      "compression": "none"}]
     }
-    results = nonProdNode.pushTransaction(jumbotxn)
-    assert(results[0])
+    # The jumbotime action writes a ~33MB row but normally completes well under max_transaction_cpu_usage.
+    # CPU is billed by wall-clock elapsed time, so under the concurrent NP/LR test sharding the nodeop thread
+    # can be descheduled mid-execution (CPU starvation) and trip the deadline anyway -- the trx is aborted
+    # with tx_cpu_usage_exceeded the instant it crosses the limit, so the billed time only ever shows up just
+    # over it and is not a true measure of the work. Raising the limit wouldn't reliably help (a bad enough
+    # stall trips any limit), but the stall is transient: retry. clio rebuilds the transaction with a fresh
+    # ref block and expiration each attempt (no duplication), and the backoff lets contention subside first.
+    jumboMaxRetries = 5
+    results = (False, None)
+    for attempt in range(1, jumboMaxRetries + 1):
+        results = nonProdNode.pushTransaction(jumbotxn)
+        if results[0]:
+            break
+        Print(f"Jumbo transaction attempt {attempt}/{jumboMaxRetries} failed (likely transient CPU contention), retrying")
+        time.sleep(attempt)
+    assert results[0], f"Failed to land jumbo transaction after {jumboMaxRetries} attempts"
 
     Print("Configure and launch txn generators")
     targetTpsPerGenerator = 10

--- a/tests/ship_streamer_test.py
+++ b/tests/ship_streamer_test.py
@@ -143,9 +143,10 @@ try:
         results = nonProdNode.pushTransaction(jumbotxn)
         if results[0]:
             break
-        Print(f"Jumbo transaction attempt {attempt}/{jumboMaxRetries} failed (likely transient CPU contention), retrying")
-        time.sleep(attempt)
-    assert results[0], f"Failed to land jumbo transaction after {jumboMaxRetries} attempts"
+        if attempt < jumboMaxRetries:
+            Print(f"Jumbo transaction attempt {attempt}/{jumboMaxRetries} failed (likely transient CPU contention), retrying")
+            time.sleep(attempt)
+    assert results[0], f"Failed to land jumbo transaction after {jumboMaxRetries} attempts; last node response: {results[1]}"
 
     Print("Configure and launch txn generators")
     targetTpsPerGenerator = 10


### PR DESCRIPTION
## Problem

Flaky CI failures in the sharded NP/LR run, e.g. [run 28249152660](https://github.com/Wire-Network/wire-sysio/actions/runs/28249152660/job/83696026622) (gcc leg) where `ship_streamer_test` (and its `ship_streamer_if_fetch_finality_data_test` sibling, same script) failed at:

```
File ".../ship_streamer_test.py", line 134, in <module>
    assert(results[0])
AssertionError
```

The test pushes a deliberately large "jumbo" transaction — the `jumborow` contract writes ~33 MB across 132 `kv_set` rows — to produce a big block for the SHiP streamer. That push came back `status: exception` (`tx_cpu_usage_exceeded`, "executing for too long 377925us … max_transaction_cpu_usage 375000us"), and the single-attempt `assert(results[0])` blew up.

## Root cause

Transaction CPU is billed by **wall-clock elapsed time**. Under the recently enabled concurrent NP/LR test sharding, the `nodeop` thread can be descheduled mid-execution (CPU starvation), so the jumbo trips the deadline even though its real work is tiny. The reported `377925µs` is not the true cost — `checktime` aborts the transaction the instant it crosses the limit, so it always reads just over.

Measured locally, standalone (no contention), on a debug build:

```
jumbotime action: cpu_usage_us = 50457  (~50 ms), elapsed = 49950, ram delta = 34.6 MB
```

So it normally uses **~13% of the 375 ms budget** (a 7.4× margin); an optimized build is faster still. Raising `max_transaction_cpu_usage` would not reliably help — a long enough scheduling stall trips any limit, and the work itself is only ~50 ms.

## Fix

Retry the jumbo push a few times with backoff to ride out transient CPU contention. `clio` rebuilds the transaction with a fresh ref block and expiration on each attempt, so retries do not duplicate it. This matches the existing per-client retry already in this test.

## Verification

Ran `ship_streamer_test` standalone on a local debug build: **passes**, jumbo lands on the first attempt (retry loop never fires), so the change is inert on the normal path and only engages when an attempt is starved out.