### PR TITLE
SEC-61: Validate generated Solidity enum decodes

### DIFF
--- a/libraries/opp/tools/protoc-gen-solidity/src/generator/enum.ts
+++ b/libraries/opp/tools/protoc-gen-solidity/src/generator/enum.ts
@@ -68,23 +68,35 @@ export function genEnumDefinition(desc: EnumDescriptor): string {
   lines.push(`using {${lib}.isValid} for ${name} global;`)
   lines.push(``)
 
-  // Library with constants and isValid
+  // Library with constants and checked conversions.
   lines.push(`library ${lib} {`)
 
   for (const val of desc.values) {
-    lines.push(`    ${name} constant ${val.name} = ${name}.wrap(${val.number});`)
+    lines.push(
+      `    ${name} constant ${val.name} = ${name}.wrap(${val.number});`
+    )
   }
 
-  if (desc.values.length > 0) {
-    const maxVal = desc.values.reduce(
-      (max, v) => (v.number > max.number ? v : max),
-      desc.values[0]
-    )
-    lines.push(``)
-    lines.push(`    function isValid(${name} _v) internal pure returns (bool) {`)
-    lines.push(`        return ${name}.unwrap(_v) <= ${name}.unwrap(${maxVal.name});`)
-    lines.push(`    }`)
+  const uniqueValues = [
+    ...new Map(desc.values.map(val => [val.number, val])).values()
+  ]
+  const checks = uniqueValues.map(val => `_raw == ${val.number}`).join(" || ")
+
+  lines.push(``)
+  lines.push(`    function isValid(${name} _v) internal pure returns (bool) {`)
+  lines.push(`        uint64 _raw = uint64(${name}.unwrap(_v));`)
+  lines.push(`        return ${checks || "false"};`)
+  lines.push(`    }`)
+
+  lines.push(``)
+  lines.push(
+    `    function fromRaw(uint64 _raw) internal pure returns (${name}) {`
+  )
+  for (const val of uniqueValues) {
+    lines.push(`        if (_raw == ${val.number}) return ${val.name};`)
   }
+  lines.push(`        revert("Invalid enum value");`)
+  lines.push(`    }`)
 
   lines.push(`}`)
 

--- a/libraries/opp/tools/protoc-gen-solidity/src/generator/enum.ts
+++ b/libraries/opp/tools/protoc-gen-solidity/src/generator/enum.ts
@@ -70,6 +70,8 @@ export function genEnumDefinition(desc: EnumDescriptor): string {
 
   // Library with constants and checked conversions.
   lines.push(`library ${lib} {`)
+  lines.push(`    error InvalidEnumValue(uint64 raw);`)
+  lines.push(``)
 
   for (const val of desc.values) {
     lines.push(
@@ -77,9 +79,12 @@ export function genEnumDefinition(desc: EnumDescriptor): string {
     )
   }
 
-  const uniqueValues = [
-    ...new Map(desc.values.map(val => [val.number, val])).values()
-  ]
+  const seenNumbers = new Set<number>()
+  const uniqueValues = desc.values.filter(val => {
+    if (seenNumbers.has(val.number)) return false
+    seenNumbers.add(val.number)
+    return true
+  })
   const checks = uniqueValues.map(val => `_raw == ${val.number}`).join(" || ")
 
   lines.push(``)
@@ -95,7 +100,7 @@ export function genEnumDefinition(desc: EnumDescriptor): string {
   for (const val of uniqueValues) {
     lines.push(`        if (_raw == ${val.number}) return ${val.name};`)
   }
-  lines.push(`        revert("Invalid enum value");`)
+  lines.push(`        revert InvalidEnumValue(_raw);`)
   lines.push(`    }`)
 
   lines.push(`}`)

--- a/libraries/opp/tools/protoc-gen-solidity/src/generator/field.ts
+++ b/libraries/opp/tools/protoc-gen-solidity/src/generator/field.ts
@@ -5,6 +5,7 @@ import {
   fieldTag,
   resolveSolType
 } from "./type-map.js"
+import { enumLibName } from "./enum.js"
 import type { EnumFieldInfo } from "./enum.js"
 import { log } from "../util/logger.js"
 
@@ -18,7 +19,12 @@ export interface FieldInfo {
   typeName?: string
   label: number // 1=optional, 2=required, 3=repeated
   oneofIndex?: number
-  mapEntry?: { keyType: number; valueType: number; valueTypeName?: string; valueEnumInfo?: EnumFieldInfo }
+  mapEntry?: {
+    keyType: number
+    valueType: number
+    valueTypeName?: string
+    valueEnumInfo?: EnumFieldInfo
+  }
   enumInfo?: EnumFieldInfo
 }
 
@@ -116,7 +122,10 @@ export interface DecodeBranch {
  * Returns the wire tag and the body statements (indented at 8 spaces)
  * to be placed inside an if/else-if block by the caller.
  */
-export function genFieldDecode(field: FieldInfo, varName: string): DecodeBranch {
+export function genFieldDecode(
+  field: FieldInfo,
+  varName: string
+): DecodeBranch {
   const solName = toSolFieldName(field.name)
   const typeInfo = PROTO_TYPE_MAP[field.type]
 
@@ -125,7 +134,10 @@ export function genFieldDecode(field: FieldInfo, varName: string): DecodeBranch 
       field.number,
       field.mapEntry ? WireType.LengthDelimited : 0
     )
-    return { tag, body: `        // TODO: unsupported field type ${field.type} for ${field.name}` }
+    return {
+      tag,
+      body: `        // TODO: unsupported field type ${field.type} for ${field.name}`
+    }
   }
 
   const tag = fieldTag(
@@ -177,14 +189,28 @@ function castToUint64(solType: string, expr: string): string {
 }
 
 /** True when _decode_varint needs an explicit cast to the target type. */
-function needsVarintDecodeCast(typeInfo: (typeof PROTO_TYPE_MAP)[number]): boolean {
-  return typeInfo.decodeFunc === "_decode_varint" && typeInfo.solType !== "uint64"
+function needsVarintDecodeCast(
+  typeInfo: (typeof PROTO_TYPE_MAP)[number]
+): boolean {
+  return (
+    typeInfo.decodeFunc === "_decode_varint" && typeInfo.solType !== "uint64"
+  )
 }
 
 /** True when _encode_varint needs an explicit cast from the source type. */
-function needsVarintEncodeCast(typeInfo: (typeof PROTO_TYPE_MAP)[number]): boolean {
-  return typeInfo.encodeFunc === "_encode_varint" &&
-    typeInfo.solType !== "uint64" && typeInfo.solType !== "uint32"
+function needsVarintEncodeCast(
+  typeInfo: (typeof PROTO_TYPE_MAP)[number]
+): boolean {
+  return (
+    typeInfo.encodeFunc === "_encode_varint" &&
+    typeInfo.solType !== "uint64" &&
+    typeInfo.solType !== "uint32"
+  )
+}
+
+/** Generate a checked enum conversion from a decoded protobuf varint. */
+function enumFromRaw(ei: EnumFieldInfo, expr: string): string {
+  return `${enumLibName(ei.solTypeName)}.fromRaw(${expr})`
 }
 
 // ── Internal codegen helpers ──────────────────────────────────────────
@@ -211,7 +237,7 @@ function genEnumFieldDecode(
   return [
     `        { uint64 _v;`,
     `        (_v, pos) = ProtobufRuntime._decode_varint(data, pos);`,
-    `        ${varName}.${solName} = ${ei.solTypeName}.wrap(${ei.underlyingType}(_v)); }`
+    `        ${varName}.${solName} = ${enumFromRaw(ei, "_v")}; }`
   ].join("\n")
 }
 
@@ -283,7 +309,11 @@ function genRepeatedEncode(
   return lines.join("\n")
 }
 
-function genMapEncode(field: FieldInfo, tagHex: string, varName: string): string {
+function genMapEncode(
+  field: FieldInfo,
+  tagHex: string,
+  varName: string
+): string {
   const solName = toSolFieldName(field.name)
   const loopVar = `_i_${solName}`
   const me = field.mapEntry!
@@ -384,7 +414,7 @@ function genRepeatedDecode(
     return [
       `        { uint64 _elem;`,
       `        (_elem, pos) = ProtobufRuntime._decode_varint(data, pos);`,
-      `        ${varName}.${solName}[${idxVar}++] = ${ei.solTypeName}.wrap(${ei.underlyingType}(_elem)); }`
+      `        ${varName}.${solName}[${idxVar}++] = ${enumFromRaw(ei, "_elem")}; }`
     ].join("\n")
   }
 
@@ -404,7 +434,11 @@ function genRepeatedDecode(
   ].join("\n")
 }
 
-function genMapDecode(field: FieldInfo, solName: string, varName: string): string {
+function genMapDecode(
+  field: FieldInfo,
+  solName: string,
+  varName: string
+): string {
   const me = field.mapEntry!
   const keyInfo = PROTO_TYPE_MAP[me.keyType]
   const valInfo = PROTO_TYPE_MAP[me.valueType]
@@ -442,7 +476,7 @@ function genMapDecode(field: FieldInfo, solName: string, varName: string): strin
       `          } else if (_entryTag == ${fieldTag(2, valInfo.wireType)}) {`,
       `            { uint64 _raw;`,
       `            (_raw, pos) = ProtobufRuntime._decode_varint(data, pos);`,
-      `            _val = ${vei.solTypeName}.wrap(${vei.underlyingType}(_raw)); }`
+      `            _val = ${enumFromRaw(vei, "_raw")}; }`
     )
   } else {
     lines.push(

--- a/libraries/opp/tools/protoc-gen-solidity/tests/enum.test.ts
+++ b/libraries/opp/tools/protoc-gen-solidity/tests/enum.test.ts
@@ -3,7 +3,7 @@ import {
   enumLibName,
   genEnumDefinition,
   EnumValueInfo,
-  EnumDescriptor,
+  EnumDescriptor
 } from "../src/generator/enum"
 
 describe("computeUnderlyingType", () => {
@@ -15,7 +15,7 @@ describe("computeUnderlyingType", () => {
     const values: EnumValueInfo[] = [
       { name: "A", number: 0 },
       { name: "B", number: 1 },
-      { name: "C", number: 255 },
+      { name: "C", number: 255 }
     ]
     expect(computeUnderlyingType(values)).toBe("uint8")
   })
@@ -23,7 +23,7 @@ describe("computeUnderlyingType", () => {
   it("returns uint16 when max value exceeds uint8", () => {
     const values: EnumValueInfo[] = [
       { name: "A", number: 0 },
-      { name: "B", number: 256 },
+      { name: "B", number: 256 }
     ]
     expect(computeUnderlyingType(values)).toBe("uint16")
   })
@@ -77,9 +77,9 @@ describe("genEnumDefinition", () => {
       values: [
         { name: "UNSPECIFIED", number: 0 },
         { name: "ADMIN", number: 1 },
-        { name: "USER", number: 2 },
+        { name: "USER", number: 2 }
       ],
-      underlyingType: "uint8",
+      underlyingType: "uint8"
     }
 
     const result = genEnumDefinition(desc)
@@ -98,9 +98,21 @@ describe("genEnumDefinition", () => {
     expect(result).toContain("Role constant ADMIN = Role.wrap(1);")
     expect(result).toContain("Role constant USER = Role.wrap(2);")
 
-    // isValid checks against max value
-    expect(result).toContain("function isValid(Role _v) internal pure returns (bool)")
-    expect(result).toContain("return Role.unwrap(_v) <= Role.unwrap(USER);")
+    // isValid checks declared values exactly
+    expect(result).toContain(
+      "function isValid(Role _v) internal pure returns (bool)"
+    )
+    expect(result).toContain("uint64 _raw = uint64(Role.unwrap(_v));")
+    expect(result).toContain("return _raw == 0 || _raw == 1 || _raw == 2;")
+
+    // fromRaw validates before wrapping, so out-of-range values cannot narrow
+    expect(result).toContain(
+      "function fromRaw(uint64 _raw) internal pure returns (Role)"
+    )
+    expect(result).toContain("if (_raw == 0) return UNSPECIFIED;")
+    expect(result).toContain("if (_raw == 1) return ADMIN;")
+    expect(result).toContain("if (_raw == 2) return USER;")
+    expect(result).toContain('revert("Invalid enum value");')
   })
 
   it("uses protoNameToSol to extract name from fullName", () => {
@@ -108,7 +120,7 @@ describe("genEnumDefinition", () => {
       name: "Status",
       fullName: "deep.nested.package.Status",
       values: [{ name: "OK", number: 0 }],
-      underlyingType: "uint8",
+      underlyingType: "uint8"
     }
 
     const result = genEnumDefinition(desc)
@@ -116,36 +128,42 @@ describe("genEnumDefinition", () => {
     expect(result).toContain("library StatusLib {")
   })
 
-  it("handles enum with no values (no isValid function body)", () => {
+  it("handles enum with no values by rejecting all raw values", () => {
     const desc: EnumDescriptor = {
       name: "Empty",
       fullName: "Empty",
       values: [],
-      underlyingType: "uint8",
+      underlyingType: "uint8"
     }
 
     const result = genEnumDefinition(desc)
     expect(result).toContain("type Empty is uint8;")
     expect(result).toContain("library EmptyLib {")
-    // The using statement is always emitted, but the function body is not
-    expect(result).not.toContain("function isValid")
+    expect(result).toContain(
+      "function isValid(Empty _v) internal pure returns (bool)"
+    )
+    expect(result).toContain("return false;")
+    expect(result).toContain(
+      "function fromRaw(uint64 _raw) internal pure returns (Empty)"
+    )
+    expect(result).toContain('revert("Invalid enum value");')
   })
 
-  it("picks the correct max value for isValid", () => {
+  it("rejects sparse enum gaps instead of accepting every value up to max", () => {
     const desc: EnumDescriptor = {
       name: "Priority",
       fullName: "Priority",
       values: [
         { name: "LOW", number: 0 },
         { name: "HIGH", number: 100 },
-        { name: "MEDIUM", number: 50 },
+        { name: "MEDIUM", number: 50 }
       ],
-      underlyingType: "uint8",
+      underlyingType: "uint8"
     }
 
     const result = genEnumDefinition(desc)
-    // HIGH has the largest number (100), so isValid checks against HIGH
-    expect(result).toContain("return Priority.unwrap(_v) <= Priority.unwrap(HIGH);")
+    expect(result).toContain("return _raw == 0 || _raw == 100 || _raw == 50;")
+    expect(result).not.toContain("Priority.unwrap(_v) <= Priority.unwrap(HIGH)")
   })
 
   it("uses the descriptor underlyingType in the UDVT", () => {
@@ -153,7 +171,7 @@ describe("genEnumDefinition", () => {
       name: "Big",
       fullName: "Big",
       values: [{ name: "VAL", number: 0x10000 }],
-      underlyingType: "uint24",
+      underlyingType: "uint24"
     }
 
     const result = genEnumDefinition(desc)

--- a/libraries/opp/tools/protoc-gen-solidity/tests/enum.test.ts
+++ b/libraries/opp/tools/protoc-gen-solidity/tests/enum.test.ts
@@ -92,6 +92,7 @@ describe("genEnumDefinition", () => {
 
     // Library header
     expect(result).toContain("library RoleLib {")
+    expect(result).toContain("error InvalidEnumValue(uint64 raw);")
 
     // Constants
     expect(result).toContain("Role constant UNSPECIFIED = Role.wrap(0);")
@@ -112,7 +113,7 @@ describe("genEnumDefinition", () => {
     expect(result).toContain("if (_raw == 0) return UNSPECIFIED;")
     expect(result).toContain("if (_raw == 1) return ADMIN;")
     expect(result).toContain("if (_raw == 2) return USER;")
-    expect(result).toContain('revert("Invalid enum value");')
+    expect(result).toContain("revert InvalidEnumValue(_raw);")
   })
 
   it("uses protoNameToSol to extract name from fullName", () => {
@@ -146,7 +147,7 @@ describe("genEnumDefinition", () => {
     expect(result).toContain(
       "function fromRaw(uint64 _raw) internal pure returns (Empty)"
     )
-    expect(result).toContain('revert("Invalid enum value");')
+    expect(result).toContain("revert InvalidEnumValue(_raw);")
   })
 
   it("rejects sparse enum gaps instead of accepting every value up to max", () => {
@@ -164,6 +165,28 @@ describe("genEnumDefinition", () => {
     const result = genEnumDefinition(desc)
     expect(result).toContain("return _raw == 0 || _raw == 100 || _raw == 50;")
     expect(result).not.toContain("Priority.unwrap(_v) <= Priority.unwrap(HIGH)")
+  })
+
+  it("deduplicates aliased enum numbers while keeping alias constants", () => {
+    const desc: EnumDescriptor = {
+      name: "Status",
+      fullName: "Status",
+      values: [
+        { name: "UNKNOWN", number: 0 },
+        { name: "RUNNING", number: 1 },
+        { name: "STARTED", number: 1 }
+      ],
+      underlyingType: "uint8"
+    }
+
+    const result = genEnumDefinition(desc)
+
+    expect(result).toContain("Status constant RUNNING = Status.wrap(1);")
+    expect(result).toContain("Status constant STARTED = Status.wrap(1);")
+    expect(result).toContain("return _raw == 0 || _raw == 1;")
+    expect(result).toContain("if (_raw == 1) return RUNNING;")
+    expect(result).not.toContain("if (_raw == 1) return STARTED;")
+    expect(result.match(/if \(_raw == 1\)/g)).toHaveLength(1)
   })
 
   it("uses the descriptor underlyingType in the UDVT", () => {

--- a/libraries/opp/tools/protoc-gen-solidity/tests/field.test.ts
+++ b/libraries/opp/tools/protoc-gen-solidity/tests/field.test.ts
@@ -1,0 +1,63 @@
+import { FieldInfo, genFieldDecode } from "../src/generator/field"
+
+const roleEnumInfo = {
+  solTypeName: "Role",
+  underlyingType: "uint8"
+}
+
+describe("genFieldDecode enum safety", () => {
+  it("decodes scalar enums through the checked enum library helper", () => {
+    const field: FieldInfo = {
+      name: "role",
+      number: 1,
+      type: 14,
+      typeName: ".example.Role",
+      label: 1,
+      enumInfo: roleEnumInfo
+    }
+
+    const result = genFieldDecode(field, "profile")
+
+    expect(result.body).toContain("profile.role = RoleLib.fromRaw(_v);")
+    expect(result.body).not.toContain("Role.wrap(uint8(_v))")
+  })
+
+  it("decodes repeated enums through the checked enum library helper", () => {
+    const field: FieldInfo = {
+      name: "roles",
+      number: 1,
+      type: 14,
+      typeName: ".example.Role",
+      label: 3,
+      enumInfo: roleEnumInfo
+    }
+
+    const result = genFieldDecode(field, "profile")
+
+    expect(result.body).toContain(
+      "profile.roles[_idx_roles++] = RoleLib.fromRaw(_elem);"
+    )
+    expect(result.body).not.toContain("Role.wrap(uint8(_elem))")
+  })
+
+  it("decodes map enum values through the checked enum library helper", () => {
+    const field: FieldInfo = {
+      name: "role_by_name",
+      number: 1,
+      type: 11,
+      typeName: ".example.Profile.RoleByNameEntry",
+      label: 3,
+      mapEntry: {
+        keyType: 9,
+        valueType: 14,
+        valueTypeName: ".example.Role",
+        valueEnumInfo: roleEnumInfo
+      }
+    }
+
+    const result = genFieldDecode(field, "profile")
+
+    expect(result.body).toContain("_val = RoleLib.fromRaw(_raw);")
+    expect(result.body).not.toContain("Role.wrap(uint8(_raw))")
+  })
+})


### PR DESCRIPTION
## Summary
- Adds checked `fromRaw(uint64)` enum conversion to generated Solidity enum libraries and routes scalar, repeated, and map enum decode paths through it.
- Tightens generated `isValid` to exact declared enum values, including sparse enums, so unknown protobuf enum discriminants fail closed instead of narrowing into valid UDVT values.
- Deduplicates aliased enum numbers for generated validity/conversion branches while retaining alias constants, and reports invalid raw values with `InvalidEnumValue(uint64 raw)`.

## Validation
- Focused `protoc-gen-solidity` Jest coverage for enum generation, alias deduplication, and enum field decode paths.
- Full OPP tools workspace tests passed locally.
- OPP bundle generation passed; generated audit targets now use `AttestationTypeLib.fromRaw(_v)` and `ActionTypeLib.fromRaw(_v)`.
- `solc` compile passed for generated `Types.sol`, `Opp.sol`, `Attestations.sol`, and `Bootstrap.sol`.
- GitHub CI is green, including Linux build/test/package matrix, Generate OPP Bundles, Root Node tooling audit, and Apple Silicon.

## Notes
- No `contracts/sysio.*` changes; system-contract e2e gate is not applicable.
- The fail-closed behavior means enum value additions require a coordinated schema/code redeploy for Solidity consumers.