### PR TITLE
Fix SEC-73 Solana vector decode bounds

### DIFF
--- a/libraries/libfc/include/fc/network/solana/solana_borsh.hpp
+++ b/libraries/libfc/include/fc/network/solana/solana_borsh.hpp
@@ -197,12 +197,18 @@ private:
    size_t _pos;
 
    void ensure_remaining(size_t n) const {
-      FC_ASSERT(_pos + n <= _size, "Borsh decoder: not enough data, need {} bytes, have {}", n, remaining());
+      FC_ASSERT(n <= remaining(), "Borsh decoder: not enough data, need {} bytes, have {}", n, remaining());
    }
 
    // Helper to read primitive type
    template <typename T>
    T read_primitive();
+
+   /**
+    * @brief Smallest Borsh byte count for a supported Vec<T> element.
+    */
+   template <typename T>
+   static constexpr size_t min_vec_element_size();
 };
 
 //=============================================================================
@@ -353,6 +359,11 @@ std::optional<T> decoder::read_option() {
 template <typename T>
 std::vector<T> decoder::read_vec() {
    uint32_t len = read_u32();
+   constexpr size_t min_element_size = min_vec_element_size<T>();
+   FC_ASSERT(len <= remaining() / min_element_size,
+             "Borsh decoder: vector length {} with minimum element size {} exceeds remaining {} bytes",
+             len, min_element_size, remaining());
+
    std::vector<T> result;
    result.reserve(len);
 
@@ -385,6 +396,25 @@ std::vector<T> decoder::read_vec() {
    }
 
    return result;
+}
+
+template <typename T>
+constexpr size_t decoder::min_vec_element_size() {
+   if constexpr (std::is_same_v<T, uint8_t> || std::is_same_v<T, int8_t> || std::is_same_v<T, bool>) {
+      return 1;
+   } else if constexpr (std::is_same_v<T, uint16_t> || std::is_same_v<T, int16_t>) {
+      return 2;
+   } else if constexpr (std::is_same_v<T, uint32_t> || std::is_same_v<T, int32_t>) {
+      return 4;
+   } else if constexpr (std::is_same_v<T, uint64_t> || std::is_same_v<T, int64_t>) {
+      return 8;
+   } else if constexpr (std::is_same_v<T, std::string>) {
+      return sizeof(uint32_t);
+   } else if constexpr (std::is_same_v<T, solana_public_key>) {
+      return solana_public_key::size;
+   } else {
+      static_assert(sizeof(T) == 0, "Unsupported type for read_vec");
+   }
 }
 
 template <typename T, size_t N>

--- a/libraries/libfc/src/network/solana/solana_client.cpp
+++ b/libraries/libfc/src/network/solana/solana_client.cpp
@@ -8,9 +8,133 @@
 #include <fc/network/solana/solana_client.hpp>
 #include <fc/task/retry.hpp>
 #include <magic_enum/magic_enum.hpp>
+#include <limits>
+#include <optional>
 #include <thread>
 
 namespace fc::network::solana {
+
+namespace {
+
+/**
+ * @brief Maximum materialized elements for vectors whose element encoding can
+ * consume zero bytes.
+ */
+constexpr uint32_t max_zero_sized_idl_vector_elements = 64u * 1024u;
+
+/**
+ * @brief Checked size_t addition for conservative Borsh size estimates.
+ */
+std::optional<size_t> checked_add_size(size_t lhs, size_t rhs) {
+   if (lhs > std::numeric_limits<size_t>::max() - rhs)
+      return std::nullopt;
+   return lhs + rhs;
+}
+
+/**
+ * @brief Checked size_t multiplication for conservative Borsh size estimates.
+ */
+std::optional<size_t> checked_mul_size(size_t lhs, size_t rhs) {
+   if (lhs != 0 && rhs > std::numeric_limits<size_t>::max() / lhs)
+      return std::nullopt;
+   return lhs * rhs;
+}
+
+std::optional<size_t> min_borsh_encoded_size(const idl::idl_type& type, const idl::program* program);
+
+/**
+ * @brief Smallest Borsh byte count for a field sequence.
+ */
+std::optional<size_t> min_borsh_fields_encoded_size(const std::vector<idl::field>& fields,
+                                                    const idl::program* program) {
+   size_t total = 0;
+   for (const auto& field : fields) {
+      auto field_size = min_borsh_encoded_size(field.type, program);
+      if (!field_size)
+         return std::nullopt;
+      auto next_total = checked_add_size(total, *field_size);
+      if (!next_total)
+         return std::nullopt;
+      total = *next_total;
+   }
+   return total;
+}
+
+/**
+ * @brief Conservative lower bound for bytes consumed by an IDL type.
+ */
+std::optional<size_t> min_borsh_encoded_size(const idl::idl_type& type, const idl::program* program) {
+   if (type.is_primitive()) {
+      switch (type.get_primitive()) {
+      case idl::primitive_type::bool_t:
+      case idl::primitive_type::u8:
+      case idl::primitive_type::i8:
+         return sizeof(uint8_t);
+      case idl::primitive_type::u16:
+      case idl::primitive_type::i16:
+         return sizeof(uint16_t);
+      case idl::primitive_type::u32:
+      case idl::primitive_type::i32:
+      case idl::primitive_type::f32:
+         return sizeof(uint32_t);
+      case idl::primitive_type::u64:
+      case idl::primitive_type::i64:
+      case idl::primitive_type::f64:
+         return sizeof(uint64_t);
+      case idl::primitive_type::u128:
+      case idl::primitive_type::i128:
+         return sizeof(uint64_t) * 2;
+      case idl::primitive_type::u256:
+      case idl::primitive_type::i256:
+         return sizeof(uint64_t) * 4;
+      case idl::primitive_type::string:
+      case idl::primitive_type::bytes:
+         return sizeof(uint32_t);
+      case idl::primitive_type::pubkey:
+         return solana_public_key::size;
+      }
+   } else if (type.is_option()) {
+      return sizeof(uint8_t);
+   } else if (type.is_vec()) {
+      return sizeof(uint32_t);
+   } else if (type.is_array()) {
+      if (!type.array_element || !type.array_len)
+         return std::nullopt;
+      auto element_size = min_borsh_encoded_size(*type.array_element, program);
+      if (!element_size)
+         return std::nullopt;
+      return checked_mul_size(*element_size, *type.array_len);
+   } else if (type.is_tuple() && type.tuple_elements) {
+      size_t total = 0;
+      for (const auto& elem_type : *type.tuple_elements) {
+         auto elem_size = min_borsh_encoded_size(elem_type, program);
+         if (!elem_size)
+            return std::nullopt;
+         auto next_total = checked_add_size(total, *elem_size);
+         if (!next_total)
+            return std::nullopt;
+         total = *next_total;
+      }
+      return total;
+   } else if (type.is_defined()) {
+      if (!program)
+         return std::nullopt;
+
+      const idl::type_def* type_def = program->find_type(type.get_defined_name());
+      if (!type_def)
+         return std::nullopt;
+
+      if (type_def->is_struct() && type_def->struct_fields)
+         return min_borsh_fields_encoded_size(*type_def->struct_fields, program);
+
+      if (type_def->is_enum() && type_def->enum_variants)
+         return sizeof(uint8_t);
+   }
+
+   return std::nullopt;
+}
+
+}  // namespace
 
 //=============================================================================
 // solana_program_data_client implementation
@@ -435,6 +559,22 @@ fc::variant solana_program_client::decode_type(borsh::decoder& decoder, const id
       return decode_type(decoder, *type.option_inner);
    } else if (type.is_vec()) {
       uint32_t len = decoder.read_u32();
+      FC_ASSERT(type.vec_element, "Borsh decoder: Vec type is missing an element type");
+      const auto min_element_size = min_borsh_encoded_size(*type.vec_element, _program.get());
+      if (!min_element_size) {
+         FC_ASSERT(len == 0,
+                   "Borsh decoder: cannot safely bound vector element type '{}' before allocation",
+                   type.vec_element->to_string());
+      } else if (*min_element_size == 0) {
+         FC_ASSERT(len <= max_zero_sized_idl_vector_elements,
+                   "Borsh decoder: zero-sized vector length {} for element type '{}' exceeds decode cap {}",
+                   len, type.vec_element->to_string(), max_zero_sized_idl_vector_elements);
+      } else {
+         FC_ASSERT(len <= decoder.remaining() / *min_element_size,
+                   "Borsh decoder: vector length {} for element type '{}' exceeds remaining {} bytes",
+                   len, type.vec_element->to_string(), decoder.remaining());
+      }
+
       fc::variants arr;
       arr.reserve(len);
 

--- a/libraries/libfc/test/network/solana/test_solana_client.cpp
+++ b/libraries/libfc/test/network/solana/test_solana_client.cpp
@@ -8,6 +8,8 @@
 #include <fc/network/solana/solana_system_programs.hpp>
 #include <fc/network/solana/solana_types.hpp>
 
+#include <limits>
+
 using namespace fc::network::solana;
 using namespace fc::crypto::solana;
 
@@ -43,6 +45,71 @@ message make_index_limit_message(size_t account_key_count) {
    instr.account_indices = {0};
    msg.instructions.push_back(instr);
    return msg;
+}
+
+/**
+ * @brief Append a little-endian u32 to a test byte buffer.
+ */
+void append_u32_le(std::vector<uint8_t>& out, uint32_t value) {
+   for (size_t i = 0; i < sizeof(value); ++i) {
+      out.push_back(static_cast<uint8_t>((value >> (i * 8)) & 0xff));
+   }
+}
+
+/**
+ * @brief Append a Borsh string to a test byte buffer.
+ */
+void append_borsh_string(std::vector<uint8_t>& out, const std::string& value) {
+   append_u32_le(out, static_cast<uint32_t>(value.size()));
+   out.insert(out.end(), value.begin(), value.end());
+}
+
+/**
+ * @brief Test adapter exposing protected decode helpers without RPC.
+ */
+struct test_solana_program_client : solana_program_client {
+   using solana_program_client::decode_account_data;
+
+   explicit test_solana_program_client(const std::vector<idl::program>& idls = {})
+      : solana_program_client(solana_client_ptr{}, make_test_pubkey(700), idls) {}
+};
+
+idl::program parse_empty_struct_vec_account_idl() {
+   std::string idl_json = R"({
+      "address": "11111111111111111111111111111111",
+      "metadata": {
+         "name": "empty_vec_account",
+         "version": "0.1.0",
+         "spec": "0.1.0"
+      },
+      "instructions": [],
+      "accounts": [
+         {
+            "name": "EmptyVecAccount",
+            "discriminator": [8, 7, 6, 5, 4, 3, 2, 1]
+         }
+      ],
+      "types": [
+         {
+            "name": "EmptyVecAccount",
+            "type": {
+               "kind": "struct",
+               "fields": [
+                  {"name": "empties", "type": {"vec": {"defined": {"name": "EmptyStruct"}}}}
+               ]
+            }
+         },
+         {
+            "name": "EmptyStruct",
+            "type": {
+               "kind": "struct",
+               "fields": []
+            }
+         }
+      ]
+   })";
+
+   return idl::parse_idl(fc::json::from_string(idl_json));
 }
 
 } // namespace
