### PR TITLE
Trace_api: bound action-range response cardinality

### DIFF
--- a/plugins/trace_api_plugin/include/sysio/trace_api/request_handler.hpp
+++ b/plugins/trace_api_plugin/include/sysio/trace_api/request_handler.hpp
@@ -68,10 +68,31 @@ namespace sysio::trace_api {
    };
 
    /**
+    * Soft ceiling on the number of action results materialized into a single get_actions /
+    * get_token_transfers response.  Complements the per-request block-window cap
+    * (trace-max-block-range): the window bounds how many blocks are scanned, this bounds how many
+    * matching actions are decoded, hex-serialized, and held in memory from that window, so a broad
+    * or unfiltered query over a busy range cannot materialize an unbounded response set.
+    *
+    * Enforced at block boundaries (see get_actions_impl): the scan stops once a fully scanned block
+    * brings the running total to this value, so a single response may exceed it by at most one
+    * block's worth of matching actions (itself bounded by consensus block limits).  Clients page
+    * past the ceiling by resuming the scan at actions_result::last_block_num + 1.
+    *
+    * Intentionally a hard-coded constant, NOT a nodeop configuration option: there is no setting to
+    * raise or disable it, so the bound holds on every node regardless of operator configuration.
+    */
+   inline constexpr uint32_t max_actions_per_response = 10'000;
+
+   /**
     * Result returned by get_actions.
     */
    struct actions_result {
       fc::variants actions;
+      /// Highest block number fully scanned by the request.  Equals the clamped block_num_end on a
+      /// complete scan; lower when max_actions_per_response stopped the scan early.  Clients resume
+      /// at last_block_num + 1.
+      uint32_t     last_block_num = 0;
    };
 
    /**
@@ -246,11 +267,14 @@ namespace sysio::trace_api {
        * Scan a block range for action traces matching the given filter.
        *
        * Blocks are scanned in ascending order.  Within each block, actions are visited in ascending
-       * global_sequence order.  All matching actions in the (caller-clamped) range are returned;
-       * the caller is responsible for capping block_num_end so that the response stays bounded.
+       * global_sequence order.  Matching actions in the (caller-clamped) block range are returned up
+       * to max_actions_per_response; if that ceiling is reached the scan stops at the next block
+       * boundary and actions_result::last_block_num reports the last block fully scanned, so the
+       * client can resume at last_block_num + 1.  Capping the block window itself remains the
+       * caller's responsibility (trace-max-block-range).
        *
        * @param query - filter parameters
-       * @return actions_result containing the matching actions
+       * @return actions_result with the matching actions and the last block scanned
        */
       actions_result get_actions(const action_query& query) {
          return get_actions_impl(query, variant_shape::full);
@@ -258,6 +282,7 @@ namespace sysio::trace_api {
 
       /// Slim response for get_token_transfers: transfer-relevant fields only.
       /// Omits execution-tree ordinals, receipt sequences, ram_deltas, and resource usage.
+      /// Subject to the same max_actions_per_response ceiling as get_actions.
       actions_result get_token_transfer_actions(const action_query& query) {
          return get_actions_impl(query, variant_shape::slim);
       }
@@ -297,6 +322,12 @@ namespace sysio::trace_api {
          // unvalidated client input on the HTTP path), so a uint32_t counter would wrap from UINT32_MAX
          // back to 0 at ++block_num and spin forever.  bn stays in [start, end+1] and never wraps; the
          // HTTP-side clamp is then only a range bound, not the sole thing preventing an infinite loop.
+
+         // Default to reporting a complete scan; lowered below only if the action ceiling stops us
+         // early.  On natural completion this stays at the clamped end, so trailing blocks with no
+         // recorded data are still counted as scanned and a client resumes past them, not before.
+         result.last_block_num = query.block_num_end;
+
          const uint64_t end = query.block_num_end;
          for (uint64_t bn = query.block_num_start; bn <= end; ++bn) {
             // bn <= end <= UINT32_MAX throughout the loop body, so this narrowing is value-preserving.
@@ -389,6 +420,15 @@ namespace sysio::trace_api {
                   }
                }
             }, std::get<0>(*data));
+
+            // Stop at this block boundary once the response reaches the ceiling.  The current block
+            // was scanned in full above, so no partial block is ever returned and a client resuming
+            // at last_block_num + 1 neither skips nor duplicates actions.  Worst-case overshoot is
+            // one block's matching actions.
+            if (result.actions.size() >= max_actions_per_response) {
+               result.last_block_num = block_num;
+               break;
+            }
          }
 
          return result;

