### PR TITLE
Fix macOS auto BP gossip CPU budget flake

### DIFF
--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -67,6 +67,9 @@ class Cluster(object):
     __finalizerCatchupMaxLagBlocks=2
     __finalizerCatchupStableRounds=3
     __finalizerCatchupReportInterval=5
+    # Default generated-genesis CPU limits used by Cluster.launch.
+    __defaultMaxBlockCpuUsage=400000
+    __defaultMaxTransactionCpuUsage=375000
 
     # pylint: disable=too-many-arguments
     def __init__(self, localCluster=True, host="localhost", port=None, walletHost="localhost", walletPort=None
@@ -208,7 +211,8 @@ class Cluster(object):
                activateIF=False, biosFinalizer=True,
                signatureProviderForNonProducer=False,
                nodeopLogPath=Path(Utils.TestLogRoot) / Path(f'{Path(sys.argv[0]).stem}{os.getpid()}'), genesisPath=None,
-               maximumP2pPerHost=0, maximumClients=25, prodsEnableTraceApi=True):
+               maximumP2pPerHost=0, maximumClients=25, prodsEnableTraceApi=True,
+               maxBlockCpuUsage=None, maxTransactionCpuUsage=None):
         """Launch cluster.
         pnodes: producer nodes count
         unstartedNodes: non-producer nodes that are configured into the launch, but not started.  Should be included in totalNodes.
@@ -237,6 +241,8 @@ class Cluster(object):
         maximumP2pPerHost:  Maximum number of client nodes from any single IP address. Defaults to totalNodes if not set.
         maximumClients: Maximum number of clients from which connections are accepted, use 0 for no limit. Defaults to 25.
         prodsEnableTraceApi: Determines whether producer nodes should have sysio::trace_api_plugin enabled. Defaults to True.
+        maxBlockCpuUsage: Override generated genesis max_block_cpu_usage when genesisPath is not supplied.
+        maxTransactionCpuUsage: Override generated genesis max_transaction_cpu_usage when genesisPath is not supplied.
         """
         assert(isinstance(topo, str))
         assert PFSetupPolicy.isValid(pfSetupPolicy)
@@ -357,10 +363,14 @@ class Cluster(object):
             argsArr.append(nodeopArgs)
 
         if genesisPath is None:
+            if maxBlockCpuUsage is None:
+                maxBlockCpuUsage = Cluster.__defaultMaxBlockCpuUsage
+            if maxTransactionCpuUsage is None:
+                maxTransactionCpuUsage = Cluster.__defaultMaxTransactionCpuUsage
             argsArr.append("--max-block-cpu-usage")
-            argsArr.append(str(400000))
+            argsArr.append(str(maxBlockCpuUsage))
             argsArr.append("--max-transaction-cpu-usage")
-            argsArr.append(str(375000))
+            argsArr.append(str(maxTransactionCpuUsage))
         else:
             argsArr.append("--genesis")
             argsArr.append(str(genesisPath))

--- a/tests/TestHarness/Cluster.py
+++ b/tests/TestHarness/Cluster.py
@@ -67,9 +67,7 @@ class Cluster(object):
     __finalizerCatchupMaxLagBlocks=2
     __finalizerCatchupStableRounds=3
     __finalizerCatchupReportInterval=5
-    # Default generated-genesis CPU limits used by Cluster.launch.
-    __defaultMaxBlockCpuUsage=400000
-    __defaultMaxTransactionCpuUsage=375000
+    __setFinalizerCpuRetryAttempts=30
 
     # pylint: disable=too-many-arguments
     def __init__(self, localCluster=True, host="localhost", port=None, walletHost="localhost", walletPort=None
@@ -211,8 +209,7 @@ class Cluster(object):
                activateIF=False, biosFinalizer=True,
                signatureProviderForNonProducer=False,
                nodeopLogPath=Path(Utils.TestLogRoot) / Path(f'{Path(sys.argv[0]).stem}{os.getpid()}'), genesisPath=None,
-               maximumP2pPerHost=0, maximumClients=25, prodsEnableTraceApi=True,
-               maxBlockCpuUsage=None, maxTransactionCpuUsage=None):
+               maximumP2pPerHost=0, maximumClients=25, prodsEnableTraceApi=True):
         """Launch cluster.
         pnodes: producer nodes count
         unstartedNodes: non-producer nodes that are configured into the launch, but not started.  Should be included in totalNodes.
@@ -241,8 +238,6 @@ class Cluster(object):
         maximumP2pPerHost:  Maximum number of client nodes from any single IP address. Defaults to totalNodes if not set.
         maximumClients: Maximum number of clients from which connections are accepted, use 0 for no limit. Defaults to 25.
         prodsEnableTraceApi: Determines whether producer nodes should have sysio::trace_api_plugin enabled. Defaults to True.
-        maxBlockCpuUsage: Override generated genesis max_block_cpu_usage when genesisPath is not supplied.
-        maxTransactionCpuUsage: Override generated genesis max_transaction_cpu_usage when genesisPath is not supplied.
         """
         assert(isinstance(topo, str))
         assert PFSetupPolicy.isValid(pfSetupPolicy)
