### PR TITLE
ci(opp-bundles): fix npm publish auth (ENEEDAUTH) + add manual trigger

### DIFF
--- a/.github/workflows/opp-bundles.yaml
+++ b/.github/workflows/opp-bundles.yaml
@@ -1,6 +1,10 @@
 name: "OPP Bundles"
 
 on:
+  # Manual trigger so a publish can be run on demand (e.g. to ship a bundle whose
+  # proto already merged to master but whose publish run failed). Publishes the
+  # current master state — same code path as the push trigger.
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -45,10 +49,18 @@ jobs:
           pnpm install
         
       - name: Generate & Publish OPP Bundles
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: fish ./libraries/opp/tools/scripts/generate-opp-bundles.fish --publish
+        run: |
+          # `npm publish` (invoked by wire-protobuf-bundler --publish) does NOT read a
+          # bare $NPM_TOKEN env var — it needs an _authToken line in .npmrc. Without
+          # this the publish fails ENEEDAUTH (regression from SEC-41, which scoped the
+          # token to this step but dropped the auth wiring). Writing ~/.npmrc here keeps
+          # the token confined to the push/dispatch publish step — it is never present
+          # during pull_request validation or the dependency install step.
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+          fish ./libraries/opp/tools/scripts/generate-opp-bundles.fish --publish
 
       - name: Validate OPP Bundles
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
The `OPP Bundles` workflow has failed at the publish step on every push to `master` since SEC-41 reworked token handling (runs #437, #444, #456). `@wireio/opp-solidity-models` is therefore stuck at **1.0.27 (2026-05-27)** even though the per-token-precision proto (`source_token_precision`) merged to master via #427. Consequence: **wire-ethereum `next` cannot be built from any published version** — the schema it needs (`ReserveAmount`, `sourceTokenPrecision`, `isPrivate`, `creatorPubKey`) exists in no npm release.

## Root cause
The publish step passes the token as a bare `NPM_TOKEN` env var:
```yaml
env:
  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
run: fish ./libraries/opp/tools/scripts/generate-opp-bundles.fish --publish
```
But `npm publish` (invoked by `wire-protobuf-bundler --publish`) does **not** read `$NPM_TOKEN` — it reads an `_authToken` line from `.npmrc`. Neither the workflow nor the bundler writes one, so publish fails `ENEEDAUTH`. Confirmed in the run #456 log: it generates fine (`npm notice version: 1.0.28`) and only the publish auth fails.

## Fix
- Write `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` into `~/.npmrc` in the publish step.
- Add `workflow_dispatch` so a publish can be triggered on demand (the proto already merged; we just need a successful publish run).

## Security (SEC-41 intent preserved)
The token is written only inside the publish step, which is gated to `push`/`workflow_dispatch`. It is **never** present during `pull_request` validation or the dependency `install` step — exactly the boundary SEC-41 established.

## After merge
Run the workflow via **Actions → OPP Bundles → Run workflow** (`workflow_dispatch`) to publish **1.0.28**. wire-ethereum `next` then builds from a clean `npm install` (pin `^1.0.9` resolves to 1.0.28).

## Verification
Built the current-master bundle locally and confirmed wire-ethereum `next` (`c9b270e`) compiles clean + `ReserveManager` suite passes (36/36).