--- a/plugins/trace_api_plugin/src/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/src/trace_api_plugin.cpp
@@ -410,7 +410,7 @@ struct trace_api_rpc_plugin_impl : public std::enable_shared_from_this<trace_api
             auto result = self->req_handler->get_actions(query);
             cb( 200, fc::mutable_variant_object()
                         ("block_num_start", query.block_num_start)
-                        ("block_num_end",   query.block_num_end)
+                        ("block_num_end",   result.last_block_num)
                         ("actions",         result.actions) );
          } catch (...) {
             http_plugin::handle_exception("trace_api", "get_actions", body, cb);
@@ -459,7 +459,7 @@ struct trace_api_rpc_plugin_impl : public std::enable_shared_from_this<trace_api
             auto result = self->req_handler->get_token_transfer_actions(query);
             cb( 200, fc::mutable_variant_object()
                         ("block_num_start", query.block_num_start)
-                        ("block_num_end",   query.block_num_end)
+                        ("block_num_end",   result.last_block_num)
                         ("transfers",       result.actions) );
          } catch (...) {
             http_plugin::handle_exception("trace_api", "get_token_transfers", body, cb);

--- a/plugins/trace_api_plugin/src/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/src/trace_api_plugin.cpp
@@ -171,8 +171,9 @@ struct trace_api_common_impl {
       cfg_options("trace-max-block-range", bpo::value<uint32_t>()->default_value(default_max_block_range),
                   "Maximum number of blocks scanned by a single get_actions or get_token_transfers request.\n"
                   "Must be in [1, 10000]. block_num_end is silently clamped to block_num_start + this - 1.\n"
-                  "Clients paginate by advancing block_num_start by this amount each call. The response\n"
-                  "envelope reports the actual range scanned.");
+                  "The response envelope reports the actual range scanned; clients paginate by resuming\n"
+                  "block_num_start at the response's block_num_end + 1 (which also absorbs early stops from\n"
+                  "the per-response action ceiling).");
    }
 
    void plugin_initialize(const appbase::variables_map& options) {

--- a/plugins/trace_api_plugin/src/trace_api_plugin.cpp
+++ b/plugins/trace_api_plugin/src/trace_api_plugin.cpp
@@ -171,9 +171,10 @@ struct trace_api_common_impl {
       cfg_options("trace-max-block-range", bpo::value<uint32_t>()->default_value(default_max_block_range),
                   "Maximum number of blocks scanned by a single get_actions or get_token_transfers request.\n"
                   "Must be in [1, 10000]. block_num_end is silently clamped to block_num_start + this - 1.\n"
-                  "The response envelope reports the actual range scanned; clients paginate by resuming\n"
-                  "block_num_start at the response's block_num_end + 1 (which also absorbs early stops from\n"
-                  "the per-response action ceiling).");
+                  "The response reports the last block actually scanned as block_num_end. To page, set the\n"
+                  "next request's block_num_start to block_num_end + 1; do not advance by a fixed step,\n"
+                  "because the scan can also stop short of the requested end when a response reaches the\n"
+                  "per-response limit on the number of actions returned.");
    }
 
    void plugin_initialize(const appbase::variables_map& options) {

--- a/plugins/trace_api_plugin/test/test_get_actions.cpp
+++ b/plugins/trace_api_plugin/test/test_get_actions.cpp
@@ -156,6 +156,21 @@ static const chain::transaction_id_type TRX2 =
 static const chain::transaction_id_type TRX3 =
    "0000000000000000000000000000000000000000000000000000000000000003"_h;
 
+// Build a block whose single transaction carries `count` matching actions with sequential
+// global_sequences starting at `first_seq`.  Used by the response-ceiling tests, which need to
+// drive the matching-action count above max_actions_per_response.  receiver/account/action default
+// to the values matched by the get_token_transfers filter so the same builder feeds both shapes.
+block_trace_v0 make_block_with_actions(uint32_t block_num, uint32_t count, uint64_t first_seq,
+                                       chain::name receiver = "sysio.token"_n,
+                                       chain::name account  = "sysio.token"_n,
+                                       chain::name act      = "transfer"_n) {
+   std::vector<action_trace_v0> actions;
+   actions.reserve(count);
+   for (uint32_t i = 0; i < count; ++i)
+      actions.push_back(make_action(first_seq + i, receiver, account, act));
+   return make_block(block_num, { make_trx(TRX1, block_num, std::move(actions)) });
+}
+
 } // anonymous namespace
 
 // ---------------------------------------------------------------------------
