### PR TITLE
net_plugin: prune out-of-schedule bp peer connections in the connection monitor

### DIFF
--- a/plugins/net_plugin/include/sysio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/sysio/net_plugin/auto_bp_peering.hpp
@@ -597,13 +597,19 @@ public:
                // do not hold mutexes when calling resolve_and_connect which acquires connections mutex since other threads
                // can be holding connections mutex when trying to acquire these mutexes
                address_set_t addresses = find_gossip_bp_addresses(pending_connections, "connect");
-               for (const auto& add : addresses) {
-                  self()->connections.resolve_and_connect(add, self()->get_first_p2p_address());
-               }
 
+               // publish the new pending set BEFORE dialing: a concurrent connection_monitor pass
+               // must see these producers in its keep set, otherwise it can prune the
+               // just-established pending-only connections as out-of-schedule — and with
+               // pending_schedule_version advanced below they would not be redialed until the
+               // schedule activates
                {
                   fc::lock_guard g(mtx);
                   pending_bps = std::move(pending_connections);
+               }
+
+               for (const auto& add : addresses) {
+                  self()->connections.resolve_and_connect(add, self()->get_first_p2p_address());
                }
 
                pending_schedule_version = schedule.version;

--- a/plugins/net_plugin/include/sysio/net_plugin/auto_bp_peering.hpp
+++ b/plugins/net_plugin/include/sysio/net_plugin/auto_bp_peering.hpp
@@ -51,7 +51,6 @@ class bp_connection_manager {
    } config; // thread safe only because modified at plugin startup currently
 
    // the following members are only accessed from main thread
-   name_set_t             pending_bps;
    uint32_t               pending_schedule_version = 0;
    uint32_t               active_schedule_version  = 0;
 
