### PR TITLE
Move underwriter diagnostics to a dedicated http api category

### DIFF
--- a/plugins/http_plugin/include/sysio/http_plugin/api_category.hpp
+++ b/plugins/http_plugin/include/sysio/http_plugin/api_category.hpp
@@ -17,6 +17,7 @@ enum class api_category : uint32_t {
    prometheus   = 1 << 9,
    test_control = 1 << 10,
    snapshot_ro  = 1 << 11,  // public read-only snapshot metadata + download
+   underwriter  = 1 << 12,  // read-only underwriter diagnostics (stats/commits)
    node        = UINT32_MAX
 };
 

--- a/plugins/http_plugin/src/http_plugin.cpp
+++ b/plugins/http_plugin/src/http_plugin.cpp
@@ -75,6 +75,7 @@ namespace sysio {
       if (name == "prometheus") return api_category::prometheus;
       if (name == "test_control") return api_category::test_control;
       if (name == "snapshot_ro") return api_category::snapshot_ro;
+      if (name == "underwriter") return api_category::underwriter;
       return api_category::unknown;
    }
 
@@ -91,6 +92,7 @@ namespace sysio {
       if (category == api_category::prometheus) return "prometheus";
       if (category == api_category::test_control) return "test_control";
       if (category == api_category::snapshot_ro) return "snapshot_ro";
+      if (category == api_category::underwriter) return "underwriter";
       if (category == api_category::node) return "node";
       // It's a programming error when the control flow reaches this point, 
       // please make sure all the category names are returned from above statements.
@@ -116,6 +118,8 @@ namespace sysio {
          return "sysio::producer_api_plugin";
       if (category == api_category::snapshot_ro)
          return "sysio::snapshot_api_plugin";
+      if (category == api_category::underwriter)
+         return "sysio::underwriter_plugin";
       // It's a programming error when the control flow reaches this point,
       // please make sure all the plugin names are returned from above statements.
       assert(false && "No corresponding plugin for the category value");
@@ -125,7 +129,7 @@ namespace sysio {
    std::string category_names(api_category_set set) {
       if (set == api_category_set::all()) return "all";
       std::string result;
-      for (uint32_t i = 1; i <= static_cast<uint32_t>(api_category::snapshot_ro); i<<=1) {
+      for (uint32_t i = 1; i <= static_cast<uint32_t>(api_category::underwriter); i<<=1) {
          if (set.contains(api_category(i))) {
             result += from_category(api_category(i));
             result += " ";
@@ -338,7 +342,7 @@ namespace sysio {
              "    in addition, unix socket path must starts with '/', './' or '../'. When relative path\n"
              "    is used, it is relative to the data path.\n\n"
              "    Valid categories include chain_ro, chain_rw, db_size, net_ro, net_rw, producer_ro\n"
-             "    producer_rw, snapshot, trace_api, prometheus, test_control, and snapshot_ro.\n\n"
+             "    producer_rw, snapshot, trace_api, prometheus, test_control, snapshot_ro, and underwriter.\n\n"
              "    A single `hostname:port` specification can be used by multiple categories\n" 
              "    However, two specifications having the same port with different hostname strings\n" 
              "    are always considered as configuration error regardless of whether they can be resolved\n"

--- a/plugins/http_plugin/test/unit_tests.cpp
+++ b/plugins/http_plugin/test/unit_tests.cpp
@@ -40,6 +40,7 @@ constexpr uint32_t category_ro_index = 2;
 constexpr uint32_t bytes_in_flight_index = 3;
 constexpr uint32_t requests_in_flight_index = 4;
 constexpr uint32_t request_body_bytes_in_flight_index = 5;
+constexpr uint32_t category_uw_index = 6;
 // Keeps unsharded IPv6 probe coverage on the historical port 9999.
 constexpr uint32_t ipv6_probe_index = 2;
 
@@ -276,9 +277,19 @@ class producer_api_plugin : public appbase::plugin<producer_api_plugin> {
    void         plugin_shutdown() {}
 };
 
+class underwriter_plugin : public appbase::plugin<underwriter_plugin> {
+ public:
+   APPBASE_PLUGIN_REQUIRES();
+   virtual void set_program_options(options_description& cli, options_description& cfg) override {}
+   void         plugin_initialize(const variables_map& options) {}
+   void         plugin_startup() {}
+   void         plugin_shutdown() {}
+};
+
 static auto _chain_api_plugin    = application::register_plugin<chain_api_plugin>();
 static auto _net_api_plugin      = application::register_plugin<net_api_plugin>();
 static auto _producer_api_plugin = application::register_plugin<producer_api_plugin>();
+static auto _underwriter_plugin  = application::register_plugin<underwriter_plugin>();
 } // namespace sysio
 
 struct http_plugin_test_fixture {
@@ -434,6 +445,11 @@ BOOST_AUTO_TEST_CASE(invalid_category_addresses) {
                                  "http-category-address", "--http-category-address", chain_ro_localhost.c_str()})
                   .contains("--plugin=sysio::chain_api_plugin is required"));
 
+   const std::string underwriter_localhost = "underwriter," + localhost_rw;
+   BOOST_TEST(app_log({test_name, "--plugin=sysio::chain_api_plugin", "--http-server-address",
+                                 "http-category-address", "--http-category-address", underwriter_localhost.c_str()})
+                  .contains("--plugin=sysio::underwriter_plugin is required"));
+
    BOOST_TEST(app_log({test_name, "--plugin=sysio::chain_api_plugin", "--http-category-address", chain_ro_localhost.c_str()})
                   .contains("http-server-address must be set as `http-category-address`"));
 
@@ -503,10 +519,12 @@ BOOST_FIXTURE_TEST_CASE(valid_category_addresses, http_plugin_test_fixture) {
    const std::string ro_localhost = test_http_endpoint("localhost", category_ro_index);
    const std::string rw_loopback = test_http_endpoint("127.0.0.1", category_rw_index);
    const std::string rw_any = ":" + rw_port;
+   const std::string uw_loopback = test_http_endpoint("127.0.0.1", category_uw_index);
    const std::string chain_ro = "chain_ro," + ro_loopback;
    const std::string chain_rw = "chain_rw," + rw_any;
    const std::string net_ro = "net_ro," + ro_loopback;
    const std::string net_rw = "net_rw," + rw_any;
+   const std::string underwriter = "underwriter," + uw_loopback;
    const std::string ipv6_rw = "[::1]:" + rw_port;
 
    // clang-format off
@@ -515,11 +533,13 @@ BOOST_FIXTURE_TEST_CASE(valid_category_addresses, http_plugin_test_fixture) {
                       "--plugin=sysio::chain_api_plugin",
                       "--plugin=sysio::net_api_plugin",
                       "--plugin=sysio::producer_api_plugin",
+                      "--plugin=sysio::underwriter_plugin",
                       "--http-server-address", "http-category-address",
                       "--http-category-address", chain_ro.c_str(),
                       "--http-category-address", chain_rw.c_str(),
                       "--http-category-address", net_ro.c_str(),
                       "--http-category-address", net_rw.c_str(),
+                      "--http-category-address", underwriter.c_str(),
                       "--http-category-address", "producer_ro,./producer_ro.sock",
                       "--http-category-address", "producer_rw,../producer_rw.sock"
                       });
@@ -554,6 +574,10 @@ BOOST_FIXTURE_TEST_CASE(valid_category_addresses, http_plugin_test_fixture) {
                          {std::string("/v1/producer_rw/hello"), api_category::producer_rw,
                           [&](string&&, string&& body, url_response_callback&& cb) {
                              cb(200, fc::variant("world!"));
+                          }},
+                         {std::string("/v1/underwriter/hello"), api_category::underwriter,
+                          [&](string&&, string&& body, url_response_callback&& cb) {
+                             cb(200, fc::variant("world!"));
                           }}},
                         appbase::exec_queue::read_write);
 
@@ -561,6 +585,7 @@ BOOST_FIXTURE_TEST_CASE(valid_category_addresses, http_plugin_test_fixture) {
    BOOST_CHECK(http_plugin->is_on_loopback(api_category::net_ro));
    BOOST_CHECK(http_plugin->is_on_loopback(api_category::producer_ro));
    BOOST_CHECK(http_plugin->is_on_loopback(api_category::producer_rw));
+   BOOST_CHECK(http_plugin->is_on_loopback(api_category::underwriter));
    BOOST_CHECK(!http_plugin->is_on_loopback(api_category::chain_rw));
    BOOST_CHECK(!http_plugin->is_on_loopback(api_category::net_rw));
 
@@ -596,6 +621,14 @@ BOOST_FIXTURE_TEST_CASE(valid_category_addresses, http_plugin_test_fixture) {
    BOOST_CHECK_EQUAL(http_response_for(rw_loopback.c_str(), "/v1/chain_rw/hello").body(), world_string);
    BOOST_CHECK_EQUAL(http_response_for(rw_loopback.c_str(), "/v1/net_rw/hello").body(), world_string);
 
+   // The dedicated underwriter category serves its own listener (where node
+   // handlers stay reachable, node being all categories) and is NOT served
+   // by other category-isolated listeners.
+   BOOST_CHECK_EQUAL(http_response_for(uw_loopback.c_str(), "/v1/underwriter/hello").body(), world_string);
+   BOOST_CHECK_EQUAL(http_response_for(uw_loopback.c_str(), "/v1/node/hello").body(), world_string);
+   BOOST_CHECK_EQUAL(http_response_for(ro_loopback.c_str(), "/v1/underwriter/hello").status(), http::status::not_found);
+   BOOST_CHECK_EQUAL(http_response_for(rw_loopback.c_str(), "/v1/underwriter/hello").status(), http::status::not_found);
+
    BOOST_CHECK_EQUAL(http_response_for(data_dir / "./producer_ro.sock", "/v1/producer_ro/hello").body(), world_string);
    BOOST_CHECK_EQUAL(http_response_for(data_dir / "../producer_rw.sock", "/v1/producer_rw/hello").body(), world_string);
 
@@ -604,6 +637,9 @@ BOOST_FIXTURE_TEST_CASE(valid_category_addresses, http_plugin_test_fixture) {
 
    BOOST_CHECK_EQUAL(http_response_for(rw_loopback.c_str(), "/v1/node/get_supported_apis").body(),
                      R"({"apis":["/v1/chain_rw/hello","/v1/net_rw/hello","/v1/node/hello"]})");
+
+   BOOST_CHECK_EQUAL(http_response_for(uw_loopback.c_str(), "/v1/node/get_supported_apis").body(),
+                     R"({"apis":["/v1/node/hello","/v1/underwriter/hello"]})");
 }
 
 

--- a/plugins/snapshot_api_plugin/README.md
+++ b/plugins/snapshot_api_plugin/README.md
@@ -57,7 +57,8 @@ nodeop \
 
 In this setup:
 - Port **8888** (loopback only) serves chain, producer, net, and admin snapshot APIs
-- Port **9090** (public) serves **only** the read-only snapshot endpoints
+- Port **9090** (public) serves the read-only snapshot endpoints plus the node-global endpoints —
+  `/v1/chain/get_info` and `/v1/node/get_supported_apis` are reachable on every listener by design
 
 When using `--http-category-address`, the `--http-server-address` must be set to the literal string `http-category-address` and `--unix-socket-path` must not be set.
 
@@ -73,7 +74,9 @@ nodeop \
   ...
 ```
 
-Only the three snapshot read-only endpoints will be reachable.
+Only the three snapshot read-only endpoints will be reachable, along with the node-global
+`/v1/node/get_supported_apis` (always served) and `/v1/chain/get_info` when `sysio::chain_api_plugin`
+is loaded — node-global endpoints are reachable on every listener by design.
 
 ## Full Provider Setup
 

--- a/plugins/underwriter_plugin/README.md
+++ b/plugins/underwriter_plugin/README.md
@@ -126,6 +126,11 @@ completes they report the startup-gate state instead of the payload
 `wiring_failed` / `startup_failed` with `detail`); once the gate opens
 they serve the payloads above with `status: "active"`.
 
+The endpoints are registered only when the underwriter is enabled:
+with the plugin loaded but `--underwriter-enabled false` (the
+default), `plugin_startup` skips endpoint registration and every
+listener returns 404 for these routes.
+
 ### Listener exposure
 
 The endpoints live in the dedicated `underwriter` HTTP API category —
@@ -148,12 +153,16 @@ nodeop \
   --http-server-address http-category-address \
   --http-category-address underwriter,127.0.0.1:8890 \
   --plugin sysio::underwriter_plugin \
+  --underwriter-enabled true \
   ...
 ```
 
-The listener also serves the node-global endpoints
-(`/v1/chain/get_info`, `/v1/node/get_supported_apis`), which are
-reachable on every listener by design. Like every category,
+The listener also serves the node-global endpoints, which are
+reachable on every listener by design: `/v1/node/get_supported_apis`
+(always registered) and `/v1/chain/get_info` when
+`sysio::chain_api_plugin` is loaded — the underwriter depends only on
+`chain_plugin`, so the example above does not load it. Like every
+category,
 `underwriter` is validated against its owning plugin: naming it in
 `--http-category-address` without `--plugin sysio::underwriter_plugin`
 is a startup configuration error. Binding it to a non-loopback address

--- a/plugins/underwriter_plugin/README.md
+++ b/plugins/underwriter_plugin/README.md
@@ -106,6 +106,63 @@ verifies the signature against every permission on `uw_account` via the
 > the underwriter's per-chain contract / program address now lives in that
 > entry rather than in a per-family scalar option.
 
+## HTTP diagnostics
+
+Read-only diagnostic endpoints, served by `http_plugin` on the
+read-only exec queue:
+
+- `/v1/underwriter/stats` — session counters + config snapshot:
+  underwriter account, enabled/active flags, scan + timeout intervals,
+  per-chain outpost wiring (`chain_code`, `kind`, `client_id`,
+  `commit_addr`, `source_deposit_addr`), uwreq/commit/failure/mismatch
+  counters, outstanding-commit count, SOL source-deposit cursor health.
+- `/v1/underwriter/commits` — outstanding confirmed commits, one entry
+  per leg: `uwreq_id`, `chain_code`, `token_code`, `reserve_code`.
+
+Both carry a `status` discriminator. Until the deferred startup body
+completes they report the startup-gate state instead of the payload
+(`waiting_for_sync` with `head_behind_sec` / `lib_behind_sec`,
+`preflight_retrying`, or a terminal `preflight_failed` /
+`wiring_failed` / `startup_failed` with `detail`); once the gate opens
+they serve the payloads above with `status: "active"`.
+
+### Listener exposure
+
+The endpoints live in the dedicated `underwriter` HTTP API category —
+not the always-on `node` category — because they expose operator
+metadata (account identity, client ids, outpost contract addresses,
+the outstanding-commit ledger).
+
+Default deployments are unchanged: the all-category listeners
+(`--http-server-address`, `--unix-socket-path`) serve
+`/v1/underwriter/*` as before.
+
+Category-isolated deployments
+(`--http-server-address http-category-address`) must opt in
+explicitly: listeners without the `underwriter` category return 404
+for these routes and omit them from `/v1/node/get_supported_apis`.
+Bind the category to loopback or a private management network:
+
+```
+nodeop \
+  --http-server-address http-category-address \
+  --http-category-address underwriter,127.0.0.1:8890 \
+  --plugin sysio::underwriter_plugin \
+  ...
+```
+
+The listener also serves the node-global endpoints
+(`/v1/chain/get_info`, `/v1/node/get_supported_apis`), which are
+reachable on every listener by design. Like every category,
+`underwriter` is validated against its owning plugin: naming it in
+`--http-category-address` without `--plugin sysio::underwriter_plugin`
+is a startup configuration error. Binding it to a non-loopback address
+logs a startup warning (the same pattern as the `snapshot_ro` exposure
+notice).
+
+Query them directly over HTTP, e.g.
+`curl http://127.0.0.1:8890/v1/underwriter/stats`.
+
 ## Dependencies
 
 - `chain_plugin` — read-only table access against `sysio.opreg`, `sysio.uwrit`, `sysio.authex`, `sysio.chains`.
@@ -131,5 +188,3 @@ for a follow-up:
 - **Outstanding-commits tracking + one-leg-stuck retry** — persistent
   in-process map of submitted commits, with retry of a missing leg
   after `max_partial_landing_wait_epochs`.
-- **Diagnostic `clio` query** — read-only HTTP endpoint exposing
-  outstanding-commit state + counters.

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -2589,10 +2589,18 @@ struct underwriter_plugin::impl {
    /// before the posted listener creation runs — never from a task queued
    /// after `exec()` is live. Until the deferred startup body completes the
    /// handlers report the gate state (see {@link respond_if_gated}).
+   ///
+   /// Both endpoints live in the dedicated `api_category::underwriter`, NOT
+   /// `api_category::node`: they expose operator metadata (account identity,
+   /// client ids, outpost contract addresses, outstanding commits) that must
+   /// not ride the always-on node category onto category-isolated public
+   /// listeners. They remain reachable on the default all-category listeners
+   /// (`http-server-address` / `unix-socket-path`); on category-isolated
+   /// setups the operator opts in with `--http-category-address=underwriter,<addr>`.
    void register_http_endpoints() {
       auto& hp = app().get_plugin<http_plugin>();
       hp.add_api({
-         {"/v1/underwriter/stats", api_category::node,
+         {"/v1/underwriter/stats", api_category::underwriter,
             [this](std::string&& /*url*/,
                     std::string&& /*body*/,
                     url_response_callback&& cb) {
@@ -2606,7 +2614,7 @@ struct underwriter_plugin::impl {
                      ("error", e.to_detail_string())));
                }
             }},
-         {"/v1/underwriter/commits", api_category::node,
+         {"/v1/underwriter/commits", api_category::underwriter,
             [this](std::string&& /*url*/,
                     std::string&& /*body*/,
                     url_response_callback&& cb) {
@@ -2621,6 +2629,13 @@ struct underwriter_plugin::impl {
                }
             }},
       }, appbase::exec_queue::read_only);
+
+      // Operator metadata should normally stay on loopback / private
+      // management networks; a public bind is a deliberate choice worth a
+      // startup warning (same pattern as the snapshot_ro exposure notice).
+      if (!hp.is_on_loopback(api_category::underwriter)) {
+         wlog("underwriter diagnostics API (/v1/underwriter/*) exposed on a non-loopback address");
+      }
    }
 };
 

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -2578,7 +2578,7 @@ struct underwriter_plugin::impl {
    }
 
    /// Register the `/v1/underwriter/*` HTTP endpoints. Called once from
-   /// `plugin_startup`, UNCONDITIONALLY and BEFORE the sync gate:
+   /// `plugin_startup` when the underwriter is enabled, BEFORE the sync gate:
    /// `http_plugin`'s handler map is read lock-free by the HTTP worker
    /// threads, so every registration must happen during plugin startup —
    /// before the posted listener creation runs — never from a task queued
@@ -2757,12 +2757,12 @@ void underwriter_plugin::plugin_startup() {
 
    ilog("underwriter_plugin: starting for account {}", _impl->underwriter_account.to_string());
 
-   // Register the `/v1/underwriter/*` endpoints FIRST, unconditionally:
-   // handler registration must complete during plugin startup (before the
-   // posted HTTP listener goes live) because the handler map is read
-   // lock-free by the HTTP threads — it must never ride the deferred
-   // startup body below. Until that body completes, the handlers answer
-   // with the gate state, so a cold-booting (or permanently-disabled)
+   // Register the `/v1/underwriter/*` endpoints FIRST, before the sync
+   // gate: handler registration must complete during plugin startup
+   // (before the posted HTTP listener goes live) because the handler map
+   // is read lock-free by the HTTP threads — it must never ride the
+   // deferred startup body below. Until that body completes, the handlers
+   // answer with the gate state, so a cold-booting (or terminally-failed)
    // underwriter is diagnosable over HTTP instead of a single ilog.
    _impl->register_http_endpoints();
 

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -208,8 +208,7 @@ struct underwriter_plugin::impl {
    std::vector<uint8_t> resolved_eth_source_deposit_selector;
    std::vector<uint8_t> resolved_sol_source_deposit_discriminator;
 
-   // ── Diagnostic counters surfaced via the `/v1/underwriter/*` HTTP API
-   //   (and the future `clio opp uw stats` wrapper).
+   // ── Diagnostic counters surfaced via the `/v1/underwriter/*` HTTP API.
    //
    //   `source_deposit_mismatch_count` increments every time a source-
    //   deposit verification fails for a uwreq the plugin tried to cover.
@@ -2485,10 +2484,6 @@ struct underwriter_plugin::impl {
    // `head_behind_sec`/`lib_behind_sec`, `preflight_retrying`, or a terminal
    // `preflight_failed`/`wiring_failed`/`startup_failed` with `detail`);
    // once active they serve the payloads below with `status:"active"`.
-   //
-   // The matching `clio opp uw <stats|commits>` CLI wrapper is planned in
-   // a follow-up; today the endpoints are addressable via `curl` against
-   // the nodeop HTTP port.
 
    fc::variant build_stats_response() {
       std::lock_guard lk{stats_mutex};


### PR DESCRIPTION
Fixes SEC-65 / WSA-146.

`/v1/underwriter/stats` and `/v1/underwriter/commits` were registered under `api_category::node` (`UINT32_MAX`). The HTTP dispatch predicate is a bit-overlap test, so node-category handlers match every listener category set, and the underwriter's operator metadata (account identity, client ids, outpost contract addresses, counters, outstanding commit ledger) was reachable on category-isolated public listeners — e.g. a public `snapshot_ro` bind configured per the snapshot README's isolation guidance.

- New `api_category::underwriter` (`1 << 12`); both underwriter endpoints register under it. They remain reachable on the default all-category listeners (`http-server-address` / `unix-socket-path`); category-isolated listeners no longer serve them unless the operator opts in with `--http-category-address=underwriter,<addr>` (gated on `--plugin=sysio::underwriter_plugin` like every other category).
- Startup warning when the underwriter category is exposed on a non-loopback address, mirroring the snapshot_ro exposure notice.
- `valid_category_addresses` / `invalid_category_addresses` http_plugin unit tests extended: the underwriter listener serves its own category plus node handlers; other isolated listeners return 404 for the underwriter route and do not enumerate it in `get_supported_apis`; the missing-plugin config error is covered.
- snapshot_api_plugin README: the isolation examples now state that node-global endpoints (`/v1/chain/get_info`, `/v1/node/get_supported_apis`) remain reachable on every listener by design (upstream behavior, unchanged here).
- underwriter_plugin README: new HTTP diagnostics section documenting both endpoints, the startup-gate `status` payloads, and listener exposure — default all-category listeners unchanged, category-isolated deployments opt in with a private `--http-category-address=underwriter,127.0.0.1:<port>` listener. The example sets `--underwriter-enabled true` (endpoint registration is skipped while the underwriter is disabled), and `/v1/chain/get_info` is qualified as present only when `sysio::chain_api_plugin` is loaded.
- The diagnostic-endpoint item is dropped from the README deferred list now that the endpoints exist; no `clio` wrapper is planned, and the stale source comments claiming one (plus the "unconditional registration" wording) are removed.