### PR TITLE
Wait for setrank before snapshot provider registration

### DIFF
--- a/tests/snapshot_api_test.py
+++ b/tests/snapshot_api_test.py
@@ -140,8 +140,13 @@ try:
         json.dumps({"producer": producerA, "rank": 1}),
         "--permission sysio@active")
     assert success, f"Failed to set rank for {producerA}: {trans}"
+    setRankTransId = node0.getTransId(trans)
 
-    assert node0.waitForHeadToAdvance(), "Head did not advance after setrank"
+    # regsnapprov reads producer ranks from the on-chain producers table. A
+    # generic head advance can race the exact setrank transaction under
+    # multi-producer scheduling, so wait for that transaction specifically.
+    assert node0.waitForTransactionInBlock(setRankTransId, timeout=60), \
+        "setrank transaction did not make it into a block before regsnapprov"
 
     success, trans = node0.pushMessage("sysio", "regsnapprov",
         json.dumps({"producer": producerA, "snap_account": snapProv1.name}),

--- a/tests/snapshot_attest_test.py
+++ b/tests/snapshot_attest_test.py
@@ -113,19 +113,26 @@ try:
     assert node0.waitForTransactionsInBlock(regProducerTransIds, timeout=60), \
         "regproducer transactions did not make it into a block before setrank"
 
+    setRankTransIds = []
     Print(f"Set rank for {producerA}")
     success, trans = node0.pushMessage("sysio", "setrank",
         json.dumps({"producer": producerA, "rank": 1}),
         "--permission sysio@active")
     assert success, f"Failed to set rank for {producerA}: {trans}"
+    setRankTransIds.append(node0.getTransId(trans))
 
     Print(f"Set rank for {producerB}")
     success, trans = node0.pushMessage("sysio", "setrank",
         json.dumps({"producer": producerB, "rank": 2}),
         "--permission sysio@active")
     assert success, f"Failed to set rank for {producerB}: {trans}"
+    setRankTransIds.append(node0.getTransId(trans))
 
-    assert node0.waitForHeadToAdvance(), "Head did not advance after setrank"
+    # regsnapprov reads producer ranks from the on-chain producers table. A
+    # generic head advance can race the exact setrank transactions under
+    # multi-producer scheduling, so wait for those transactions specifically.
+    assert node0.waitForTransactionsInBlock(setRankTransIds, timeout=60), \
+        "setrank transactions did not make it into a block before regsnapprov"
 
     # ---------------------------------------------------------------
     # Register snapshot providers


### PR DESCRIPTION
## Summary
- Wait for the exact `setrank` transactions to land in a block before `regsnapprov` runs in `snapshot_attest_test.py`.
- Apply the same exact-transaction wait in `snapshot_api_test.py`, which has the same setup dependency.

## Why
The linked assert-on CI job failed in `snapshot_attest_test` because `regsnapprov` read producer rank state before the preceding `setrank` transaction was applied, causing `producer rank exceeds maximum for snapshot providers`. A generic head advance is not sufficient under multi-producer scheduling.

Failing job: https://github.com/Wire-Network/wire-sysio/actions/runs/28453105189/job/84320531114?pr=356

## Validation
- `python3 -m py_compile tests/snapshot_attest_test.py tests/snapshot_api_test.py`
- `git diff --check`
- `ctest --output-on-failure -R 'snapshot_(attest|api)_test' -j1 --timeout 2700` from `build/codex-release-e2e` passed: 2/2 tests.\n- Review subagent Sartre: APPROVED with no blocking findings.