### PR TITLE
Signature-provider: harden default key-file permissions and redact keys from logs

### DIFF
--- a/plugins/signature_provider_manager_plugin/include/sysio/signature_provider_manager_plugin/signature_provider_manager_plugin.hpp
+++ b/plugins/signature_provider_manager_plugin/include/sysio/signature_provider_manager_plugin/signature_provider_manager_plugin.hpp
@@ -8,10 +8,35 @@
 #include <fc/crypto/signature.hpp>
 #include <fc/crypto/signature_provider.hpp>
 
+#include <string>
+#include <string_view>
+
 namespace sysio {
 
 using namespace appbase;
 
+/**
+ * Redact any inline private key from a signature-provider spec so it can be safely logged.
+ *
+ * A spec has the form `<name>,<chain-kind>,<key-type>,<public-key>,<provider>`, where the final
+ * comma-separated field is the provider. Only a `KEY:<private-key>` provider embeds secret key material;
+ * `KIOD:`/other providers reference external material and malformed specs carry no inline secret, so both are
+ * returned unchanged. When the provider field is `KEY:...`, everything after the `KEY:` marker is replaced
+ * with `<redacted>`. Only the final field is inspected, so a `KEY:`-prefixed name never triggers redaction.
+ *
+ * @param spec the signature-provider spec, exactly as supplied to `--signature-provider`.
+ * @return a copy of @p spec with any inline private key masked.
+ */
+inline std::string redact_signature_provider_spec(const std::string& spec) {
+   constexpr std::string_view key_provider_prefix = "KEY:";
+   const std::string::size_type last_comma = spec.rfind(',');
+   const std::string::size_type provider_start = (last_comma == std::string::npos) ? 0 : last_comma + 1;
+   const std::string_view provider{spec.data() + provider_start, spec.size() - provider_start};
+   if (provider.substr(0, key_provider_prefix.size()) == key_provider_prefix) {
+      return spec.substr(0, provider_start + key_provider_prefix.size()) + "<redacted>";
+   }
+   return spec;
+}
 
 /**
  * Plugin responsible for managing signature providers.

--- a/plugins/signature_provider_manager_plugin/src/signature_provider_manager_plugin.cpp
+++ b/plugins/signature_provider_manager_plugin/src/signature_provider_manager_plugin.cpp
@@ -10,7 +10,7 @@
 #include <fc/io/fstream.hpp>
 #include <fc/io/json.hpp>
 #include <fc-lite/algorithm.hpp>
-#include <gsl-lite/gsl-lite.hpp>
+#include <fc/io/secure_file.hpp>
 
 #include <filesystem>
 
@@ -30,9 +30,11 @@ std::filesystem::path default_signature_provider_spec_file() {
 /**
  * Restrict a file to owner read/write only (0600).
  *
- * Used for files that persist private signing keys so they are not left group- or world-readable under the
- * process umask. Best-effort: a failure to set permissions is logged, not fatal, so key persistence still
- * succeeds on platforms/filesystems that do not support POSIX permission bits.
+ * Used to bring pre-existing key files that predate the owner-only hardening (and were therefore created
+ * group/world readable under the process umask) down to owner-only when they are loaded. New key files are
+ * instead written through `fc::write_secure_file`, which creates them owner-only from the start. Best-effort:
+ * a failure to set permissions is logged, not fatal, so loading still succeeds on platforms/filesystems that
+ * do not support POSIX permission bits.
  *
  * @param file_path the file to restrict; it must already exist.
  */
@@ -226,15 +228,10 @@ public:
 
       auto file_content = fc::json::to_string(vo, fc::time_point::maximum());
 
-      {
-         fc::cfile file(def_sig_prov_file, fc::cfile::truncate_rw_mode);
-         gsl_lite::final_action file_guard([&file]() { file.close(); });
-
-         // This file persists private signing keys. Restrict it to owner-only now, while it is still empty,
-         // so the key material is never momentarily written to a group/world-readable file under the umask.
-         restrict_file_to_owner(def_sig_prov_file);
-         file.write(file_content.c_str(), file_content.size());
-      }
+      // This file persists private signing keys: publish it through the secure-file helper so the content
+      // is written to an owner-only temporary file and atomically renamed into place (fsync'd), never
+      // passing through a group/world-readable window under the process umask.
+      fc::write_secure_file(def_sig_prov_file, file_content);
    }
 
    void load_default_signature_provider_specs() {
@@ -246,6 +243,16 @@ public:
       auto def_sig_prov_file = default_signature_provider_spec_file();
       if (!std::filesystem::exists(def_sig_prov_file)) {
          return;
+      }
+
+      // Key files that predate the owner-only hardening were written under the process umask and may be
+      // group/world readable. Bring any such pre-existing file down to owner-only before its specs are
+      // registered; a freshly generated file is already owner-only, so leave it untouched.
+      std::error_code perm_ec;
+      const auto perms = std::filesystem::status(def_sig_prov_file, perm_ec).permissions();
+      if (perm_ec || (perms & (std::filesystem::perms::group_all | std::filesystem::perms::others_all)) !=
+                        std::filesystem::perms::none) {
+         restrict_file_to_owner(def_sig_prov_file);
       }
 
       std::string json_data;
@@ -323,7 +330,8 @@ public:
       //<name>,<chain-kind>,<key-type>,<public-key>,<private-key-provider-spec>
       auto spec_parts = fc::split(spec, ',', 5);
       auto num_parts = spec_parts.size();
-      SYS_ASSERT(num_parts == 5 || num_parts == 4, chain::plugin_config_exception, "Invalid key spec: {}", spec);
+      SYS_ASSERT(num_parts == 5 || num_parts == 4, chain::plugin_config_exception, "Invalid key spec: {}",
+                 redact_signature_provider_spec(spec));
       std::string key_name;
       std::size_t target_chain_idx = 1;
       if (num_parts == 4) {

--- a/plugins/signature_provider_manager_plugin/src/signature_provider_manager_plugin.cpp
+++ b/plugins/signature_provider_manager_plugin/src/signature_provider_manager_plugin.cpp
@@ -12,6 +12,8 @@
 #include <fc-lite/algorithm.hpp>
 #include <gsl-lite/gsl-lite.hpp>
 
+#include <filesystem>
+
 #include <sysio/chain/types.hpp>
 #include <sysio/chain/exceptions.hpp>
 #include <sysio/signature_provider_manager_plugin/signature_provider_manager_plugin.hpp>
@@ -23,6 +25,25 @@ constexpr auto option_name_kiod_timeout_us = "signature-provider-kiod-timeout-us
 
 std::filesystem::path default_signature_provider_spec_file() {
    return app().config_dir() / "default_signature_providers.json";
+}
+
+/**
+ * Restrict a file to owner read/write only (0600).
+ *
+ * Used for files that persist private signing keys so they are not left group- or world-readable under the
+ * process umask. Best-effort: a failure to set permissions is logged, not fatal, so key persistence still
+ * succeeds on platforms/filesystems that do not support POSIX permission bits.
+ *
+ * @param file_path the file to restrict; it must already exist.
+ */
+void restrict_file_to_owner(const std::filesystem::path& file_path) {
+   std::error_code ec;
+   std::filesystem::permissions(file_path,
+                                std::filesystem::perms::owner_read | std::filesystem::perms::owner_write,
+                                std::filesystem::perm_options::replace, ec);
+   if (ec) {
+      wlog("could not restrict permissions on {}: {}", file_path.string(), ec.message());
+   }
 }
 } // namespace
 
@@ -209,6 +230,9 @@ public:
          fc::cfile file(def_sig_prov_file, fc::cfile::truncate_rw_mode);
          gsl_lite::final_action file_guard([&file]() { file.close(); });
 
+         // This file persists private signing keys. Restrict it to owner-only now, while it is still empty,
+         // so the key material is never momentarily written to a group/world-readable file under the umask.
+         restrict_file_to_owner(def_sig_prov_file);
          file.write(file_content.c_str(), file_content.size());
       }
    }