@@ -60,6 +59,7 @@ class bp_connection_manager {
 
    fc::mutex                     mtx;
    gossip_buffer_initial_factory initial_gossip_msg_factory GUARDED_BY(mtx);
+   name_set_t                    pending_bps GUARDED_BY(mtx); // written on main thread, read by gossip_bp_addresses_to_drop() on net threads
    name_set_t                    active_bps GUARDED_BY(mtx);
    name_set_t                    active_schedule GUARDED_BY(mtx);
 
@@ -116,6 +116,16 @@ class bp_connection_manager {
    void set_active_bps(name_set_t bps) {
       fc::lock_guard g(mtx);
       active_bps = std::move(bps);
+   }
+   // for testing
+   name_set_t get_pending_bps() {
+      fc::lock_guard g(mtx);
+      return pending_bps;
+   }
+   // for testing
+   void set_pending_bps(name_set_t bps) {
+      fc::lock_guard g(mtx);
+      pending_bps = std::move(bps);
    }
 
 public:
@@ -479,33 +489,67 @@ public:
       return false;
    }
 
+   // desc is a log label; pass nullptr to skip the per-address logging (periodic callers)
    address_set_t find_gossip_bp_addresses(const name_set_t& accounts, const char* desc) const {
       address_set_t addresses;
       fc::lock_guard g(gossip_bps.mtx);
       const auto& prod_idx = gossip_bps.index.get<by_producer>();
       for (const auto& account : accounts) {
          if (auto i = config.auto_bp_addresses.find(account); i != config.auto_bp_addresses.end()) {
-            fc_dlog(p2p_conn_log, "{} manual bp peer {}", desc, i->second.address());
+            if (desc)
+               fc_dlog(p2p_conn_log, "{} manual bp peer {}", desc, i->second.address());
             addresses.insert(i->second.address());
          }
          auto r = prod_idx.equal_range(account);
          for (auto i = r.first; i != r.second; ++i) {
-            fc_dlog(p2p_conn_log, "{} gossip bp peer {}", desc, i->server_endpoint());
+            if (desc)
+               fc_dlog(p2p_conn_log, "{} gossip bp peer {}", desc, i->server_endpoint());
             addresses.insert(i->server_endpoint());
          }
       }
       return addresses;
    }
 
+   // desc is a log label; pass nullptr to skip the per-address logging (periodic callers)
    address_set_t all_gossip_bp_addresses(const char* desc) const {
       address_set_t addresses;
       fc::lock_guard g(gossip_bps.mtx);
       const auto& prod_idx = gossip_bps.index.get<by_producer>();
       for (auto& i : prod_idx) {
-         fc_dlog(p2p_conn_log, "{} gossip bp peer {}", desc, i.server_endpoint());
+         if (desc)
+            fc_dlog(p2p_conn_log, "{} gossip bp peer {}", desc, i.server_endpoint());
          addresses.insert(i.server_endpoint());
       }
       return addresses;
+   }
+
+   // thread-safe
+   // The gossip + configured bp peer addresses whose producers are no longer within scheduling
+   // proximity (neither in the active nor in the pending schedule) — or every known bp peer
+   // address when this node has left the bp gossip group. The connection monitor prunes
+   // outbound connections to these addresses (see connections_manager::connection_monitor);
+   // supplied peers (p2p-peer-address / API connect) are exempted there. Reconciling via the
+   // periodic monitor instead of a one-shot disconnect on the schedule-change edge means a
+   // concurrent connect_to_active_bp_peers() working from a pre-change address snapshot can at
+   // worst resurrect a connection until the next monitor pass, not permanently.
+   // Empty when auto bp peering is not enabled, so non-participating nodes pay no cost.
+   address_set_t gossip_bp_addresses_to_drop() {
+      if (!auto_bp_peering_enabled())
+         return {};
+
+      name_set_t keep_accounts;
+      if (connect_bp_gossip_peers) {
+         fc::lock_guard g(mtx);
+         keep_accounts = active_bps;
+         keep_accounts.insert(pending_bps.begin(), pending_bps.end());
+      } // else: dropped out of the bp gossip group, no bp peer connection is kept
+
+      address_set_t drop = all_gossip_bp_addresses(nullptr);
+      for (const auto& [account, e] : config.auto_bp_addresses)
+         drop.insert(e.address());
+      for (const auto& add : find_gossip_bp_addresses(keep_accounts, nullptr))
+         drop.erase(add);
+      return drop;
    }
 
    // thread-safe
@@ -557,12 +601,16 @@ public:
                   self()->connections.resolve_and_connect(add, self()->get_first_p2p_address());
                }
 
-               pending_bps = std::move(pending_connections);
+               {
+                  fc::lock_guard g(mtx);
+                  pending_bps = std::move(pending_connections);
+               }
 
                pending_schedule_version = schedule.version;
             }
          } else {
             fc_dlog(p2p_conn_log, "pending producer schedule version {} is being cleared", schedule.version);
+            fc::lock_guard g(mtx);
             pending_bps.clear();
          }
       }
