### PR TITLE
Fix snapshot attest deregistration CI race

### DIFF
--- a/tests/snapshot_attest_test.py
+++ b/tests/snapshot_attest_test.py
@@ -400,8 +400,10 @@ try:
         json.dumps({"account": snapProv2.name}),
         f"--permission {snapProv2.name}@active")
     assert success, f"Failed to deregister provider: {trans}"
+    delSnapProvTransId = node0.getTransId(trans)
 
-    assert node0.waitForHeadToAdvance(), "Head did not advance after deregistration"
+    assert node0.waitForTransactionsInBlock([delSnapProvTransId], timeout=60), \
+        "delsnapprov transaction did not make it into a block before provider table check"
 
     providers = node0.getTableRows("sysio", "sysio", "snapprovs")
     assert len(providers) == 1, f"Expected 1 provider after deregistration, got {len(providers)}"


### PR DESCRIPTION
## Summary

Fixes a CI-only race in `snapshot_attest_test`'s final provider deregistration check.

The failed job was:

- [Build, test, and package (asserton)](https://github.com/Wire-Network/wire-sysio/actions/runs/29048119488/job/86221810352)
- Failed step: `Run Sharded NP/LR Tests`
- Failed test: `snapshot_attest_test`

## Failure Mode

The failing CI run executed `sysio::delsnapprov` successfully, then the test waited for a generic head-block advance before reading the `snapprovs` table. In a multi-producer cluster, `pushMessage` can return an `executed` transaction while the transaction is still pending inclusion in a produced block visible to the node being queried. A generic head advance is not strong enough to prove that the specific deregistration transaction has been applied.

That leaves a narrow race where `snapprovs` is read too early and still contains both providers. The observed failure was:

```text
AssertionError: Expected 1 provider after deregistration, got 2
```

This is the same synchronization class already handled earlier in `snapshot_attest_test` for `regproducer`, `setrank`, `regsnapprov`, and `setsnpcfg`.

## Change

Capture the `delsnapprov` transaction id and wait for that exact transaction to appear in a block before asserting the provider table contents.

This does not change snapshot attestation behavior or contract logic; it only makes the integration test wait on the correct condition before reading chain state.

## Validation

```bash
ctest --test-dir build/sec-66-pr20-release --output-on-failure -R '^snapshot_attest_test$' --timeout 2700
```

Result:

```text
1/1 Test #2216: snapshot_attest_test .............   Passed  121.89 sec
```
