### PR TITLE
Standardize pull request workflow triggers

### DIFF
--- a/.github/workflows/linux_amd64_build.yaml
+++ b/.github/workflows/linux_amd64_build.yaml
@@ -8,7 +8,7 @@ on:
     tags:
       - "v*"
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened]
     branches:
       - master
   workflow_dispatch:

--- a/.github/workflows/macos_arm64_build.yaml
+++ b/.github/workflows/macos_arm64_build.yaml
@@ -26,6 +26,7 @@ on:
       - "vcpkg.json"
       - "vcpkg-configuration.json"
   pull_request:
+    types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/macos_arm64_build.yaml"
       - ".github/vcpkg-triplets/**"

--- a/.github/workflows/opp-bundles.yaml
+++ b/.github/workflows/opp-bundles.yaml
@@ -11,7 +11,7 @@ on:
     paths:
       - "libraries/opp/**"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches:
       - master
     paths:


### PR DESCRIPTION
## Summary

- remove the `ready_for_review` trigger from the Linux and OPP Bundles workflows
- explicitly configure the macOS workflow with the same `opened`, `synchronize`, and `reopened` pull request events
- preserve each workflow-specific branch and path filters

## Why

Draft pull requests already run CI when they are opened and synchronized. Subscribing to `ready_for_review` starts a duplicate workflow run on the same commit when a draft is promoted for review.

## Impact

Marking a draft pull request ready for review no longer starts another CI run. CI continues to run when a pull request is opened, reopened, or receives new commits.

## Validation

- `actionlint` on all three changed workflows
- `git diff --check`
- verified that `.github` contains no remaining `ready_for_review` workflow trigger