### PR TITLE
Http: count request bodies against the in-flight byte budget

### DIFF
--- a/plugins/http_plugin/include/sysio/http_plugin/beast_http_session.hpp
+++ b/plugins/http_plugin/include/sysio/http_plugin/beast_http_session.hpp
@@ -464,11 +464,13 @@ public:
       }
    }
 
-   void increment_bytes_in_flight(size_t sz) {
+   /// @copydoc detail::abstract_conn::increment_bytes_in_flight
+   virtual void increment_bytes_in_flight(size_t sz) final {
       plugin_state_->bytes_in_flight += sz;
    }
 
-   void decrement_bytes_in_flight(size_t sz) {
+   /// @copydoc detail::abstract_conn::decrement_bytes_in_flight
+   virtual void decrement_bytes_in_flight(size_t sz) final {
       plugin_state_->bytes_in_flight -= sz;
    }
 

--- a/plugins/http_plugin/include/sysio/http_plugin/common.hpp
+++ b/plugins/http_plugin/include/sysio/http_plugin/common.hpp
@@ -60,6 +60,13 @@ struct abstract_conn {
    virtual ~abstract_conn() = default;
    virtual std::string verify_max_bytes_in_flight(size_t extra_bytes) = 0;
    virtual std::string verify_max_requests_in_flight() = 0;
+
+   /// Reserve sz bytes against the bytes_in_flight budget. Used to account for request/response payload
+   /// memory held while work is in flight. Must be paired with exactly one decrement_bytes_in_flight(sz).
+   virtual void increment_bytes_in_flight(size_t sz) = 0;
+
+   /// Release sz bytes previously reserved with increment_bytes_in_flight.
+   virtual void decrement_bytes_in_flight(size_t sz) = 0;
    virtual void send_busy_response(std::string&& what) = 0;
    virtual void handle_exception() = 0;
 

--- a/plugins/http_plugin/src/http_plugin.cpp
+++ b/plugins/http_plugin/src/http_plugin.cpp
@@ -7,9 +7,11 @@
 #include <fc/log/logger_config.hpp>
 #include <fc/reflect/variant.hpp>
 #include <fc/network/listener.hpp>
+#include <fc/scoped_exit.hpp>
 
 #include <boost/asio.hpp>
 
+#include <functional>
 #include <memory>
 #include <regex>
 
@@ -132,7 +134,8 @@ namespace sysio {
           * Make an internal_url_handler that will run the url_handler on the app() thread and then
           * return to the http thread pool for response processing
           *
-          * @pre b.size() has been added to bytes_in_flight by caller
+          * The returned handler reserves the request body against bytes_in_flight on admission and releases
+          * it (via a shared scoped_exit) when the posted app-thread work completes or is discarded.
           * @param priority - priority to post to the app thread at
           * @param to_queue - execution queue to post to
           * @param next - the next handler for responses
@@ -148,8 +151,21 @@ namespace sysio {
                        ( detail::abstract_conn_ptr conn, string&& r, string&& b, url_response_callback&& then ) {
                if (auto error_str = conn->verify_max_bytes_in_flight(b.size()); !error_str.empty()) {
                   conn->send_busy_response(std::move(error_str));
-                  return;
+                  return; // admission rejected before any reservation was made, nothing to release
                }
+
+               // The request body is about to be moved into the (unbounded) app-thread queue, where it can
+               // sit until a possibly-slow handler runs. Reserve its bytes against bytes_in_flight now that
+               // admission passed so that the memory is visible to concurrent verify_max_bytes_in_flight()
+               // checks instead of accumulating uncounted. The reservation is released exactly once when the
+               // posted work below is destroyed -- whether it runs to completion, throws, returns early on
+               // shutdown, or is discarded unrun when the queue is cleared. The guard is held through a
+               // shared_ptr so the posted lambda stays copyable (as boost::asio::post requires) and so the
+               // release fires only when the final copy of the lambda is destroyed.
+               const size_t body_size = b.size();
+               conn->increment_bytes_in_flight(body_size);
+               auto body_in_flight_guard = std::make_shared<fc::scoped_exit<std::function<void()>>>(
+                     [conn, body_size]() { conn->decrement_bytes_in_flight(body_size); } );
 
                url_response_callback wrapped_then = [then=std::move(then)](int code, std::optional<fc::variant> resp) {
                   then(code, std::move(resp));
@@ -158,7 +174,7 @@ namespace sysio {
                // post to the app thread taking shared ownership of next (via std::shared_ptr),
                // sole ownership of the tracked body and the passed in parameters
                // we can't std::move() next_ptr because we post a new lambda for each http request and we need to keep the original
-               app().executor().post( priority, to_queue, [next_ptr, conn=std::move(conn), r=std::move(r), b = std::move(b), wrapped_then=std::move(wrapped_then)]() mutable {
+               app().executor().post( priority, to_queue, [next_ptr, conn=std::move(conn), r=std::move(r), b = std::move(b), wrapped_then=std::move(wrapped_then), body_in_flight_guard=std::move(body_in_flight_guard)]() mutable {
                   try {
                      if( app().is_quiting() ) return; // http_plugin shutting down, do not call callback
                      // call the `next` url_handler and wrap the response handler
@@ -174,7 +190,8 @@ namespace sysio {
          /**
           * Make an internal_url_handler that will run the url_handler directly
           *
-          * @pre b.size() has been added to bytes_in_flight by caller
+          * Runs inline on the http thread with no app-thread queueing, so the request body does not linger
+          * in a queue and is not separately reserved against bytes_in_flight here.
           * @param next - the next handler for responses
           * @return the constructed internal_url_handler
           */

--- a/plugins/http_plugin/src/http_plugin.cpp
+++ b/plugins/http_plugin/src/http_plugin.cpp
@@ -7,7 +7,6 @@
 #include <fc/log/logger_config.hpp>
 #include <fc/reflect/variant.hpp>
 #include <fc/network/listener.hpp>
-#include <fc/scoped_exit.hpp>
 
 #include <boost/asio.hpp>
 
@@ -22,6 +21,27 @@ namespace sysio {
          static fc::logger log{ "http_plugin" };
          return log;
       }
+
+      /**
+       * RAII reservation against http_plugin_state::bytes_in_flight.  The increment runs in the
+       * constructor and the decrement in the destructor, so the reservation is bound to a successfully
+       * constructed guard: if allocating the guard throws (e.g. std::bad_alloc while admitting a request
+       * under memory pressure) the increment never runs, and once constructed the matching decrement is
+       * guaranteed exactly once when the guard is destroyed.  Held via shared_ptr at the call site so the
+       * posted app-thread lambda stays copyable (boost::asio::post requires a copyable handler) and the
+       * release fires only when the final copy is destroyed.
+       */
+      struct bytes_in_flight_reservation {
+         detail::abstract_conn_ptr conn;
+         size_t                    size = 0;
+
+         bytes_in_flight_reservation(detail::abstract_conn_ptr c, size_t sz)
+            : conn(std::move(c)), size(sz) { conn->increment_bytes_in_flight(size); }
+         ~bytes_in_flight_reservation() { conn->decrement_bytes_in_flight(size); }
+
+         bytes_in_flight_reservation(const bytes_in_flight_reservation&) = delete;
+         bytes_in_flight_reservation& operator=(const bytes_in_flight_reservation&) = delete;
+      };
    }
 
    using std::vector;
@@ -135,7 +155,7 @@ namespace sysio {
           * return to the http thread pool for response processing
           *
           * The returned handler reserves the request body against bytes_in_flight on admission and releases
-          * it (via a shared scoped_exit) when the posted app-thread work completes or is discarded.
+          * it (via a shared bytes_in_flight_reservation) when the posted app-thread work completes or is discarded.
           * @param priority - priority to post to the app thread at
           * @param to_queue - execution queue to post to
           * @param next - the next handler for responses
@@ -155,17 +175,12 @@ namespace sysio {
                }
 
                // The request body is about to be moved into the (unbounded) app-thread queue, where it can
-               // sit until a possibly-slow handler runs. Reserve its bytes against bytes_in_flight now that
-               // admission passed so that the memory is visible to concurrent verify_max_bytes_in_flight()
-               // checks instead of accumulating uncounted. The reservation is released exactly once when the
+               // sit until a possibly-slow handler runs.  Reserve its bytes against bytes_in_flight now that
+               // admission passed, so the queued memory is visible to concurrent verify_max_bytes_in_flight()
+               // checks instead of accumulating uncounted.  The reservation is released exactly once when the
                // posted work below is destroyed -- whether it runs to completion, throws, returns early on
-               // shutdown, or is discarded unrun when the queue is cleared. The guard is held through a
-               // shared_ptr so the posted lambda stays copyable (as boost::asio::post requires) and so the
-               // release fires only when the final copy of the lambda is destroyed.
-               const size_t body_size = b.size();
-               conn->increment_bytes_in_flight(body_size);
-               auto body_in_flight_guard = std::make_shared<fc::scoped_exit<std::function<void()>>>(
-                     [conn, body_size]() { conn->decrement_bytes_in_flight(body_size); } );
+               // shutdown, or is discarded unrun when the queue is cleared.
+               auto body_in_flight_guard = std::make_shared<bytes_in_flight_reservation>(conn, b.size());
 
                url_response_callback wrapped_then = [then=std::move(then)](int code, std::optional<fc::variant> resp) {
                   then(code, std::move(resp));

--- a/plugins/http_plugin/test/unit_tests.cpp
+++ b/plugins/http_plugin/test/unit_tests.cpp
@@ -39,6 +39,7 @@ constexpr uint32_t category_rw_index = 1;
 constexpr uint32_t category_ro_index = 2;
 constexpr uint32_t bytes_in_flight_index = 3;
 constexpr uint32_t requests_in_flight_index = 4;
+constexpr uint32_t request_body_bytes_in_flight_index = 5;
 // Keeps unsharded IPv6 probe coverage on the historical port 9999.
 constexpr uint32_t ipv6_probe_index = 2;
 
@@ -725,6 +726,78 @@ BOOST_FIXTURE_TEST_CASE(bytes_in_flight, http_plugin_test_fixture) {
       ilog( "response: {}, count: {}", std::string(obsolete_reason(e.first)), e.second );
    }
    BOOST_REQUIRE_EQUAL(r[boost::beast::http::status::ok], 8u);
+}
+
+// Regression test for request bodies queued to the app thread being accounted against the bytes_in_flight
+// budget. The handler samples the budget while the request body is still in flight (after admission/reservation
+// but before the response payload is accounted), so the sampled value reflects only the request-body
+// reservation. Without request-body accounting that sample is 0; with it, the in-flight body is counted. The
+// budget must also return to zero after the request completes, proving the reservation is released exactly once.
+BOOST_FIXTURE_TEST_CASE(request_body_bytes_in_flight, http_plugin_test_fixture) {
+   const std::string endpoint = test_http_endpoint("127.0.0.1", request_body_bytes_in_flight_index);
+   const std::string server_address = "--http-server-address=" + endpoint;
+   const std::string port = test_http_port(request_body_bytes_in_flight_index);
+
+   http_plugin* http_plugin = init({"--plugin=sysio::http_plugin",
+                                    server_address.c_str(),
+                                    "--http-max-bytes-in-flight-mb=64"});
+   BOOST_REQUIRE(http_plugin);
+
+   std::atomic<size_t> observed_body_size{0};
+   std::atomic<size_t> observed_bytes_in_flight{0};
+   http_plugin->add_api({{std::string("/echo_body"), api_category::node,
+                          [&](string&&, string&& body, url_response_callback&& cb) {
+                             // Sampled on the app thread while the request body is still in flight and before the
+                             // response payload is accounted, so it reflects only the request-body reservation.
+                             observed_body_size.store(body.size());
+                             observed_bytes_in_flight.store(http_plugin->bytes_in_flight());
+                             cb(200, "ok");
+                          }}}, appbase::exec_queue::read_write);
+
+   boost::asio::io_context ctx;
+   boost::asio::ip::tcp::resolver resolver(ctx);
+
+   // 1 MiB body: comfortably under the 2 MiB max-body-size and the 64 MiB in-flight budget.
+   const size_t body_size = 1024 * 1024;
+
+   auto post_body = [&]() {
+      boost::asio::ip::tcp::socket s(ctx, boost::asio::ip::tcp::v4());
+      boost::asio::connect(s, resolver.resolve("127.0.0.1", port));
+      boost::beast::http::request<boost::beast::http::string_body> req(boost::beast::http::verb::post, "/echo_body", 11);
+      req.keep_alive(true);
+      req.set(http::field::host, endpoint);
+      req.body() = std::string(body_size, 'x');
+      req.prepare_payload();
+      boost::beast::http::write(s, req);
+
+      boost::beast::http::response<boost::beast::http::string_body> resp;
+      boost::beast::flat_buffer buffer;
+      boost::beast::http::read(s, buffer, resp);
+      return resp.result();
+   };
+
+   auto wait_for_no_bytes_in_flight = [&]() {
+      uint16_t max = std::numeric_limits<uint16_t>::max();
+      while (http_plugin->requests_in_flight() > 0 && --max)
+         std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      BOOST_CHECK(max > 0);
+      BOOST_CHECK_EQUAL(http_plugin->bytes_in_flight(), 0u);
+   };
+
+   BOOST_REQUIRE(post_body() == boost::beast::http::status::ok);
+   // The handler saw the full request body...
+   BOOST_CHECK_EQUAL(observed_body_size.load(), body_size);
+   // ...and the body was reserved against bytes_in_flight while in flight. This is the regression assertion:
+   // it reads 0 on the unfixed code (request bodies uncounted) and >= body_size with the fix.
+   BOOST_CHECK_GE(observed_bytes_in_flight.load(), body_size);
+   // The reservation is released once the request completes.
+   wait_for_no_bytes_in_flight();
+
+   // A second request must be admitted and counted the same way: no leaked or double-counted reservation.
+   observed_bytes_in_flight.store(0);
+   BOOST_REQUIRE(post_body() == boost::beast::http::status::ok);
+   BOOST_CHECK_GE(observed_bytes_in_flight.load(), body_size);
+   wait_for_no_bytes_in_flight();
 }
 
 BOOST_FIXTURE_TEST_CASE(requests_in_flight, http_plugin_test_fixture) {


### PR DESCRIPTION
App-thread HTTP handlers checked `verify_max_bytes_in_flight(b.size())` but never reserved the
request body before moving it into the unbounded app-thread exec queue. `bytes_in_flight` only ever
tracked response and file payloads, so concurrent request bodies accumulated uncounted and the
`http-max-bytes-in-flight` budget did not bound them — a set of near-`max-body-size` POSTs against a
slow handler could pin request-body memory well past the configured budget. The factory documented
`@pre b.size() has been added to bytes_in_flight by caller`, a precondition no caller satisfied.

This reserves the body against `bytes_in_flight` on admission and releases it exactly once via a
`shared_ptr`-held `scoped_exit` captured into the posted lambda, so the release fires whether the work
runs, throws, returns early on shutdown, or is discarded un-run when the queue is cleared. The guard
is `shared_ptr`-wrapped to keep the posted lambda copyable, as `boost::asio::post` requires.
`increment_bytes_in_flight` / `decrement_bytes_in_flight` are promoted onto the `abstract_conn`
interface (sole implementer `beast_http_session`) so the static handler factory can reach them.

The inline http-thread handler path runs synchronously with no queueing, so it has no accumulation
window and is left unchanged; its stale precondition comment is corrected.

A regression test registers an app-thread handler that samples `bytes_in_flight` while the request
body is in flight, asserting the budget reflects the body and returns to zero afterward. It fails on
the prior code (request body uncounted) and passes with the fix.

`bytes_in_flight` is a process-local atomic for HTTP admission control, never part of consensus or
serialization.

Resolves SEC-82.