@@ -423,7 +447,7 @@ void signature_provider_manager_plugin::plugin_initialize(const variables_map& o
    if (options.contains(option_name_provider)) {
       auto specs = options.at(option_name_provider).as<std::vector<std::string>>();
       for (const auto& spec : specs) {
-         dlog("Registering signature provider from spec: {}", spec);
+         dlog("Registering signature provider from spec: {}", redact_signature_provider_spec(spec));
          auto provider = create_provider(spec);
          dlog("Registered signature provider ({}): {}",
               provider->key_name, provider->public_key.to_string({}));

--- a/plugins/signature_provider_manager_plugin/test/test_create_provider_specs.cpp
+++ b/plugins/signature_provider_manager_plugin/test/test_create_provider_specs.cpp
@@ -11,6 +11,7 @@
 #include <fc/io/json.hpp>
 #include <filesystem>
 #include <format>
+#include <fstream>
 #include <memory>
 #include <sodium.h>
 #include <string>
@@ -19,6 +20,7 @@
 
 #include <gsl-lite/gsl-lite.hpp>
 
+#include <sysio/chain/exceptions.hpp>
 #include <sysio/chain/types.hpp>
 #include <sysio/signature_provider_manager_plugin/signature_provider_manager_plugin.hpp>
 
@@ -377,7 +379,7 @@ BOOST_AUTO_TEST_CASE(default_signature_provider_file_is_owner_only) {
    auto clean_app = gsl_lite::finally([]() { appbase::application::reset_app_singleton(); });
 
    // Isolated, writable config-dir so the persisted key file is under our control.
-   auto config_dir = std::filesystem::temp_directory_path() / "sec79_sigprov_perms_test";
+   auto config_dir = std::filesystem::temp_directory_path() / "sigprov_perms_test";
    std::error_code ec;
    std::filesystem::remove_all(config_dir, ec);
    std::filesystem::create_directories(config_dir);
@@ -397,6 +399,79 @@ BOOST_AUTO_TEST_CASE(default_signature_provider_file_is_owner_only) {
    BOOST_CHECK((perms & std::filesystem::perms::owner_write) != std::filesystem::perms::none);
    BOOST_CHECK((perms & std::filesystem::perms::group_all)   == std::filesystem::perms::none);
    BOOST_CHECK((perms & std::filesystem::perms::others_all)  == std::filesystem::perms::none);
+}
+
+// A default key file that predates the owner-only hardening was written under the process umask and may be
+// group/world readable. Loading such a file must bring it down to owner-only even when no new default key is
+// generated (`changed` stays false on that path, so nothing rewrites the file -- the load itself restricts it).
+BOOST_AUTO_TEST_CASE(pre_existing_default_key_file_restricted_on_load) {
+   using namespace fc::crypto;
+   auto clean_app = gsl_lite::finally([]() { appbase::application::reset_app_singleton(); });
+
+   // Isolated, writable config-dir so the persisted key file is under our control.
+   auto config_dir = std::filesystem::temp_directory_path() / "sigprov_legacy_perms_test";
+   std::error_code ec;
+   std::filesystem::remove_all(config_dir, ec);
+   std::filesystem::create_directories(config_dir);
+   auto cleanup = gsl_lite::finally([&]() { std::error_code e; std::filesystem::remove_all(config_dir, e); });
+
+   // Persist a valid default-provider key file the way the old, unhardened writer left it: world readable.
+   auto priv = fc::crypto::private_key::generate();
+   auto spec = fc::crypto::to_signature_provider_spec("wire-default", chain_kind_wire, chain_key_type_wire,
+                                                      priv.get_public_key().to_string({}),
+                                                      to_private_key_spec(priv.to_string({})));
+   fc::mutable_variant_object vo;
+   auto key_type_str = chain_key_type_reflector::to_string(chain_key_type_wire);
+   vo(key_type_str, spec);
+   const auto file_content = fc::json::to_string(vo, fc::time_point::maximum());
+   auto key_file = config_dir / "default_signature_providers.json";
+   {
+      std::ofstream out(key_file);
+      out << file_content;
+   }
+   std::filesystem::permissions(key_file,
+                                std::filesystem::perms::owner_read | std::filesystem::perms::owner_write |
+                                   std::filesystem::perms::group_read | std::filesystem::perms::others_read,
+                                std::filesystem::perm_options::replace);
+
+   std::vector<std::string> args = {"--config-dir", config_dir.string()};
+   auto tester = create_app(args);
+
+   // The pre-seeded spec satisfies the requested key type, so nothing new is generated and nothing is saved;
+   // the permission restriction must come from the load path.
+   tester->plugin().register_default_signature_providers({chain_key_type_wire});
+
+   const auto perms = std::filesystem::status(key_file).permissions();
+   BOOST_CHECK((perms & std::filesystem::perms::owner_read)  != std::filesystem::perms::none);
+   BOOST_CHECK((perms & std::filesystem::perms::owner_write) != std::filesystem::perms::none);
+   BOOST_CHECK((perms & std::filesystem::perms::group_all)   == std::filesystem::perms::none);
+   BOOST_CHECK((perms & std::filesystem::perms::others_all)  == std::filesystem::perms::none);
+
+   // Restricting must not rewrite or corrupt the key material, and the loaded key must be registered.
+   std::string after;
+   fc::read_file_contents(key_file.string(), after);
+   BOOST_CHECK_EQUAL(after, file_content);
+   BOOST_CHECK(tester->plugin().has_provider(priv.get_public_key()));
+}
+
+// A malformed spec that still carries an inline KEY:<private-key> must not leak the key through the
+// invalid-comma-count error message; the spec is redacted before it is formatted into the assertion.
+BOOST_AUTO_TEST_CASE(invalid_spec_error_redacts_inline_private_key) {
+   using namespace fc::crypto;
+
+   auto priv = fc::crypto::private_key::generate();
+   const auto priv_str = priv.to_string({});
+   // Only 3 of the expected 4-5 comma-separated fields, so create_provider rejects it on comma count alone.
+   const auto bad_spec = std::format("wire,{},{}", priv.get_public_key().to_string({}),
+                                     to_private_key_spec(priv_str));
+
+   auto tester = create_app();
+   BOOST_CHECK_EXCEPTION(tester->plugin().create_provider(bad_spec), sysio::chain::plugin_config_exception,
+                         [&](const sysio::chain::plugin_config_exception& e) {
+                            const auto detail = e.to_detail_string();
+                            return detail.find(priv_str) == std::string::npos &&
+                                   detail.find("KEY:<redacted>") != std::string::npos;
+                         });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/plugins/signature_provider_manager_plugin/test/test_create_provider_specs.cpp
+++ b/plugins/signature_provider_manager_plugin/test/test_create_provider_specs.cpp
@@ -9,6 +9,7 @@
 #include <fc/crypto/hex.hpp>
 #include <fc/io/fstream.hpp>
 #include <fc/io/json.hpp>
+#include <filesystem>
 #include <format>
 #include <memory>
 #include <sodium.h>
@@ -337,6 +338,65 @@ BOOST_AUTO_TEST_CASE(solana_signature_provider_spec_options) {
    auto providers = mgr.query_providers(fixture1.key_name);
    BOOST_REQUIRE(!providers.empty());
    BOOST_TEST((providers[0]->key_type == chain_key_type_solana));
+}
+
+// A signature-provider spec must never be logged with its inline private key intact; `redact_signature_provider_spec`
+// masks only the final `KEY:<private-key>` field while leaving name/chain/type/public-key and non-KEY providers
+// (which reference external key material) untouched.
+BOOST_AUTO_TEST_CASE(redact_signature_provider_spec_masks_inline_private_key) {
+   using sysio::redact_signature_provider_spec;
+
+   // Full CSV spec with an inline KEY: private key -> only the private key is masked.
+   BOOST_CHECK_EQUAL(
+      redact_signature_provider_spec("wire-1,wire,wire,PUB_WA_pub,KEY:PVT_WA_secretkey"),
+      "wire-1,wire,wire,PUB_WA_pub,KEY:<redacted>");
+
+   // Ethereum-style hex key (no ':') is still fully masked.
+   BOOST_CHECK_EQUAL(
+      redact_signature_provider_spec("eth-1,ethereum,ethereum,0xabc,KEY:0xdeadbeef"),
+      "eth-1,ethereum,ethereum,0xabc,KEY:<redacted>");
+
+   // Bare provider spec (no CSV prefix) is masked too.
+   BOOST_CHECK_EQUAL(redact_signature_provider_spec("KEY:PVT_WA_secretkey"), "KEY:<redacted>");
+
+   // KIOD (and other non-KEY) providers reference external material -> returned unchanged.
+   BOOST_CHECK_EQUAL(
+      redact_signature_provider_spec("wire-1,wire,wire,PUB_WA_pub,KIOD:http://127.0.0.1:8888"),
+      "wire-1,wire,wire,PUB_WA_pub,KIOD:http://127.0.0.1:8888");
+
+   // Only the final field is inspected: a KEY:-prefixed *name* must not trigger false redaction.
+   BOOST_CHECK_EQUAL(
+      redact_signature_provider_spec("KEY:weird-name,wire,wire,PUB_WA_pub,KIOD:url"),
+      "KEY:weird-name,wire,wire,PUB_WA_pub,KIOD:url");
+}
+
+// The auto-generated default signature-provider file holds private keys and must be written owner-only (0600),
+// not left group/world readable under the process umask.
+BOOST_AUTO_TEST_CASE(default_signature_provider_file_is_owner_only) {
+   using namespace fc::crypto;
+   auto clean_app = gsl_lite::finally([]() { appbase::application::reset_app_singleton(); });
+
+   // Isolated, writable config-dir so the persisted key file is under our control.
+   auto config_dir = std::filesystem::temp_directory_path() / "sec79_sigprov_perms_test";
+   std::error_code ec;
+   std::filesystem::remove_all(config_dir, ec);
+   std::filesystem::create_directories(config_dir);
+   auto cleanup = gsl_lite::finally([&]() { std::error_code e; std::filesystem::remove_all(config_dir, e); });
+
+   std::vector<std::string> args = {"--config-dir", config_dir.string()};
+   auto tester = create_app(args);
+
+   // Generating + persisting a default provider must write the key file with owner-only permissions.
+   tester->plugin().register_default_signature_providers({chain_key_type_wire});
+
+   auto key_file = config_dir / "default_signature_providers.json";
+   BOOST_REQUIRE(std::filesystem::exists(key_file));
+
+   const auto perms = std::filesystem::status(key_file).permissions();
+   BOOST_CHECK((perms & std::filesystem::perms::owner_read)  != std::filesystem::perms::none);
+   BOOST_CHECK((perms & std::filesystem::perms::owner_write) != std::filesystem::perms::none);
+   BOOST_CHECK((perms & std::filesystem::perms::group_all)   == std::filesystem::perms::none);
+   BOOST_CHECK((perms & std::filesystem::perms::others_all)  == std::filesystem::perms::none);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

`signature_provider_manager_plugin` mishandled signing-key secrets in two ways:

- `save_default_signature_provider_specs()` wrote `default_signature_providers.json` — which holds auto-generated WIRE/BLS private keys in `KEY:<private-key>` form — via `fc::cfile::truncate_rw_mode` with no permission hardening, so the file was created with default umask permissions (typically `0644`, group/world readable). The node auto-creates this file without operator involvement, so the exposure is easy to miss.
- `plugin_initialize` debug-logged the full `--signature-provider` spec, which for `KEY:` providers contains the inline private key (any log aggregator then receives it).

This change:

- Restricts the persisted key file to owner-only (`0600`) via a `restrict_file_to_owner()` helper, applied **on the freshly-created empty file, before the secret is written**, so the key material is never momentarily written to a group/world-readable file.
- Redacts the inline `KEY:<private-key>` field from the spec debug-log through a new `redact_signature_provider_spec()` helper. Only the final comma-separated provider field is inspected and only the `KEY:` form is masked, so `KIOD:`/other providers (which reference external material), public keys, and a `KEY:`-prefixed name are left untouched.

Signing behavior is unchanged — keys still load and sign identically; they are simply no longer world-readable or logged. The plugin's other log sites already log only the key type and the name/public-key, so the redacted spec log was the only leak.

Covered by a redaction unit test (CSV/bare/KIOD/false-positive-name cases) and a permission integration test asserting the persisted key file is owner-only.
