### PR TITLE
Test: keep ship_restart_test clear of the state-history-stride boundary

### DIFF
--- a/tests/ship_restart_test.py
+++ b/tests/ship_restart_test.py
@@ -34,6 +34,10 @@ testSuccessful=False
 prodNodeId = 0
 shipNodeId = 1
 
+# SHiP log rotation stride. The shutdown guard below keeps the stop point clear of stride
+# boundaries so the head log/index files the test operates on are never empty.
+shipStride = 200
+
 origStateHistoryLog   = ""
 stateHistoryLog       = ""
 origStateHistoryIndex = ""
@@ -63,7 +67,7 @@ try:
     specificExtraNodeopArgs[shipNodeId]=(
         "--plugin sysio::state_history_plugin "
         "--trace-history --chain-state-history --finality-data-history "
-        "--state-history-stride 200 "
+        f"--state-history-stride {shipStride} "
         f"--state-history-endpoint 127.0.0.1:{Utils.getPort(Utils.PortStateHistory)} "
         "--plugin sysio::net_api_plugin --plugin sysio::producer_api_plugin"
     )
@@ -85,6 +89,19 @@ try:
     shipNode = cluster.getNode(shipNodeId)
 
     Print("Shutdown producer and SHiP nodes")
+
+    # Stay clear of a state-history-stride boundary before stopping. When the last stored block is
+    # exactly a stride multiple, rotation has just moved every entry into retained/ and the head
+    # log/index files are 0 bytes, so the file surgery below would operate on empty files. A few
+    # more blocks can be produced between this check and the pause taking effect, so keep a margin
+    # on both sides of the boundary.
+    head = prodNode.getHeadBlockNum()
+    posInStride = head % shipStride
+    if posInStride < 5 or posInStride > shipStride - 10:
+        safeBlock = head - posInStride + (5 if posInStride < 5 else shipStride + 5)
+        Print(f"Head block {head} is near a stride boundary, waiting for block {safeBlock}")
+        assert prodNode.waitForBlock(safeBlock, timeout=30), f"Timed out waiting for block {safeBlock}"
+
     prodNode.processUrllibRequest("producer", "pause", exitOnError=True)
     blockNum = prodNode.getHeadBlockNum()
     shipNode.waitForBlock(blockNum)


### PR DESCRIPTION
ship_restart_test failed on master CI ([run 28587809209](https://github.com/Wire-Network/wire-sysio/actions/runs/28587809209/job/84763751464)) with `OSError: [Errno 22] Invalid argument` raised by the test's own `f.truncate(newSize)` during the "Truncated index file test" phase.

The SHiP node runs with `--state-history-stride 200` and cluster bootstrap takes close to 200 half-second blocks, so the test's shutdown can land exactly on a stride boundary. When the SHiP node stops exactly at block 200, rotation has just moved every entry into `retained/` and the head `chain_state_history.log`/`.index` are 0 bytes: the CI artifact shows 0-byte head files, a fully populated `retained/chain_state_history-1-200.*`, and the SHiP node's last applied block exactly #200. The test then computes `newSize = getsize(index) - 8 = -8`, and `truncate(-8)` raises EINVAL. The preceding "index file removed" phase also passes vacuously when the files are empty. nodeop behaved correctly throughout; this is purely a test-timing bug, and upstream Spring's ship_restart_test.py has the same latent issue.

Before pausing the producer, wait until the head block is a few blocks past a stride boundary and not within pause latency of the next one, so the head log and index always contain entries when the SHiP node stops. The stride is now a named constant shared with the SHiP node arguments. When the guard engages, the rest of the test exercises the restart scenarios against a post-rotation head log with retained/ segments present, which is exactly the shape the CI failure exposed.