### PR TITLE
Net: Confine P2P frame parsers to the declared message length

### DIFF
--- a/libraries/libfc/include/fc/io/datastream.hpp
+++ b/libraries/libfc/include/fc/io/datastream.hpp
@@ -211,6 +211,52 @@ private:
    std::vector<char> mirror;
 };
 
+/**
+ * Datastream wrapper that confines reads to an upper bound of bytes taken from the underlying
+ * stream. A read or skip that would cross the bound throws a range error instead of consuming
+ * bytes beyond it, leaving the underlying stream untouched for that read.
+ *
+ * The motivating use is a length-prefixed frame parser reading from a buffer that may already
+ * hold the next, pipelined frame. Without a bound, an under-length frame can satisfy missing
+ * fields from bytes belonging to the following frame (a cross-frame overread). Wrapping the
+ * underlying stream in a bounded_datastream sized to the declared frame length isolates the
+ * parser to its own payload: any attempt to read past the declared length throws rather than
+ * silently spilling into the next frame.
+ *
+ * @tparam DataStream datastream to wrap
+ */
+template <typename DataStream>
+class bounded_datastream {
+public:
+   bounded_datastream( DataStream& ds, size_t limit ) : ds(ds), remaining_(limit) {}
+
+   void skip( size_t s ) {
+      if( s > remaining_ )
+         detail::throw_datastream_range_error( "skip", remaining_, int64_t(s - remaining_) );
+      ds.skip(s);
+      remaining_ -= s;
+   }
+   bool read( char* d, size_t s ) {
+      if( s > remaining_ )
+         detail::throw_datastream_range_error( "read", remaining_, int64_t(s - remaining_) );
+      if( ds.read(d, s) ) {
+         remaining_ -= s;
+         return true;
+      }
+      return false;
+   }
+
+   bool get( unsigned char& c ) { return read( (char*)&c, 1 ); }
+   bool get( char& c ) { return read( &c, 1 ); }
+
+   /// Bytes still readable before the bound is reached.
+   size_t remaining() const { return remaining_; }
+
+private:
+   DataStream& ds;
+   size_t      remaining_;
+};
+
 
 template<typename ST>
 inline datastream<ST>& operator<<(datastream<ST>& ds, const __int128& d) {

--- a/libraries/libfc/test/network/test_message_buffer.cpp
+++ b/libraries/libfc/test/network/test_message_buffer.cpp
@@ -1,5 +1,8 @@
 #include <fc/network/message_buffer.hpp>
+#include <fc/io/datastream.hpp>
+#include <fc/io/raw.hpp>
 
+#include <string>
 #include <thread>
 
 #include <boost/test/unit_test.hpp>
@@ -327,6 +330,123 @@ BOOST_AUTO_TEST_CASE(message_buffer_advance_read_ptr_bounds) {
    BOOST_CHECK_EQUAL(mbuff.bytes_to_read(), 12u);
    mbuff.advance_read_ptr(12);
    BOOST_CHECK_EQUAL(mbuff.bytes_to_read(), 0u);
+}
+
+// fc::bounded_datastream confines reads/skips to a byte budget taken from the wrapped stream,
+// even when the underlying stream physically holds more. This is the primitive the net_plugin
+// frame parsers use to keep an under-length P2P frame from reading into the next pipelined frame.
+BOOST_AUTO_TEST_CASE(bounded_datastream_respects_limit) {
+   char buf[16];
+   for (int i = 0; i < 16; ++i) buf[i] = static_cast<char>(i);
+   fc::datastream<char*> inner( buf, sizeof(buf) );
+   fc::bounded_datastream bounded( inner, 4 );          // only 4 of 16 bytes are in-bounds
+
+   BOOST_CHECK_EQUAL( bounded.remaining(), 4u );
+   bounded.skip( 2 );
+   BOOST_CHECK_EQUAL( bounded.remaining(), 2u );
+   char c = 0;
+   bounded.get( c );
+   BOOST_CHECK_EQUAL( c, 2 );
+   char two[2];
+   bounded.read( two, 1 );                              // exactly reaches the bound
+   BOOST_CHECK_EQUAL( two[0], 3 );
+   BOOST_CHECK_EQUAL( bounded.remaining(), 0u );
+
+   // Reading or skipping past the bound throws, even though `inner` still holds 12 bytes.
+   BOOST_CHECK_THROW( bounded.get( c ), fc::out_of_range_exception );
+   BOOST_CHECK_THROW( bounded.read( two, 2 ), fc::out_of_range_exception );
+   BOOST_CHECK_THROW( bounded.skip( 1 ), fc::out_of_range_exception );
+   BOOST_CHECK_EQUAL( bounded.remaining(), 0u );        // failed operations do not advance
+}
+
+// Realistic scenario: a length-prefixed frame whose declared length is shorter than the fields it
+// claims. Without a bound, fc::raw::unpack would satisfy the missing bytes from the next pipelined
+// frame already sitting in the message_buffer. Bounded to the declared frame length, it throws.
+BOOST_AUTO_TEST_CASE(bounded_datastream_blocks_cross_frame_overread) {
+   using mb_t = fc::message_buffer<1024>;
+   mb_t mb;
+
+   // Lay out two back-to-back frames in the buffer:
+   //   frame 1 payload: a std::string claiming 5 chars ("AAAAA") -> 6 wire bytes (length + data)
+   //   frame 2 payload: distinct "BBBBBBBB" pipelined bytes
+   char buf[64];
+   fc::datastream<char*> ds( buf, sizeof(buf) );
+   fc::raw::pack( ds, std::string( "AAAAA" ) );
+   const char pipelined[] = { 'B','B','B','B','B','B','B','B' };
+   ds.write( pipelined, sizeof(pipelined) );
+   const size_t total = ds.tellp();
+   memcpy( mb.write_ptr(), buf, total );
+   mb.advance_write_ptr( total );
+
+   // Declare frame 1 as only 3 bytes: the string's 1-byte length prefix plus 2 of its 5 chars.
+   constexpr uint32_t frame_len = 3;
+   auto mb_ds = mb.create_datastream();
+   fc::bounded_datastream bounded( mb_ds, frame_len );
+   std::string s;
+   BOOST_CHECK_THROW( fc::raw::unpack( bounded, s ), fc::out_of_range_exception );
+}
+
+// A well-formed frame unpacks fully within its bound, and the bound prevents any read from reaching
+// the following frame's bytes, which remain buffered for the next parse.
+BOOST_AUTO_TEST_CASE(bounded_datastream_leaves_pipelined_frame_intact) {
+   using mb_t = fc::message_buffer<1024>;
+   mb_t mb;
+
+   char buf[64];
+   fc::datastream<char*> ds( buf, sizeof(buf) );
+   fc::raw::pack( ds, std::string( "hello" ) );         // 6 wire bytes
+   const char pipelined[] = { 'X','X','X','X','X','X' };
+   ds.write( pipelined, sizeof(pipelined) );
+   const size_t total = ds.tellp();
+   memcpy( mb.write_ptr(), buf, total );
+   mb.advance_write_ptr( total );
+
+   auto mb_ds = mb.create_datastream();
+   fc::bounded_datastream bounded( mb_ds, 6 );           // bound to exactly frame 1
+   std::string s;
+   fc::raw::unpack( bounded, s );
+   BOOST_CHECK_EQUAL( s, std::string( "hello" ) );
+   BOOST_CHECK_EQUAL( bounded.remaining(), 0u );
+
+   // The pipelined frame is off-limits to the bounded stream...
+   char c = 0;
+   BOOST_CHECK_THROW( bounded.read( &c, 1 ), fc::out_of_range_exception );
+   // ...but is still physically present in the buffer for the next frame's parser.
+   BOOST_CHECK_EQUAL( mb.bytes_to_read(), total - 6 );
+}
+
+// The signed_block relay path composes datastream_mirror over a bounded_datastream so the packed
+// block bytes are still captured for relay while reads stay within the frame. Verify that exact
+// composition: the mirror reflects precisely the in-bound bytes and never the pipelined frame.
+BOOST_AUTO_TEST_CASE(bounded_datastream_composes_with_mirror) {
+   using mb_t = fc::message_buffer<1024>;
+   mb_t mb;
+
+   char buf[64];
+   fc::datastream<char*> ds( buf, sizeof(buf) );
+   fc::raw::pack( ds, std::string( "payload" ) );       // 8 wire bytes (length 7 + "payload")
+   const char pipelined[] = { 'Z','Z','Z','Z' };
+   ds.write( pipelined, sizeof(pipelined) );
+   const size_t total = ds.tellp();
+   memcpy( mb.write_ptr(), buf, total );
+   mb.advance_write_ptr( total );
+
+   constexpr uint32_t frame_len = 8;
+   auto mb_ds = mb.create_datastream();
+   fc::bounded_datastream bounded( mb_ds, frame_len );
+   fc::datastream_mirror mirror( bounded, frame_len );   // same composition as the block path
+   std::string s;
+   fc::raw::unpack( mirror, s );
+   BOOST_CHECK_EQUAL( s, std::string( "payload" ) );
+
+   // The mirror captured exactly the frame's bytes — this is what the block path stores as
+   // signed_block::packed_block for relay.
+   auto captured = mirror.extract_mirror();
+   BOOST_CHECK_EQUAL( captured.size(), static_cast<size_t>(frame_len) );
+   BOOST_CHECK_EQUAL( std::string( captured.begin(), captured.end() ),
+                      std::string( buf, buf + frame_len ) );
+   // The pipelined bytes were never reachable through the bounded mirror.
+   BOOST_CHECK_EQUAL( mb.bytes_to_read(), total - frame_len );
 }
 
 BOOST_AUTO_TEST_CASE(message_buffer_datastream) {

--- a/plugins/net_plugin/src/net_plugin.cpp
+++ b/plugins/net_plugin/src/net_plugin.cpp
@@ -809,6 +809,15 @@ namespace sysio {
       bool process_next_trx_message(uint32_t message_length);
       bool process_next_trx_notice_message(uint32_t message_length);
       bool process_next_vote_message(uint32_t message_length);
+
+      /// Advance the read pointer to the exact end of the frame currently being parsed.
+      /// @param bytes_before pending_message_buffer.bytes_to_read() captured at the frame body start
+      /// @param message_length the peer-declared payload length of the frame
+      /// Skips any declared payload bytes the parser did not consume so the next pipelined frame
+      /// stays aligned. Parsers must bound their reads to message_length (see fc::bounded_datastream),
+      /// so the consumed count can never exceed message_length.
+      void advance_to_frame_end(uint32_t bytes_before, uint32_t message_length);
+
       void update_endpoints(const tcp::endpoint& endpoint = tcp::endpoint());
 
       void send_gossip_bp_peers_initial_message();
@@ -3136,16 +3145,28 @@ namespace sysio {
    }
 
    // called from connection strand
+   void connection::advance_to_frame_end( uint32_t bytes_before, uint32_t message_length ) {
+      const uint32_t consumed = bytes_before - pending_message_buffer.bytes_to_read();
+      // Frame parsers read through fc::bounded_datastream limited to message_length, so they can
+      // never consume past the declared frame; assert to catch any future path that omits the bound.
+      SYS_ASSERT( consumed <= message_length, plugin_exception,
+                  "frame parser consumed {} bytes, exceeding declared length {}", consumed, message_length );
+      pending_message_buffer.advance_read_ptr( message_length - consumed );
+   }
+
+   // called from connection strand
    bool connection::process_next_message( uint32_t message_length ) {
       bytes_received += message_length;
       last_bytes_received = get_time();
       try {
          auto now = latest_msg_time = std::chrono::steady_clock::now();
 
-         // if next message is a block we already have, exit early
+         // if next message is a block we already have, exit early. Bound the type-tag peek to the
+         // declared frame so a truncated frame cannot source its routing tag from a pipelined frame.
          auto peek_ds = pending_message_buffer.create_peek_datastream();
+         fc::bounded_datastream bounded_peek( peek_ds, message_length );
          unsigned_int which{};
-         fc::raw::unpack( peek_ds, which );
+         fc::raw::unpack( bounded_peek, which );
 
          msg_type_t net_msg = to_msg_type_t(which.value);
 
@@ -3171,9 +3192,14 @@ namespace sysio {
          } else if( net_msg == msg_type_t::vote_message ) {
             return process_next_vote_message( message_length );
          } else {
-            auto ds = pending_message_buffer.create_datastream();
+            // Confine the generic net_message parse to the declared frame, then advance to the
+            // frame boundary so an under-length message cannot read into the next pipelined frame.
+            const auto bytes_before = pending_message_buffer.bytes_to_read();
+            auto mb_ds = pending_message_buffer.create_datastream();
+            fc::bounded_datastream ds( mb_ds, message_length );
             net_message msg;
             fc::raw::unpack( ds, msg );
+            advance_to_frame_end( bytes_before, message_length );
             msg_handler m( shared_from_this() );
             std::visit( m, msg );
          }
@@ -3188,11 +3214,14 @@ namespace sysio {
 
    // called from connection strand
    bool connection::process_next_block_message(uint32_t message_length) {
+      // Bound the header peek to the declared frame so the block id is derived only from this
+      // frame's bytes, never from a pipelined frame following an under-length block.
       auto peek_ds = pending_message_buffer.create_peek_datastream();
+      fc::bounded_datastream bounded_peek( peek_ds, message_length );
       unsigned_int which{};
-      fc::raw::unpack( peek_ds, which ); // throw away
+      fc::raw::unpack( bounded_peek, which ); // throw away
       block_header bh;
-      fc::raw::unpack( peek_ds, bh );
+      fc::raw::unpack( bounded_peek, bh );
       const block_id_type blk_id = bh.calculate_id();
       const uint32_t blk_num = last_received_block_num = block_header::num_from_id(blk_id);
       const fc::time_point now = fc::time_point::now();
@@ -3237,12 +3266,18 @@ namespace sysio {
             return true;
       }
 
+      // Confine the full block unpack to the declared frame. The datastream_mirror captures the
+      // packed block bytes for relay (consumed by fc::raw::unpack(signed_block)); wrapping a
+      // bounded_datastream preserves that capture while preventing reads from crossing the frame.
+      const auto bytes_before = pending_message_buffer.bytes_to_read();
       auto mb_ds = pending_message_buffer.create_datastream();
-      fc::raw::unpack( mb_ds, which );
+      fc::bounded_datastream bounded_ds( mb_ds, message_length );
+      fc::raw::unpack( bounded_ds, which );
 
-      fc::datastream_mirror ds(mb_ds, message_length);
+      fc::datastream_mirror ds( bounded_ds, message_length );
       shared_ptr<signed_block> ptr = std::make_shared<signed_block>();
       fc::raw::unpack( ds, *ptr );
+      advance_to_frame_end( bytes_before, message_length );
 
       handle_message( blk_id, std::move( ptr ), now );
       return true;
@@ -3294,7 +3329,11 @@ namespace sysio {
       auto now = fc::time_point::now();
       // shared_ptr<packed_transaction> needed here because packed_transaction_ptr is shared_ptr<const packed_transaction>
       std::shared_ptr<packed_transaction> ptr = std::make_shared<packed_transaction>();
-      fc::raw::unpack( ds, *ptr );
+      // Confine the body to the remaining declared frame bytes, then advance to the frame boundary,
+      // so the transaction cannot be unpacked from bytes belonging to a following pipelined frame.
+      fc::bounded_datastream body_ds( ds, message_length - header_bytes );
+      fc::raw::unpack( body_ds, *ptr );
+      advance_to_frame_end( bytes_before, message_length );
 
       // Validate that the wire ID matches the actual transaction ID.
       if( ptr->id() != trx_id ) {
@@ -3357,11 +3396,16 @@ namespace sysio {
          return true;
       }
 
-      auto ds = pending_message_buffer.create_datastream();
+      // Confine the notice parse to the declared frame so the tracked transaction id cannot be
+      // sourced from a following pipelined frame, then advance to the frame boundary.
+      const auto bytes_before = pending_message_buffer.bytes_to_read();
+      auto mb_ds = pending_message_buffer.create_datastream();
+      fc::bounded_datastream ds( mb_ds, message_length );
       unsigned_int which{};
       fc::raw::unpack( ds, which );
       transaction_notice_message msg;
       fc::raw::unpack( ds, msg );
+      advance_to_frame_end( bytes_before, message_length );
 
       size_t trx_entries_sz = my_impl->dispatcher.add_peer_txn_notice( msg.id, *this );
       if (trx_entries_sz > def_max_trx_entries_per_conn_size) {
@@ -3408,7 +3452,11 @@ namespace sysio {
          return true;
       }
       vote_message_ptr ptr = std::make_shared<vote_message>();
-      fc::raw::unpack( ds, *ptr );
+      // Confine the body to the remaining declared frame bytes, then advance to the frame boundary,
+      // so the vote cannot be unpacked from bytes belonging to a following pipelined frame.
+      fc::bounded_datastream body_ds( ds, message_length - header_bytes );
+      fc::raw::unpack( body_ds, *ptr );
+      advance_to_frame_end( bytes_before, message_length );
 
       // Validate that the wire vote_id matches the actual computed vote_id.
       auto computed_vote_id = compute_vote_id(*ptr);

--- a/plugins/net_plugin/src/net_plugin.cpp
+++ b/plugins/net_plugin/src/net_plugin.cpp
@@ -3299,24 +3299,19 @@ namespace sysio {
       // Early dedup: check if we already have this transaction — zero heap allocations on the duplicate path.
       // Consume which + trx_id from buffer
       // Wire format: [which (varint)][transaction_id (32 bytes)][packed_transaction ...]
+      // Bound the entire parse to the declared frame. A frame too short to hold which + trx_id (or a
+      // body that runs past message_length) throws here; process_next_message then closes the peer and
+      // returns false, stopping the read loop rather than consuming or acting on bytes from a following
+      // pipelined frame. Because the bound guarantees header_bytes <= message_length, the duplicate-path
+      // advance below cannot underflow.
       const auto bytes_before = pending_message_buffer.bytes_to_read();
-      auto ds = pending_message_buffer.create_datastream();
+      auto mb_ds = pending_message_buffer.create_datastream();
+      fc::bounded_datastream ds( mb_ds, message_length );
       unsigned_int which{};
       fc::raw::unpack( ds, which );
       transaction_id_type trx_id;
       fc::raw::unpack( ds, trx_id );
       const auto header_bytes = bytes_before - pending_message_buffer.bytes_to_read();
-
-      // A well-formed transaction_message frame contains at least which + trx_id. If the
-      // peer-declared message_length is shorter than the bytes just consumed, the id was read
-      // by spilling past this frame into pipelined bytes; closing here avoids underflowing the
-      // unsigned `message_length - header_bytes` advance below (which would corrupt the buffer).
-      if( header_bytes > message_length ) {
-         peer_wlog( p2p_trx_log, this, "transaction_message frame too short: length {} < header {} - closing",
-                    message_length, header_bytes );
-         close();
-         return true;
-      }
 
       if( my_impl->dispatcher.have_peer_txn( trx_id, *this ) ) {
          peer_dlog( p2p_trx_log, this, "got a duplicate transaction - dropping {}", trx_id );
@@ -3329,10 +3324,9 @@ namespace sysio {
       auto now = fc::time_point::now();
       // shared_ptr<packed_transaction> needed here because packed_transaction_ptr is shared_ptr<const packed_transaction>
       std::shared_ptr<packed_transaction> ptr = std::make_shared<packed_transaction>();
-      // Confine the body to the remaining declared frame bytes, then advance to the frame boundary,
-      // so the transaction cannot be unpacked from bytes belonging to a following pipelined frame.
-      fc::bounded_datastream body_ds( ds, message_length - header_bytes );
-      fc::raw::unpack( body_ds, *ptr );
+      // ds is bounded to message_length, so the body cannot be unpacked from bytes belonging to a
+      // following pipelined frame; advance to the frame boundary once the body is consumed.
+      fc::raw::unpack( ds, *ptr );
       advance_to_frame_end( bytes_before, message_length );
 
       // Validate that the wire ID matches the actual transaction ID.
@@ -3428,8 +3422,13 @@ namespace sysio {
 
       // Early dedup: consume which + vote_id from buffer
       // Wire format: [which (varint)][vote_id (32 bytes)][vote_message ...]
+      // See process_next_trx_message: bound the entire parse to the declared frame so an under-length
+      // frame throws (the caller then closes the peer and stops the read loop) rather than reading the
+      // id or body from a following pipelined frame. The bound also keeps the duplicate-path advance
+      // below from underflowing.
       const auto bytes_before = pending_message_buffer.bytes_to_read();
-      auto ds = pending_message_buffer.create_datastream();
+      auto mb_ds = pending_message_buffer.create_datastream();
+      fc::bounded_datastream ds( mb_ds, message_length );
       unsigned_int which{};
       fc::raw::unpack( ds, which );
       assert(to_msg_type_t(which) == msg_type_t::vote_message); // verified by caller
@@ -3437,25 +3436,15 @@ namespace sysio {
       fc::raw::unpack( ds, vote_id );
       const auto header_bytes = bytes_before - pending_message_buffer.bytes_to_read();
 
-      // See process_next_trx_message: a frame shorter than which + vote_id means the id was read
-      // from pipelined bytes past this frame; close rather than underflow the advance below.
-      if( header_bytes > message_length ) {
-         peer_wlog( vote_logger, this, "vote_message frame too short: length {} < header {} - closing",
-                    message_length, header_bytes );
-         close();
-         return true;
-      }
-
       if( my_impl->dispatcher.have_vote( vote_id ) ) {
          peer_dlog( vote_logger, this, "duplicate vote - dropping {}", vote_id );
          pending_message_buffer.advance_read_ptr( message_length - header_bytes );
          return true;
       }
       vote_message_ptr ptr = std::make_shared<vote_message>();
-      // Confine the body to the remaining declared frame bytes, then advance to the frame boundary,
-      // so the vote cannot be unpacked from bytes belonging to a following pipelined frame.
-      fc::bounded_datastream body_ds( ds, message_length - header_bytes );
-      fc::raw::unpack( body_ds, *ptr );
+      // ds is bounded to message_length, so the body cannot be unpacked from bytes belonging to a
+      // following pipelined frame; advance to the frame boundary once the body is consumed.
+      fc::raw::unpack( ds, *ptr );
       advance_to_frame_end( bytes_before, message_length );
 
       // Validate that the wire vote_id matches the actual computed vote_id.


### PR DESCRIPTION
The native P2P read loop buffers at least one declared frame before dispatching a parser, but the buffer may already hold the next pipelined frame. The generic `net_message`, signed-block, and transaction-notice parsers read from an `mb_datastream` over the entire pending buffer with no per-frame bound, so a peer sending an under-length frame could have missing fields satisfied from the following frame's bytes — desynchronizing the stream and letting a handler act on bytes outside the declared payload (a wrong block id from a short signed-block header, a notice id sourced from the next frame, sync/nack state from a truncated generic message). The transaction and vote paths already rejected frames shorter than their fixed header but still unpacked their variable bodies unbounded.

This adds `fc::bounded_datastream`, a datastream adapter that throws as soon as a read or skip would cross a byte limit, and routes every frame parse through it bounded to the frame's declared length: the routing-tag peek, the generic `net_message`, the signed-block id peek and full unpack, the transaction-notice, and the transaction/vote bodies. After parsing, `connection::advance_to_frame_end` advances the read pointer to the exact end of the frame, skipping any declared bytes the parser did not consume so the next pipelined frame stays aligned.

The signed-block path captures `packed_block` for relay via `datastream_mirror::extract_mirror()`; the bounded stream is nested inside the mirror so that capture is preserved while reads can no longer spill past the frame. New `bounded_datastream` unit tests cover the in/out-of-bound reads, the cross-frame overread, an intact trailing frame, and the mirror-over-bounded composition the block path relies on.