@@ -363,14 +358,10 @@ class Cluster(object):
             argsArr.append(nodeopArgs)
 
         if genesisPath is None:
-            if maxBlockCpuUsage is None:
-                maxBlockCpuUsage = Cluster.__defaultMaxBlockCpuUsage
-            if maxTransactionCpuUsage is None:
-                maxTransactionCpuUsage = Cluster.__defaultMaxTransactionCpuUsage
             argsArr.append("--max-block-cpu-usage")
-            argsArr.append(str(maxBlockCpuUsage))
+            argsArr.append(str(400000))
             argsArr.append("--max-transaction-cpu-usage")
-            argsArr.append(str(maxTransactionCpuUsage))
+            argsArr.append(str(375000))
         else:
             argsArr.append("--genesis")
             argsArr.append(str(genesisPath))
@@ -1145,6 +1136,7 @@ class Cluster(object):
 
     # finalizerNames specifies non-default finalizer name for each node
     def setFinalizers(self, nodes, node=None, finalizerNames=None):
+        """Set the active finalizer policy, retrying transient CPU overages during bootstrap."""
         # finalizerNames, if present, must specify finalizer names for all the nodes
         assert(finalizerNames is None or len(nodes) == len(finalizerNames))
         if node is None:
@@ -1171,15 +1163,8 @@ class Cluster(object):
         if Utils.Debug: Utils.Print("setfinalizers: %s" % (setFinStr))
         Utils.Print("Setting finalizers")
         opts = "--permission sysio@active"
-        # setfinalizer can fail on ci/cd because it required too much CPU, try a few times
-        retries = 3
-        while retries > 0:
-            trans = node.pushMessage("sysio", "setfinalizer", setFinStr, opts)
-            if trans is None or not trans[0]:
-                retries = retries - 1
-                continue
-            else:
-                break
+        trans = node.pushMessage("sysio", "setfinalizer", setFinStr, opts,
+                                 cpuRetryAttempts=Cluster.__setFinalizerCpuRetryAttempts)
         if trans is None or not trans[0]:
             Utils.Print("ERROR: Failed to set finalizers")
             return None

--- a/tests/TestHarness/transactions.py
+++ b/tests/TestHarness/transactions.py
@@ -14,6 +14,8 @@ class Transactions(NodeopQueries):
     retry_num_blocks_default = 1
     # Default clio action-push subprocess timeout, in seconds, used to bound a stuck push.
     push_message_timeout_default = 45
+    # Default number of clio action-push attempts for transient subjective CPU overages.
+    push_message_cpu_retry_attempts_default = 5
 
     def __init__(self, host, port, walletMgr=None):
         super().__init__(host, port, walletMgr)
@@ -264,10 +266,13 @@ class Transactions(NodeopQueries):
 
     # returns tuple with transaction execution status and transaction
     def pushMessage(self, account, action, data, opts, silentErrors=False, signatures=None, expectTrxTrace=True,
-                    timeout=None):
-        """Push an action with clio, bounding the clio subprocess runtime by default."""
+                    timeout=None, cpuRetryAttempts=None):
+        """Push an action with clio, retrying transient subjective CPU failures."""
         if timeout is None:
             timeout = self.push_message_timeout_default
