### PR TITLE
Underwriter: contain deferred-startup escapes and report the LIB gap on the sync gate

### DIFF
--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/sync_detail.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/sync_detail.hpp
@@ -6,11 +6,12 @@
  *
  * The underwriter's startup preflight validates depot-side state (opreg
  * registration, chain registry, authex links) via LOCAL table reads. On a
- * cold-booting operator node those reads see mid-replay (possibly genesis)
+ * cold-booting operator node those reads see mid-sync (possibly genesis)
  * state and fail spuriously, so the plugin must not begin underwriting until
- * the chain plugin reports the node synced. "Synced" here is the same recency
- * notion producer_plugin uses to decide it may produce: the head block time is
- * within a small window of wall-clock now.
+ * the node is synced. "Synced" here means the LAST IRREVERSIBLE block's time
+ * is within a small window of wall-clock now — the irreversible state is what
+ * the plugin's table reads actually serve (operator daemons run read-mode =
+ * irreversible).
  */
 
 #include <fc/time.hpp>
@@ -21,21 +22,33 @@
 namespace sysio::underwriter_detail {
 
 /**
- * @brief True when the chain head is recent enough to treat the node as synced.
+ * @brief True when a block time is recent enough to treat the node as synced.
  *
- * While a cold-booting node replays blocks its head time trails `now` by the
- * replay gap; once caught up, the head tracks `now` to within block-interval
+ * While a cold-booting node syncs blocks the tested time trails `now` by the
+ * catch-up gap; once caught up, it tracks `now` to within finality-lag
  * jitter. The window must exceed that jitter (plus scheduling slack) but stay
  * well under one epoch so underwriting never starts against stale state.
  *
- * @param head_time      The chain head block's timestamp.
+ * @param head_time      The block timestamp to test — the caller's sync
+ *                       criterion (the underwriter feeds the LAST IRREVERSIBLE
+ *                       block's time, since that is the state its reads serve).
  * @param now            Wall-clock now.
- * @param recency_window Maximum head-behind-now gap still considered synced.
+ * @param recency_window Maximum behind-now gap still considered synced.
  * @return True when `head_time >= now - recency_window`.
  */
 inline bool head_is_recent(fc::time_point head_time, fc::time_point now,
                            fc::microseconds recency_window) {
    return head_time >= now - recency_window;
+}
+
+/// JSON field keys shared by the gate payloads below, the post-startup
+/// response builders in `underwriter_plugin.cpp`, and their tests — one
+/// spelling authority instead of per-translation-unit string literals.
+namespace field {
+   inline constexpr auto status          = "status";
+   inline constexpr auto head_behind_sec = "head_behind_sec";
+   inline constexpr auto lib_behind_sec  = "lib_behind_sec";
+   inline constexpr auto detail          = "detail";
 }
 
 /**
@@ -56,8 +69,19 @@ enum class startup_state : uint8_t {
    preflight_retrying, ///< Gate armed; preflight incomplete, retrying within the bounded grace.
    preflight_failed,   ///< Preflight still failing after the retry grace (terminal).
    wiring_failed,      ///< Preflight passed but outpost client wiring threw (terminal).
+   startup_failed,     ///< The deferred startup body threw past the specific
+                       ///< failure paths above (terminal). Exists so an escaping
+                       ///< exception is contained as a diagnosable gate state
+                       ///< instead of unwinding the app executor — which would
+                       ///< tear down the whole node — with the gate still
+                       ///< claiming `waiting_for_sync`.
    active              ///< Deferred startup completed — the scan cron is scheduled.
 };
+
+/// The wire `status` spelling of {@link startup_state::active} — shared by the
+/// post-startup response builders so the value has one authority beside the
+/// enum whose member spellings define the wire format.
+inline constexpr std::string_view active_status = magic_enum::enum_name(startup_state::active);
 
 /// `detail` carried by the {@link startup_state::preflight_failed} gate payload.
 inline constexpr std::string_view preflight_failed_detail =
@@ -67,30 +91,48 @@ inline constexpr std::string_view preflight_failed_detail =
 inline constexpr std::string_view wiring_failed_detail =
    "outpost client wiring failed after preflight; underwriting is disabled "
    "(see node log)";
+/// `detail` carried by the {@link startup_state::startup_failed} gate payload.
+inline constexpr std::string_view startup_failed_detail =
+   "deferred startup failed unexpectedly; underwriting is disabled "
+   "(see node log)";
 
 /**
  * @brief The JSON body a `/v1/underwriter/...` endpoint answers with for `state`.
  *
  * Pure (unit-testable without a chain). Shape per state:
- *   - `waiting_for_sync` → `{"status":"waiting_for_sync","head_behind_sec":N}`
- *   - `preflight_failed` / `wiring_failed` → `{"status":...,"detail":...}`
+ *   - `waiting_for_sync` → `{"status":"waiting_for_sync","head_behind_sec":N,
+ *     "lib_behind_sec":M}` — the gate's criterion is the IRREVERSIBLE state
+ *     (`lib_behind_sec`); the head gap is reported alongside so a
+ *     head-current-but-finality-stalled node is distinguishable from one
+ *     still catching up. `lib_behind_sec` is -1 until an irreversible root
+ *     exists (matching the startup wait log).
+ *   - `preflight_retrying` → `{"status":"preflight_retrying"}`
+ *   - `preflight_failed` / `wiring_failed` / `startup_failed` →
+ *     `{"status":...,"detail":...}`
  *   - `active` → `{"status":"active"}` (callers normally serve the real
  *     payload instead once active — the builders stamp the same field).
  *
  * @param state           The current deferred-startup lifecycle state.
  * @param head_behind_sec How far the head trails wall-clock now (seconds);
  *                        consumed only by the `waiting_for_sync` payload.
+ * @param lib_behind_sec  How far the last-irreversible block trails wall-clock
+ *                        now (seconds; -1 when no root yet); consumed only by
+ *                        the `waiting_for_sync` payload.
  * @return The response body as an `fc::variant`.
  */
-inline fc::variant startup_gate_payload(startup_state state, int64_t head_behind_sec) {
+inline fc::variant startup_gate_payload(startup_state state, int64_t head_behind_sec,
+                                        int64_t lib_behind_sec) {
    fc::mutable_variant_object body;
-   body("status", std::string{magic_enum::enum_name(state)});
+   body(field::status, std::string{magic_enum::enum_name(state)});
    if (state == startup_state::waiting_for_sync) {
-      body("head_behind_sec", head_behind_sec);
+      body(field::head_behind_sec, head_behind_sec);
+      body(field::lib_behind_sec, lib_behind_sec);
    } else if (state == startup_state::preflight_failed) {
-      body("detail", std::string{preflight_failed_detail});
+      body(field::detail, std::string{preflight_failed_detail});
    } else if (state == startup_state::wiring_failed) {
-      body("detail", std::string{wiring_failed_detail});
+      body(field::detail, std::string{wiring_failed_detail});
+   } else if (state == startup_state::startup_failed) {
+      body(field::detail, std::string{startup_failed_detail});
    }
    return fc::variant(std::move(body));
 }

--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/sync_detail.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/sync_detail.hpp
@@ -19,6 +19,8 @@
 
 #include <magic_enum/magic_enum.hpp>
 
+#include <optional>
+
 namespace sysio::underwriter_detail {
 
 /**
@@ -112,21 +114,22 @@ inline constexpr std::string_view startup_failed_detail =
  *   - `active` → `{"status":"active"}` (callers normally serve the real
  *     payload instead once active — the builders stamp the same field).
  *
- * @param state           The current deferred-startup lifecycle state.
- * @param head_behind_sec How far the head trails wall-clock now (seconds);
- *                        consumed only by the `waiting_for_sync` payload.
- * @param lib_behind_sec  How far the last-irreversible block trails wall-clock
- *                        now (seconds; -1 when no root yet); consumed only by
- *                        the `waiting_for_sync` payload.
+ * @param state       The current deferred-startup lifecycle state.
+ * @param head_behind How far the head trails wall-clock now; consumed only by
+ *                    the `waiting_for_sync` payload (emitted in whole seconds).
+ * @param lib_behind  How far the last-irreversible block trails wall-clock
+ *                    now, or empty while no irreversible root exists yet
+ *                    (emitted as -1, matching the startup wait log); consumed
+ *                    only by the `waiting_for_sync` payload.
  * @return The response body as an `fc::variant`.
  */
-inline fc::variant startup_gate_payload(startup_state state, int64_t head_behind_sec,
-                                        int64_t lib_behind_sec) {
+inline fc::variant startup_gate_payload(startup_state state, fc::microseconds head_behind,
+                                        std::optional<fc::microseconds> lib_behind) {
    fc::mutable_variant_object body;
    body(field::status, std::string{magic_enum::enum_name(state)});
    if (state == startup_state::waiting_for_sync) {
-      body(field::head_behind_sec, head_behind_sec);
-      body(field::lib_behind_sec, lib_behind_sec);
+      body(field::head_behind_sec, head_behind.to_seconds());
+      body(field::lib_behind_sec, lib_behind ? lib_behind->to_seconds() : -1);
    } else if (state == startup_state::preflight_failed) {
       body(field::detail, std::string{preflight_failed_detail});
    } else if (state == startup_state::wiring_failed) {

--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/sync_detail.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/sync_detail.hpp
@@ -31,16 +31,16 @@ namespace sysio::underwriter_detail {
  * jitter. The window must exceed that jitter (plus scheduling slack) but stay
  * well under one epoch so underwriting never starts against stale state.
  *
- * @param head_time      The block timestamp to test — the caller's sync
+ * @param block_time     The block timestamp to test — the caller's sync
  *                       criterion (the underwriter feeds the LAST IRREVERSIBLE
  *                       block's time, since that is the state its reads serve).
  * @param now            Wall-clock now.
  * @param recency_window Maximum behind-now gap still considered synced.
- * @return True when `head_time >= now - recency_window`.
+ * @return True when `block_time >= now - recency_window`.
  */
-inline bool head_is_recent(fc::time_point head_time, fc::time_point now,
-                           fc::microseconds recency_window) {
-   return head_time >= now - recency_window;
+inline bool block_time_is_recent(fc::time_point block_time, fc::time_point now,
+                                 fc::microseconds recency_window) {
+   return block_time >= now - recency_window;
 }
 
 /// JSON field keys shared by the gate payloads below, the post-startup
@@ -84,6 +84,9 @@ enum class startup_state : uint8_t {
 /// post-startup response builders so the value has one authority beside the
 /// enum whose member spellings define the wire format.
 inline constexpr std::string_view active_status = magic_enum::enum_name(startup_state::active);
+// Compile-time wire-format pin: renaming the enum member would silently change
+// the HTTP `status` value every consumer switches on.
+static_assert(active_status == "active");
 
 /// `detail` carried by the {@link startup_state::preflight_failed} gate payload.
 inline constexpr std::string_view preflight_failed_detail =
@@ -102,12 +105,13 @@ inline constexpr std::string_view startup_failed_detail =
  * @brief The JSON body a `/v1/underwriter/...` endpoint answers with for `state`.
  *
  * Pure (unit-testable without a chain). Shape per state:
- *   - `waiting_for_sync` → `{"status":"waiting_for_sync","head_behind_sec":N,
- *     "lib_behind_sec":M}` — the gate's criterion is the IRREVERSIBLE state
- *     (`lib_behind_sec`); the head gap is reported alongside so a
+ *   - `waiting_for_sync` → `{"status":"waiting_for_sync","head_behind_sec":N
+ *     [,"lib_behind_sec":M]}` — the gate's criterion is the IRREVERSIBLE
+ *     state (`lib_behind_sec`); the head gap is reported alongside so a
  *     head-current-but-finality-stalled node is distinguishable from one
- *     still catching up. `lib_behind_sec` is -1 until an irreversible root
- *     exists (matching the startup wait log).
+ *     still catching up. `lib_behind_sec` is ABSENT until an irreversible
+ *     root exists: an in-band sentinel would collide with real negative
+ *     gaps (clock skew) after whole-second truncation.
  *   - `preflight_retrying` → `{"status":"preflight_retrying"}`
  *   - `preflight_failed` / `wiring_failed` / `startup_failed` →
  *     `{"status":...,"detail":...}`
@@ -116,11 +120,12 @@ inline constexpr std::string_view startup_failed_detail =
  *
  * @param state       The current deferred-startup lifecycle state.
  * @param head_behind How far the head trails wall-clock now; consumed only by
- *                    the `waiting_for_sync` payload (emitted in whole seconds).
+ *                    the `waiting_for_sync` payload (emitted in whole seconds;
+ *                    may be negative under clock skew).
  * @param lib_behind  How far the last-irreversible block trails wall-clock
- *                    now, or empty while no irreversible root exists yet
- *                    (emitted as -1, matching the startup wait log); consumed
- *                    only by the `waiting_for_sync` payload.
+ *                    now, or empty while no irreversible root exists yet (the
+ *                    key is then omitted); consumed only by the
+ *                    `waiting_for_sync` payload.
  * @return The response body as an `fc::variant`.
  */
 inline fc::variant startup_gate_payload(startup_state state, fc::microseconds head_behind,
@@ -129,7 +134,9 @@ inline fc::variant startup_gate_payload(startup_state state, fc::microseconds he
    body(field::status, std::string{magic_enum::enum_name(state)});
    if (state == startup_state::waiting_for_sync) {
       body(field::head_behind_sec, head_behind.to_seconds());
-      body(field::lib_behind_sec, lib_behind ? lib_behind->to_seconds() : -1);
+      if (lib_behind) {
+         body(field::lib_behind_sec, lib_behind->to_seconds());
+      }
    } else if (state == startup_state::preflight_failed) {
       body(field::detail, std::string{preflight_failed_detail});
    } else if (state == startup_state::wiring_failed) {

--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/underwriter_plugin.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/underwriter_plugin.hpp
@@ -27,7 +27,7 @@ namespace sysio {
       /// against the LAST IRREVERSIBLE block's time — the state the plugin's
       /// table reads actually serve (operator daemons run read-mode =
       /// irreversible). Gates the deferred startup (preflight → cron) on
-      /// cold-booting operator nodes; see `sync_detail.hpp::head_is_recent`.
+      /// cold-booting operator nodes; see `sync_detail.hpp::block_time_is_recent`.
       /// Must exceed steady-state finality lag (a few blocks) and stay well
       /// under one epoch.
       constexpr uint32_t sync_recency_ms     = 5000;

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -2536,17 +2536,19 @@ struct underwriter_plugin::impl {
       // the chain reads for the other states. `lib_behind_sec` is the gate's
       // actual criterion (reads serve the irreversible state); the head gap
       // distinguishes a finality-stalled node from one still catching up.
-      int64_t head_behind_sec = 0;
-      int64_t lib_behind_sec  = 0;
+      // An absent irreversible root stays a typed empty optional here — the
+      // payload builder turns it into the wire's -1 sentinel.
+      fc::microseconds                head_behind{};
+      std::optional<fc::microseconds> lib_behind;
       if (state == underwriter_detail::startup_state::waiting_for_sync) {
          auto&      chain = chain_plug->chain();
          const auto now   = fc::time_point::now();
-         head_behind_sec  = (now - chain.head().block_time()).to_seconds();
-         lib_behind_sec   = chain.fork_db_has_root()
-                               ? (now - chain.fork_db_root().block_time()).to_seconds()
-                               : -1;
+         head_behind      = now - chain.head().block_time();
+         if (chain.fork_db_has_root()) {
+            lib_behind = now - chain.fork_db_root().block_time();
+         }
       }
-      cb(200, underwriter_detail::startup_gate_payload(state, head_behind_sec, lib_behind_sec));
+      cb(200, underwriter_detail::startup_gate_payload(state, head_behind, lib_behind));
       return true;
    }
 

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -14,6 +14,8 @@
 #include <boost/endian/conversion.hpp>
 #include <magic_enum/magic_enum.hpp>
 
+#include <cassert>
+
 #include <sysio/chain_plugin/chain_plugin.hpp>
 #include <sysio/chain/authorization_manager.hpp>
 #include <sysio/chain/controller.hpp>
@@ -246,7 +248,7 @@ struct underwriter_plugin::impl {
 
    /// Sync gate: `accepted_block` subscription that arms {@link run_deferred_startup}
    /// once the local irreversible state is current (see
-   /// `sync_detail.hpp::head_is_recent`). Disconnected after arming; reset on
+   /// `sync_detail.hpp::block_time_is_recent`). Disconnected after arming; reset on
    /// shutdown.
    std::optional<boost::signals2::scoped_connection> sync_gate_connection;
    /// When the sync gate armed — bounds the preflight retry grace window.
@@ -763,10 +765,19 @@ struct underwriter_plugin::impl {
       if (!chain.fork_db_has_root()) {
          return false;
       }
-      return underwriter_detail::head_is_recent(
+      return underwriter_detail::block_time_is_recent(
          chain.fork_db_root().block_time(), fc::time_point::now(),
          fc::milliseconds(underwriter_defaults::sync_recency_ms));
    }
+
+   /// What an exception escaping the deferred startup body does. The
+   /// synchronous `plugin_startup` path must ABORT node startup — fail-fast,
+   /// supervisor-visible; booting without underwriting would hide a broken
+   /// deployment behind one log line. Tasks posted after `exec()` is live
+   /// must CONTAIN the escape as a terminal gate state instead: unwinding
+   /// out of a posted task makes appbase `quit()` and tear down a node that
+   /// may be serving other roles.
+   enum class escape_policy : uint8_t { abort_on_escape, contain_escapes };
 
    /// Arm the deferred startup: runs AT MOST once (re-entry is guarded by
    /// {@link startup_attempted}), on the main thread (either directly from
@@ -774,13 +785,13 @@ struct underwriter_plugin::impl {
    /// `accepted_block` signal once it becomes synced). The body itself lives
    /// in {@link attempt_deferred_startup}, which may retry the preflight
    /// within a bounded grace.
-   void run_deferred_startup() {
+   void run_deferred_startup(escape_policy policy) {
       startup_armed_at = fc::time_point::now();
       // Release the gate slot; the callback already disconnected it before
       // posting, so this is an idempotent cleanup, not the load-bearing
       // disconnect.
       sync_gate_connection.reset();
-      attempt_deferred_startup();
+      attempt_deferred_startup(policy);
    }
 
    /// One attempt of the deferred startup body: preflight → outpost client
@@ -793,32 +804,42 @@ struct underwriter_plugin::impl {
    /// `preflight_retry_interval_ms` until the grace expires. Past the grace,
    /// a preflight failure on a synced chain remains a loud, terminal
    /// bootstrap bug — no cron job, no dev escape hatch — exactly as before.
-   void attempt_deferred_startup() {
+   void attempt_deferred_startup(escape_policy policy) {
       if (shutting_down) {
          return;
       }
-      // Contain every escape as a terminal, diagnosable gate state. This runs
-      // from tasks posted to the app executor (the sync-gate callback and the
-      // preflight retry timer) as well as directly from plugin_startup; an
-      // exception unwinding out of a posted task makes appbase quit() and
-      // tear down the whole node, with the gate still claiming
-      // waiting_for_sync. The expected preflight/wiring failures inside the
-      // body set their own more specific states; this catches what they
-      // don't (a throwing table decode in the preflight or registry read, a
-      // non-fc exception from client wiring, a cron add_job failure).
-      try {
+      if (policy == escape_policy::abort_on_escape) {
+         // Synchronous plugin_startup path: let an escape abort node startup
+         // (nodeop exits nonzero) exactly as before the sync gate existed.
          attempt_deferred_startup_body();
-      } catch (const fc::exception& e) {
-         gate_state = underwriter_detail::startup_state::startup_failed;
-         elog("underwriter_plugin: deferred startup failed unexpectedly: {}",
-              e.to_detail_string());
-      } catch (const std::exception& e) {
-         gate_state = underwriter_detail::startup_state::startup_failed;
-         elog("underwriter_plugin: deferred startup failed unexpectedly: {}", e.what());
-      } catch (...) {
-         gate_state = underwriter_detail::startup_state::startup_failed;
-         elog("underwriter_plugin: deferred startup failed unexpectedly (unknown exception)");
+      } else {
+         // Posted contexts (the sync-gate callback's task and the preflight
+         // retry timer): contain every escape as a terminal, diagnosable gate
+         // state — unwinding out of a posted task makes appbase quit() and
+         // tear down the whole node, with the gate still claiming
+         // waiting_for_sync. The expected preflight/wiring failures inside
+         // the body set their own more specific states; this catches what
+         // they don't (a throwing table decode in the preflight or registry
+         // read, a non-fc exception from client wiring, a cron add_job
+         // failure). FC_LOG_AND_DROP is the tree's containment idiom (see
+         // scan_cycle below) and deliberately rethrows
+         // boost::interprocess::bad_alloc — chainbase shared-memory
+         // exhaustion must stay fatal rather than linger as a gate state.
+         bool completed = false;
+         try {
+            attempt_deferred_startup_body();
+            completed = true;
+         } FC_LOG_AND_DROP("underwriter_plugin: deferred startup failed unexpectedly:");
+         if (!completed) {
+            gate_state = underwriter_detail::startup_state::startup_failed;
+         }
       }
+      // Tripwire for the {@link startup_attempted} derivation: every attempt
+      // that returns normally must have left `waiting_for_sync` — a future
+      // early return in the body before its first gate_state store would
+      // otherwise strand the node in undiagnosable limbo (gate connection
+      // already released, nothing left to re-arm).
+      assert(startup_attempted());
    }
 
    /// The deferred startup body proper — see {@link attempt_deferred_startup}
@@ -910,13 +931,15 @@ struct underwriter_plugin::impl {
          [this]() { scan_cycle(); },
          meta
       );
+      // Stored immediately after the job exists — anything thrown between a
+      // successful add_job and this store would otherwise leave the scan cron
+      // running while the gate reports a terminal failure. The
+      // `/v1/underwriter/*` endpoints (registered back in `plugin_startup`)
+      // switch from gate-state reporting to the real payloads here.
+      gate_state = underwriter_detail::startup_state::active;
 
       ilog("underwriter_plugin: scheduled scan (id={}, interval={}ms)",
            scan_job_id, scan_interval_ms);
-
-      // The `/v1/underwriter/*` endpoints (registered back in `plugin_startup`)
-      // switch from gate-state reporting to the real payloads.
-      gate_state = underwriter_detail::startup_state::active;
    }
 
    /// Re-run {@link attempt_deferred_startup} after one retry interval, on
@@ -935,9 +958,16 @@ struct underwriter_plugin::impl {
             return;
          }
          app().executor().post(appbase::priority::medium, [this]() {
-            if (!shutting_down) {
-               attempt_deferred_startup();
+            // Proceed only while the retry grace is the live state: a
+            // terminal state stored between the timer firing and this task
+            // running must stay terminal. Structural guard — today no such
+            // interleaving exists, but the terminal-stays-terminal invariant
+            // should not rest on statement order in schedule_preflight_retry.
+            if (shutting_down ||
+                gate_state.load() != underwriter_detail::startup_state::preflight_retrying) {
+               return;
             }
+            attempt_deferred_startup(escape_policy::contain_escapes);
          });
       });
    }
@@ -2740,7 +2770,10 @@ void underwriter_plugin::plugin_startup() {
    // remains no dev escape hatch.
    auto& chain = _impl->chain_plug->chain();
    if (_impl->chain_is_synced()) {
-      _impl->run_deferred_startup();
+      // Synchronous boot path: an escape aborts node startup (fail-fast,
+      // supervisor-visible) rather than booting with underwriting silently
+      // disabled.
+      _impl->run_deferred_startup(impl::escape_policy::abort_on_escape);
       return;
    }
 
@@ -2772,7 +2805,7 @@ void underwriter_plugin::plugin_startup() {
             if (_impl->startup_attempted() || _impl->shutting_down) {
                return;
             }
-            _impl->run_deferred_startup();
+            _impl->run_deferred_startup(impl::escape_policy::contain_escapes);
          });
       }));
 }

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -245,12 +245,10 @@ struct underwriter_plugin::impl {
    std::atomic<bool>                 shutting_down{false};
 
    /// Sync gate: `accepted_block` subscription that arms {@link run_deferred_startup}
-   /// once the local head is current (see `sync_detail.hpp::head_is_recent`).
-   /// Disconnected after arming; reset on shutdown.
+   /// once the local irreversible state is current (see
+   /// `sync_detail.hpp::head_is_recent`). Disconnected after arming; reset on
+   /// shutdown.
    std::optional<boost::signals2::scoped_connection> sync_gate_connection;
-   /// True once the deferred startup body (preflight → wiring → cron) has run —
-   /// the gate callback must arm at most once.
-   bool                              startup_armed = false;
    /// When the sync gate armed — bounds the preflight retry grace window.
    fc::time_point                    startup_armed_at;
    /// Bounded-grace preflight retry timer (main io_context; main-thread wait).
@@ -258,9 +256,23 @@ struct underwriter_plugin::impl {
    /// Deferred-startup lifecycle surfaced by the `/v1/underwriter/*` handlers
    /// (which register in `plugin_startup`, BEFORE the gate arms). Written on
    /// the main thread by {@link run_deferred_startup}; read from the HTTP
-   /// handlers' read-only queue — hence atomic.
+   /// handlers' read-only queue — hence atomic. Also the single source of
+   /// truth for "has the deferred startup been armed" ({@link
+   /// startup_attempted}) — every armed attempt leaves `waiting_for_sync`
+   /// before it returns, so no separate armed flag exists to drift.
    std::atomic<underwriter_detail::startup_state> gate_state{
       underwriter_detail::startup_state::waiting_for_sync};
+
+   /// True once the deferred startup has been armed: {@link
+   /// attempt_deferred_startup} stores a non-waiting `gate_state` on every
+   /// path (retrying / a terminal failure / active), so "still
+   /// `waiting_for_sync`" IS "not yet armed". Guards the gate callback and
+   /// its posted task against re-arming (each site also checks
+   /// `shutting_down`, which covers the only path that returns before the
+   /// first store).
+   bool startup_attempted() const {
+      return gate_state.load() != underwriter_detail::startup_state::waiting_for_sync;
+   }
 
    // Outpost chain_kind cache: chain_code -> ChainKind
    std::map<uint64_t, ChainKind>     outpost_chain_kinds;
@@ -756,17 +768,18 @@ struct underwriter_plugin::impl {
          fc::milliseconds(underwriter_defaults::sync_recency_ms));
    }
 
-   /// Arm the deferred startup: runs AT MOST once (`startup_armed`), on the
-   /// main thread (either directly from `plugin_startup` when the node is
-   /// already synced, or from the `accepted_block` signal once it becomes
-   /// synced). The body itself lives in {@link attempt_deferred_startup},
-   /// which may retry the preflight within a bounded grace.
+   /// Arm the deferred startup: runs AT MOST once (re-entry is guarded by
+   /// {@link startup_attempted}), on the main thread (either directly from
+   /// `plugin_startup` when the node is already synced, or from the
+   /// `accepted_block` signal once it becomes synced). The body itself lives
+   /// in {@link attempt_deferred_startup}, which may retry the preflight
+   /// within a bounded grace.
    void run_deferred_startup() {
-      startup_armed    = true;
       startup_armed_at = fc::time_point::now();
-      if (sync_gate_connection) {
-         sync_gate_connection->disconnect();
-      }
+      // Release the gate slot; the callback already disconnected it before
+      // posting, so this is an idempotent cleanup, not the load-bearing
+      // disconnect.
+      sync_gate_connection.reset();
       attempt_deferred_startup();
    }
 
@@ -784,7 +797,33 @@ struct underwriter_plugin::impl {
       if (shutting_down) {
          return;
       }
+      // Contain every escape as a terminal, diagnosable gate state. This runs
+      // from tasks posted to the app executor (the sync-gate callback and the
+      // preflight retry timer) as well as directly from plugin_startup; an
+      // exception unwinding out of a posted task makes appbase quit() and
+      // tear down the whole node, with the gate still claiming
+      // waiting_for_sync. The expected preflight/wiring failures inside the
+      // body set their own more specific states; this catches what they
+      // don't (a throwing table decode in the preflight or registry read, a
+      // non-fc exception from client wiring, a cron add_job failure).
+      try {
+         attempt_deferred_startup_body();
+      } catch (const fc::exception& e) {
+         gate_state = underwriter_detail::startup_state::startup_failed;
+         elog("underwriter_plugin: deferred startup failed unexpectedly: {}",
+              e.to_detail_string());
+      } catch (const std::exception& e) {
+         gate_state = underwriter_detail::startup_state::startup_failed;
+         elog("underwriter_plugin: deferred startup failed unexpectedly: {}", e.what());
+      } catch (...) {
+         gate_state = underwriter_detail::startup_state::startup_failed;
+         elog("underwriter_plugin: deferred startup failed unexpectedly (unknown exception)");
+      }
+   }
 
+   /// The deferred startup body proper — see {@link attempt_deferred_startup}
+   /// for the retry semantics and the exception containment around it.
+   void attempt_deferred_startup_body() {
       // Pre-flight: bail (no cron job) if the depot-side state for this
       // underwriter is incomplete. Cluster bootstrap is responsible for
       // establishing the missing state — there is no dev escape hatch.
@@ -2413,18 +2452,13 @@ struct underwriter_plugin::impl {
    //
    // Both carry a `status` discriminator: until the deferred startup body
    // completes they answer with the gate state (`waiting_for_sync` +
-   // `head_behind_sec`, or a terminal `preflight_failed`/`wiring_failed`
-   // with `detail`); once active they serve the payloads below with
-   // `status:"active"`.
+   // `head_behind_sec`/`lib_behind_sec`, `preflight_retrying`, or a terminal
+   // `preflight_failed`/`wiring_failed`/`startup_failed` with `detail`);
+   // once active they serve the payloads below with `status:"active"`.
    //
    // The matching `clio opp uw <stats|commits>` CLI wrapper is planned in
    // a follow-up; today the endpoints are addressable via `curl` against
    // the nodeop HTTP port.
-
-   /// The uniform `status` spelling for the post-startup payloads.
-   static std::string active_status_name() {
-      return std::string{magic_enum::enum_name(underwriter_detail::startup_state::active)};
-   }
 
    fc::variant build_stats_response() {
       std::lock_guard lk{stats_mutex};
@@ -2451,7 +2485,7 @@ struct underwriter_plugin::impl {
             ("source_deposit_addr", ep.source_deposit_addr));
       }
       return fc::variant(fc::mutable_variant_object()
-         ("status",                         active_status_name())
+         (underwriter_detail::field::status, std::string{underwriter_detail::active_status})
          ("underwriter_account",            underwriter_account.to_string())
          ("enabled",                        enabled)
          ("is_active",                      is_active)
@@ -2483,24 +2517,36 @@ struct underwriter_plugin::impl {
          ));
       }
       return fc::variant(fc::mutable_variant_object()
-         ("status",  active_status_name())
+         (underwriter_detail::field::status, std::string{underwriter_detail::active_status})
          ("count",   entries.size())
          ("entries", std::move(entries))
       );
    }
 
    /// Answer `cb` with the gate-state payload and return true when the
-   /// deferred startup body has not completed (waiting for sync, or failed
-   /// terminally); return false once {@link run_deferred_startup} reached
-   /// `active` so the caller serves the real payload.
+   /// deferred startup body has not completed (waiting for sync, retrying,
+   /// or failed terminally); return false once {@link run_deferred_startup}
+   /// reached `active` so the caller serves the real payload.
    bool respond_if_gated(const url_response_callback& cb) {
       const auto state = gate_state.load();
       if (state == underwriter_detail::startup_state::active) {
          return false;
       }
-      const int64_t head_behind_sec =
-         (fc::time_point::now() - chain_plug->chain().head().block_time()).to_seconds();
-      cb(200, underwriter_detail::startup_gate_payload(state, head_behind_sec));
+      // Only the waiting_for_sync payload carries the behind-now gaps; skip
+      // the chain reads for the other states. `lib_behind_sec` is the gate's
+      // actual criterion (reads serve the irreversible state); the head gap
+      // distinguishes a finality-stalled node from one still catching up.
+      int64_t head_behind_sec = 0;
+      int64_t lib_behind_sec  = 0;
+      if (state == underwriter_detail::startup_state::waiting_for_sync) {
+         auto&      chain = chain_plug->chain();
+         const auto now   = fc::time_point::now();
+         head_behind_sec  = (now - chain.head().block_time()).to_seconds();
+         lib_behind_sec   = chain.fork_db_has_root()
+                               ? (now - chain.fork_db_root().block_time()).to_seconds()
+                               : -1;
+      }
+      cb(200, underwriter_detail::startup_gate_payload(state, head_behind_sec, lib_behind_sec));
       return true;
    }
 
@@ -2705,7 +2751,7 @@ void underwriter_plugin::plugin_startup() {
            : -1);
    _impl->sync_gate_connection.emplace(
       chain.accepted_block().connect([this](const chain::block_signal_params&) {
-         if (_impl->startup_armed || _impl->shutting_down) {
+         if (_impl->startup_attempted() || _impl->shutting_down) {
             return;
          }
          if (!_impl->chain_is_synced()) {
@@ -2721,7 +2767,7 @@ void underwriter_plugin::plugin_startup() {
          _impl->sync_gate_connection->disconnect();
          ilog("underwriter_plugin: chain synced — scheduling deferred startup");
          app().executor().post(appbase::priority::medium, [this]() {
-            if (_impl->startup_armed || _impl->shutting_down) {
+            if (_impl->startup_attempted() || _impl->shutting_down) {
                return;
             }
             _impl->run_deferred_startup();

--- a/plugins/underwriter_plugin/test/test_underwriter_sync.cpp
+++ b/plugins/underwriter_plugin/test/test_underwriter_sync.cpp
@@ -1,7 +1,7 @@
 /**
  * @file test_underwriter_sync.cpp
  * @brief Unit tests for the underwriter plugin's sync-gate predicate
- *        (`sysio::underwriter_detail::head_is_recent`) — the pure decision
+ *        (`sysio::underwriter_detail::block_time_is_recent`) — the pure decision
  *        behind deferring preflight until the chain plugin reports the node
  *        synced.
  */
@@ -10,7 +10,7 @@
 #include <sysio/underwriter_plugin/sync_detail.hpp>
 #include <sysio/underwriter_plugin/underwriter_plugin.hpp>
 
-using sysio::underwriter_detail::head_is_recent;
+using sysio::underwriter_detail::block_time_is_recent;
 
 BOOST_AUTO_TEST_SUITE(underwriter_sync_tests)
 
@@ -24,57 +24,65 @@ static const fc::microseconds default_window =
    fc::milliseconds(sysio::underwriter_defaults::sync_recency_ms);
 
 BOOST_AUTO_TEST_CASE(head_at_now_is_synced) {
-   BOOST_TEST(head_is_recent(reference_now, reference_now, default_window));
+   BOOST_TEST(block_time_is_recent(reference_now, reference_now, default_window));
 }
 
 BOOST_AUTO_TEST_CASE(head_slightly_behind_within_window_is_synced) {
    // One block interval behind — the steady-state of a caught-up node.
-   BOOST_TEST(head_is_recent(reference_now - fc::milliseconds(500),
-                             reference_now, default_window));
+   BOOST_TEST(block_time_is_recent(reference_now - fc::milliseconds(500),
+                                   reference_now, default_window));
 }
 
 BOOST_AUTO_TEST_CASE(head_exactly_at_window_boundary_is_synced) {
-   BOOST_TEST(head_is_recent(reference_now - default_window,
-                             reference_now, default_window));
+   BOOST_TEST(block_time_is_recent(reference_now - default_window,
+                                   reference_now, default_window));
 }
 
 BOOST_AUTO_TEST_CASE(head_just_past_window_is_not_synced) {
-   BOOST_TEST(!head_is_recent(reference_now - default_window - fc::microseconds(1),
-                              reference_now, default_window));
+   BOOST_TEST(!block_time_is_recent(reference_now - default_window - fc::microseconds(1),
+                                    reference_now, default_window));
 }
 
 BOOST_AUTO_TEST_CASE(cold_boot_replay_gap_is_not_synced) {
    // A node mid-replay: head hours behind wall clock — the exact state whose
    // genesis-era table reads used to false-fail the preflight.
-   BOOST_TEST(!head_is_recent(reference_now - fc::hours(2),
-                              reference_now, default_window));
+   BOOST_TEST(!block_time_is_recent(reference_now - fc::hours(2),
+                                    reference_now, default_window));
 }
 
 BOOST_AUTO_TEST_CASE(head_ahead_of_now_is_synced) {
    // Clock skew / head stamped marginally ahead of the observer's clock must
    // never read as "behind".
-   BOOST_TEST(head_is_recent(reference_now + fc::seconds(1),
-                             reference_now, default_window));
+   BOOST_TEST(block_time_is_recent(reference_now + fc::seconds(1),
+                                   reference_now, default_window));
 }
 
 BOOST_AUTO_TEST_CASE(zero_window_requires_head_at_or_past_now) {
-   BOOST_TEST(head_is_recent(reference_now, reference_now, fc::microseconds(0)));
-   BOOST_TEST(!head_is_recent(reference_now - fc::microseconds(1),
-                              reference_now, fc::microseconds(0)));
+   BOOST_TEST(block_time_is_recent(reference_now, reference_now, fc::microseconds(0)));
+   BOOST_TEST(!block_time_is_recent(reference_now - fc::microseconds(1),
+                                    reference_now, fc::microseconds(0)));
 }
 
 // ── startup_gate_payload: the /v1/underwriter/* body served until the ──
 // ── deferred startup body completes (registration is unconditional at ──
 // ── plugin_startup, so these payloads are what a cold-boot query sees) ──
 //
-// Field KEYS come from the shared `field::` constants (one spelling
-// authority with the payload builder); the `status` VALUES stay literal on
-// purpose — they pin the wire contract, so an enum-member rename that would
-// silently change the HTTP format fails here.
+// Wire-format pinning: the static_asserts below pin each shared `field::`
+// KEY constant to its literal wire spelling once (a typo'd or renamed
+// constant would otherwise change the HTTP format with builder and tests
+// agreeing tautologically); every assertion after that is free to use the
+// constants. The `status` VALUES stay literal in the cases for the same
+// reason — an enum-member rename that would silently change the wire format
+// fails here.
 
 using sysio::underwriter_detail::startup_gate_payload;
 using sysio::underwriter_detail::startup_state;
 namespace field = sysio::underwriter_detail::field;
+
+static_assert(std::string_view{field::status} == "status");
+static_assert(std::string_view{field::head_behind_sec} == "head_behind_sec");
+static_assert(std::string_view{field::lib_behind_sec} == "lib_behind_sec");
+static_assert(std::string_view{field::detail} == "detail");
 
 BOOST_AUTO_TEST_CASE(gate_payload_waiting_for_sync_reports_behind_gaps) {
    const auto body = startup_gate_payload(startup_state::waiting_for_sync,
@@ -86,13 +94,24 @@ BOOST_AUTO_TEST_CASE(gate_payload_waiting_for_sync_reports_behind_gaps) {
    BOOST_TEST(!body.contains(field::detail));
 }
 
-BOOST_AUTO_TEST_CASE(gate_payload_no_root_emits_minus_one_sentinel) {
-   // Before the fork database has a root the caller passes an empty optional;
-   // the payload builder emits the wire's -1 sentinel (matching the startup
-   // wait log).
+BOOST_AUTO_TEST_CASE(gate_payload_no_root_omits_lib_gap) {
+   // Before the fork database has a root the caller passes an empty optional
+   // and the key is omitted — an in-band sentinel would collide with real
+   // negative (clock-skew) gaps after whole-second truncation.
    const auto body = startup_gate_payload(startup_state::waiting_for_sync,
                                           fc::seconds(3), std::nullopt)
                         .get_object();
+   BOOST_TEST(body[field::head_behind_sec].as_int64() == 3);
+   BOOST_TEST(!body.contains(field::lib_behind_sec));
+}
+
+BOOST_AUTO_TEST_CASE(gate_payload_passes_negative_skew_gaps_through) {
+   // A block time ahead of local wall clock (clock skew) yields a negative
+   // gap; it is reported as-is — the skew is itself diagnostic signal.
+   const auto body = startup_gate_payload(startup_state::waiting_for_sync,
+                                          fc::milliseconds(-1500), fc::milliseconds(-1500))
+                        .get_object();
+   BOOST_TEST(body[field::head_behind_sec].as_int64() == -1);
    BOOST_TEST(body[field::lib_behind_sec].as_int64() == -1);
 }
 
@@ -157,11 +176,7 @@ BOOST_AUTO_TEST_CASE(gate_payload_active_is_status_only) {
    BOOST_TEST(body.size() == 1u);
 }
 
-BOOST_AUTO_TEST_CASE(active_status_constant_matches_enum_spelling) {
-   // The post-startup response builders stamp `active_status`; it must stay
-   // in lock-step with the enum member the gate payload spells via
-   // magic_enum.
-   BOOST_TEST(std::string{sysio::underwriter_detail::active_status} == "active");
-}
+// `active_status` is pinned at compile time next to its definition in
+// sync_detail.hpp (static_assert), so no runtime case is needed for it.
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/plugins/underwriter_plugin/test/test_underwriter_sync.cpp
+++ b/plugins/underwriter_plugin/test/test_underwriter_sync.cpp
@@ -66,47 +66,83 @@ BOOST_AUTO_TEST_CASE(zero_window_requires_head_at_or_past_now) {
 // ── startup_gate_payload: the /v1/underwriter/* body served until the ──
 // ── deferred startup body completes (registration is unconditional at ──
 // ── plugin_startup, so these payloads are what a cold-boot query sees) ──
+//
+// Field KEYS come from the shared `field::` constants (one spelling
+// authority with the payload builder); the `status` VALUES stay literal on
+// purpose — they pin the wire contract, so an enum-member rename that would
+// silently change the HTTP format fails here.
 
 using sysio::underwriter_detail::startup_gate_payload;
 using sysio::underwriter_detail::startup_state;
+namespace field = sysio::underwriter_detail::field;
 
-BOOST_AUTO_TEST_CASE(gate_payload_waiting_for_sync_reports_head_gap) {
-   const auto body = startup_gate_payload(startup_state::waiting_for_sync, 204)
+BOOST_AUTO_TEST_CASE(gate_payload_waiting_for_sync_reports_behind_gaps) {
+   const auto body = startup_gate_payload(startup_state::waiting_for_sync, 204, 206)
                         .get_object();
-   BOOST_TEST(body["status"].as_string() == "waiting_for_sync");
-   BOOST_TEST(body["head_behind_sec"].as_int64() == 204);
-   BOOST_TEST(!body.contains("detail"));
+   BOOST_TEST(body[field::status].as_string() == "waiting_for_sync");
+   BOOST_TEST(body[field::head_behind_sec].as_int64() == 204);
+   BOOST_TEST(body[field::lib_behind_sec].as_int64() == 206);
+   BOOST_TEST(!body.contains(field::detail));
+}
+
+BOOST_AUTO_TEST_CASE(gate_payload_waiting_for_sync_passes_no_root_sentinel) {
+   // Before the fork database has a root the caller reports -1 (matching the
+   // startup wait log); the payload forwards it untouched.
+   const auto body = startup_gate_payload(startup_state::waiting_for_sync, 3, -1)
+                        .get_object();
+   BOOST_TEST(body[field::lib_behind_sec].as_int64() == -1);
 }
 
 BOOST_AUTO_TEST_CASE(gate_payload_preflight_failed_carries_detail) {
-   const auto body = startup_gate_payload(startup_state::preflight_failed, 0)
+   const auto body = startup_gate_payload(startup_state::preflight_failed, 0, 0)
                         .get_object();
-   BOOST_TEST(body["status"].as_string() == "preflight_failed");
-   BOOST_TEST(body["detail"].as_string() ==
+   BOOST_TEST(body[field::status].as_string() == "preflight_failed");
+   BOOST_TEST(body[field::detail].as_string() ==
               std::string{sysio::underwriter_detail::preflight_failed_detail});
-   BOOST_TEST(!body.contains("head_behind_sec"));
+   BOOST_TEST(!body.contains(field::head_behind_sec));
+   BOOST_TEST(!body.contains(field::lib_behind_sec));
 }
 
 BOOST_AUTO_TEST_CASE(gate_payload_wiring_failed_carries_detail) {
-   const auto body = startup_gate_payload(startup_state::wiring_failed, 0)
+   const auto body = startup_gate_payload(startup_state::wiring_failed, 0, 0)
                         .get_object();
-   BOOST_TEST(body["status"].as_string() == "wiring_failed");
-   BOOST_TEST(body["detail"].as_string() ==
+   BOOST_TEST(body[field::status].as_string() == "wiring_failed");
+   BOOST_TEST(body[field::detail].as_string() ==
               std::string{sysio::underwriter_detail::wiring_failed_detail});
-   BOOST_TEST(!body.contains("head_behind_sec"));
+   BOOST_TEST(!body.contains(field::head_behind_sec));
+   BOOST_TEST(!body.contains(field::lib_behind_sec));
+}
+
+BOOST_AUTO_TEST_CASE(gate_payload_startup_failed_carries_detail) {
+   // The catch-all terminal state: the deferred startup body threw past the
+   // specific preflight/wiring failure paths.
+   const auto body = startup_gate_payload(startup_state::startup_failed, 0, 0)
+                        .get_object();
+   BOOST_TEST(body[field::status].as_string() == "startup_failed");
+   BOOST_TEST(body[field::detail].as_string() ==
+              std::string{sysio::underwriter_detail::startup_failed_detail});
+   BOOST_TEST(!body.contains(field::head_behind_sec));
+   BOOST_TEST(!body.contains(field::lib_behind_sec));
 }
 
 BOOST_AUTO_TEST_CASE(gate_payload_preflight_retrying_is_status_only) {
    const auto body =
-      startup_gate_payload(startup_state::preflight_retrying, 0).get_object();
-   BOOST_TEST(body["status"].as_string() == "preflight_retrying");
+      startup_gate_payload(startup_state::preflight_retrying, 0, 0).get_object();
+   BOOST_TEST(body[field::status].as_string() == "preflight_retrying");
    BOOST_TEST(body.size() == 1u);
 }
 
 BOOST_AUTO_TEST_CASE(gate_payload_active_is_status_only) {
-   const auto body = startup_gate_payload(startup_state::active, 99).get_object();
-   BOOST_TEST(body["status"].as_string() == "active");
+   const auto body = startup_gate_payload(startup_state::active, 99, 99).get_object();
+   BOOST_TEST(body[field::status].as_string() == "active");
    BOOST_TEST(body.size() == 1u);
+}
+
+BOOST_AUTO_TEST_CASE(active_status_constant_matches_enum_spelling) {
+   // The post-startup response builders stamp `active_status`; it must stay
+   // in lock-step with the enum member the gate payload spells via
+   // magic_enum.
+   BOOST_TEST(std::string{sysio::underwriter_detail::active_status} == "active");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/plugins/underwriter_plugin/test/test_underwriter_sync.cpp
+++ b/plugins/underwriter_plugin/test/test_underwriter_sync.cpp
@@ -77,7 +77,8 @@ using sysio::underwriter_detail::startup_state;
 namespace field = sysio::underwriter_detail::field;
 
 BOOST_AUTO_TEST_CASE(gate_payload_waiting_for_sync_reports_behind_gaps) {
-   const auto body = startup_gate_payload(startup_state::waiting_for_sync, 204, 206)
+   const auto body = startup_gate_payload(startup_state::waiting_for_sync,
+                                          fc::seconds(204), fc::seconds(206))
                         .get_object();
    BOOST_TEST(body[field::status].as_string() == "waiting_for_sync");
    BOOST_TEST(body[field::head_behind_sec].as_int64() == 204);
@@ -85,16 +86,29 @@ BOOST_AUTO_TEST_CASE(gate_payload_waiting_for_sync_reports_behind_gaps) {
    BOOST_TEST(!body.contains(field::detail));
 }
 
-BOOST_AUTO_TEST_CASE(gate_payload_waiting_for_sync_passes_no_root_sentinel) {
-   // Before the fork database has a root the caller reports -1 (matching the
-   // startup wait log); the payload forwards it untouched.
-   const auto body = startup_gate_payload(startup_state::waiting_for_sync, 3, -1)
+BOOST_AUTO_TEST_CASE(gate_payload_no_root_emits_minus_one_sentinel) {
+   // Before the fork database has a root the caller passes an empty optional;
+   // the payload builder emits the wire's -1 sentinel (matching the startup
+   // wait log).
+   const auto body = startup_gate_payload(startup_state::waiting_for_sync,
+                                          fc::seconds(3), std::nullopt)
                         .get_object();
    BOOST_TEST(body[field::lib_behind_sec].as_int64() == -1);
 }
 
+BOOST_AUTO_TEST_CASE(gate_payload_truncates_to_whole_seconds) {
+   // Durations travel as fc::microseconds; the JSON boundary emits whole
+   // seconds.
+   const auto body = startup_gate_payload(startup_state::waiting_for_sync,
+                                          fc::milliseconds(2500), fc::milliseconds(1999))
+                        .get_object();
+   BOOST_TEST(body[field::head_behind_sec].as_int64() == 2);
+   BOOST_TEST(body[field::lib_behind_sec].as_int64() == 1);
+}
+
 BOOST_AUTO_TEST_CASE(gate_payload_preflight_failed_carries_detail) {
-   const auto body = startup_gate_payload(startup_state::preflight_failed, 0, 0)
+   const auto body = startup_gate_payload(startup_state::preflight_failed,
+                                          fc::microseconds(0), std::nullopt)
                         .get_object();
    BOOST_TEST(body[field::status].as_string() == "preflight_failed");
    BOOST_TEST(body[field::detail].as_string() ==
@@ -104,7 +118,8 @@ BOOST_AUTO_TEST_CASE(gate_payload_preflight_failed_carries_detail) {
 }
 
 BOOST_AUTO_TEST_CASE(gate_payload_wiring_failed_carries_detail) {
-   const auto body = startup_gate_payload(startup_state::wiring_failed, 0, 0)
+   const auto body = startup_gate_payload(startup_state::wiring_failed,
+                                          fc::microseconds(0), std::nullopt)
                         .get_object();
    BOOST_TEST(body[field::status].as_string() == "wiring_failed");
    BOOST_TEST(body[field::detail].as_string() ==
@@ -116,7 +131,8 @@ BOOST_AUTO_TEST_CASE(gate_payload_wiring_failed_carries_detail) {
 BOOST_AUTO_TEST_CASE(gate_payload_startup_failed_carries_detail) {
    // The catch-all terminal state: the deferred startup body threw past the
    // specific preflight/wiring failure paths.
-   const auto body = startup_gate_payload(startup_state::startup_failed, 0, 0)
+   const auto body = startup_gate_payload(startup_state::startup_failed,
+                                          fc::microseconds(0), std::nullopt)
                         .get_object();
    BOOST_TEST(body[field::status].as_string() == "startup_failed");
    BOOST_TEST(body[field::detail].as_string() ==
@@ -127,13 +143,16 @@ BOOST_AUTO_TEST_CASE(gate_payload_startup_failed_carries_detail) {
 
 BOOST_AUTO_TEST_CASE(gate_payload_preflight_retrying_is_status_only) {
    const auto body =
-      startup_gate_payload(startup_state::preflight_retrying, 0, 0).get_object();
+      startup_gate_payload(startup_state::preflight_retrying, fc::microseconds(0), std::nullopt)
+         .get_object();
    BOOST_TEST(body[field::status].as_string() == "preflight_retrying");
    BOOST_TEST(body.size() == 1u);
 }
 
 BOOST_AUTO_TEST_CASE(gate_payload_active_is_status_only) {
-   const auto body = startup_gate_payload(startup_state::active, 99, 99).get_object();
+   const auto body = startup_gate_payload(startup_state::active,
+                                          fc::seconds(99), fc::seconds(99))
+                        .get_object();
    BOOST_TEST(body[field::status].as_string() == "active");
    BOOST_TEST(body.size() == 1u);
 }


### PR DESCRIPTION
Hardening follow-ups to the underwriter sync gate, from the PR #477 review (applies on top of the LIB-gate/preflight-retry follow-up).

**Contain deferred-startup escapes, with a boot/posted policy split.** The deferred startup body runs from tasks posted to the app executor — the sync-gate callback's post and the preflight retry timer — where an escaping exception unwinds into `application::exec()`, which `quit()`s and shuts down every plugin: a mid-operation teardown of the whole node, with `/v1/underwriter/*` still reporting `waiting_for_sync`. Escapes were possible from a throwing table decode in the preflight or registry read (both sat outside any handler), a non-fc exception from outpost client wiring, and cron `add_job` (outside the try entirely). Posted contexts now contain any escape as a terminal `startup_failed` gate state with a `detail` payload, using `FC_LOG_AND_DROP` — the tree's containment idiom, which deliberately rethrows `boost::interprocess::bad_alloc` so chainbase shared-memory exhaustion stays fatal. The synchronous `plugin_startup` path deliberately does not contain: a node that would boot without underwriting exits instead, fail-fast and supervisor-visible. Terminal states are structurally protected — `gate_state = active` is stored immediately after the scan cron is added (a later throw cannot leave the cron running under a terminal gate state), and the preflight retry task proceeds only while `preflight_retrying` is the live state (a stale retry can never overwrite a terminal state).

**Report the gate's actual criterion while waiting.** Since the gate arms on last-irreversible recency, the `waiting_for_sync` payload's head-based `head_behind_sec` could read ~0 on a finality-stalled node whose gate correctly stays closed. The payload now carries `head_behind_sec` and `lib_behind_sec`; durations travel through the plumbing as `fc::microseconds` (the absent-irreversible-root case a typed empty optional) and integers materialize only at the JSON boundary. `lib_behind_sec` is omitted while no fork-db root exists — an in-band -1 sentinel would collide with real negative clock-skew gaps after whole-second truncation — and negative gaps are reported as-is, since the skew is itself diagnostic signal. The chain reads happen only for the `waiting_for_sync` state; terminal responses do no chain access.

**Cleanups.** The `startup_armed` flag is removed: every armed attempt stores a non-waiting `gate_state` before returning, so `startup_attempted()` derives arming from the gate state, and an assert after the containment wrapper turns that invariant into a tripwire. The JSON field keys shared across the payload builder, the post-startup response builders, and the tests move behind `field::` constants in `sync_detail.hpp`, pinned once to their literal wire spellings via static_asserts so builder and tests cannot drift in tandem; a compile-time-pinned `active_status` constant replaces the per-request `active_status_name()`. `head_is_recent` is renamed `block_time_is_recent` — its only production caller feeds the last-irreversible block's time, and the head-named identifier sat exactly on the head-vs-LIB distinction the gate fix exists for. The `sync_detail.hpp` header docs drop the inaccurate "same recency notion producer_plugin uses" claim and describe the LIB criterion the gate actually measures.

Tests: `underwriter_sync_tests` covers the `startup_failed` payload, the omitted-key no-root case, negative skew gaps passing through, whole-second truncation, and both behind-gap fields; wire keys are pinned by static_asserts while the `status` values stay literal in the cases to pin the wire format.
