### PR TITLE
Chore: prune stale ccache entries

### DIFF
--- a/.github/workflows/actions_cache_cleanup.yaml
+++ b/.github/workflows/actions_cache_cleanup.yaml
@@ -19,6 +19,10 @@ permissions:
   actions: write
   contents: read
 
+concurrency:
+  group: actions-cache-cleanup
+  cancel-in-progress: false
+
 defaults:
   run:
     shell: bash
@@ -43,6 +47,10 @@ jobs:
               exit 1
               ;;
           esac
+          if (( KEEP_PER_PREFIX < 1 )); then
+            echo "::error::keep_per_prefix must be >= 1 to preserve the restore baseline"
+            exit 1
+          fi
 
           caches_json="$(mktemp)"
           delete_list="$(mktemp)"
@@ -54,14 +62,7 @@ jobs:
 
           jq -s -r --argjson keep "$KEEP_PER_PREFIX" '
             def prefix:
-              if .key | startswith("ccache-macos-arm64-") then "ccache-macos-arm64"
-              elif .key | startswith("ccache-ubuntu24-") then "ccache-ubuntu24"
-              elif .key | startswith("ccache-asserton-") then "ccache-asserton"
-              elif .key | startswith("ccache-ubsan-") then "ccache-ubsan"
-              elif .key | startswith("ccache-asan-") then "ccache-asan"
-              elif .key | startswith("ccache-gcc-") then "ccache-gcc"
-              else empty
-              end;
+              .key | sub("-[0-9a-f]{7,40}$"; "");
 
             def candidate:
               . + {prefix: prefix};
@@ -104,5 +105,7 @@ jobs:
             fi
 
             echo "Deleting ${cache_key} (${cache_ref}, ${reason})"
-            gh cache delete "$cache_id" --repo "$GH_REPO"
+            if ! gh cache delete "$cache_id" --repo "$GH_REPO"; then
+              echo "::warning::failed to delete ${cache_key} (${cache_ref}); continuing"
+            fi
           done < "$delete_list"