@@ -248,6 +315,14 @@ BOOST_AUTO_TEST_CASE(test_borsh_vec) {
    borsh::decoder dec(data);
    auto decoded = dec.read_vec<uint32_t>();
    BOOST_CHECK(decoded == test_vec);
+}
+
+BOOST_AUTO_TEST_CASE(test_borsh_vec_rejects_declared_length_before_reserve) {
+   std::vector<uint8_t> data;
+   append_u32_le(data, std::numeric_limits<uint32_t>::max());
+
+   borsh::decoder dec(data);
+   BOOST_CHECK_THROW(dec.read_vec<uint32_t>(), fc::assert_exception);
 }
 
 //=============================================================================
@@ -1217,6 +1292,114 @@ BOOST_AUTO_TEST_CASE(test_anchor_idl_account_fields_in_types_section) {
    // Verify decoded values
    BOOST_CHECK_EQUAL(result["count"].as_uint64(), 42u);
    BOOST_CHECK_EQUAL(result["bump"].as_uint64(), 253u);
+}
+
+BOOST_AUTO_TEST_CASE(test_anchor_idl_account_vec_rejects_declared_length_before_reserve) {
+   std::string idl_json = R"({
+      "address": "11111111111111111111111111111111",
+      "metadata": {
+         "name": "vec_account",
+         "version": "0.1.0",
+         "spec": "0.1.0"
+      },
+      "instructions": [],
+      "accounts": [
+         {
+            "name": "VecAccount",
+            "discriminator": [1, 2, 3, 4, 5, 6, 7, 8]
+         }
+      ],
+      "types": [
+         {
+            "name": "VecAccount",
+            "type": {
+               "kind": "struct",
+               "fields": [
+                  {"name": "scores", "type": {"vec": "u64"}}
+               ]
+            }
+         }
+      ]
+   })";
+
+   auto prog = idl::parse_idl(fc::json::from_string(idl_json));
+   test_solana_program_client client({prog});
+
+   std::vector<uint8_t> account_data = {1, 2, 3, 4, 5, 6, 7, 8};
+   append_u32_le(account_data, std::numeric_limits<uint32_t>::max());
+
+   BOOST_CHECK_THROW(client.decode_account_data(account_data, "VecAccount"), fc::assert_exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_anchor_idl_account_vec_decodes_dynamic_elements) {
+   std::string idl_json = R"({
+      "address": "11111111111111111111111111111111",
+      "metadata": {
+         "name": "string_vec_account",
+         "version": "0.1.0",
+         "spec": "0.1.0"
+      },
+      "instructions": [],
+      "accounts": [
+         {
+            "name": "StringVecAccount",
+            "discriminator": [2, 4, 6, 8, 10, 12, 14, 16]
+         }
+      ],
+      "types": [
+         {
+            "name": "StringVecAccount",
+            "type": {
+               "kind": "struct",
+               "fields": [
+                  {"name": "labels", "type": {"vec": "string"}}
+               ]
+            }
+         }
+      ]
+   })";
+
+   auto prog = idl::parse_idl(fc::json::from_string(idl_json));
+   test_solana_program_client client({prog});
+
+   std::vector<uint8_t> account_data = {2, 4, 6, 8, 10, 12, 14, 16};
+   append_u32_le(account_data, 2);
+   append_borsh_string(account_data, "alpha");
+   append_borsh_string(account_data, "beta");
+
+   auto result = client.decode_account_data(account_data, "StringVecAccount").get_object();
+   auto labels = result["labels"].get_array();
+
+   BOOST_CHECK_EQUAL(labels.size(), 2u);
+   BOOST_CHECK_EQUAL(labels[0].as_string(), "alpha");
+   BOOST_CHECK_EQUAL(labels[1].as_string(), "beta");
+}
+
+BOOST_AUTO_TEST_CASE(test_anchor_idl_account_zero_sized_vec_decodes_small_length) {
+   auto prog = parse_empty_struct_vec_account_idl();
+   test_solana_program_client client({prog});
+
+   std::vector<uint8_t> account_data = {8, 7, 6, 5, 4, 3, 2, 1};
+   append_u32_le(account_data, 3);
+
+   auto result = client.decode_account_data(account_data, "EmptyVecAccount").get_object();
+   auto empties = result["empties"].get_array();
+
+   BOOST_CHECK_EQUAL(empties.size(), 3u);
+   for (const auto& empty : empties) {
+      BOOST_CHECK(empty.is_object());
+      BOOST_CHECK_EQUAL(empty.get_object().size(), 0u);
+   }
+}
+
+BOOST_AUTO_TEST_CASE(test_anchor_idl_account_zero_sized_vec_rejects_unbounded_length) {
+   auto prog = parse_empty_struct_vec_account_idl();
+   test_solana_program_client client({prog});
+
+   std::vector<uint8_t> account_data = {8, 7, 6, 5, 4, 3, 2, 1};
+   append_u32_le(account_data, std::numeric_limits<uint32_t>::max());
+
+   BOOST_CHECK_THROW(client.decode_account_data(account_data, "EmptyVecAccount"), fc::assert_exception);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- Bound templated Borsh `read_vec<T>()` lengths against remaining bytes before `reserve()`.
- Bound Anchor IDL `Vec<T>` account decoding using conservative minimum encoded sizes before materializing `fc::variants`.
- Preserve valid zero-sized element vectors with an explicit materialization cap, and reject huge zero-sized lengths before allocation.
- Add regression tests for huge short-payload vector lengths, valid dynamic `Vec<string>` decoding, and zero-sized `Vec<EmptyStruct>` behavior.

## Validation
- `git diff --check`
- `cmake --build build/sec-73-release --target test_fc -- -j"$(nproc)"`
- `cmake --build build/sec-73-release --target test_outpost_solana_client_plugin -- -j"$(nproc)"`
- `./build/sec-73-release/libraries/libfc/test/test_fc --run_test=solana_client_tests`
- `ctest --test-dir build/sec-73-release -j"$(nproc)" -R '^test_fc$' --output-on-failure`
- `ctest --test-dir build/sec-73-release -j"$(nproc)" -R '^test_outpost_solana_client_plugin$' --output-on-failure`

## Review Notes
- Security review subagent found the initial zero-sized element edge; this PR includes the follow-up fix and the second review pass reported no findings.
- The zero-sized vector cap intentionally rejects vectors above 65,536 materialized elements because their encoded bytes cannot bound allocation work.
- No system-contract artifacts or generated OPP bindings are changed.