### PR TITLE
SEC-84: Harden CLI secret file outputs

### DIFF
--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -13,6 +13,7 @@ set(fc_sources
         src/io/json.cpp
         src/io/varint.cpp
         src/io/fstream.cpp
+        src/io/secure_file.cpp
         src/io/console.cpp
         src/filesystem.cpp
         src/interprocess/file_mapping.cpp
@@ -143,4 +144,3 @@ install(
         DIRECTORY include/fc
         DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
-

--- a/libraries/libfc/include/fc/io/secure_file.hpp
+++ b/libraries/libfc/include/fc/io/secure_file.hpp
@@ -12,15 +12,14 @@ namespace fc {
 /**
  * Owner-only output file for newly generated secret material.
  *
- * On POSIX systems the file is opened without following the final path component
- * when the platform exposes that flag, restricted to owner read/write
- * permissions, truncated, and then written through the opened descriptor.
+ * On POSIX systems content is written to an owner-only temporary file in the
+ * target directory and then committed with rename after a successful close. The
+ * final target is rejected when it is already a symlink or non-regular file.
  */
 class secure_output_file {
 public:
    /**
-    * Opens a secret output file and applies owner-only permissions before any
-    * caller-provided content is written.
+    * Opens an owner-only temporary file for a secret output.
     *
     * @param file_path path to the secret file to create or replace
     * @throws std::ios_base::failure when the file cannot be opened securely
@@ -59,13 +58,15 @@ public:
 private:
    void close_noexcept() noexcept;
 
+   std::filesystem::path file_path_;
+
 #ifndef _WIN32
    static constexpr int invalid_file_descriptor = -1;
    int                  file_descriptor_        = invalid_file_descriptor;
+   std::filesystem::path temp_file_path_;
 #else
    std::ofstream file_;
 #endif
-   std::filesystem::path file_path_;
 };
 
 /**

--- a/libraries/libfc/include/fc/io/secure_file.hpp
+++ b/libraries/libfc/include/fc/io/secure_file.hpp
@@ -10,11 +10,17 @@
 namespace fc {
 
 /**
- * Owner-only output file for newly generated secret material.
+ * Output file for newly generated secret material.
  *
- * On POSIX systems content is written to an owner-only temporary file in the
- * target directory and then committed with rename after a successful close. The
- * final target is rejected when it is already a symlink or non-regular file.
+ * On POSIX systems content is written to an owner-only temporary file in the target directory. Calling close()
+ * publishes the file by syncing the temporary file, renaming it into place, and syncing the target directory.
+ * Destroying the object before the rename commit point discards the temporary file without publishing it. If close()
+ * reports a directory sync failure after the rename succeeds, the final file may already be visible but its directory
+ * entry durability could not be confirmed. Existing final symlinks and non-regular final targets are rejected, but
+ * intermediate directory symlinks are still resolved by the platform.
+ *
+ * On Windows this helper currently falls back to plain std::ofstream semantics; owner-only permissions, final-target
+ * rejection, and temporary-file rename commit guarantees are POSIX-only.
  */
 class secure_output_file {
 public:
@@ -30,6 +36,9 @@ public:
    secure_output_file& operator=(const secure_output_file&) = delete;
    secure_output_file(secure_output_file&& other) noexcept;
    secure_output_file& operator=(secure_output_file&& other) noexcept;
+   /**
+    * Destroys the output file, discarding any uncommitted POSIX temporary file.
+    */
    ~secure_output_file();
 
    /**
@@ -41,10 +50,11 @@ public:
    void write(std::string_view content);
 
    /**
-    * Closes the opened secret file and reports close errors.
+    * Closes the opened secret file, publishes it on POSIX, and reports close errors.
     *
-    * Destruction also closes the file, but close errors are intentionally not
-    * thrown from the destructor.
+    * Destruction before the POSIX rename commit point discards pending output. Once the rename succeeds, a later
+    * directory sync failure can still be reported even though the final file may already be visible. Close errors are
+    * intentionally not thrown from the destructor.
     *
     * @throws std::ios_base::failure when close fails
     */

--- a/libraries/libfc/include/fc/io/secure_file.hpp
+++ b/libraries/libfc/include/fc/io/secure_file.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <filesystem>
+#include <string_view>
+
+#ifdef _WIN32
+#include <fstream>
+#endif
+
+namespace fc {
+
+/**
+ * Owner-only output file for newly generated secret material.
+ *
+ * On POSIX systems the file is opened without following the final path component
+ * when the platform exposes that flag, restricted to owner read/write
+ * permissions, truncated, and then written through the opened descriptor.
+ */
+class secure_output_file {
+public:
+   /**
+    * Opens a secret output file and applies owner-only permissions before any
+    * caller-provided content is written.
+    *
+    * @param file_path path to the secret file to create or replace
+    * @throws std::ios_base::failure when the file cannot be opened securely
+    */
+   explicit secure_output_file(std::filesystem::path file_path);
+
+   secure_output_file(const secure_output_file&) = delete;
+   secure_output_file& operator=(const secure_output_file&) = delete;
+   secure_output_file(secure_output_file&& other) noexcept;
+   secure_output_file& operator=(secure_output_file&& other) noexcept;
+   ~secure_output_file();
+
+   /**
+    * Writes bytes to the opened secret file.
+    *
+    * @param content content to write
+    * @throws std::ios_base::failure when the write fails
+    */
+   void write(std::string_view content);
+
+   /**
+    * Closes the opened secret file and reports close errors.
+    *
+    * Destruction also closes the file, but close errors are intentionally not
+    * thrown from the destructor.
+    *
+    * @throws std::ios_base::failure when close fails
+    */
+   void close();
+
+   /**
+    * Returns the path associated with this secure output file.
+    */
+   const std::filesystem::path& path() const noexcept { return file_path_; }
+
+private:
+   void close_noexcept() noexcept;
+
+#ifndef _WIN32
+   static constexpr int invalid_file_descriptor = -1;
+   int                  file_descriptor_        = invalid_file_descriptor;
+#else
+   std::ofstream file_;
+#endif
+   std::filesystem::path file_path_;
+};
+
+/**
+ * Writes a complete secret file with owner-only permissions.
+ *
+ * @param file_path path to the secret file to create or replace
+ * @param content content to write
+ * @throws std::ios_base::failure when the file cannot be opened, written, or closed securely
+ */
+void write_secure_file(const std::filesystem::path& file_path, std::string_view content);
+
+} // namespace fc

--- a/libraries/libfc/src/io/secure_file.cpp
+++ b/libraries/libfc/src/io/secure_file.cpp
@@ -1,0 +1,178 @@
+#include <fc/io/secure_file.hpp>
+
+#include <algorithm>
+#include <cerrno>
+#include <ios>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace fc {
+
+namespace {
+
+#ifndef _WIN32
+constexpr mode_t secret_file_mode = S_IRUSR | S_IWUSR;
+constexpr int    invalid_descriptor = -1;
+
+/**
+ * Returns the platform open flags needed for secret output files.
+ */
+int secret_file_open_flags() {
+   int flags = O_WRONLY | O_CREAT | O_NONBLOCK;
+#ifdef O_CLOEXEC
+   flags |= O_CLOEXEC;
+#endif
+#ifdef O_NOFOLLOW
+   flags |= O_NOFOLLOW;
+#endif
+   return flags;
+}
+#endif
+
+/**
+ * Throws a filesystem failure tagged with the secret-file operation.
+ */
+[[noreturn]] void throw_file_failure(const std::filesystem::path& file_path,
+                                     const std::string& action,
+                                     int err) {
+   throw std::ios_base::failure("secure_output_file unable to " + action + ": " + file_path.string(),
+                                std::error_code(err, std::generic_category()));
+}
+
+} // namespace
+
+secure_output_file::secure_output_file(std::filesystem::path file_path)
+   : file_path_(std::move(file_path)) {
+#ifndef _WIN32
+   int fd = ::open(file_path_.c_str(), secret_file_open_flags(), secret_file_mode);
+   if (fd == invalid_descriptor)
+      throw_file_failure(file_path_, "open", errno);
+
+   auto close_on_failure = [fd]() noexcept { ::close(fd); };
+
+   struct stat stat_result {};
+   if (::fstat(fd, &stat_result) == -1) {
+      const int saved_errno = errno;
+      close_on_failure();
+      throw_file_failure(file_path_, "stat", saved_errno);
+   }
+
+   if (!S_ISREG(stat_result.st_mode)) {
+      close_on_failure();
+      throw_file_failure(file_path_, "open regular file", EINVAL);
+   }
+
+   if (::fchmod(fd, secret_file_mode) == -1) {
+      const int saved_errno = errno;
+      close_on_failure();
+      throw_file_failure(file_path_, "restrict permissions", saved_errno);
+   }
+
+   if (::ftruncate(fd, 0) == -1) {
+      const int saved_errno = errno;
+      close_on_failure();
+      throw_file_failure(file_path_, "truncate", saved_errno);
+   }
+
+   file_descriptor_ = fd;
+#else
+   file_.open(file_path_, std::ios::out | std::ios::binary | std::ios::trunc);
+   if (!file_)
+      throw_file_failure(file_path_, "open", errno);
+#endif
+}
+
+secure_output_file::secure_output_file(secure_output_file&& other) noexcept
+   : file_path_(std::move(other.file_path_)) {
+#ifndef _WIN32
+   file_descriptor_ = std::exchange(other.file_descriptor_, invalid_file_descriptor);
+#else
+   file_ = std::move(other.file_);
+#endif
+}
+
+secure_output_file& secure_output_file::operator=(secure_output_file&& other) noexcept {
+   if (this != &other) {
+      close_noexcept();
+      file_path_ = std::move(other.file_path_);
+#ifndef _WIN32
+      file_descriptor_ = std::exchange(other.file_descriptor_, invalid_file_descriptor);
+#else
+      file_ = std::move(other.file_);
+#endif
+   }
+   return *this;
+}
+
+secure_output_file::~secure_output_file() {
+   close_noexcept();
+}
+
+void secure_output_file::write(std::string_view content) {
+#ifndef _WIN32
+   auto*  cursor    = content.data();
+   size_t remaining = content.size();
+   while (remaining > 0) {
+      const auto chunk = std::min(remaining, static_cast<size_t>(std::numeric_limits<ssize_t>::max()));
+      const auto result = ::write(file_descriptor_, cursor, chunk);
+      if (result > 0) {
+         cursor += result;
+         remaining -= static_cast<size_t>(result);
+      } else if (result == -1 && errno == EINTR) {
+         continue;
+      } else {
+         throw_file_failure(file_path_, "write", result == -1 ? errno : EIO);
+      }
+   }
+#else
+   file_.write(content.data(), static_cast<std::streamsize>(content.size()));
+   if (!file_)
+      throw_file_failure(file_path_, "write", errno);
+#endif
+}
+
+void secure_output_file::close() {
+#ifndef _WIN32
+   if (file_descriptor_ == invalid_file_descriptor)
+      return;
+
+   const int fd = std::exchange(file_descriptor_, invalid_file_descriptor);
+   if (::close(fd) == -1)
+      throw_file_failure(file_path_, "close", errno);
+#else
+   if (!file_.is_open())
+      return;
+
+   file_.close();
+   if (!file_)
+      throw_file_failure(file_path_, "close", errno);
+#endif
+}
+
+void secure_output_file::close_noexcept() noexcept {
+#ifndef _WIN32
+   if (file_descriptor_ != invalid_file_descriptor) {
+      ::close(file_descriptor_);
+      file_descriptor_ = invalid_file_descriptor;
+   }
+#else
+   if (file_.is_open())
+      file_.close();
+#endif
+}
+
+void write_secure_file(const std::filesystem::path& file_path, std::string_view content) {
+   secure_output_file out(file_path);
+   out.write(content);
+   out.close();
+}
+
+} // namespace fc

--- a/libraries/libfc/src/io/secure_file.cpp
+++ b/libraries/libfc/src/io/secure_file.cpp
@@ -1,4 +1,5 @@
 #include <fc/io/secure_file.hpp>
+#include <fc/scoped_exit.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -27,6 +28,7 @@ constexpr auto        temp_file_prefix        = ".";
 constexpr auto        temp_file_separator     = ".tmp.";
 constexpr auto        temp_file_fallback_name = "secure-output";
 constexpr unsigned    max_temp_file_attempts  = 100;
+constexpr size_t      fallback_name_max       = 255;
 std::atomic<uint64_t> temp_file_counter{0};
 
 /**
@@ -44,6 +46,20 @@ int secret_file_open_flags() {
 }
 
 /**
+ * Returns the platform open flags needed to sync a containing directory.
+ */
+int directory_open_flags() {
+   int flags = O_RDONLY;
+#ifdef O_CLOEXEC
+   flags |= O_CLOEXEC;
+#endif
+#ifdef O_DIRECTORY
+   flags |= O_DIRECTORY;
+#endif
+   return flags;
+}
+
+/**
  * Returns the directory where the temporary file should be created.
  */
 std::filesystem::path temp_file_directory(const std::filesystem::path& file_path) {
@@ -52,21 +68,42 @@ std::filesystem::path temp_file_directory(const std::filesystem::path& file_path
 }
 
 /**
- * Returns a filename component suitable for deriving a temporary secret-file path.
+ * Returns the maximum filename component length supported by a directory.
  */
-std::string temp_file_base_name(const std::filesystem::path& file_path) {
+size_t directory_name_max(const std::filesystem::path& directory_path) noexcept {
+   errno             = 0;
+   const auto result = ::pathconf(directory_path.c_str(), _PC_NAME_MAX);
+   if (result > 0)
+      return static_cast<size_t>(result);
+   return fallback_name_max;
+}
+
+/**
+ * Returns a bounded filename component suitable for deriving a temporary secret-file path.
+ */
+std::string temp_file_base_name(const std::filesystem::path& file_path, size_t max_length) {
    auto base_name = file_path.filename().string();
-   return base_name.empty() ? std::string(temp_file_fallback_name) : base_name;
+   if (base_name.empty())
+      base_name = temp_file_fallback_name;
+   if (base_name.size() > max_length)
+      base_name.resize(max_length);
+   return base_name;
 }
 
 /**
  * Returns a candidate temporary path in the target directory.
  */
 std::filesystem::path make_temp_file_path(const std::filesystem::path& file_path, uint64_t attempt) {
+   const auto directory = temp_file_directory(file_path);
    const auto unique_id = temp_file_counter.fetch_add(1, std::memory_order_relaxed);
-   auto       temp_name = std::string(temp_file_prefix) + temp_file_base_name(file_path) + temp_file_separator +
-                    std::to_string(::getpid()) + "." + std::to_string(unique_id) + "." + std::to_string(attempt);
-   return temp_file_directory(file_path) / temp_name;
+   const auto suffix    = std::string(temp_file_separator) + std::to_string(::getpid()) + "." +
+                       std::to_string(unique_id) + "." + std::to_string(attempt);
+   const auto prefix_size       = std::string_view(temp_file_prefix).size();
+   const auto max_name_length   = directory_name_max(directory);
+   const auto fixed_name_length = prefix_size + suffix.size();
+   const auto max_base_length   = max_name_length > fixed_name_length ? max_name_length - fixed_name_length : 0;
+   const auto temp_name = std::string(temp_file_prefix) + temp_file_base_name(file_path, max_base_length) + suffix;
+   return directory / temp_name;
 }
 
 /**
@@ -84,11 +121,6 @@ void close_descriptor_noexcept(int file_descriptor) noexcept {
    if (file_descriptor >= 0)
       ::close(file_descriptor);
 }
-
-/**
- * Rejects existing final targets that should not be replaced by a secret file.
- */
-void throw_if_target_is_not_replaceable(const std::filesystem::path& file_path);
 #endif
 
 /**
@@ -102,6 +134,30 @@ void throw_if_target_is_not_replaceable(const std::filesystem::path& file_path);
 }
 
 #ifndef _WIN32
+/**
+ * Syncs the directory containing the published target path.
+ */
+void sync_target_directory(const std::filesystem::path& file_path) {
+   const auto directory_path = temp_file_directory(file_path);
+   int        directory_fd   = ::open(directory_path.c_str(), directory_open_flags());
+   if (directory_fd == -1)
+      throw_file_failure(file_path, "open target directory", errno);
+
+   auto close_directory = fc::make_scoped_exit([&]() noexcept { close_descriptor_noexcept(directory_fd); });
+
+   if (::fsync(directory_fd) == -1) {
+      const int saved_errno = errno;
+      throw_file_failure(file_path, "sync published target directory", saved_errno);
+   }
+
+   close_directory.cancel();
+   if (::close(directory_fd) == -1)
+      throw_file_failure(file_path, "close target directory", errno);
+}
+
+/**
+ * Rejects existing final targets that should not be replaced by a secret file.
+ */
 void throw_if_target_is_not_replaceable(const std::filesystem::path& file_path) {
    struct stat stat_result {};
    if (::lstat(file_path.c_str(), &stat_result) == -1) {
@@ -143,31 +199,29 @@ secure_output_file::secure_output_file(std::filesystem::path file_path)
    throw_if_target_is_not_replaceable(file_path_);
 
    auto [fd, temp_path] = open_temp_file(file_path_);
-   auto cleanup_on_failure = [&]() noexcept {
+   auto cleanup_on_failure = fc::make_scoped_exit([&]() noexcept {
       close_descriptor_noexcept(fd);
       unlink_noexcept(temp_path);
-   };
+   });
 
    struct stat stat_result {};
    if (::fstat(fd, &stat_result) == -1) {
       const int saved_errno = errno;
-      cleanup_on_failure();
       throw_file_failure(file_path_, "stat temporary file", saved_errno);
    }
 
    if (!S_ISREG(stat_result.st_mode)) {
-      cleanup_on_failure();
       throw_file_failure(file_path_, "open regular temporary file", EINVAL);
    }
 
    if (::fchmod(fd, secret_file_mode) == -1) {
       const int saved_errno = errno;
-      cleanup_on_failure();
       throw_file_failure(file_path_, "restrict temporary file permissions", saved_errno);
    }
 
    file_descriptor_ = fd;
    temp_file_path_  = std::move(temp_path);
+   cleanup_on_failure.cancel();
 #else
    file_.open(file_path_, std::ios::out | std::ios::binary | std::ios::trunc);
    if (!file_)
@@ -234,29 +288,32 @@ void secure_output_file::close() {
       return;
 
    const int fd = std::exchange(file_descriptor_, invalid_file_descriptor);
-   if (::fsync(fd) == -1) {
-      const int saved_errno = errno;
-      close_descriptor_noexcept(fd);
+   auto      cleanup_temp_file = fc::make_scoped_exit([this]() noexcept {
       unlink_noexcept(temp_file_path_);
       temp_file_path_.clear();
+   });
+   auto      close_descriptor   = fc::make_scoped_exit([fd]() noexcept { close_descriptor_noexcept(fd); });
+
+   if (::fsync(fd) == -1) {
+      const int saved_errno = errno;
       throw_file_failure(file_path_, "sync temporary file", saved_errno);
    }
 
+   close_descriptor.cancel();
    if (::close(fd) == -1) {
       const int saved_errno = errno;
-      unlink_noexcept(temp_file_path_);
-      temp_file_path_.clear();
       throw_file_failure(file_path_, "close temporary file", saved_errno);
    }
 
    if (::rename(temp_file_path_.c_str(), file_path_.c_str()) == -1) {
       const int saved_errno = errno;
-      unlink_noexcept(temp_file_path_);
-      temp_file_path_.clear();
       throw_file_failure(file_path_, "commit temporary file", saved_errno);
    }
 
+   // After rename succeeds, the final path is published; later failures can report only durability uncertainty.
+   cleanup_temp_file.cancel();
    temp_file_path_.clear();
+   sync_target_directory(file_path_);
 #else
    if (!file_.is_open())
       return;

--- a/libraries/libfc/src/io/secure_file.cpp
+++ b/libraries/libfc/src/io/secure_file.cpp
@@ -1,10 +1,13 @@
 #include <fc/io/secure_file.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cerrno>
+#include <cstdint>
 #include <ios>
 #include <limits>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <utility>
 
@@ -19,14 +22,18 @@ namespace fc {
 namespace {
 
 #ifndef _WIN32
-constexpr mode_t secret_file_mode = S_IRUSR | S_IWUSR;
-constexpr int    invalid_descriptor = -1;
+constexpr mode_t      secret_file_mode        = S_IRUSR | S_IWUSR;
+constexpr auto        temp_file_prefix        = ".";
+constexpr auto        temp_file_separator     = ".tmp.";
+constexpr auto        temp_file_fallback_name = "secure-output";
+constexpr unsigned    max_temp_file_attempts  = 100;
+std::atomic<uint64_t> temp_file_counter{0};
 
 /**
- * Returns the platform open flags needed for secret output files.
+ * Returns the platform open flags needed for temporary secret output files.
  */
 int secret_file_open_flags() {
-   int flags = O_WRONLY | O_CREAT | O_NONBLOCK;
+   int flags = O_WRONLY | O_CREAT | O_EXCL;
 #ifdef O_CLOEXEC
    flags |= O_CLOEXEC;
 #endif
@@ -35,6 +42,53 @@ int secret_file_open_flags() {
 #endif
    return flags;
 }
+
+/**
+ * Returns the directory where the temporary file should be created.
+ */
+std::filesystem::path temp_file_directory(const std::filesystem::path& file_path) {
+   const auto parent = file_path.parent_path();
+   return parent.empty() ? std::filesystem::path(".") : parent;
+}
+
+/**
+ * Returns a filename component suitable for deriving a temporary secret-file path.
+ */
+std::string temp_file_base_name(const std::filesystem::path& file_path) {
+   auto base_name = file_path.filename().string();
+   return base_name.empty() ? std::string(temp_file_fallback_name) : base_name;
+}
+
+/**
+ * Returns a candidate temporary path in the target directory.
+ */
+std::filesystem::path make_temp_file_path(const std::filesystem::path& file_path, uint64_t attempt) {
+   const auto unique_id = temp_file_counter.fetch_add(1, std::memory_order_relaxed);
+   auto       temp_name = std::string(temp_file_prefix) + temp_file_base_name(file_path) + temp_file_separator +
+                    std::to_string(::getpid()) + "." + std::to_string(unique_id) + "." + std::to_string(attempt);
+   return temp_file_directory(file_path) / temp_name;
+}
+
+/**
+ * Removes a temporary file without throwing.
+ */
+void unlink_noexcept(const std::filesystem::path& file_path) noexcept {
+   if (!file_path.empty())
+      ::unlink(file_path.c_str());
+}
+
+/**
+ * Closes a file descriptor without throwing.
+ */
+void close_descriptor_noexcept(int file_descriptor) noexcept {
+   if (file_descriptor >= 0)
+      ::close(file_descriptor);
+}
+
+/**
+ * Rejects existing final targets that should not be replaced by a secret file.
+ */
+void throw_if_target_is_not_replaceable(const std::filesystem::path& file_path);
 #endif
 
 /**
@@ -47,42 +101,73 @@ int secret_file_open_flags() {
                                 std::error_code(err, std::generic_category()));
 }
 
+#ifndef _WIN32
+void throw_if_target_is_not_replaceable(const std::filesystem::path& file_path) {
+   struct stat stat_result {};
+   if (::lstat(file_path.c_str(), &stat_result) == -1) {
+      if (errno == ENOENT)
+         return;
+      throw_file_failure(file_path, "stat target", errno);
+   }
+
+   if (S_ISLNK(stat_result.st_mode))
+      throw_file_failure(file_path, "replace symlink target", ELOOP);
+
+   if (!S_ISREG(stat_result.st_mode))
+      throw_file_failure(file_path, "replace regular file", EINVAL);
+}
+
+/**
+ * Opens a unique owner-only temporary file in the target directory.
+ */
+std::pair<int, std::filesystem::path> open_temp_file(const std::filesystem::path& file_path) {
+   for (unsigned attempt = 0; attempt < max_temp_file_attempts; ++attempt) {
+      auto temp_path = make_temp_file_path(file_path, attempt);
+      int  fd        = ::open(temp_path.c_str(), secret_file_open_flags(), secret_file_mode);
+      if (fd >= 0)
+         return {fd, std::move(temp_path)};
+
+      if (errno != EEXIST)
+         throw_file_failure(file_path, "open temporary file", errno);
+   }
+
+   throw_file_failure(file_path, "create unique temporary file", EEXIST);
+}
+#endif
+
 } // namespace
 
 secure_output_file::secure_output_file(std::filesystem::path file_path)
    : file_path_(std::move(file_path)) {
 #ifndef _WIN32
-   int fd = ::open(file_path_.c_str(), secret_file_open_flags(), secret_file_mode);
-   if (fd == invalid_descriptor)
-      throw_file_failure(file_path_, "open", errno);
+   throw_if_target_is_not_replaceable(file_path_);
 
-   auto close_on_failure = [fd]() noexcept { ::close(fd); };
+   auto [fd, temp_path] = open_temp_file(file_path_);
+   auto cleanup_on_failure = [&]() noexcept {
+      close_descriptor_noexcept(fd);
+      unlink_noexcept(temp_path);
+   };
 
    struct stat stat_result {};
    if (::fstat(fd, &stat_result) == -1) {
       const int saved_errno = errno;
-      close_on_failure();
-      throw_file_failure(file_path_, "stat", saved_errno);
+      cleanup_on_failure();
+      throw_file_failure(file_path_, "stat temporary file", saved_errno);
    }
 
    if (!S_ISREG(stat_result.st_mode)) {
-      close_on_failure();
-      throw_file_failure(file_path_, "open regular file", EINVAL);
+      cleanup_on_failure();
+      throw_file_failure(file_path_, "open regular temporary file", EINVAL);
    }
 
    if (::fchmod(fd, secret_file_mode) == -1) {
       const int saved_errno = errno;
-      close_on_failure();
-      throw_file_failure(file_path_, "restrict permissions", saved_errno);
-   }
-
-   if (::ftruncate(fd, 0) == -1) {
-      const int saved_errno = errno;
-      close_on_failure();
-      throw_file_failure(file_path_, "truncate", saved_errno);
+      cleanup_on_failure();
+      throw_file_failure(file_path_, "restrict temporary file permissions", saved_errno);
    }
 
    file_descriptor_ = fd;
+   temp_file_path_  = std::move(temp_path);
 #else
    file_.open(file_path_, std::ios::out | std::ios::binary | std::ios::trunc);
    if (!file_)
@@ -94,6 +179,8 @@ secure_output_file::secure_output_file(secure_output_file&& other) noexcept
    : file_path_(std::move(other.file_path_)) {
 #ifndef _WIN32
    file_descriptor_ = std::exchange(other.file_descriptor_, invalid_file_descriptor);
+   temp_file_path_  = std::move(other.temp_file_path_);
+   other.temp_file_path_.clear();
 #else
    file_ = std::move(other.file_);
 #endif
@@ -105,6 +192,8 @@ secure_output_file& secure_output_file::operator=(secure_output_file&& other) no
       file_path_ = std::move(other.file_path_);
 #ifndef _WIN32
       file_descriptor_ = std::exchange(other.file_descriptor_, invalid_file_descriptor);
+      temp_file_path_  = std::move(other.temp_file_path_);
+      other.temp_file_path_.clear();
 #else
       file_ = std::move(other.file_);
 #endif
@@ -121,7 +210,7 @@ void secure_output_file::write(std::string_view content) {
    auto*  cursor    = content.data();
    size_t remaining = content.size();
    while (remaining > 0) {
-      const auto chunk = std::min(remaining, static_cast<size_t>(std::numeric_limits<ssize_t>::max()));
+      const auto chunk  = std::min(remaining, static_cast<size_t>(std::numeric_limits<ssize_t>::max()));
       const auto result = ::write(file_descriptor_, cursor, chunk);
       if (result > 0) {
          cursor += result;
@@ -145,8 +234,29 @@ void secure_output_file::close() {
       return;
 
    const int fd = std::exchange(file_descriptor_, invalid_file_descriptor);
-   if (::close(fd) == -1)
-      throw_file_failure(file_path_, "close", errno);
+   if (::fsync(fd) == -1) {
+      const int saved_errno = errno;
+      close_descriptor_noexcept(fd);
+      unlink_noexcept(temp_file_path_);
+      temp_file_path_.clear();
+      throw_file_failure(file_path_, "sync temporary file", saved_errno);
+   }
+
+   if (::close(fd) == -1) {
+      const int saved_errno = errno;
+      unlink_noexcept(temp_file_path_);
+      temp_file_path_.clear();
+      throw_file_failure(file_path_, "close temporary file", saved_errno);
+   }
+
+   if (::rename(temp_file_path_.c_str(), file_path_.c_str()) == -1) {
+      const int saved_errno = errno;
+      unlink_noexcept(temp_file_path_);
+      temp_file_path_.clear();
+      throw_file_failure(file_path_, "commit temporary file", saved_errno);
+   }
+
+   temp_file_path_.clear();
 #else
    if (!file_.is_open())
       return;
@@ -163,6 +273,8 @@ void secure_output_file::close_noexcept() noexcept {
       ::close(file_descriptor_);
       file_descriptor_ = invalid_file_descriptor;
    }
+   unlink_noexcept(temp_file_path_);
+   temp_file_path_.clear();
 #else
    if (file_.is_open())
       file_.close();

--- a/libraries/libfc/test/CMakeLists.txt
+++ b/libraries/libfc/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable( test_fc
         crypto/test_webauthn.cpp
         io/test_cfile.cpp
         io/test_json.cpp
+        io/test_secure_file.cpp
         log/test_json_formatter.cpp
         io/test_json_variant.cpp
         io/test_random_access_file.cpp

--- a/libraries/libfc/test/io/test_secure_file.cpp
+++ b/libraries/libfc/test/io/test_secure_file.cpp
@@ -1,12 +1,15 @@
 #include <boost/test/unit_test.hpp>
 
+#include <fc/filesystem.hpp>
 #include <fc/io/fstream.hpp>
 #include <fc/io/secure_file.hpp>
 
 #include <fstream>
 #include <string>
+#include <utility>
 
 #ifndef _WIN32
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
@@ -22,6 +25,50 @@ constexpr mode_t group_world_readable_mode     = S_IRUSR | S_IWUSR | S_IRGRP | S
 constexpr auto   first_secret_contents         = "secret\n";
 constexpr auto   second_secret_contents        = "replacement\n";
 constexpr auto   symlink_target_contents       = "target\n";
+
+/**
+ * Closes a POSIX file descriptor when a test scope exits.
+ */
+class scoped_file_descriptor {
+public:
+   explicit scoped_file_descriptor(int file_descriptor)
+      : file_descriptor_(file_descriptor) {}
+
+   scoped_file_descriptor(const scoped_file_descriptor&) = delete;
+   scoped_file_descriptor& operator=(const scoped_file_descriptor&) = delete;
+
+   scoped_file_descriptor(scoped_file_descriptor&& other) noexcept
+      : file_descriptor_(std::exchange(other.file_descriptor_, closed_file_descriptor)) {}
+
+   scoped_file_descriptor& operator=(scoped_file_descriptor&& other) noexcept {
+      if (this != &other) {
+         close();
+         file_descriptor_ = std::exchange(other.file_descriptor_, closed_file_descriptor);
+      }
+      return *this;
+   }
+
+   ~scoped_file_descriptor() {
+      close();
+   }
+
+   /**
+    * Returns the wrapped file descriptor.
+    */
+   int get() const { return file_descriptor_; }
+
+private:
+   static constexpr int closed_file_descriptor = -1;
+
+   void close() noexcept {
+      if (file_descriptor_ != closed_file_descriptor) {
+         ::close(file_descriptor_);
+         file_descriptor_ = closed_file_descriptor;
+      }
+   }
+
+   int file_descriptor_;
+};
 
 /**
  * Restores the process umask when a test scope exits.
@@ -57,6 +104,18 @@ std::string file_contents(const std::filesystem::path& file_path) {
    return contents;
 }
 
+/**
+ * Reads the remaining contents of an opened file descriptor from the beginning.
+ */
+std::string descriptor_contents(int file_descriptor) {
+   BOOST_REQUIRE_EQUAL(::lseek(file_descriptor, 0, SEEK_SET), 0);
+
+   char       buffer[128];
+   const auto bytes_read = ::read(file_descriptor, buffer, sizeof(buffer));
+   BOOST_REQUIRE_GE(bytes_read, 0);
+   return std::string(buffer, static_cast<size_t>(bytes_read));
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_CASE(write_secure_file_creates_owner_only_file_under_permissive_umask) {
@@ -72,7 +131,7 @@ BOOST_AUTO_TEST_CASE(write_secure_file_creates_owner_only_file_under_permissive_
    BOOST_REQUIRE_EQUAL(file_contents(secret_path), first_secret_contents);
 }
 
-BOOST_AUTO_TEST_CASE(write_secure_file_restricts_existing_file_before_replacing_contents) {
+BOOST_AUTO_TEST_CASE(write_secure_file_replaces_existing_file_with_owner_only_file) {
    fc::temp_directory tempdir;
    const auto         secret_path = tempdir.path() / "existing-secret.txt";
 
@@ -82,11 +141,44 @@ BOOST_AUTO_TEST_CASE(write_secure_file_restricts_existing_file_before_replacing_
    }
    BOOST_REQUIRE_EQUAL(::chmod(secret_path.c_str(), group_world_readable_mode), 0);
    BOOST_REQUIRE_EQUAL(file_mode(secret_path), group_world_readable_mode);
+   scoped_file_descriptor existing_reader(::open(secret_path.c_str(), O_RDONLY));
+   BOOST_REQUIRE_GE(existing_reader.get(), 0);
 
    fc::write_secure_file(secret_path, second_secret_contents);
 
    BOOST_REQUIRE_EQUAL(file_mode(secret_path), secret_file_mode);
    BOOST_REQUIRE_EQUAL(file_contents(secret_path), second_secret_contents);
+   BOOST_REQUIRE_EQUAL(descriptor_contents(existing_reader.get()), first_secret_contents);
+}
+
+BOOST_AUTO_TEST_CASE(secure_output_file_supports_move_construction_and_assignment) {
+   fc::temp_directory tempdir;
+   const auto         move_constructed_path = tempdir.path() / "move-constructed-secret.txt";
+   const auto         move_assigned_path    = tempdir.path() / "move-assigned-secret.txt";
+   const auto         discarded_path        = tempdir.path() / "discarded-secret.txt";
+
+   fc::secure_output_file original(move_constructed_path);
+   fc::secure_output_file move_constructed(std::move(original));
+   move_constructed.write(first_secret_contents);
+   move_constructed.close();
+
+   fc::secure_output_file move_source(move_assigned_path);
+   fc::secure_output_file move_assigned(discarded_path);
+   move_assigned = std::move(move_source);
+   move_assigned.write(second_secret_contents);
+   move_assigned.close();
+
+   BOOST_REQUIRE_EQUAL(file_contents(move_constructed_path), first_secret_contents);
+   BOOST_REQUIRE_EQUAL(file_contents(move_assigned_path), second_secret_contents);
+   BOOST_REQUIRE(!std::filesystem::exists(discarded_path));
+}
+
+BOOST_AUTO_TEST_CASE(write_secure_file_rejects_non_regular_target) {
+   fc::temp_directory tempdir;
+   const auto         fifo_path = tempdir.path() / "secret.fifo";
+
+   BOOST_REQUIRE_EQUAL(::mkfifo(fifo_path.c_str(), secret_file_mode), 0);
+   BOOST_CHECK_THROW(fc::write_secure_file(fifo_path, first_secret_contents), std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_CASE(write_secure_file_rejects_final_symlink_target) {

--- a/libraries/libfc/test/io/test_secure_file.cpp
+++ b/libraries/libfc/test/io/test_secure_file.cpp
@@ -26,6 +26,8 @@ constexpr mode_t group_world_readable_mode     = S_IRUSR | S_IWUSR | S_IRGRP | S
 constexpr auto   first_secret_contents         = "secret\n";
 constexpr auto   second_secret_contents        = "replacement\n";
 constexpr auto   symlink_target_contents       = "target\n";
+constexpr long   fallback_name_max             = 255;
+constexpr long   minimum_long_filename_name_max = 64;
 
 /**
  * Owns an open file stream and closes its underlying descriptor when a test scope exits.
@@ -78,6 +80,16 @@ std::string stream_contents(std::FILE* file) {
    return std::string(buffer, bytes_read);
 }
 
+/**
+ * Returns a test-safe near-limit filename length for the temporary directory.
+ */
+size_t near_limit_file_name_length(const std::filesystem::path& directory_path) {
+   const auto name_max = ::pathconf(directory_path.c_str(), _PC_NAME_MAX);
+   const auto limit    = name_max > 0 ? name_max : fallback_name_max;
+   BOOST_REQUIRE_GT(limit, minimum_long_filename_name_max);
+   return static_cast<size_t>(limit - 1);
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_CASE(write_secure_file_creates_owner_only_file_under_permissive_umask) {
@@ -113,6 +125,16 @@ BOOST_AUTO_TEST_CASE(write_secure_file_replaces_existing_file_with_owner_only_fi
    BOOST_REQUIRE_EQUAL(stream_contents(existing_reader.get()), first_secret_contents);
 }
 
+BOOST_AUTO_TEST_CASE(write_secure_file_handles_near_limit_file_name) {
+   fc::temp_directory tempdir;
+   const auto         secret_path = tempdir.path() / std::string(near_limit_file_name_length(tempdir.path()), 's');
+
+   fc::write_secure_file(secret_path, first_secret_contents);
+
+   BOOST_REQUIRE_EQUAL(file_mode(secret_path), secret_file_mode);
+   BOOST_REQUIRE_EQUAL(file_contents(secret_path), first_secret_contents);
+}
+
 BOOST_AUTO_TEST_CASE(secure_output_file_supports_move_construction_and_assignment) {
    fc::temp_directory tempdir;
    const auto         move_constructed_path = tempdir.path() / "move-constructed-secret.txt";
@@ -133,6 +155,18 @@ BOOST_AUTO_TEST_CASE(secure_output_file_supports_move_construction_and_assignmen
    BOOST_REQUIRE_EQUAL(file_contents(move_constructed_path), first_secret_contents);
    BOOST_REQUIRE_EQUAL(file_contents(move_assigned_path), second_secret_contents);
    BOOST_REQUIRE(!std::filesystem::exists(discarded_path));
+}
+
+BOOST_AUTO_TEST_CASE(secure_output_file_destruction_without_close_discards_pending_file) {
+   fc::temp_directory tempdir;
+   const auto         secret_path = tempdir.path() / "discarded-secret.txt";
+
+   {
+      fc::secure_output_file output_file(secret_path);
+      output_file.write(first_secret_contents);
+   }
+
+   BOOST_REQUIRE(!std::filesystem::exists(secret_path));
 }
 
 BOOST_AUTO_TEST_CASE(write_secure_file_rejects_non_regular_target) {

--- a/libraries/libfc/test/io/test_secure_file.cpp
+++ b/libraries/libfc/test/io/test_secure_file.cpp
@@ -4,13 +4,13 @@
 #include <fc/io/fstream.hpp>
 #include <fc/io/secure_file.hpp>
 
+#include <cstdio>
 #include <fstream>
 #include <memory>
 #include <string>
 #include <utility>
 
 #ifndef _WIN32
-#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
@@ -28,20 +28,9 @@ constexpr auto   second_secret_contents        = "replacement\n";
 constexpr auto   symlink_target_contents       = "target\n";
 
 /**
- * Closes and releases a heap-owned POSIX file descriptor when a test scope exits.
+ * Owns an open file stream and closes its underlying descriptor when a test scope exits.
  */
-struct file_descriptor_deleter {
-   void operator()(int* file_descriptor) const noexcept {
-      if (file_descriptor != nullptr) {
-         if (*file_descriptor >= 0) {
-            ::close(*file_descriptor);
-         }
-         delete file_descriptor;
-      }
-   }
-};
-
-using file_descriptor_ptr = std::unique_ptr<int, file_descriptor_deleter>;
+using file_stream_ptr = std::unique_ptr<std::FILE, decltype(&std::fclose)>;
 
 /**
  * Restores the process umask when a test scope exits.
@@ -78,15 +67,15 @@ std::string file_contents(const std::filesystem::path& file_path) {
 }
 
 /**
- * Reads the remaining contents of an opened file descriptor from the beginning.
+ * Reads the contents of an opened file stream from the beginning.
  */
-std::string descriptor_contents(int file_descriptor) {
-   BOOST_REQUIRE_EQUAL(::lseek(file_descriptor, 0, SEEK_SET), 0);
+std::string stream_contents(std::FILE* file) {
+   BOOST_REQUIRE_EQUAL(std::fseek(file, 0, SEEK_SET), 0);
 
    char       buffer[128];
-   const auto bytes_read = ::read(file_descriptor, buffer, sizeof(buffer));
-   BOOST_REQUIRE_GE(bytes_read, 0);
-   return std::string(buffer, static_cast<size_t>(bytes_read));
+   const auto bytes_read = std::fread(buffer, sizeof(char), sizeof(buffer), file);
+   BOOST_REQUIRE(!std::ferror(file));
+   return std::string(buffer, bytes_read);
 }
 
 } // namespace
@@ -114,14 +103,14 @@ BOOST_AUTO_TEST_CASE(write_secure_file_replaces_existing_file_with_owner_only_fi
    }
    BOOST_REQUIRE_EQUAL(::chmod(secret_path.c_str(), group_world_readable_mode), 0);
    BOOST_REQUIRE_EQUAL(file_mode(secret_path), group_world_readable_mode);
-   file_descriptor_ptr existing_reader(new int(::open(secret_path.c_str(), O_RDONLY)));
-   BOOST_REQUIRE_GE(*existing_reader, 0);
+   file_stream_ptr existing_reader(std::fopen(secret_path.c_str(), "r"), &std::fclose);
+   BOOST_REQUIRE(existing_reader != nullptr);
 
    fc::write_secure_file(secret_path, second_secret_contents);
 
    BOOST_REQUIRE_EQUAL(file_mode(secret_path), secret_file_mode);
    BOOST_REQUIRE_EQUAL(file_contents(secret_path), second_secret_contents);
-   BOOST_REQUIRE_EQUAL(descriptor_contents(*existing_reader), first_secret_contents);
+   BOOST_REQUIRE_EQUAL(stream_contents(existing_reader.get()), first_secret_contents);
 }
 
 BOOST_AUTO_TEST_CASE(secure_output_file_supports_move_construction_and_assignment) {

--- a/libraries/libfc/test/io/test_secure_file.cpp
+++ b/libraries/libfc/test/io/test_secure_file.cpp
@@ -5,6 +5,7 @@
 #include <fc/io/secure_file.hpp>
 
 #include <fstream>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -27,48 +28,20 @@ constexpr auto   second_secret_contents        = "replacement\n";
 constexpr auto   symlink_target_contents       = "target\n";
 
 /**
- * Closes a POSIX file descriptor when a test scope exits.
+ * Closes and releases a heap-owned POSIX file descriptor when a test scope exits.
  */
-class scoped_file_descriptor {
-public:
-   explicit scoped_file_descriptor(int file_descriptor)
-      : file_descriptor_(file_descriptor) {}
-
-   scoped_file_descriptor(const scoped_file_descriptor&) = delete;
-   scoped_file_descriptor& operator=(const scoped_file_descriptor&) = delete;
-
-   scoped_file_descriptor(scoped_file_descriptor&& other) noexcept
-      : file_descriptor_(std::exchange(other.file_descriptor_, closed_file_descriptor)) {}
-
-   scoped_file_descriptor& operator=(scoped_file_descriptor&& other) noexcept {
-      if (this != &other) {
-         close();
-         file_descriptor_ = std::exchange(other.file_descriptor_, closed_file_descriptor);
-      }
-      return *this;
-   }
-
-   ~scoped_file_descriptor() {
-      close();
-   }
-
-   /**
-    * Returns the wrapped file descriptor.
-    */
-   int get() const { return file_descriptor_; }
-
-private:
-   static constexpr int closed_file_descriptor = -1;
-
-   void close() noexcept {
-      if (file_descriptor_ != closed_file_descriptor) {
-         ::close(file_descriptor_);
-         file_descriptor_ = closed_file_descriptor;
+struct file_descriptor_deleter {
+   void operator()(int* file_descriptor) const noexcept {
+      if (file_descriptor != nullptr) {
+         if (*file_descriptor >= 0) {
+            ::close(*file_descriptor);
+         }
+         delete file_descriptor;
       }
    }
-
-   int file_descriptor_;
 };
+
+using file_descriptor_ptr = std::unique_ptr<int, file_descriptor_deleter>;
 
 /**
  * Restores the process umask when a test scope exits.
@@ -141,14 +114,14 @@ BOOST_AUTO_TEST_CASE(write_secure_file_replaces_existing_file_with_owner_only_fi
    }
    BOOST_REQUIRE_EQUAL(::chmod(secret_path.c_str(), group_world_readable_mode), 0);
    BOOST_REQUIRE_EQUAL(file_mode(secret_path), group_world_readable_mode);
-   scoped_file_descriptor existing_reader(::open(secret_path.c_str(), O_RDONLY));
-   BOOST_REQUIRE_GE(existing_reader.get(), 0);
+   file_descriptor_ptr existing_reader(new int(::open(secret_path.c_str(), O_RDONLY)));
+   BOOST_REQUIRE_GE(*existing_reader, 0);
 
    fc::write_secure_file(secret_path, second_secret_contents);
 
    BOOST_REQUIRE_EQUAL(file_mode(secret_path), secret_file_mode);
    BOOST_REQUIRE_EQUAL(file_contents(secret_path), second_secret_contents);
-   BOOST_REQUIRE_EQUAL(descriptor_contents(existing_reader.get()), first_secret_contents);
+   BOOST_REQUIRE_EQUAL(descriptor_contents(*existing_reader), first_secret_contents);
 }
 
 BOOST_AUTO_TEST_CASE(secure_output_file_supports_move_construction_and_assignment) {

--- a/libraries/libfc/test/io/test_secure_file.cpp
+++ b/libraries/libfc/test/io/test_secure_file.cpp
@@ -1,0 +1,108 @@
+#include <boost/test/unit_test.hpp>
+
+#include <fc/io/fstream.hpp>
+#include <fc/io/secure_file.hpp>
+
+#include <fstream>
+#include <string>
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+BOOST_AUTO_TEST_SUITE(secure_file_test_suite)
+
+#ifndef _WIN32
+namespace {
+
+constexpr mode_t permissive_file_creation_umask = S_IWGRP | S_IWOTH;
+constexpr mode_t secret_file_mode              = S_IRUSR | S_IWUSR;
+constexpr mode_t group_world_readable_mode     = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+constexpr auto   first_secret_contents         = "secret\n";
+constexpr auto   second_secret_contents        = "replacement\n";
+constexpr auto   symlink_target_contents       = "target\n";
+
+/**
+ * Restores the process umask when a test scope exits.
+ */
+class scoped_umask {
+public:
+   explicit scoped_umask(mode_t new_umask)
+      : old_umask_(::umask(new_umask)) {}
+
+   ~scoped_umask() {
+      ::umask(old_umask_);
+   }
+
+private:
+   mode_t old_umask_;
+};
+
+/**
+ * Returns POSIX permission bits for a filesystem path.
+ */
+mode_t file_mode(const std::filesystem::path& file_path) {
+   struct stat stat_result {};
+   BOOST_REQUIRE_EQUAL(::stat(file_path.c_str(), &stat_result), 0);
+   return stat_result.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+}
+
+/**
+ * Reads a whole file as a string for content assertions.
+ */
+std::string file_contents(const std::filesystem::path& file_path) {
+   std::string contents;
+   fc::read_file_contents(file_path, contents);
+   return contents;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(write_secure_file_creates_owner_only_file_under_permissive_umask) {
+   fc::temp_directory tempdir;
+   const auto         secret_path = tempdir.path() / "generated-secret.txt";
+
+   {
+      scoped_umask umask_guard(permissive_file_creation_umask);
+      fc::write_secure_file(secret_path, first_secret_contents);
+   }
+
+   BOOST_REQUIRE_EQUAL(file_mode(secret_path), secret_file_mode);
+   BOOST_REQUIRE_EQUAL(file_contents(secret_path), first_secret_contents);
+}
+
+BOOST_AUTO_TEST_CASE(write_secure_file_restricts_existing_file_before_replacing_contents) {
+   fc::temp_directory tempdir;
+   const auto         secret_path = tempdir.path() / "existing-secret.txt";
+
+   {
+      std::ofstream out(secret_path);
+      out << first_secret_contents;
+   }
+   BOOST_REQUIRE_EQUAL(::chmod(secret_path.c_str(), group_world_readable_mode), 0);
+   BOOST_REQUIRE_EQUAL(file_mode(secret_path), group_world_readable_mode);
+
+   fc::write_secure_file(secret_path, second_secret_contents);
+
+   BOOST_REQUIRE_EQUAL(file_mode(secret_path), secret_file_mode);
+   BOOST_REQUIRE_EQUAL(file_contents(secret_path), second_secret_contents);
+}
+
+BOOST_AUTO_TEST_CASE(write_secure_file_rejects_final_symlink_target) {
+   fc::temp_directory tempdir;
+   const auto         target_path = tempdir.path() / "target.txt";
+   const auto         link_path   = tempdir.path() / "linked-secret.txt";
+
+   {
+      std::ofstream out(target_path);
+      out << symlink_target_contents;
+   }
+   std::filesystem::create_symlink(target_path, link_path);
+
+   BOOST_CHECK_THROW(fc::write_secure_file(link_path, first_secret_contents), std::ios_base::failure);
+   BOOST_REQUIRE_EQUAL(file_contents(target_path), symlink_target_contents);
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/programs/clio/main.cpp
+++ b/programs/clio/main.cpp
@@ -3126,8 +3126,9 @@ int main( int argc, char** argv ) {
          std::cerr << localized("saving password to ${filename}", ("filename", password_file)) << std::endl;
          auto password_str = fc::json::to_pretty_string(v);
          boost::replace_all(password_str, "\"", "");
-         password_out->write(password_str);
-         password_out->close();
+         auto& out = password_out.value();
+         out.write(password_str);
+         out.close();
       }
    });
 

--- a/programs/clio/main.cpp
+++ b/programs/clio/main.cpp
@@ -69,6 +69,7 @@ Options:
 #include <regex>
 #include <iostream>
 #include <locale>
+#include <optional>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -81,6 +82,7 @@ Options:
 #include <fc/exception/exception.hpp>
 #include <fc/variant_object.hpp>
 #include <fc/io/fstream.hpp>
+#include <fc/io/secure_file.hpp>
 
 #include <sysio/chain/name.hpp>
 #include <sysio/chain/config.hpp>
@@ -1987,9 +1989,8 @@ int main( int argc, char** argv ) {
          std::cout << localized("Public key: ${key}", ("key", pubs ) ) << std::endl;
       } else {
          std::cerr << localized("saving keys to ${filename}", ("filename", key_file)) << std::endl;
-         std::ofstream out( key_file.c_str() );
-         out << localized("Private key: ${key}", ("key",  privs) ) << std::endl;
-         out << localized("Public key: ${key}", ("key", pubs ) ) << std::endl;
+         fc::write_secure_file(key_file, localized("Private key: ${key}", ("key", privs)) + "\n" +
+                                            localized("Public key: ${key}", ("key", pubs)) + "\n");
       }
    });
    auto k1_flag  = create_key_cmd->add_flag( "--k1", k1, "Generate a key using the K1 curve (Bitcoin) with PUB_K1_ & PVT_K1_ prefix instead of legacy"  );
@@ -2177,11 +2178,11 @@ int main( int argc, char** argv ) {
          std::cout << localized("Public key: ${key}", ("key", pubk.to_string({}, true) ) ) << std::endl;
       } else {
          std::cerr << localized("saving keys to ${filename}", ("filename", key_file)) << std::endl;
-         std::ofstream out( key_file.c_str() );
-         out << localized("Private key: ${key}", ("key", privk.to_string({})) ) << std::endl;
-         out << localized("Public key: ${key}", ("key", pubk.to_string({}) ) ) << std::endl;
-         out << localized("Private key: ${key}", ("key", privk.to_string({}, true)) ) << std::endl;
-         out << localized("Public key: ${key}", ("key", pubk.to_string({}, true) ) ) << std::endl;
+         fc::write_secure_file(key_file,
+                               localized("Private key: ${key}", ("key", privk.to_string({}))) + "\n" +
+                                  localized("Public key: ${key}", ("key", pubk.to_string({}))) + "\n" +
+                                  localized("Private key: ${key}", ("key", privk.to_string({}, true))) + "\n" +
+                                  localized("Public key: ${key}", ("key", pubk.to_string({}, true))) + "\n");
       }
    });
 
@@ -2241,9 +2242,8 @@ int main( int argc, char** argv ) {
          std::cout << localized("Public key: ${key}",  ("key", pubk.to_string({}, true))  ) << std::endl;
       } else {
          std::cerr << localized("saving keys to ${filename}", ("filename", key_file)) << std::endl;
-         std::ofstream out( key_file.c_str() );
-         out << localized("Private key: ${key}", ("key", privk.to_string({}, true)) ) << std::endl;
-         out << localized("Public key: ${key}",  ("key", pubk.to_string({}, true))  ) << std::endl;
+         fc::write_secure_file(key_file, localized("Private key: ${key}", ("key", privk.to_string({}, true))) + "\n" +
+                                            localized("Public key: ${key}", ("key", pubk.to_string({}, true))) + "\n");
       }
    });
 
@@ -2335,10 +2335,9 @@ int main( int argc, char** argv ) {
          std::cout << localized("Ethereum address: ${a}", ("a", addr)) << std::endl;
       } else {
          std::cerr << localized("saving keys to ${f}", ("f", key_file)) << std::endl;
-         std::ofstream out( key_file.c_str() );
-         out << localized("Private key: ${k}", ("k", k1_priv.to_string({}, true))) << std::endl;
-         out << localized("Public key: ${k}",  ("k", k1_pub.to_string({}, true)))  << std::endl;
-         out << localized("Ethereum address: ${a}", ("a", addr)) << std::endl;
+         fc::write_secure_file(key_file, localized("Private key: ${k}", ("k", k1_priv.to_string({}, true))) + "\n" +
+                                            localized("Public key: ${k}", ("k", k1_pub.to_string({}, true))) + "\n" +
+                                            localized("Ethereum address: ${a}", ("a", addr)) + "\n");
       }
    });
 
@@ -3113,7 +3112,9 @@ int main( int argc, char** argv ) {
    create_wallet_cmd->add_flag( "--to-console", print_console, localized("Print password to console."));
    create_wallet_cmd->callback([&wallet_name, &password_file, &print_console] {
       SYSC_ASSERT( !password_file.empty() ^ print_console, "ERROR: Either indicate a file using \"--file\" or pass \"--to-console\"" );
-      SYSC_ASSERT( password_file.empty() || !std::ofstream(password_file.c_str()).fail(), "ERROR: Failed to create file in specified path" );
+      std::optional<fc::secure_output_file> password_out;
+      if (!password_file.empty())
+         password_out.emplace(password_file);
 
       const auto& v = call(wallet_url, wallet_create, wallet_name);
       std::cout << localized("Creating wallet: ${wallet_name}", ("wallet_name", wallet_name)) << std::endl;
@@ -3125,8 +3126,8 @@ int main( int argc, char** argv ) {
          std::cerr << localized("saving password to ${filename}", ("filename", password_file)) << std::endl;
          auto password_str = fc::json::to_pretty_string(v);
          boost::replace_all(password_str, "\"", "");
-         std::ofstream out( password_file.c_str() );
-         out << password_str;
+         password_out->write(password_str);
+         password_out->close();
       }
    });
 

--- a/programs/sys-util/actions/bls_actions.cpp
+++ b/programs/sys-util/actions/bls_actions.cpp
@@ -3,6 +3,7 @@
 #include <fc/crypto/bls_private_key.hpp>
 #include <fc/crypto/bls_public_key.hpp>
 #include <fc/crypto/bls_signature.hpp>
+#include <fc/io/secure_file.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -66,8 +67,7 @@ int bls_actions::create_key() {
       std::cout << out_str;
    } else {
       std::cout << "saving keys to " << opt->key_file << "\n";
-      std::ofstream out( opt->key_file.c_str() );
-      out << out_str;
+      fc::write_secure_file(opt->key_file, out_str);
    }
 
    return 0;

--- a/tests/clio_em_key_test.py
+++ b/tests/clio_em_key_test.py
@@ -31,7 +31,9 @@ be edited to match a code change -- a mismatch means clio/libfc diverged from
 the Ethereum ecosystem, which is a bug in libfc, not in this vector.
 """
 
+import os
 import re
+import stat
 import subprocess
 import tempfile
 
@@ -64,6 +66,23 @@ KAT_PVT_K1      = "PVT_K1_Xx4wsMynSZ39WiwEn8wzRL9trcKK33ZzwaZKJmymYx5UTjKvv"
 KAT_PUB_K1      = "PUB_K1_5TrYnZP1RkDSUMzBY4GanCy6AP68kCMdkAb5EACkAwkdc8tm4t"
 
 testSuccessful = False
+PERMISSIVE_UMASK = stat.S_IWGRP | stat.S_IWOTH
+SECRET_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR
+
+
+def run_with_umask(mask, callback):
+    """Run ``callback`` while the process umask is temporarily set to ``mask``."""
+    old_umask = os.umask(mask)
+    try:
+        return callback()
+    finally:
+        os.umask(old_umask)
+
+
+def assert_owner_only_secret_file(path):
+    """Assert that a generated secret file is readable and writable only by its owner."""
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == SECRET_FILE_MODE, "expected %s to have mode 0o600, got 0o%03o" % (path, mode)
 
 
 def clio(*args, expect_fail=False, raw=False):
@@ -116,13 +135,31 @@ def test_create_key_sol():
     assert clio("create", "key", "--sol", "--to-console")["Private key"] != r["Private key"]
 
 
-def test_create_key_to_file():
-    """--file persists the same forms --to-console prints."""
-    with tempfile.NamedTemporaryFile(mode="w+") as f:
-        clio("create", "key", "--em", "--file", f.name)
-        f.seek(0)
-        body = f.read()
-    assert "PVT_EM_" in body and "PUB_EM_" in body, body
+def test_secret_key_output_files_are_owner_only():
+    """Secret-bearing ``--file`` outputs are owner-only even under a permissive umask."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        def create_secret_files():
+            """Create representative clio secret-output files in ``temp_dir``."""
+            create_path = os.path.join(temp_dir, "created-em-key.txt")
+            clio("create", "key", "--em", "--file", create_path)
+            assert_owner_only_secret_file(create_path)
+            with open(create_path, encoding="utf-8") as f:
+                body = f.read()
+            assert "PVT_EM_" in body and "PUB_EM_" in body, body
+
+            k1_convert_path = os.path.join(temp_dir, "converted-k1-key.txt")
+            clio("convert", "k1_private_key", "--private-key", KAT_PVT_K1, "--file", k1_convert_path)
+            assert_owner_only_secret_file(k1_convert_path)
+
+            em_convert_path = os.path.join(temp_dir, "converted-em-key.txt")
+            clio("convert", "em_private_key", "--private-key", KAT_ETH_SECRET, "--file", em_convert_path)
+            assert_owner_only_secret_file(em_convert_path)
+
+            eth_to_k1_path = os.path.join(temp_dir, "eth-to-k1-key.txt")
+            clio("convert", "eth_to_k1_private", "--private-key", KAT_ETH_SECRET, "--file", eth_to_k1_path)
+            assert_owner_only_secret_file(eth_to_k1_path)
+
+        run_with_umask(PERMISSIVE_UMASK, create_secret_files)
 
 
 def test_known_answer_vector():
@@ -227,7 +264,7 @@ def test_eth_to_k1():
 try:
     test_create_key_em_roundtrip()
     test_create_key_sol()
-    test_create_key_to_file()
+    test_secret_key_output_files_are_owner_only()
     test_known_answer_vector()
     test_recover_is_digest_bound()
     test_error_handling()

--- a/tests/sysio_util_bls_test.py
+++ b/tests/sysio_util_bls_test.py
@@ -2,6 +2,8 @@
 
 import os
 import re
+import shlex
+import stat
 import tempfile
 
 from TestHarness import Utils
@@ -18,17 +20,44 @@ from TestHarness import Utils
 
 Print=Utils.Print
 testSuccessful=False
+PERMISSIVE_UMASK = stat.S_IWGRP | stat.S_IWOTH
+SECRET_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR
+
+def run_with_umask(mask, callback):
+    """Run ``callback`` while the process umask is temporarily set to ``mask``."""
+    old_umask = os.umask(mask)
+    try:
+        return callback()
+    finally:
+        os.umask(old_umask)
+
+def assert_owner_only_secret_file(path):
+    """Assert that a generated secret file is readable and writable only by its owner."""
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == SECRET_FILE_MODE, "expected %s to have mode 0o600, got 0o%03o" % (path, mode)
+
 
 def test_create_key_to_console():
     rslts = Utils.processSysioUtilCmd("bls create key --to-console", "create key to console", silentErrors=False)
     check_create_key_results(rslts)
 
 def test_create_key_to_file():
-    with tempfile.NamedTemporaryFile(mode="w+") as tmp_file:
-        Utils.processSysioUtilCmd("bls create key --file {}".format(tmp_file.name), "create key to file", silentErrors=False)
+    """``bls create key --file`` creates owner-only secret files under permissive umask."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        secret_path = os.path.join(temp_dir, "bls-key.txt")
 
-        tmp_file.seek(0)
-        rslts = tmp_file.read()
+        def create_secret_file():
+            """Create the BLS secret file while the test umask is active."""
+            Utils.processSysioUtilCmd(
+                "bls create key --file {}".format(shlex.quote(secret_path)),
+                "create key to file",
+                silentErrors=False,
+            )
+
+        run_with_umask(PERMISSIVE_UMASK, create_secret_file)
+        assert_owner_only_secret_file(secret_path)
+        with open(secret_path, encoding="utf-8") as secret_file:
+            rslts = secret_file.read()
         check_create_key_results(rslts)
 
 def test_create_pop_from_command_line():


### PR DESCRIPTION
## Motivation / Why

SEC-84 covers secret-bearing CLI outputs that were written with regular stream file creation, allowing the caller's umask to decide the final file mode. Under a permissive umask, generated private keys, BLS keys, or wallet passwords could become group/world-readable. This PR centralizes those writes behind a POSIX helper that creates owner-only outputs and avoids publishing incomplete replacements.

## What Changed

- Added `fc::secure_output_file` / `fc::write_secure_file` for secret file writes.
- On POSIX, the helper writes to an owner-only temporary file in the target directory, syncs and closes it, atomically publishes it with `rename`, then syncs the containing directory.
- Existing final symlinks and non-regular final targets are rejected; uncommitted temporary files are discarded on destruction.
- Temporary file names are bounded to the target directory's filename limit so near-limit destination names still work.
- Internal fd/temp-file cleanup uses `fc::make_scoped_exit` while preserving explicit close-error reporting.
- Updated affected `clio` key/wallet password and `sys-util bls` `--file` paths to use the secure helper instead of `std::ofstream`.
- Added regression coverage for permissive umask behavior, existing-file replacement without disturbing already-open readers, move operations, destructor discard before close, near-limit filenames, non-regular targets, and final symlink targets.

## Reviewer Notes

- POSIX hardening guarantees are POSIX-only; Windows currently keeps the fallback `std::ofstream` behavior.
- `wallet create --file` uses the same secure helper, but does not have a separate service-backed wallet integration test.
- System-contract e2e validation is not applicable; this PR does not modify `contracts/sysio.*`.

## Validation

- Focused local Release validation passed: `fc`, `test_fc`, `clio`, and `sys-util` build targets; `secure_file_test_suite` (`7` cases); `clio_em_key_test.py`; `sysio_util_bls_test.py`; `git diff --check`.
- GitHub PR CI passed for latest head `5f5b0ac7c7ec2db9061377fb96d0c2476ac1b162`: Linux amd64 matrix and Apple Silicon.