--- a/.github/workflows/actions_cache_cleanup.yaml
+++ b/.github/workflows/actions_cache_cleanup.yaml
@@ -1,0 +1,108 @@
+name: "Actions cache cleanup"
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List eligible ccache entries without deleting them"
+        type: boolean
+        default: false
+      keep_per_prefix:
+        description: "Non-PR ccache entries to keep per platform prefix"
+        type: number
+        default: 2
+  schedule:
+    # Keep Actions cache usage below the repository cap so ccache families do not thrash each other.
+    - cron: "35 3 * * *"
+
+permissions:
+  actions: write
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prune-ccache:
+    name: Prune ccache entries
+    runs-on: ubuntu-latest
+    env:
+      CACHE_CLEANUP_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+      KEEP_PER_PREFIX: ${{ github.event.inputs.keep_per_prefix || '2' }}
+    steps:
+      - name: Delete stale ccache entries
+        run: |
+          set -euo pipefail
+
+          case "$KEEP_PER_PREFIX" in
+            ''|*[!0-9]*)
+              echo "::error::keep_per_prefix must be a non-negative integer"
+              exit 1
+              ;;
+          esac
+
+          caches_json="$(mktemp)"
+          delete_list="$(mktemp)"
+
+          # Collect ccache entries across all refs. PR-scoped entries are deleted first because
+          # PR jobs restore shared caches but no longer save new ccache blobs.
+          gh api --paginate "/repos/${GH_REPO}/actions/caches?per_page=100" \
+            --jq '.actions_caches[] | select(.key | startswith("ccache-"))' > "$caches_json"
+
+          jq -s -r --argjson keep "$KEEP_PER_PREFIX" '
+            def prefix:
+              if .key | startswith("ccache-macos-arm64-") then "ccache-macos-arm64"
+              elif .key | startswith("ccache-ubuntu24-") then "ccache-ubuntu24"
+              elif .key | startswith("ccache-asserton-") then "ccache-asserton"
+              elif .key | startswith("ccache-ubsan-") then "ccache-ubsan"
+              elif .key | startswith("ccache-asan-") then "ccache-asan"
+              elif .key | startswith("ccache-gcc-") then "ccache-gcc"
+              else empty
+              end;
+
+            def candidate:
+              . + {prefix: prefix};
+
+            [.[] | candidate] as $all
+            | (
+                $all[]
+                | select(.ref | startswith("refs/pull/"))
+                | . + {reason: "pull-request scope"}
+              ),
+              (
+                $all
+                | map(select((.ref | startswith("refs/pull/")) | not))
+                | sort_by(.prefix)
+                | group_by(.prefix)[]
+                | sort_by(.last_accessed_at // .created_at)
+                | reverse
+                | .[$keep:][]
+                | . + {reason: "older than keep_per_prefix"}
+              )
+            | [.id, .key, .ref, .reason, (.size_in_bytes | tostring)]
+            | @tsv
+          ' "$caches_json" > "$delete_list"
+
+          if [[ ! -s "$delete_list" ]]; then
+            echo "No ccache entries are eligible for deletion."
+            exit 0
+          fi
+
+          total_bytes="$(awk -F '\t' '{sum += $5} END {print sum + 0}' "$delete_list")"
+          total_mib="$((total_bytes / 1024 / 1024))"
+          echo "Eligible ccache entries:"
+          awk -F '\t' '{printf "- %s (%s, %s, %d MiB) [%s]\n", $2, $3, $4, $5 / 1024 / 1024, $1}' "$delete_list"
+          echo "Total eligible size: ${total_mib} MiB"
+
+          while IFS=$'\t' read -r cache_id cache_key cache_ref reason size_bytes; do
+            if [[ "$CACHE_CLEANUP_DRY_RUN" == "true" ]]; then
+              echo "Dry run: would delete ${cache_key} (${cache_ref}, ${reason})"
+              continue
+            fi
+
+            echo "Deleting ${cache_key} (${cache_ref}, ${reason})"
+            gh cache delete "$cache_id" --repo "$GH_REPO"
+          done < "$delete_list"

--- a/.github/workflows/linux_amd64_build.yaml
+++ b/.github/workflows/linux_amd64_build.yaml
@@ -298,7 +298,7 @@ jobs:
           key: ctest-cost-${{ matrix.platform }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Save ccache
-        if: ${{ always() && steps.restore-ccache.outputs.cache-hit != 'true' }}
+        if: ${{ always() && github.event_name != 'pull_request' && steps.restore-ccache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/.ccache

--- a/.github/workflows/macos_arm64_build.yaml
+++ b/.github/workflows/macos_arm64_build.yaml
@@ -136,7 +136,7 @@ jobs:
           key: ctest-cost-macos-arm64-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Save ccache
-        if: ${{ always() && steps.restore-ccache.outputs.cache-hit != 'true' }}
+        if: ${{ always() && github.event_name != 'pull_request' && steps.restore-ccache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/.ccache


### PR DESCRIPTION
## Summary
- Prevent Linux and macOS PR jobs from saving new ccache blobs while still allowing them to restore existing caches.
- Add a scheduled/manual Actions cache cleanup workflow that deletes PR-scoped ccache entries and prunes older non-PR ccache entries beyond a rolling keep count.
- Harden the cleanup workflow with a concurrency guard, `keep_per_prefix >= 1` validation, generic ccache prefix grouping for future platforms, and best-effort deletion so racy missing cache ids do not abort the whole cleanup.
- Leave vcpkg binary caches and CTest cost data untouched.

## Why
The macOS ccache miss in run 29034160705 was caused by repo-wide Actions cache pressure and eviction. The repo had exceeded the default cache storage size, and the macOS ccache family had been evicted while larger Linux ccache entries remained. PR-scoped ccache saves add pressure without providing broadly reusable caches, so PR jobs should be restore-only.

## Validation
- Parsed all `.github/workflows/*.yaml` files with PyYAML.
- Ran `git diff --check`.
- Exercised the cleanup jq against the live cache list in dry-run form; it selected PR-scoped ccache entries and preserved current master caches.
- Exercised the cleanup jq against synthetic unknown-platform `ccache-*` keys to verify future ccache prefixes are still pruned.
