### PR TITLE
SEC-66: Consume hardened vcpkg registry

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -10,8 +10,8 @@
     {
       "kind": "git",
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
-      "baseline": "48df24b051469b7849483768c167ab739bbac421",
-      "reference": "48df24b051469b7849483768c167ab739bbac421",
+      "baseline": "6aace41ed50413fe5e9b50891b0c90f46ff85165",
+      "reference": "6aace41ed50413fe5e9b50891b0c90f46ff85165",
       "packages": [
         "boost",
         "softfloat",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -89,7 +89,7 @@
     },
     {
       "name": "boost",
-      "version": "1.89.0#3"
+      "version": "1.89.0#4"
     },
     {
       "name": "llvm",
@@ -101,11 +101,11 @@
     },
     {
       "name": "bls12-381",
-      "version": "1.0.0-wire"
+      "version": "1.0.0-wire#1"
     },
     {
       "name": "bn256",
-      "version": "2.0.1"
+      "version": "2.0.2#1"
     },
     {
       "name": "boringssl-custom",
@@ -117,15 +117,15 @@
     },
     {
       "name": "cli11",
-      "version": "2.4.2"
+      "version": "2.4.2#1"
     },
     {
       "name": "libsodium",
-      "version": "1.0.20-wire"
+      "version": "1.0.20-wire#1"
     },
     {
       "name": "secp256k1-internal",
-      "version": "0.7.0#1"
+      "version": "0.7.0#2"
     },
     {
       "name": "prometheus-cpp",
@@ -137,11 +137,11 @@
     },
     {
       "name": "softfloat",
-      "version": "3.0.0#1"
+      "version": "3.0.0#2"
     },
     {
       "name": "wire-sys-vm",
-      "version": "1.2.0"
+      "version": "1.2.0#1"
     },
     {
       "name": "nlohmann-json",


### PR DESCRIPTION
## Summary

- Pins `wire-vcpkg-registry` to merged commit `6aace41ed50413fe5e9b50891b0c90f46ff85165`, which contains `Wire-Network/wire-vcpkg-registry#20`.
- Updates the sysio manifest overrides to the hardened custom port revisions for `boost`, `bls12-381`, `bn256`, `cli11`, `libsodium`, `secp256k1-internal`, `softfloat`, and `wire-sys-vm`.
- Keeps this PR scoped to dependency registry consumption; no `contracts/sysio.*` production contract paths are changed.

## Validation

- `vcpkg install --dry-run` resolves with `x64-linux-release` target/host triplets against the merged registry commit.
- Release configure/build completed in `build/sec-66-pr20-release`.
- `git diff --check`

GitHub PR CI is pending. The system-contract e2e gate is not applicable because this PR does not change production system contract paths.
