### PR TITLE
Prometheus: bound p2p per-connection metric cardinality

### DIFF
--- a/plugins/prometheus_plugin/src/metrics.hpp
+++ b/plugins/prometheus_plugin/src/metrics.hpp
@@ -10,6 +10,13 @@
 #include <prometheus/registry.h>
 #include <prometheus/text_serializer.h>
 #include <fc/log/logger.hpp>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
 namespace sysio::metrics {
 
 struct catalog_type {
@@ -44,7 +51,6 @@ struct catalog_type {
       Gauge& num_peers;
       Gauge& num_clients;
 
-      prometheus::Family<Gauge>& addr; // Empty gauge; ipv6 address can't be transmitted as a double
       prometheus::Family<Gauge>& port;
       prometheus::Family<Gauge>& connection_number;
       prometheus::Family<Gauge>& accepting_blocks;
@@ -62,9 +68,13 @@ struct catalog_type {
       prometheus::Family<Gauge>& block_sync_throttling;
       prometheus::Family<Gauge>& connection_start_time;
       prometheus::Family<Gauge>& peer_score;
-      prometheus::Family<Gauge>& peer_addr; // Empty gauge; we only want the label
    };
    p2p_connection_metrics p2p_metrics;
+
+   // Live per-connection gauge handles, keyed by "<remote_ip>|<connection_id>", so that when a connection
+   // leaves the net_plugin snapshot its series can be removed from every p2p family. Bounds registry growth
+   // from P2P connection churn. Only accessed on the prometheus update strand, so it needs no locking.
+   std::unordered_map<std::string, std::vector<std::pair<prometheus::Family<Gauge>*, Gauge*>>> tracked_p2p_series;
 
    prometheus::Family<Counter>& cpu_usage_us;
    prometheus::Family<Counter>& net_usage_us;
@@ -122,7 +132,6 @@ struct catalog_type {
        , p2p_metrics{
               .num_peers{build<Gauge>("nodeop_p2p_peers", "current number of connected outgoing peers")}
             , .num_clients{build<Gauge>("nodeop_p2p_clients", "current number of connected incoming clients")}
-            , .addr{family<Gauge>("nodeop_p2p_addr", "ipv6 address")}
             , .port{family<Gauge>("nodeop_p2p_port", "port")}
             , .connection_number{family<Gauge>("nodeop_p2p_connection_number", "monatomic increasing connection number")}
             , .accepting_blocks{family<Gauge>("nodeop_p2p_accepting_blocks", "accepting blocks on connection")}
@@ -140,7 +149,6 @@ struct catalog_type {
             , .block_sync_throttling{family<Gauge>("nodeop_p2p_block_sync_throttling", "is block sync throttling currently active")}
             , .connection_start_time{family<Gauge>("nodeop_p2p_connection_start_time", "time of last connection to peer")}
             , .peer_score{family<Gauge>("nodeop_p2p_peer_score", "peer quality score")}
-            , .peer_addr{family<Gauge>("nodeop_p2p_peer_addr", "peer address")}
          }
        , cpu_usage_us(family<Counter>("nodeop_cpu_usage_us_total", "total cpu usage in microseconds for blocks"))
        , net_usage_us(family<Counter>("nodeop_net_usage_us_total", "total net usage in microseconds for blocks"))
@@ -205,16 +213,29 @@ struct catalog_type {
    void update(const net_plugin::p2p_connections_metrics& metrics) {
       p2p_metrics.num_peers.Set(metrics.num_peers);
       p2p_metrics.num_clients.Set(metrics.num_clients);
-      for(size_t i = 0; i < metrics.stats.peers.size(); ++i) {
-         const auto& peer = metrics.stats.peers[i];
-         const auto& conn_id = peer.unique_conn_node_id;
 
-         const auto addr = boost::asio::ip::make_address_v6(peer.address).to_string();
-         p2p_metrics.addr.Add({{"connid", conn_id},{"ipv6", addr},{"address", peer.p2p_address}});
+      // Per-connection series are keyed by {remote_ip, connection_id}: the real socket peer IP and the node's
+      // own monotonic connection counter. Both are observed locally, never values the remote peer supplies in
+      // its handshake, so a peer cannot inject arbitrary label text or inflate label cardinality by
+      // reconnecting with fresh node ids. Stale series are pruned below once a connection leaves the snapshot.
+      std::unordered_set<std::string> live_keys;
+      live_keys.reserve(metrics.stats.peers.size());
 
-         auto add_and_set_gauge = [&](auto& fam, const auto& value) {
-            auto& gauge = fam.Add({{"connid", conn_id}});
+      for (const auto& peer : metrics.stats.peers) {
+         const std::string remote_ip = boost::asio::ip::make_address_v6(peer.address).to_string();
+         const std::string conn_num  = std::to_string(peer.connection_id);
+         const std::string key       = remote_ip + '|' + conn_num;
+         live_keys.insert(key);
+
+         const prometheus::Labels labels{{"remote_ip", remote_ip}, {"connection_id", conn_num}};
+         auto&      handles    = tracked_p2p_series[key];
+         const bool first_seen = handles.empty();
+
+         auto add_and_set_gauge = [&](prometheus::Family<Gauge>& fam, const auto& value) {
+            auto& gauge = fam.Add(labels);
             gauge.Set(value);
+            if (first_seen)
+               handles.emplace_back(&fam, &gauge);
          };
 
          add_and_set_gauge(p2p_metrics.connection_number, peer.connection_id);
@@ -234,6 +255,18 @@ struct catalog_type {
          add_and_set_gauge(p2p_metrics.block_sync_throttling, peer.block_sync_throttling);
          add_and_set_gauge(p2p_metrics.connection_start_time, peer.connection_start_time.count());
          add_and_set_gauge(p2p_metrics.peer_score, peer.peer_score);
+      }
+
+      // Prune series for connections no longer present in the snapshot so peer-driven churn cannot accumulate
+      // stale per-connection labels in the registry.
+      for (auto it = tracked_p2p_series.begin(); it != tracked_p2p_series.end();) {
+         if (live_keys.count(it->first) == 0) {
+            for (auto& [fam, gauge] : it->second)
+               fam->Remove(gauge);
+            it = tracked_p2p_series.erase(it);
+         } else {
+            ++it;
+         }
       }
    }
 

--- a/plugins/prometheus_plugin/test/main.cpp
+++ b/plugins/prometheus_plugin/test/main.cpp
@@ -1,0 +1,2 @@
+#define BOOST_TEST_MODULE prometheus_plugin
+#include <boost/test/included/unit_test.hpp>

--- a/plugins/prometheus_plugin/test/test_p2p_metrics.cpp
+++ b/plugins/prometheus_plugin/test/test_p2p_metrics.cpp
@@ -1,0 +1,97 @@
+/**
+ * @file test_p2p_metrics.cpp
+ * @brief Unit tests for the P2P per-connection metrics in `sysio::metrics::catalog_type` (suite
+ *        `prometheus_p2p_metrics`).
+ *
+ * These pin down the SEC-69 hardening:
+ * - per-connection series are keyed by the locally-observed {remote_ip, connection_id}, never the
+ *   peer-supplied handshake node id / advertised p2p_address (no label injection);
+ * - series for connections that leave the net_plugin snapshot are removed, so P2P churn cannot accumulate
+ *   stale series in the registry.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../src/metrics.hpp"
+
+using namespace sysio;
+using sysio::metrics::catalog_type;
+
+namespace {
+
+/// Canonical IPv6 bytes for a synthetic peer address.
+boost::asio::ip::address_v6::bytes_type ip_bytes(const char* s) {
+   return boost::asio::ip::make_address_v6(s).to_bytes();
+}
+
+/// Build a P2P snapshot from a list of {connection_id, ipv6-literal} pairs. Every connection also carries
+/// peer-controlled identifiers (node id / p2p_address) that must never reach the exported labels.
+net_plugin::p2p_connections_metrics
+make_snapshot(const std::vector<std::pair<uint32_t, const char*>>& conns) {
+   net_plugin::p2p_per_connection_metrics stats(conns.size());
+   for (const auto& [cid, ip] : conns) {
+      net_plugin::p2p_per_connection_metrics::connection_metric cm{};
+      cm.connection_id       = cid;
+      cm.address             = ip_bytes(ip);
+      cm.port                = 9876;
+      cm.latency             = 42;
+      cm.unique_conn_node_id = "attacker-controlled-node-id";
+      cm.p2p_address         = "attacker-controlled-p2p-addr";
+      stats.peers.push_back(std::move(cm));
+   }
+   return net_plugin::p2p_connections_metrics(conns.size(), 0, std::move(stats));
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(prometheus_p2p_metrics)
+
+// Series are keyed by the locally-observed {remote_ip, connection_id}; the peer-supplied node id and
+// advertised p2p_address never appear in the exported labels.
+BOOST_AUTO_TEST_CASE(p2p_series_keyed_by_stable_local_identity) {
+   catalog_type cat;
+   cat.update(make_snapshot({{1, "::1"}}));
+   const std::string out = cat.report();
+
+   BOOST_CHECK(out.find("remote_ip=\"::1\"") != std::string::npos);
+   BOOST_CHECK(out.find("connection_id=\"1\"") != std::string::npos);
+   // Peer-controlled identifiers must not be exported, and the old peer-controlled label must be gone.
+   BOOST_CHECK(out.find("attacker-controlled-node-id") == std::string::npos);
+   BOOST_CHECK(out.find("attacker-controlled-p2p-addr") == std::string::npos);
+   BOOST_CHECK(out.find("connid=") == std::string::npos);
+}
+
+// A connection that drops out of the snapshot has its per-connection series removed, so churn does not
+// accumulate stale series.
+BOOST_AUTO_TEST_CASE(stale_series_removed_on_churn) {
+   catalog_type cat;
+
+   cat.update(make_snapshot({{1, "2001:db8::1"}, {2, "2001:db8::2"}}));
+   {
+      const std::string out = cat.report();
+      BOOST_CHECK(out.find("2001:db8::1") != std::string::npos);
+      BOOST_CHECK(out.find("2001:db8::2") != std::string::npos);
+   }
+
+   // Second connection leaves the snapshot -> its series must be pruned; the first remains.
+   cat.update(make_snapshot({{1, "2001:db8::1"}}));
+   {
+      const std::string out = cat.report();
+      BOOST_CHECK(out.find("2001:db8::1") != std::string::npos);
+      BOOST_CHECK(out.find("2001:db8::2") == std::string::npos);
+   }
+
+   // All connections gone -> no per-connection series remain.
+   cat.update(make_snapshot({}));
+   {
+      const std::string out = cat.report();
+      BOOST_CHECK(out.find("2001:db8::1") == std::string::npos);
+   }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Ultimately, `prometheus_plugin` may go away, but for now...

`prometheus_plugin` subscribes to net_plugin's P2P connection snapshots and, for each peer, adds ~18 `nodeop_p2p_*` gauge series keyed by a `connid` label derived from the peer's handshake node id (`node_id.short_id()`). It never removes those series when a peer disconnects, and the default P2P `allowed-connection = any` accepts peers without authentication. An unauthenticated peer that reconnects with fresh node ids therefore piles up ~18 stale series per generation, and every `/v1/prometheus/prometheus` scrape then serializes the whole retained registry — growing scrape CPU, memory, and response size over time.

This re-keys the per-connection series by the composite **`{remote_ip, connection_id}`** — the real socket peer IP (canonical; a completed TCP handshake proves the source, so minting N series needs N real IPs) and the node's own monotonic connection counter — neither of which the peer supplies in its handshake. It also prunes series for connections that are no longer in the snapshot each update, so the registry tracks live connections instead of accumulating. Removal is safe against concurrent scrapes because prometheus-cpp's `Family` guards its metric map with a mutex.

The redundant `nodeop_p2p_addr` (the IP is now a label on every series) and the unused `nodeop_p2p_peer_addr` families are removed; all other per-peer telemetry is preserved.

**Operator note — metric label schema change:** per-peer series that were keyed `connid="<node id>"` are now keyed `remote_ip="…"` / `connection_id="…"`, and `nodeop_p2p_addr` / `nodeop_p2p_peer_addr` no longer exist. Dashboards keyed on `connid` need updating. The old `connid` changed on every reconnect (so it was never stable for tracking a peer), whereas `remote_ip` is stable across a peer's reconnects.

A new `test_prometheus_plugin` target (auto-discovered by the `plugin_target` macro) covers it: one case asserts the series carry the local `{remote_ip, connection_id}` labels and none of the peer-supplied node id / advertised address; another asserts a connection dropping out of the snapshot has its series pruned.