@@ -571,7 +619,13 @@ public:
    // Only called from main thread
    void on_active_schedule(const chain::producer_authority_schedule& schedule) {
       if (auto_bp_peering_enabled() && active_schedule_version != schedule.version && !self()->is_lib_catchup()) {
-         /// drops any BP connection which is no longer within our scheduling proximity
+         /// BP connections which are no longer within our scheduling proximity are pruned by the
+         /// connection monitor via gossip_bp_addresses_to_drop(). Pruning is deliberately NOT a
+         /// one-shot disconnect on the schedule-change edge: connect_to_active_bp_peers() runs
+         /// concurrently on net threads from address snapshots computed against the previous
+         /// schedule, and a disconnect sweep here races those snapshots — the sweep erases the
+         /// connections and the stale snapshots immediately re-establish them, after which
+         /// nothing would ever disconnect them again.
          fc_dlog(p2p_conn_log, "active producer schedule switches from version {} to {}",
                  active_schedule_version, schedule.version);
 
@@ -589,31 +643,18 @@ public:
 
          fc_dlog(p2p_conn_log, "active_bps: {}", to_string(active_bps));
 
-         name_set_t peers_to_stay;
-         std::set_union(active_bps.begin(), active_bps.end(), pending_bps.begin(), pending_bps.end(),
-                        std::inserter(peers_to_stay, peers_to_stay.begin()));
-         gm.unlock();
-
-         fc_dlog(p2p_conn_log, "peers_to_stay: {}", to_string(peers_to_stay));
-
-         name_set_t peers_to_drop;
-         std::set_difference(old_bps.begin(), old_bps.end(), peers_to_stay.begin(), peers_to_stay.end(),
-                             std::inserter(peers_to_drop, peers_to_drop.end()));
-         fc_dlog(p2p_conn_log, "peers to drop: {}", to_string(peers_to_drop));
-
-         // if we dropped out of active schedule then disconnect from all
-         bool disconnect_from_all = !config.my_bp_gossip_accounts.empty() &&
-                                    std::all_of(config.my_bp_gossip_accounts.begin(), config.my_bp_gossip_accounts.end(),
-                                                [&](const auto& e) { return peers_to_drop.contains(e.first); });
-         if (disconnect_from_all) {
+         // if all our bp accounts dropped out of scheduling proximity (were active, now neither
+         // active nor pending) then leave the bp gossip group: stop connecting to bp peers and
+         // let the connection monitor prune every bp peer connection
+         bool dropped_out = !config.my_bp_gossip_accounts.empty() &&
+                            std::all_of(config.my_bp_gossip_accounts.begin(), config.my_bp_gossip_accounts.end(),
+                                        [&](const auto& e) {
+                                           return old_bps.contains(e.first) && !active_bps.contains(e.first) &&
+                                                  !pending_bps.contains(e.first);
+                                        });
+         if (dropped_out) {
+            fc_dlog(p2p_conn_log, "dropped out of bp gossip group, no longer connecting to bp peers");
             connect_bp_gossip_peers = false;
-         }
-
-         address_set_t addresses = disconnect_from_all
-                                   ? all_gossip_bp_addresses("disconnect")
-                                   : find_gossip_bp_addresses(peers_to_drop, "disconnect");
-         for (const auto& add : addresses) {
-            self()->connections.disconnect_gossip_connection(add);
          }
 
          active_schedule_version = schedule.version;

--- a/plugins/net_plugin/src/net_plugin.cpp
+++ b/plugins/net_plugin/src/net_plugin.cpp
@@ -385,7 +385,6 @@ namespace sysio {
       string resolve_and_connect(const string& peer_address, const string& listen_address);
       connection_ptr is_other_connected(const string& peer_address, const connection_ptr& c) const;
       string disconnect(const string& host);
-      void disconnect_gossip_connection(const string& host);
       void close_all();
 
       std::optional<connection_status> status(const string& host) const;
@@ -5110,19 +5109,6 @@ namespace sysio {
       return true;
    }
 
-   void connections_manager::disconnect_gossip_connection(const string& host) {
-      std::lock_guard g( connections_mtx );
-      // do not disconnect if a p2p-peer-address
-      if (supplied_peers.contains(host))
-         return;
-      auto& index = connections.get<by_host>();
-      if( auto i = index.find( host ); i != index.end() ) {
-         fc_ilog( p2p_conn_log, "disconnecting: '{}' - {}", host, i->c->connection_id );
-         i->c->close();
-         connections.erase(i);
-      }
-   }
-
    // called by API
    string connections_manager::disconnect( const string& host ) {
       std::lock_guard g( connections_mtx );
@@ -5229,6 +5215,12 @@ namespace sysio {
    // called from any thread
    void connections_manager::connection_monitor(const std::weak_ptr<connection>& from_connection) {
       size_t num_rm = 0, num_clients = 0, num_peers = 0, num_bp_peers = 0;
+      // bp peer addresses whose producers have left scheduling proximity: outbound connections to
+      // them are pruned below (a supplied peer is never pruned). Always empty when auto bp
+      // peering is not enabled — a config check, no locks — so nodes not participating in bp
+      // gossip pay no per-connection cost (the empty() gate below short-circuits).
+      // Computed before acquiring connections_mtx (it takes the bp gossip mutexes).
+      const auto bp_addresses_to_drop = my_impl->gossip_bp_addresses_to_drop();
       auto cleanup = [&num_rm, this](vector<connection_ptr>&& reconnecting, vector<connection_ptr>&& removing) {
          for( auto& c : reconnecting ) {
             if (!c->resolve_and_connect()) {
@@ -5261,6 +5253,21 @@ namespace sysio {
             return;
          }
          const connection_ptr& c = it->c;
+         if (!bp_addresses_to_drop.empty() && !c->incoming()) {
+            // prune the outbound connection (open, or closed and awaiting reconnect) of a bp peer
+            // which is no longer within scheduling proximity; its own outbound side is pruned by
+            // the peer, so the connection heals on both ends without either closing inbound ones
+            const std::string& peer_addr = c->peer_address();
+            if (bp_addresses_to_drop.contains(peer_addr) && !supplied_peers.contains(peer_addr)) {
+               fc_ilog( p2p_conn_log, "pruning connection to bp peer no longer in scheduling proximity: '{}' - {}",
+                        peer_addr, c->connection_id );
+               c->close();
+               ++num_rm;
+               removing.push_back(c);
+               ++it;
+               continue;
+            }
+         }
          if (c->bp_connection != connection::bp_connection_type::non_bp) {
             ++num_bp_peers;
          } else if (c->incoming()) {

--- a/plugins/net_plugin/test/auto_bp_peering_unittest.cpp
+++ b/plugins/net_plugin/test/auto_bp_peering_unittest.cpp
@@ -27,7 +27,6 @@ struct mock_connections_manager {
    std::vector<std::shared_ptr<mock_connection>> connections;
 
    std::function<void(std::string, std::string)> resolve_and_connect;
-   std::function<void(std::string)> disconnect_gossip_connection;
 
    uint32_t get_max_client_count() const { return max_client_count; }
 
@@ -160,11 +159,19 @@ const sysio::chain::name_set_t producers_minus_prodkt{
 
 const sysio::chain::producer_authority_schedule reset_schedule1{ 1, {} };
 
+/// address_set_t is unordered; sort into a vector for stable comparisons
+template <typename Set>
+std::vector<std::string> sorted(const Set& addresses) {
+   std::vector<std::string> result(addresses.begin(), addresses.end());
+   std::ranges::sort(result);
+   return result;
+}
+
 BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
 
    mock_net_plugin plugin;
    plugin.setup_test_peers();
-   plugin.pending_bps = { "prodj"_n, "prodm"_n };
+   plugin.set_pending_bps({ "prodj"_n, "prodm"_n });
 
    std::vector<std::string> connected_hosts;
 
@@ -175,7 +182,7 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
    plugin.on_pending_schedule(test_schedule1);
 
    BOOST_CHECK_EQUAL(connected_hosts, (std::vector<std::string>{}));
-   BOOST_TEST(plugin.pending_bps == (sysio::chain::name_set_t{ "prodj"_n, "prodm"_n }));
+   BOOST_TEST(plugin.get_pending_bps() == (sysio::chain::name_set_t{ "prodj"_n, "prodm"_n }));
    BOOST_CHECK_EQUAL(plugin.pending_schedule_version, 0u);
 
    // when it is in sync and on_pending_schedule is called
@@ -183,7 +190,7 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
    plugin.on_pending_schedule(test_schedule1);
 
    // the pending are connected to
-   BOOST_TEST(plugin.pending_bps == producers_minus_prodkt);
+   BOOST_TEST(plugin.get_pending_bps() == producers_minus_prodkt);
 
    // all connect to bp peers should be invoked
    std::ranges::sort(connected_hosts);
@@ -200,7 +207,7 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
    BOOST_CHECK_EQUAL(connected_hosts, (std::vector<std::string>{}));
 
    plugin.on_pending_schedule(reset_schedule1);
-   BOOST_TEST(plugin.pending_bps == sysio::chain::name_set_t{});
+   BOOST_TEST(plugin.get_pending_bps() == sysio::chain::name_set_t{});
 }
 
 BOOST_AUTO_TEST_CASE(test_on_active_schedule1) {
@@ -211,14 +218,10 @@ BOOST_AUTO_TEST_CASE(test_on_active_schedule1) {
    plugin.set_active_bps( { "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n } );
    plugin.connections.resolve_and_connect = [](std::string host, std::string p2p_address) {};
 
-   std::vector<std::string> disconnected_hosts;
-   plugin.connections.disconnect_gossip_connection = [&disconnected_hosts](std::string host) { disconnected_hosts.push_back(host); };
-
    // make sure nothing happens when it is not in_sync
    plugin.lib_catchup = true;
    plugin.on_active_schedule(test_schedule1);
 
-   BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{}));
    BOOST_TEST(plugin.get_active_bps() == (sysio::chain::name_set_t{ "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n }));
    BOOST_CHECK_EQUAL(plugin.active_schedule_version, 0u);
 
@@ -226,13 +229,14 @@ BOOST_AUTO_TEST_CASE(test_on_active_schedule1) {
    plugin.lib_catchup = false;
    plugin.on_pending_schedule(test_schedule1);
    plugin.on_active_schedule(test_schedule1);
-   // then disconnect to prodt
-   BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{ "127.0.0.1:8020"s }));
 
    BOOST_TEST(plugin.get_active_bps() == producers_minus_prodkt);
 
    // make sure we change the active_schedule_version
    BOOST_CHECK_EQUAL(plugin.active_schedule_version, 1u);
+
+   // prodt is configured but neither active nor pending: the connection monitor prunes its address
+   BOOST_CHECK_EQUAL(sorted(plugin.gossip_bp_addresses_to_drop()), (std::vector<std::string>{ "127.0.0.1:8020"s }));
 }
 
 BOOST_AUTO_TEST_CASE(test_on_active_schedule2) {
@@ -242,20 +246,65 @@ BOOST_AUTO_TEST_CASE(test_on_active_schedule2) {
 
    plugin.set_active_bps( { "proda"_n, "prodh"_n, "prodn"_n, "prodt"_n } );
    plugin.connections.resolve_and_connect = [](std::string host, std::string p2p_address) {};
-   std::vector<std::string> disconnected_hosts;
-   plugin.connections.disconnect_gossip_connection = [&disconnected_hosts](std::string host) { disconnected_hosts.push_back(host); };
 
    // when pending and active schedules are changed simultaneously
    plugin.lib_catchup = false;
    plugin.on_pending_schedule(test_schedule2);
    plugin.on_active_schedule(test_schedule1);
-   // then disconnect prodt
-   BOOST_CHECK_EQUAL(disconnected_hosts, (std::vector<std::string>{ "127.0.0.1:8020"s }));
 
    BOOST_TEST(plugin.get_active_bps() == producers_minus_prodkt);
 
    // make sure we change the active_schedule_version
    BOOST_CHECK_EQUAL(plugin.active_schedule_version, 1u);
+
+   // prodt is configured but neither in the active nor in the pending schedule
+   BOOST_CHECK_EQUAL(sorted(plugin.gossip_bp_addresses_to_drop()), (std::vector<std::string>{ "127.0.0.1:8020"s }));
+}
+
+BOOST_AUTO_TEST_CASE(test_drop_out_of_gossip_group) {
+
+   mock_net_plugin plugin;
+   plugin.setup_test_peers();
+   // this node's own bp account (prodt) participates in bp gossip
+   plugin.set_bp_producer_peers({ "prodt,127.0.0.1:8020,127.0.0.1"s });
+   plugin.connections.resolve_and_connect = [](std::string host, std::string p2p_address) {};
+   plugin.lib_catchup = false;
+
+   // prodt was active, and is in neither the new active schedule nor the pending one: drop out
+   plugin.set_active_bps({ "proda"_n, "prodt"_n });
+   plugin.on_active_schedule(test_schedule1);
+
+   BOOST_CHECK(!plugin.connect_bp_gossip_peers);
+
+   // out of the gossip group every known bp peer address is pruned
+   std::vector<std::string> all_configured_addresses = peer_addresses;
+   all_configured_addresses.push_back("127.0.0.1:8020"s);
+   std::ranges::sort(all_configured_addresses);
+   BOOST_CHECK_EQUAL(sorted(plugin.gossip_bp_addresses_to_drop()), all_configured_addresses);
+
+   // a new pending schedule re-enters the gossip group and shrinks the prune set again
+   plugin.on_pending_schedule(test_schedule2);
+   BOOST_CHECK(plugin.connect_bp_gossip_peers);
+   BOOST_CHECK_EQUAL(sorted(plugin.gossip_bp_addresses_to_drop()), (std::vector<std::string>{ "127.0.0.1:8020"s }));
+}
+
+BOOST_AUTO_TEST_CASE(test_no_drop_out_while_pending) {
+
+   mock_net_plugin plugin;
+   plugin.setup_test_peers();
+   plugin.set_bp_producer_peers({ "prodt,127.0.0.1:8020,127.0.0.1"s });
+   plugin.connections.resolve_and_connect = [](std::string host, std::string p2p_address) {};
+   plugin.lib_catchup = false;
+
+   // prodt leaves the active schedule but is still in the pending one: stay in the gossip group
+   plugin.set_active_bps({ "proda"_n, "prodt"_n });
+   plugin.set_pending_bps({ "prodt"_n });
+   plugin.on_active_schedule(test_schedule1);
+
+   BOOST_CHECK(plugin.connect_bp_gossip_peers);
+
+   // prodt's own address stays connected while prodt is pending
+   BOOST_CHECK_EQUAL(sorted(plugin.gossip_bp_addresses_to_drop()), (std::vector<std::string>{}));
 }
 
 BOOST_AUTO_TEST_CASE(test_exceeding_connection_limit) {

--- a/plugins/net_plugin/test/auto_bp_peering_unittest.cpp
+++ b/plugins/net_plugin/test/auto_bp_peering_unittest.cpp
@@ -175,7 +175,12 @@ BOOST_AUTO_TEST_CASE(test_on_pending_schedule) {
 
    std::vector<std::string> connected_hosts;
 
-   plugin.connections.resolve_and_connect = [&connected_hosts](std::string host, std::string p2p_address) { connected_hosts.push_back(host); };
+   plugin.connections.resolve_and_connect = [&connected_hosts, &plugin](std::string host, std::string p2p_address) {
+      // the new pending set must be published before any dial goes out, otherwise a concurrent
+      // connection_monitor pass could prune the just-established pending-only connections
+      BOOST_TEST(plugin.get_pending_bps() == producers_minus_prodkt);
+      connected_hosts.push_back(host);
+   };
 
    // make sure nothing happens when it is not in_sync
    plugin.lib_catchup = true;


### PR DESCRIPTION
# net_plugin: reconcile bp gossip connections via the connection monitor instead of a schedule-edge disconnect sweep

## Problem

`auto_bp_gossip_peering_test` fails intermittently on its final check: after the producer
schedule shrinks, an unscheduled node keeps a gossip connection to a still-scheduled producer
for the entire 60s timeout (e.g. [run 28885478787](https://github.com/Wire-Network/wire-sysio/actions/runs/28885478787/job/85684524524)).

The nodeop logs from that run show a race between the two auto-bp-peering code paths
(node_07 = defproducerh, all within one second at 17:43:36):

| time | thread | event |
|---|---|---|
| .044 / .045 | net-0 / net-3 | incoming gossip messages trigger `connect_to_active_bp_peers()`, which snapshots the connect-address list from the **still-old schedule (all 21 producers)** |
| .053 | main | `on_active_schedule` fires (v1 -> v2, 4-producer schedule) |
| .127–.137 | main | the disconnect sweep closes all 17 dropped producers' addresses and **erases them from the connections index** (`disconnecting: 'localhost:27580' - 48`) |
| .1387–.1395 | net-3 | the stale connect loop, still iterating its 21-address snapshot, finds those addresses missing from the index and **re-creates connections 61–74 to every just-dropped producer** (`created connection - 74 to localhost:27580`) |

Once re-established, nothing ever disconnects the connection again: `on_active_schedule`
only acts on a schedule *version change* and the connection monitor only reaps closed
sockets. The prior flaky-test fixes (extending the retry window to 60s, 8472433b44 etc.)
could not help — the stale connection is not slow to prune, it is never pruned.

Two secondary defects with the same root:

- The disconnect sweep looks connections up by host in the (non-unique) `by_host` index, so
  it can act on a dead object while the live socket between the same pair survives. In the
  failing run, `disconnecting: 'localhost:27580' - 48` closed a connection object that had
  already lost the duplicate-handshake race at 17:42:53; the live socket was untouched.
- A closed outbound entry to a now-unscheduled producer left in the index is perpetually
  re-dialed by the connection monitor's reconnect logic once its duplicate disappears.

## Fix

Replace the one-shot disconnect sweep with periodic reconciliation in the connection
monitor:

- `bp_connection_manager::gossip_bp_addresses_to_drop()` (new): the gossip + configured bp
  peer addresses whose producers are neither in the active nor in the pending schedule — or
  every known bp peer address once this node has dropped out of the bp gossip group.
- `connections_manager::connection_monitor()` prunes outbound connections (open, or closed
  and awaiting reconnect) to those addresses each pass. Supplied peers
  (`p2p-peer-address` / `/v1/net/connect`) are never pruned, matching the old
  `disconnect_gossip_connection` exemption.
- `on_active_schedule()` keeps the group-membership decision (set
  `connect_bp_gossip_peers = false` when all of this node's bp accounts drop out of
  scheduling proximity) but no longer disconnects anything itself.
- `disconnect_gossip_connection()` is removed.

Why reconciliation is the right shape: a concurrent `connect_to_active_bp_peers()` working
from a pre-change address snapshot can now at worst resurrect a connection until the next
monitor pass (`connection-cleanup-period`, default 30s, 5s in the failing test), not
permanently. Pruning only *outbound* connections means each side closes the connections it
dialed, the TCP close heals the other end, and neither side ever closes an inbound
connection (which is what protects a manually requested connection on its accepting side).

## Overhead for nodes not using bp gossip

Most nodes run neither `--p2p-bp-gossip-endpoint` nor `--p2p-auto-bp-peer`. For them
`gossip_bp_addresses_to_drop()` returns immediately on the `auto_bp_peering_enabled()`
config check (no locks taken), and the per-connection prune check short-circuits on the
empty address set — one boolean test per monitor pass, zero per-connection work. Nodes with
only `--p2p-auto-bp-peer` build a set bounded by their configured peer count once per pass.

## Testing

- `test_net_plugin`: reworked `test_on_active_schedule1/2` to assert the prune set, added
  `test_drop_out_of_gossip_group` (drop-out sets `connect_bp_gossip_peers=false` and prunes
  every known address; a new pending schedule re-enters the group) and
  `test_no_drop_out_while_pending` (a bp account still in the pending schedule keeps the
  node in the group and its address unpruned). All 78 cases pass.
- `tests/auto_bp_gossip_peering_test.py` passes locally, 2/2 runs (the failing scenario:
  schedule shrink 21 -> 4, node_19 keeps the manual connection and drops the stale gossip
  peer). The test log shows the reconciliation converging: node_19's stale connections
  prune down each cleanup cycle (20 -> 18 -> 15 -> 12 ...), defproducerh gone within ~3s.
- `tests/auto_bp_peering_test.py` passes locally in both variants (`-v` as CI runs it, and
  `--activate-if`) — the auto-bp-peer connect path.