@@ -911,6 +926,149 @@ BOOST_AUTO_TEST_CASE(clamp_query_end_to_recorded_bounds_scan) {
       clamp_query_end_to_recorded(q, /*last_recorded=*/0);
       BOOST_TEST(q.block_num_end == 0u);
    }
+}
+
+// ---------------------------------------------------------------------------
+// Response cardinality ceiling (max_actions_per_response)
+// ---------------------------------------------------------------------------
+// The block window bounds how many blocks are scanned; max_actions_per_response bounds how many
+// matching actions are materialized from that window, so a broad query cannot build an unbounded
+// response.  The scan stops at a block boundary once the ceiling is reached: the last block is
+// returned in full (never partial) and last_block_num reports it, so a client resumes at
+// last_block_num + 1 without skipping or duplicating an action.
+
+// Under the ceiling the whole requested window is reported as scanned -- including trailing blocks
+// that held no data -- so a resuming client advances past them instead of re-scanning.
+BOOST_FIXTURE_TEST_CASE(under_ceiling_reports_requested_end, get_actions_fixture)
+{
+   blocks[1] = make_block(1, { make_trx(TRX1, 1, { make_action(1, "a"_n, "tok"_n, "transfer"_n) }) });
+   blocks[2] = make_block(2, { make_trx(TRX2, 2, { make_action(2, "a"_n, "tok"_n, "transfer"_n) }) });
+
+   action_query q;
+   q.block_num_start = 1;
+   q.block_num_end   = 5;   // blocks 3..5 hold no data
+
+   auto r = get_actions(q);
+
+   BOOST_REQUIRE_EQUAL(r.actions.size(), 2u);
+   BOOST_TEST(r.last_block_num == 5u);
+}
+
+// Crossing the ceiling across several blocks stops the scan at a block boundary: the result holds a
+// whole number of blocks, overshoots the ceiling by less than one block, and last_block_num is below
+// the requested end.
+BOOST_FIXTURE_TEST_CASE(ceiling_truncates_at_block_boundary, get_actions_fixture)
+{
+   constexpr uint32_t per_block = 1000;
+   const uint32_t stop_block   = (max_actions_per_response + per_block - 1) / per_block;
+   const uint32_t total_blocks = stop_block + 5;
+
+   uint64_t seq = 1;
+   for (uint32_t b = 1; b <= total_blocks; ++b, seq += per_block)
+      blocks[b] = make_block_with_actions(b, per_block, seq);
+
+   action_query q;
+   q.block_num_start = 1;
+   q.block_num_end   = total_blocks;
+
+   auto r = get_actions(q);
+
+   BOOST_TEST(r.actions.size() >= static_cast<size_t>(max_actions_per_response));
+   BOOST_TEST(r.actions.size() <  static_cast<size_t>(max_actions_per_response) + per_block);
+   BOOST_REQUIRE_EQUAL(r.actions.size(), static_cast<size_t>(per_block) * stop_block);
+   BOOST_TEST(r.last_block_num == stop_block);
+   BOOST_TEST(r.last_block_num <  q.block_num_end);
+
+   // No action from beyond the reported boundary leaked into the result.
+   for (const auto& a : r.actions) {
+      const uint32_t bn = a.get_object()["block_num"].as<uint32_t>();
+      BOOST_TEST(bn >= 1u);
+      BOOST_TEST(bn <= r.last_block_num);
+   }
+}
+
+// A single block whose matching actions exceed the ceiling is still returned in full (forward
+// progress -- the client never gets stuck unable to page past it), and the scan stops there rather
+// than spilling into later blocks.
+BOOST_FIXTURE_TEST_CASE(single_block_over_ceiling_returns_full_block, get_actions_fixture)
+{
+   const uint32_t count = max_actions_per_response + 500;
+   blocks[1] = make_block_with_actions(1, count, 1);
+   blocks[2] = make_block_with_actions(2, 10, uint64_t{count} + 1);  // must not be scanned
+
+   action_query q;
+   q.block_num_start = 1;
+   q.block_num_end   = 2;
+
+   auto r = get_actions(q);
+
+   BOOST_REQUIRE_EQUAL(r.actions.size(), static_cast<size_t>(count));
+   BOOST_TEST(r.last_block_num == 1u);
+   for (const auto& a : r.actions)
+      BOOST_TEST(a.get_object()["block_num"].as<uint32_t>() == 1u);
+}
+
+// Resuming from last_block_num + 1 after a truncation yields the remaining actions with no gap and
+// no duplicate: the two pages together cover the full global_sequence range exactly once.
+BOOST_FIXTURE_TEST_CASE(resume_after_ceiling_has_no_gap_or_duplicate, get_actions_fixture)
+{
+   constexpr uint32_t per_block  = 1000;
+   const uint32_t stop_block     = (max_actions_per_response + per_block - 1) / per_block;
+   const uint32_t total_blocks   = stop_block + 3;
+   const uint64_t total_actions  = static_cast<uint64_t>(per_block) * total_blocks;
+
+   uint64_t seq = 1;
+   for (uint32_t b = 1; b <= total_blocks; ++b, seq += per_block)
+      blocks[b] = make_block_with_actions(b, per_block, seq);
+
+   action_query q1;
+   q1.block_num_start = 1;
+   q1.block_num_end   = total_blocks;
+   auto r1 = get_actions(q1);
+   BOOST_TEST(r1.last_block_num < total_blocks);    // first page truncated
+
+   action_query q2;
+   q2.block_num_start = r1.last_block_num + 1;
+   q2.block_num_end   = total_blocks;
+   auto r2 = get_actions(q2);
+   BOOST_TEST(r2.last_block_num == total_blocks);    // remaining fits in one page
+
+   std::set<uint64_t> seqs;
+   for (const auto& a : r1.actions) seqs.insert(a.get_object()["global_sequence"].as_uint64());
+   for (const auto& a : r2.actions) seqs.insert(a.get_object()["global_sequence"].as_uint64());
+
+   // No duplicates across pages, and the union is the contiguous full set [1, total_actions].
+   BOOST_REQUIRE_EQUAL(r1.actions.size() + r2.actions.size(), static_cast<size_t>(total_actions));
+   BOOST_REQUIRE_EQUAL(seqs.size(), static_cast<size_t>(total_actions));
+   BOOST_TEST(*seqs.begin()  == 1u);
+   BOOST_TEST(*seqs.rbegin() == total_actions);
+}
+
+// get_token_transfers funnels through the same get_actions_impl, so the ceiling applies to the slim
+// shape identically.
+BOOST_FIXTURE_TEST_CASE(ceiling_applies_to_token_transfers, get_actions_fixture)
+{
+   constexpr uint32_t per_block = 1000;
+   const uint32_t stop_block   = (max_actions_per_response + per_block - 1) / per_block;
+   const uint32_t total_blocks = stop_block + 2;
+
+   uint64_t seq = 1;
+   for (uint32_t b = 1; b <= total_blocks; ++b, seq += per_block)
+      blocks[b] = make_block_with_actions(b, per_block, seq);  // receiver==account==sysio.token, transfer
+
+   action_query q;
+   q.block_num_start = 1;
+   q.block_num_end   = total_blocks;
+   q.receiver        = "sysio.token"_n;
+   q.account         = "sysio.token"_n;
+   q.action          = "transfer"_n;
+
+   auto r = get_token_transfer_actions(q);
+
+   BOOST_TEST(r.actions.size() >= static_cast<size_t>(max_actions_per_response));
+   BOOST_TEST(r.actions.size() <  static_cast<size_t>(max_actions_per_response) + per_block);
+   BOOST_TEST(r.last_block_num == stop_block);
+   BOOST_TEST(r.last_block_num <  q.block_num_end);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/plugins/trace_api_plugin/trace_api_plugin.md
+++ b/plugins/trace_api_plugin/trace_api_plugin.md
@@ -312,11 +312,14 @@ for the cursor pattern.
 
 `block_num_start` and `block_num_end` on the response reflect the actual
 range scanned (after clamping), so a client can detect a clamp and
-resume pagination from `block_num_end + 1`.  Because the server also
-clamps to its last recorded block, resuming at `block_num_end + 1` can
-never skip blocks that had not been produced (or recorded) at the time
-of the request.  When nothing in the requested window has been recorded
-yet, the response carries `block_num_end == block_num_start - 1`
+resume pagination from `block_num_end + 1`.  The reported `block_num_end`
+is also reduced when a response reaches the `max_actions_per_response`
+ceiling (see the [Pagination guide](#pagination-guide)); the resume rule
+is identical.  Because the server also clamps to its last recorded block,
+resuming at `block_num_end + 1` can never skip blocks that had not been
+produced (or recorded) at the time of the request.  When nothing in the
+requested window has been recorded yet, the response carries
+`block_num_end == block_num_start - 1`
 ("nothing scanned") — retry the same `block_num_start` later.
 
 **Response fields:**
@@ -324,8 +327,8 @@ yet, the response carries `block_num_end == block_num_start - 1`
 | Field | Description |
 |-------|-------------|
 | `block_num_start` | First block number actually scanned. |
-| `block_num_end` | Last block number actually scanned (after clamping to the range cap and the last recorded block). |
-| `actions` | Array of matching action objects, ordered by `(block_num, global_sequence)`. |
+| `block_num_end` | Last block number actually scanned. Reduced below the requested end by the `trace-max-block-range` window, the last recorded block, or the `max_actions_per_response` (10,000) action ceiling — whichever stops the scan first. Resume the next page at `block_num_end + 1`. |
+| `actions` | Array of matching action objects, ordered by `(block_num, global_sequence)`. Capped per response by `max_actions_per_response` (see the Pagination guide). |
 
 **Action object fields:**
 
@@ -467,6 +470,12 @@ just as much as general action consumers. See the `get_actions` field
 table above for its semantics, including the irreversible-mode operator
 note.
 
+Pagination is identical to `get_actions`: the same `trace-max-block-range`
+window and `max_actions_per_response` (10,000) ceiling apply, with matched
+transfers counted toward the ceiling, and the response's `block_num_end`
+drives the `block_num_end + 1` resume cursor.  See the
+[Pagination guide](#pagination-guide).
+
 **Error responses:**
 
 | Code | Condition |
@@ -484,14 +493,32 @@ clamped to `block_num_start + trace-max-block-range - 1` if the client asks
 for more. The response always includes the actual `block_num_start` and
 `block_num_end` scanned so the client can page reliably.
 
-Within that window, ALL matching actions are returned — there is no
-per-result limit and no in-window cursor.
+Within that window the number of actions returned in one response is
+bounded by a hard ceiling, `max_actions_per_response` (10,000). This
+complements the block-window cap: the window bounds how many blocks are
+scanned, the action ceiling bounds how many matching actions are decoded,
+serialized, and held in memory, so a broad or unfiltered query over a
+busy range cannot materialize an unbounded result set. The ceiling is a
+hard-coded constant, not a nodeop setting — it cannot be raised or
+disabled, so the bound holds on every node.
 
-The server clamps the reported `block_num_end` twice: to the
-`trace-max-block-range` window AND to the last block it has actually
-recorded.  Resuming at `block_num_end + 1` is therefore always safe:
-blocks that had not been produced (or had not reached this node) when
-you asked are never reported as scanned, so they cannot be skipped.
+The ceiling is enforced at block boundaries: the scan stops once a fully
+scanned block brings the running action total to the ceiling, and the
+response's `block_num_end` is set to that last fully-scanned block. A
+response is never split in the middle of a block, so it may exceed the
+ceiling by at most one block's worth of matching actions (itself bounded
+by consensus block limits). Resume at `block_num_end + 1` exactly as for
+the block-window clamp — block-boundary truncation means resuming neither
+skips nor duplicates actions.
+
+The server therefore reduces the reported `block_num_end` below the
+requested end for any of three reasons: the `trace-max-block-range`
+window, the last block it has actually recorded, or the
+`max_actions_per_response` ceiling.  Resuming at `block_num_end + 1` is
+safe in all three cases: blocks that had not been produced (or had not
+reached this node) when you asked are never reported as scanned, so they
+cannot be skipped, and a truncated block is always reported either as
+fully scanned or not at all.
 
 To page across a wide range, advance `block_num_start` to the response's
 `block_num_end + 1` each call:
@@ -511,11 +538,13 @@ POST /v1/trace_api/get_actions
 ```
 
 Continue until `block_num_end` returned by the server equals the
-requested `block_num_end` (no clamp happened).  When you catch up to the
-chain head, the server's recorded-block clamp shrinks the reported
-window for you: a response with `block_num_end < block_num_start` means
-nothing new is scannable yet — wait and retry the same
-`block_num_start`.
+requested `block_num_end` (no truncation happened).  The same loop
+absorbs the action ceiling transparently: over a busy range a single
+window may take several requests to cross, each resuming at the previous
+`block_num_end + 1`.  When you catch up to the chain head, the server's
+recorded-block clamp shrinks the reported window for you: a response with
+`block_num_end < block_num_start` means nothing new is scannable yet —
+wait and retry the same `block_num_start`.
 
 Notes:
 - Within each transaction, actions are sorted by `global_sequence`
@@ -524,9 +553,12 @@ Notes:
 - The maximum supported `trace-max-block-range` is 10,000. Raise it via
   `config.ini` on private/trusted nodes; public nodes should typically
   leave it at the default.
-- There is no per-response row cap: the range cap bounds scan work, not
-  result volume.  A busy receiver over a 10,000-block window can produce
-  a very large response — size your window to your traffic.
+- A response carries at most `max_actions_per_response` (10,000) matching
+  actions plus the overflow from the final block, then stops at that
+  block boundary (reported via `block_num_end`).  This caps result volume
+  independently of the block-window cap, so a busy receiver over a wide
+  window is paged across multiple responses instead of returned all at
+  once.
 - Retention pruning (`trace-minimum-irreversible-history-blocks`) deletes
   old slices.  A query into a pruned range returns an empty result
   indistinguishable from "no matches" — indexers backfilling history must

--- a/plugins/trace_api_plugin/trace_api_plugin.md
+++ b/plugins/trace_api_plugin/trace_api_plugin.md
@@ -538,9 +538,9 @@ POST /v1/trace_api/get_actions
 ```
 
 Continue until `block_num_end` returned by the server equals the
-requested `block_num_end` (no truncation happened).  The same loop
-absorbs the action ceiling transparently: over a busy range a single
-window may take several requests to cross, each resuming at the previous
+requested `block_num_end` (no truncation happened).  The same loop also
+handles the action ceiling: over a busy range a single window may take
+several requests to cross, each resuming at the previous
 `block_num_end + 1`.  When you catch up to the chain head, the server's
 recorded-block clamp shrinks the reported window for you: a response with
 `block_num_end < block_num_start` means nothing new is scannable yet —


### PR DESCRIPTION
## Summary

`/v1/trace_api/get_actions` and `/v1/trace_api/get_token_transfers` clamp the block window they scan (`trace-max-block-range`, default 1000 / max 10000) but do not bound the number of matching actions returned from that window. `get_actions_impl()` appends every match -- ABI-decoded and hex-serialized -- to the response array with no ceiling, so a single small request over a transfer-heavy or unfiltered range can make the node materialize a very large `actions`/`transfers` array (memory + HTTP-worker CPU), degrading the trace/debug service.

## Change

- Add `max_actions_per_response`, a **hard-coded** soft ceiling on the actions materialized per response. It is deliberately a compile-time constant and **not** a nodeop configuration option -- there is no setting to raise or disable it, so the bound holds on every node regardless of operator configuration.
- The ceiling is enforced at block boundaries: the scan stops once a fully scanned block brings the running total to it. A block is never returned partially, so no action within the reported range is omitted; worst-case overshoot is one block's matches (itself bounded by consensus block limits).
- `actions_result` carries `last_block_num` (the highest block fully scanned). Both handlers report it as `block_num_end`, so clients resume at `block_num_end + 1` with no gap or duplicate -- the same block-range pagination the block-window clamp already relies on.
- Unit tests cover truncation at a block boundary, single-block-over-ceiling forward progress, gap/duplicate-free resume, and get_token_transfers parity.

## Notes

- No wall-clock deadline is used: the handlers run on the HTTP thread pool and never block the chain thread, and the block-range cap together with the action ceiling already bounds blocks scanned, actions decoded, and bytes serialized.
- Response shape is unchanged; `block_num_end` differs from prior behavior only when the ceiling truncates a scan.

Jira: https://wire-network.atlassian.net/browse/SEC-64 (WSA-145)
