### PR TITLE
SEC-47: Isolate fork PRs from host coredumps

### DIFF
--- a/.github/scripts/check-coredump-policy.py
+++ b/.github/scripts/check-coredump-policy.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Verify that fork pull requests cannot access or upload host coredumps."""
+
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[1] / "workflows" / "linux_amd64_build.yaml"
+HOST_COREDUMP_MOUNT = "--mount type=bind,source=/var/lib/systemd/coredump,target=/cores"
+TRUSTED_SOURCE_CONDITION = (
+    "github.event_name != 'pull_request' || "
+    "github.event.pull_request.head.repo.full_name == github.repository"
+)
+TRUSTED_MOUNT_EXPRESSION = (
+    "${{ (" + TRUSTED_SOURCE_CONDITION + ") && '" + HOST_COREDUMP_MOUNT + "' || '' }}"
+)
+TRUSTED_CORE_UPLOAD_CONDITION = "${{ failure() && (" + TRUSTED_SOURCE_CONDITION + ") }}"
+EXPECTED_HOST_MOUNT_COUNT = 1
+EXPECTED_CORES_REFERENCE_COUNT = 2
+CONTAINER_MARKER = "    container:\n"
+CONTAINER_END_MARKER = "    env:\n"
+LOG_UPLOAD_MARKER = "      - name: Upload logs from failed tests\n"
+CORE_UPLOAD_MARKER = "      - name: Upload core files from failed tests\n"
+CORE_UPLOAD_END_MARKER = "      - name: Check CPU Features\n"
+
+
+def extract_block(contents: str, start_marker: str, end_marker: str) -> str:
+    """Return the workflow text between two unique markers."""
+    start = contents.index(start_marker)
+    end = contents.index(end_marker, start)
+    return contents[start:end]
+
+
+def normalize_whitespace(contents: str) -> str:
+    """Collapse YAML formatting so policy expressions can be compared reliably."""
+    return " ".join(contents.split())
+
+
+def require(fragment: str, contents: str, message: str) -> None:
+    """Raise an actionable error when a required policy fragment is absent."""
+    if fragment not in contents:
+        raise RuntimeError(message)
+
+
+def require_count(fragment: str, expected: int, contents: str, message: str) -> None:
+    """Raise an actionable error when a policy fragment count is unexpected."""
+    actual = contents.count(fragment)
+    if actual != expected:
+        raise RuntimeError(f"{message} Expected {expected}, found {actual}.")
+
+
+def main() -> None:
+    """Validate the SEC-47 workflow trust boundary."""
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    container = normalize_whitespace(extract_block(workflow, CONTAINER_MARKER, CONTAINER_END_MARKER))
+    log_upload = normalize_whitespace(extract_block(workflow, LOG_UPLOAD_MARKER, CORE_UPLOAD_MARKER))
+    core_upload = normalize_whitespace(extract_block(workflow, CORE_UPLOAD_MARKER, CORE_UPLOAD_END_MARKER))
+
+    require_count(
+        HOST_COREDUMP_MOUNT,
+        EXPECTED_HOST_MOUNT_COUNT,
+        workflow,
+        "The workflow must contain exactly one host coredump mount.",
+    )
+    require(
+        TRUSTED_MOUNT_EXPRESSION,
+        container,
+        "The only host coredump mount must be guarded against fork pull requests.",
+    )
+    require_count(
+        "/cores",
+        EXPECTED_CORES_REFERENCE_COUNT,
+        workflow,
+        "Only the guarded mount and guarded artifact may reference /cores.",
+    )
+    if "/cores" in log_upload:
+        raise RuntimeError("The general failure-log artifact must not contain /cores.")
+    require(
+        TRUSTED_CORE_UPLOAD_CONDITION,
+        core_upload,
+        "The core artifact must be skipped for fork pull requests.",
+    )
+    require("path: /cores", core_upload, "The trusted core artifact must upload /cores.")
+
+    print("SEC-47 coredump isolation policy validated")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/linux_amd64_build.yaml
+++ b/.github/workflows/linux_amd64_build.yaml
@@ -46,6 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
 
+      - name: Validate coredump isolation policy
+        run: python3 .github/scripts/check-coredump-policy.py
+
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # actions/setup-node@v4
         with:
           node-version: "24"
@@ -91,7 +94,7 @@ jobs:
 
   build-test-package:
     name: Build, test, and package (${{matrix.platform}})
-    needs: [platform-cache, v]
+    needs: [platform-cache, root-node-tooling, v]
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +123,14 @@ jobs:
       credentials:
         username: dev-wire
         password: ${{ secrets.GH_TOKEN_DEV }}
-      options: --security-opt seccomp=unconfined --mount type=bind,source=/var/lib/systemd/coredump,target=/cores
+      # Fork PR code must not see the shared runner's host dumps; same-repository and non-PR runs retain debug access.
+      # SEC-112 tracks enforcing the protected workflow revision at the runner-group boundary.
+      options: >-
+        --security-opt seccomp=unconfined
+        ${{ (github.event_name != 'pull_request' ||
+             github.event.pull_request.head.repo.full_name == github.repository)
+            && '--mount type=bind,source=/var/lib/systemd/coredump,target=/cores'
+            || '' }}
       volumes:
       - ${{ github.workspace }}:/__w/wire-sysio/wire-sysio
     env:
@@ -304,17 +314,27 @@ jobs:
           path: ${{ github.workspace }}/.ccache
           key: ccache-${{ matrix.platform }}-${{ github.sha }}
 
-      - name: Upload core files from failed tests
+      - name: Upload logs from failed tests
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # actions/upload-artifact@v6
         if: failure()
         with:
           name: ${{matrix.platform}}-tests-logs
           if-no-files-found: warn
           path: |
-              /cores
               build/Testing/Temporary/
               build/TestLogs/
               build/PerformanceHarnessScenarioRunnerLogs/
+
+      - name: Upload core files from failed tests
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # actions/upload-artifact@v6
+        if: >-
+          ${{ failure() &&
+              (github.event_name != 'pull_request' ||
+               github.event.pull_request.head.repo.full_name == github.repository) }}
+        with:
+          name: ${{matrix.platform}}-test-cores
+          if-no-files-found: warn
+          path: /cores
 
       - name: Check CPU Features
         if: ${{ steps.build.outcome == 'success' && !cancelled() }}


### PR DESCRIPTION
## Summary

- omit the self-hosted runner coredump bind mount for fork-originated pull requests
- upload failure logs independently, and upload `/cores` only for same-repository PRs and non-PR runs
- gate the self-hosted build matrix on a static coredump-policy preflight that rejects unguarded or duplicate `/cores` paths

## Validation

- `python3 .github/scripts/check-coredump-policy.py`
- `actionlint` v1.7.12 on `linux_amd64_build.yaml`
- `git diff --check`

GitHub PR CI passed: [Linux amd64 build & tests](https://github.com/Wire-Network/wire-sysio/actions/runs/29113977549), including the policy preflight and all five build/test/package variants. The system-contract e2e gate is not applicable because this changes only CI workflow policy.

## Residual risk

This intentionally scoped fix retains host-coredump access for same-repository PRs and non-PR runs. Because a `pull_request` workflow revision is itself PR-controlled, SEC-112 must enforce the protected workflow revision at the runner-group boundary. Core artifacts also retain the repository's existing public visibility.