+        if cpuRetryAttempts is None:
+            cpuRetryAttempts = self.push_message_cpu_retry_attempts_default
+        assert(isinstance(cpuRetryAttempts, int) and cpuRetryAttempts > 0)
         cmd="%s %s push action -j %s %s" % (Utils.SysClientPath, self.sysClientArgs(), account, action)
         cmdArr=cmd.split()
         # not using sign_str, since cmdArr messes up the string
@@ -279,7 +284,7 @@ class Transactions(NodeopQueries):
         if opts is not None:
             cmdArr += opts.split()
         if Utils.Debug: Utils.Print("cmd: %s" % (cmdArr))
-        retries = 5
+        retries = cpuRetryAttempts
         start=time.perf_counter()
         while retries > 0:
             retries -= 1

--- a/tests/auto_bp_gossip_peering_test.py
+++ b/tests/auto_bp_gossip_peering_test.py
@@ -26,6 +26,9 @@ cmdError = Utils.cmdError
 producerNodes = 21
 producerCountInEachNode = 1
 totalNodes = producerNodes
+# The 7-finalizer bootstrap action can exceed the default generated-genesis CPU budget on slower macOS arm64 runners.
+autoBpGossipMaxBlockCpuUsage = 1000000
+autoBpGossipMaxTransactionCpuUsage = 900000
 
 # Parse command line arguments
 args = TestHelper.parse_args({
@@ -94,6 +97,8 @@ try:
         topo="./tests/auto_bp_peering_test_shape.json",
         extraNodeopArgs=extraNodeopArgs,
         specificExtraNodeopArgs=specificNodeopArgs,
+        maxBlockCpuUsage=autoBpGossipMaxBlockCpuUsage,
+        maxTransactionCpuUsage=autoBpGossipMaxTransactionCpuUsage,
     ):
         errorExit("Failed to stand up cluster.")
 

--- a/tests/auto_bp_gossip_peering_test.py
+++ b/tests/auto_bp_gossip_peering_test.py
@@ -26,9 +26,6 @@ cmdError = Utils.cmdError
 producerNodes = 21
 producerCountInEachNode = 1
 totalNodes = producerNodes
-# The 7-finalizer bootstrap action can exceed the default generated-genesis CPU budget on slower macOS arm64 runners.
-autoBpGossipMaxBlockCpuUsage = 1000000
-autoBpGossipMaxTransactionCpuUsage = 900000
 
 # Parse command line arguments
 args = TestHelper.parse_args({
@@ -97,8 +94,6 @@ try:
         topo="./tests/auto_bp_peering_test_shape.json",
         extraNodeopArgs=extraNodeopArgs,
         specificExtraNodeopArgs=specificNodeopArgs,
-        maxBlockCpuUsage=autoBpGossipMaxBlockCpuUsage,
-        maxTransactionCpuUsage=autoBpGossipMaxTransactionCpuUsage,
     ):
         errorExit("Failed to stand up cluster.")
 


### PR DESCRIPTION
## Summary
- Keep the generated genesis CPU budgets unchanged for `auto_bp_gossip_peering_test` and all other `Cluster.launch` callers.
- Make `Transactions.pushMessage` accept a configurable `cpuRetryAttempts` value while preserving the existing default of 5 attempts.
- Have `Cluster.setFinalizers` use a larger retry window for transient `tx_cpu_usage_exceeded` failures during instant-finality bootstrap.

## CI failure
- Diagnosed from failed CI run: https://github.com/Wire-Network/wire-sysio/actions/runs/28735544717
- Failure was isolated to `auto_bp_gossip_peering_test` in the scheduled macOS arm64 sharded NP/LR step.
- The failing bootstrap action was `sysio::setfinalizer`, which intermittently exceeded subjective transaction CPU on the runner.

## Review notes
- Addresses review feedback to retry the transaction instead of increasing the max CPU budget.
- The current PR diff no longer changes `auto_bp_gossip_peering_test.py` or adds any genesis CPU-budget override API.

## Validation
- `python3 -m py_compile tests/TestHarness/Cluster.py tests/TestHarness/transactions.py tests/auto_bp_gossip_peering_test.py`
- `git diff --check origin/master...HEAD`

## Not run
- Full `auto_bp_gossip_peering_test`; this worktree does not have the macOS arm64 build/test artifacts needed to reproduce the scheduled CI shard locally.