### PR TITLE
Test: share the state-history-stride boundary guard across ship-log tests

### DIFF
--- a/tests/TestHarness/Node.py
+++ b/tests/TestHarness/Node.py
@@ -281,6 +281,22 @@ class Node(Transactions):
                 return False
         return True
 
+    def waitForBlockClearOfStride(self, stride, lowerMargin=5, upperMargin=10, timeout=None):
+        """Advance the head clear of a state-history-stride rotation boundary before stopping.
+
+        When the last stored block is exactly a stride multiple, SHiP log rotation has just moved
+        every entry into retained/ and the head log/index files are 0 bytes, so tooling that reads
+        the head log has nothing to work with. A few more blocks can be produced between this check
+        and a pause taking effect, so a margin is kept on both sides of the boundary. Returns True
+        once the head is clear of the boundary, waiting for a safe block if needed."""
+        head = self.getHeadBlockNum()
+        posInStride = head % stride
+        if lowerMargin <= posInStride <= stride - upperMargin:
+            return True
+        safeBlock = head - posInStride + (lowerMargin if posInStride < lowerMargin else stride + lowerMargin)
+        Utils.Print(f"Head block {head} is near a state-history-stride boundary, waiting for block {safeBlock}")
+        return self.waitForBlock(safeBlock, timeout=timeout)
+
     def waitForAnyProducer(self, producers, timeout=None, exitOnError=False):
         if timeout is None:
             # default to the typical configuration of 21 producers, each producing 12 blocks in a row (every 1/2 second)

--- a/tests/ship_log_util_test.py
+++ b/tests/ship_log_util_test.py
@@ -116,6 +116,11 @@ try:
     assert Utils.waitForBool(lambda: prodNode.getHeadBlockNum() > shipStride + 10, timeout=300), \
         f"chain did not reach block {shipStride + 10}"
 
+    # Stop clear of a state-history-stride boundary: on an exact multiple the head log/index have
+    # just rotated into retained/ and are empty, which the info/range checks below cannot parse.
+    assert prodNode.waitForBlockClearOfStride(shipStride, timeout=30), \
+        "producer did not advance clear of a state-history-stride boundary"
+
     Print("Pause producer and stop both nodes")
     prodNode.processUrllibRequest("producer", "pause", exitOnError=True)
     # pause can return while one more block is mid-production; wait for the head to settle so the

--- a/tests/ship_restart_test.py
+++ b/tests/ship_restart_test.py
@@ -90,17 +90,11 @@ try:
 
     Print("Shutdown producer and SHiP nodes")
 
-    # Stay clear of a state-history-stride boundary before stopping. When the last stored block is
-    # exactly a stride multiple, rotation has just moved every entry into retained/ and the head
-    # log/index files are 0 bytes, so the file surgery below would operate on empty files. A few
-    # more blocks can be produced between this check and the pause taking effect, so keep a margin
-    # on both sides of the boundary.
-    head = prodNode.getHeadBlockNum()
-    posInStride = head % shipStride
-    if posInStride < 5 or posInStride > shipStride - 10:
-        safeBlock = head - posInStride + (5 if posInStride < 5 else shipStride + 5)
-        Print(f"Head block {head} is near a stride boundary, waiting for block {safeBlock}")
-        assert prodNode.waitForBlock(safeBlock, timeout=30), f"Timed out waiting for block {safeBlock}"
+    # Stop clear of a state-history-stride boundary: on an exact multiple the head log/index have
+    # just rotated into retained/ and are 0 bytes, so the file surgery below would operate on empty
+    # files.
+    assert prodNode.waitForBlockClearOfStride(shipStride, timeout=30), \
+        "producer did not advance clear of a state-history-stride boundary"
 
     prodNode.processUrllibRequest("producer", "pause", exitOnError=True)
     blockNum = prodNode.getHeadBlockNum()


### PR DESCRIPTION
## Summary

`ship_log_util_test` failed on the PR #461 gcc job (run 28591056813): the producer settled on block 200, an exact `--state-history-stride 50` multiple. SHiP log rotation had just moved every entry into `retained/` (last bundle `chain_state_history-151-200`), leaving the head `chain_state_history.{log,index}` at 0 bytes, so the first `info` check found an empty log and aborted in `parseInfoBlocks`.

This is the same boundary hazard PR #469 fixed for `ship_restart_test`, which stops the producer and operates on the head SHiP files the same way.

## Fix

Add `Node.waitForBlockClearOfStride(stride)` and call it before stopping the producer in both `ship_log_util_test` and `ship_restart_test`, replacing #469's inline guard so the boundary calculation lives in one place. The helper advances the head to a safe offset past the boundary — with a margin on both sides to absorb the couple of blocks produced while the pause takes effect — so the head log/index always have entries when the node stops.
