### PR TITLE
Test: fix nodeop_read_terminate_at_block flake from late snapshots

### DIFF
--- a/tests/nodeop_read_terminate_at_block_test.py
+++ b/tests/nodeop_read_terminate_at_block_test.py
@@ -313,9 +313,14 @@ try:
         termAt = headBlockNum + 5
         replayTermAt[nodeId] = termAt
 
-    # wait for all to terminate, needs to be larger than largest terminate-at-block
-    # and leave room for snapshot blocks
-    producingNode.waitForBlock( 250, timeout=150 )
+    # Wait for the producer to advance past every terminate-at-block target before the
+    # cluster is torn down. Regular nodes (1-4) terminate at <=180, but the snapshot-replay
+    # nodes terminate at snapshot_head+5, which is only known now and can land at/beyond a
+    # fixed cap when bootstrap is slow. If the producer stopped exactly at a replay node's
+    # termAt, that node's block log would hold no block beyond termAt and the later
+    # "advance past termAt" check could never pass. The 250 floor keeps the regular nodes
+    # covered; the +5 margin lets a lagging replay node still sync a block beyond termAt.
+    producingNode.waitForBlock( max(250, max(replayTermAt.values()) + 5), timeout=150 )
     cluster.biosNode.kill(signal.SIGTERM)
     producingNode.kill(signal.SIGTERM)
 


### PR DESCRIPTION
## Summary

`nodeop_read_terminate_at_block_lr_test` is a latent flake (test unchanged since the Spring merge) that surfaced on master — run for #464, commit 62ec3356.

The snapshot-replay portion snapshots nodes 5-10, terminates each at `snapshot_head + 5`, then checks the node can relaunch and advance *past* that block. But the producer was only driven to a fixed `waitForBlock(250)` before the cluster is torn down. When bootstrap runs slowly (CI load), the snapshots are taken near the chain head, so `snapshot_head + 5` reaches or exceeds 250 — the producer then stops at exactly a replay node's terminate block and no block beyond it ever exists. In the failing run, node 9 terminated at 251 while the producer's max block was also 251, so `Writing chain_head block 251 > 251` failed.

## Fix

Wait for `max(250, max(replayTermAt.values()) + 5)` instead of a fixed 250. The floor keeps the regular nodes (terminate ≤ 180) covered and leaves the fast-bootstrap case unchanged; the margin guarantees each replay node has a block beyond its terminate target so the post-terminate check is always satisfiable.
