### PR TITLE
SEC-67: Bound external debugging backpressure

### DIFF
--- a/libraries/libfc/include/fc/network/json_rpc/json_rpc_client.hpp
+++ b/libraries/libfc/include/fc/network/json_rpc/json_rpc_client.hpp
@@ -23,6 +23,9 @@ namespace asio = boost::asio;
 // -----------------------------------------------------------------------
 enum class http_verb { GET, PUT, POST, DELETE_ };
 
+/// Control whether connection failures invalidate the client's startup DNS result.
+enum class endpoint_refresh_policy { on_connection_failure, never };
+
 // JSON-RPC error type
 struct json_rpc_error : fc::exception {
    int      code;
@@ -35,8 +38,8 @@ struct json_rpc_error : fc::exception {
 // raw HTTP verb support for REST-style endpoints.
 class json_rpc_client {
 public:
-   explicit json_rpc_client(fc::url                           url,
-                            const std::optional<std::string>& user_agent = std::nullopt);
+   explicit json_rpc_client(fc::url url, const std::optional<std::string>& user_agent = std::nullopt,
+                            endpoint_refresh_policy refresh_policy = endpoint_refresh_policy::on_connection_failure);
 
    // -----------------------------------------------------------------------
    //  JSON-RPC 2.0 methods (unchanged, backwards compatible)
@@ -76,6 +79,7 @@ private:
    std::int64_t _next_id;
    tcp::resolver::results_type _resolved_endpoints;
    bool                        _resolved_endpoints_stale;
+   endpoint_refresh_policy _refresh_policy;
 
    // Perform HTTP POST with JSON payload; optionally parse JSON body.
    variant send_json(const variant& payload, bool expect_json_body = true);

--- a/libraries/libfc/include/fc/parallel/worker_task_queue.hpp
+++ b/libraries/libfc/include/fc/parallel/worker_task_queue.hpp
@@ -3,12 +3,14 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <queue>
+#include <utility>
 
 namespace fc::parallel {
 
@@ -18,6 +20,8 @@ struct worker_task_queue_config {
    uint64_t max_threads    = 1;
    bool     prune_threads  = false;
    bool     skip_autostart = false;
+   /// Maximum waiting items, excluding callbacks already in progress. Null means unbounded.
+   std::optional<std::size_t> max_pending_items;
 };
 
 /// Thread-pool-backed work queue that delivers items of type T to a callback.
@@ -51,27 +55,19 @@ public:
 
    ~worker_task_queue() { stop(); }
 
-   /// Enqueue an item. No-op if the queue has been stopped.
-   void push(const T& item) {
-      {
-         std::lock_guard<std::mutex> lock(_mtx);
-         if (_stopped)
-            return;
-         _queue.push(item);
-      }
-      _cv.notify_one();
-   }
+   /// Enqueue an item. No-op if the queue has been stopped or is at capacity.
+   void push(const T& item) { (void)try_push(item); }
 
-   /// Enqueue an item (move). No-op if the queue has been stopped.
-   void push(T&& item) {
-      {
-         std::lock_guard<std::mutex> lock(_mtx);
-         if (_stopped)
-            return;
-         _queue.push(std::move(item));
-      }
-      _cv.notify_one();
-   }
+   /// Enqueue an item (move). No-op if the queue has been stopped or is at capacity.
+   void push(T&& item) { (void)try_push(std::move(item)); }
+
+   /// Attempt to enqueue a copied item.
+   /// @return True when admitted; false when stopped or at the pending-item limit.
+   bool try_push(const T& item) { return try_push_impl(item); }
+
+   /// Attempt to enqueue a moved item.
+   /// @return True when admitted; false when stopped or at the pending-item limit.
+   bool try_push(T&& item) { return try_push_impl(std::move(item)); }
 
    /// Start the thread pool and worker loops.
    /// Called automatically by create() unless skip_autostart is set.
@@ -117,10 +113,35 @@ public:
       return _queue.size();
    }
 
+   /// Remove and return the number of pending items without affecting an active callback.
+   std::size_t discard_pending() {
+      std::queue<T> discarded;
+      {
+         std::lock_guard<std::mutex> lock(_mtx);
+         _queue.swap(discarded);
+      }
+      const auto count = discarded.size();
+      return count;
+   }
+
 private:
    worker_task_queue(worker_task_queue_config config, callback_t cb)
       : _config(std::move(config))
       , _callback(std::move(cb)) {}
+
+   /// Admit an item while holding the capacity check and queue mutation under the same lock.
+   template <typename U>
+   bool try_push_impl(U&& item) {
+      {
+         std::lock_guard<std::mutex> lock(_mtx);
+         if (_stopped || (_config.max_pending_items && _queue.size() >= *_config.max_pending_items)) {
+            return false;
+         }
+         _queue.push(std::forward<U>(item));
+      }
+      _cv.notify_one();
+      return true;
+   }
 
    void worker_loop() {
       while (true) {

--- a/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
+++ b/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
@@ -347,15 +347,16 @@ json_rpc_client json_rpc_client::create(const std::variant<std::string, fc::url>
 }
 
 // json_rpc_client
-json_rpc_client::json_rpc_client(fc::url                           url,
-                                 const std::optional<std::string>& user_agent)
+json_rpc_client::json_rpc_client(fc::url url, const std::optional<std::string>& user_agent,
+                                 endpoint_refresh_policy refresh_policy)
    : _url(std::move(url))
-     , _host()
-     , _port()
-     , _user_agent(user_agent.value_or(BOOST_BEAST_VERSION_STRING))
-     , _next_id(1)
-     , _resolved_endpoints()
-     , _resolved_endpoints_stale(false) {
+   , _host()
+   , _port()
+   , _user_agent(user_agent.value_or(BOOST_BEAST_VERSION_STRING))
+   , _next_id(1)
+   , _resolved_endpoints()
+   , _resolved_endpoints_stale(false)
+   , _refresh_policy(refresh_policy) {
    const auto scheme = _url.proto();
    FC_ASSERT(scheme == HTTP_SCHEME || scheme == HTTPS_SCHEME, "Unsupported URL scheme: {}", scheme);
    FC_ASSERT(_url.host(), "JSON-RPC URL is missing host");
@@ -376,7 +377,9 @@ void json_rpc_client::refresh_resolved_endpoints_with_active_deadline() {
 }
 
 void json_rpc_client::mark_resolved_endpoints_stale() {
-   _resolved_endpoints_stale = true;
+   if (_refresh_policy == endpoint_refresh_policy::on_connection_failure) {
+      _resolved_endpoints_stale = true;
+   }
 }
 
 const json_rpc_client::tcp::resolver::results_type& json_rpc_client::resolved_endpoints() {

--- a/libraries/libfc/test/network/test_json_rpc_client.cpp
+++ b/libraries/libfc/test/network/test_json_rpc_client.cpp
@@ -240,6 +240,25 @@ BOOST_AUTO_TEST_CASE(stale_endpoint_refresh_respects_expired_deadline) {
       is_resolve_timeout_error);
 }
 
+/// Callers that require bounded runtime behavior can retain the startup DNS result
+/// instead of re-entering platform DNS after a connection failure.
+BOOST_AUTO_TEST_CASE(endpoint_refresh_can_be_disabled) {
+   fc::network::json_rpc::json_rpc_client client(fc::url("http://localhost:" + std::to_string(closed_loopback_port())),
+                                                 std::nullopt, fc::network::json_rpc::endpoint_refresh_policy::never);
+
+   BOOST_CHECK_THROW(client.call("wire_cached_endpoint_probe"), fc::exception);
+
+   BOOST_CHECK_EXCEPTION(
+      [&] {
+         fc::task::deadline_scope deadline(fc::time_point::now() - fc::milliseconds(1));
+         client.call("wire_cached_endpoint_probe");
+      }(),
+      fc::timeout_exception,
+      [](const fc::exception& e) {
+         return e.to_detail_string().find("JSON-RPC connect timed out") != std::string::npos;
+      });
+}
+
 /// A peer that completes HTTP 200 with an oversized body must be rejected by
 /// the transport parser before JSON parsing or outpost envelope decoding.
 BOOST_AUTO_TEST_CASE(call_rejects_oversized_response_body) {

--- a/libraries/libfc/test/parallel/test_worker_task_queue.cpp
+++ b/libraries/libfc/test/parallel/test_worker_task_queue.cpp
@@ -71,8 +71,64 @@ BOOST_AUTO_TEST_CASE(push_after_stop_is_noop) {
    q->stop();
    q->push(1);
    q->push(2);
+   BOOST_TEST(!q->try_push(3));
    BOOST_TEST(processed.load() == 0);
    BOOST_TEST(q->size() == 0u);
+}
+
+/// Appending capacity to the public aggregate preserves the meaning of legacy
+/// five-field positional initializers.
+BOOST_AUTO_TEST_CASE(config_positional_initialization_remains_compatible) {
+   const worker_task_queue_config config{false, true, 1, false, true};
+
+   BOOST_TEST(!config.dynamic_size);
+   BOOST_TEST(config.reuse_thread);
+   BOOST_TEST(config.max_threads == 1u);
+   BOOST_TEST(!config.prune_threads);
+   BOOST_TEST(config.skip_autostart);
+   BOOST_TEST(!config.max_pending_items.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(bounded_queue_rejects_items_beyond_pending_limit) {
+   auto q =
+      worker_task_queue<int>::create({.max_threads = 1, .skip_autostart = true, .max_pending_items = 2}, [](int&) {});
+
+   BOOST_TEST(q->try_push(1));
+   BOOST_TEST(q->try_push(2));
+   BOOST_TEST(!q->try_push(3));
+   BOOST_TEST(q->size() == 2u);
+
+   q->stop();
+}
+
+/// A callback already in progress does not consume pending capacity, while a stalled callback
+/// cannot allow the waiting queue to grow past its configured bound.
+BOOST_AUTO_TEST_CASE(bounded_queue_stays_bounded_behind_blocked_worker) {
+   constexpr std::size_t pending_limit = 2;
+   std::atomic<int> processed{0};
+   std::latch callback_started(1);
+   std::latch release_callback(1);
+
+   auto q = worker_task_queue<int>::create({.max_threads = 1, .max_pending_items = pending_limit}, [&](int&) {
+      callback_started.count_down();
+      release_callback.wait();
+      ++processed;
+   });
+
+   BOOST_REQUIRE(q->try_push(0));
+   callback_started.wait();
+
+   BOOST_TEST(q->try_push(1));
+   BOOST_TEST(q->try_push(2));
+   BOOST_TEST(!q->try_push(3));
+   BOOST_TEST(q->size() == pending_limit);
+
+   release_callback.count_down();
+   while (processed.load() < 3)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+   q->stop();
+   BOOST_TEST(processed.load() == 3);
 }
 
 BOOST_AUTO_TEST_CASE(skip_autostart_requires_manual_start) {

--- a/plugins/external_debugging_plugin/include/sysio/external_debugging_plugin/debug_envelope_event_sink.hpp
+++ b/plugins/external_debugging_plugin/include/sysio/external_debugging_plugin/debug_envelope_event_sink.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <sysio/batch_operator_plugin/debug_envelope_event.hpp>
+
+namespace fc::parallel {
+template <typename T>
+class worker_task_queue;
+}
+
+namespace sysio::external_debugging {
+
+/** Bounded asynchronous sink for batch-operator debug-envelope events. */
+class debug_envelope_event_sink {
+public:
+   using event_type = opp::debugging::DebugEnvelopeEvent;
+   using callback_type = std::function<void(event_type&)>;
+
+   /** Create a running sink with a fixed pending-envelope capacity. */
+   debug_envelope_event_sink(std::size_t pending_capacity, callback_type callback);
+
+   /** Stop and join the worker before releasing queue storage. */
+   ~debug_envelope_event_sink();
+
+   debug_envelope_event_sink(const debug_envelope_event_sink&) = delete;
+   debug_envelope_event_sink& operator=(const debug_envelope_event_sink&) = delete;
+   debug_envelope_event_sink(debug_envelope_event_sink&&) = delete;
+   debug_envelope_event_sink& operator=(debug_envelope_event_sink&&) = delete;
+
+   /** Admit an event or record an explicit drop when the queue is unavailable. */
+   void enqueue(const event_type& event);
+
+   /** Stop accepting work and join the active callback. */
+   void stop();
+
+   /** Return the number of events rejected by bounded admission or shutdown. */
+   uint64_t dropped_envelopes() const;
+
+   /** Return the number of admitted events waiting behind the active callback. */
+   std::size_t pending_envelopes() const;
+
+   /** Return whether the queue can still dispatch callbacks. */
+   bool running() const;
+
+private:
+   using queue_type = fc::parallel::worker_task_queue<event_type>;
+
+   std::size_t _pending_capacity;
+   std::shared_ptr<queue_type> _queue;
+   std::atomic<uint64_t> _dropped_envelopes{0};
+   std::once_flag _stop_once;
+};
+
+using debug_envelope_slot = std::function<void(const debug_envelope_event_sink::event_type&)>;
+
+/** Build a signal slot that retains sink ownership through concurrent disconnect/shutdown. */
+debug_envelope_slot make_debug_envelope_slot(std::shared_ptr<debug_envelope_event_sink> sink);
+
+} // namespace sysio::external_debugging

--- a/plugins/external_debugging_plugin/src/debug_envelope_event_sink.cpp
+++ b/plugins/external_debugging_plugin/src/debug_envelope_event_sink.cpp
@@ -1,0 +1,58 @@
+#include <fc/log/logger.hpp>
+#include <fc/parallel/worker_task_queue.hpp>
+#include <sysio/external_debugging_plugin/debug_envelope_event_sink.hpp>
+#include <utility>
+
+namespace sysio::external_debugging {
+
+debug_envelope_event_sink::debug_envelope_event_sink(std::size_t pending_capacity, callback_type callback)
+   : _pending_capacity(pending_capacity)
+   , _queue(queue_type::create({.max_threads = 1, .max_pending_items = pending_capacity}, std::move(callback))) {}
+
+debug_envelope_event_sink::~debug_envelope_event_sink() {
+   stop();
+}
+
+void debug_envelope_event_sink::enqueue(const event_type& event) {
+   if (_queue->try_push(event)) {
+      return;
+   }
+
+   const auto total_dropped = _dropped_envelopes.fetch_add(1, std::memory_order_relaxed) + 1;
+   wlog("external_debugging_plugin: event not admitted; dropping epoch={} endpoints={} batch_op={} "
+        "pending={} capacity={} total_dropped={}",
+        std::get<0>(event), opp::debugging::DebugOutpostEndpointsType_Name(std::get<1>(event)),
+        std::get<2>(event).to_string(), _queue->size(), _pending_capacity, total_dropped);
+}
+
+void debug_envelope_event_sink::stop() {
+   std::call_once(_stop_once, [this] {
+      _queue->stop();
+      const auto discarded = _queue->discard_pending();
+      if (discarded == 0) {
+         return;
+      }
+
+      const auto total_dropped = _dropped_envelopes.fetch_add(discarded, std::memory_order_relaxed) + discarded;
+      wlog("external_debugging_plugin: discarding {} pending envelopes during shutdown; total_dropped={}", discarded,
+           total_dropped);
+   });
+}
+
+uint64_t debug_envelope_event_sink::dropped_envelopes() const {
+   return _dropped_envelopes.load(std::memory_order_relaxed);
+}
+
+std::size_t debug_envelope_event_sink::pending_envelopes() const {
+   return _queue->size();
+}
+
+bool debug_envelope_event_sink::running() const {
+   return _queue->running();
+}
+
+debug_envelope_slot make_debug_envelope_slot(std::shared_ptr<debug_envelope_event_sink> sink) {
+   return [sink = std::move(sink)](const debug_envelope_event_sink::event_type& event) { sink->enqueue(event); };
+}
+
+} // namespace sysio::external_debugging

--- a/plugins/external_debugging_plugin/src/external_debugging_plugin.cpp
+++ b/plugins/external_debugging_plugin/src/external_debugging_plugin.cpp
@@ -1,8 +1,10 @@
 #include <boost/signals2/connection.hpp>
 #include <fc/log/logger.hpp>
 #include <fc/network/json_rpc/json_rpc_client.hpp>
-#include <fc/parallel/worker_task_queue.hpp>
+#include <fc/task/deadline.hpp>
 #include <sysio/batch_operator_plugin/batch_operator_plugin.hpp>
+#include <sysio/chain/exceptions.hpp>
+#include <sysio/external_debugging_plugin/debug_envelope_event_sink.hpp>
 #include <sysio/external_debugging_plugin/external_debugging_plugin.hpp>
 #include <sysio/external_debugging_plugin/external_debugging_rpc_client.hpp>
 #include <sysio/opp/debugging/debugging.pb.h>
@@ -15,26 +17,36 @@ namespace rpc = fc::network::json_rpc;
 
 namespace {
 constexpr auto option_name_ext_debugging_server = "ext-debugging-server";
+constexpr auto option_name_ext_debugging_max_pending_envelopes = "ext-debugging-max-pending-envelopes";
+constexpr auto option_name_ext_debugging_request_timeout_ms = "ext-debugging-request-timeout-ms";
+constexpr uint32_t default_max_pending_envelopes = 16;
+constexpr uint32_t default_request_timeout_ms = 5'000;
 }
 
 struct external_debugging_plugin::impl {
    std::string server_url;
    bool enabled = false;
+   uint32_t max_pending_envelopes = default_max_pending_envelopes;
+   uint32_t request_timeout_ms = default_request_timeout_ms;
 
    // Signal connection to batch_operator_plugin
    std::optional<scoped_connection> bo_signal_connection;
 
-   // RPC client — created on startup after server validation
+   // RPC client — resolves once at startup and then uses request deadlines
    std::unique_ptr<rpc::json_rpc_client> rpc_client;
 
-   // Async event delivery queue
-   std::shared_ptr<fc::parallel::worker_task_queue<opp::debugging::DebugEnvelopeEvent>> event_queue;
+   // Async event delivery sink
+   std::shared_ptr<external_debugging::debug_envelope_event_sink> event_sink;
+
+   /** Return the absolute deadline for one debugging-server request. */
+   fc::time_point next_request_deadline() const { return fc::time_point::now() + fc::milliseconds(request_timeout_ms); }
 
    // ------------------------------------------------------------------
    //  Serialize DebugEnvelopeEvent to PutEnvelopeRequest and send
    //  via typed protobuf RPC. No manual JSON construction.
    // ------------------------------------------------------------------
    void send_envelope(opp::debugging::DebugEnvelopeEvent& event) {
+      fc::task::deadline_scope request_deadline(next_request_deadline());
       auto& [epoch_index, endpoints_type, batch_op_name, envelope_data] = event;
 
       opp::debugging::PutEnvelopeRequest req;
@@ -45,7 +57,7 @@ struct external_debugging_plugin::impl {
       auto res =
          sysio::debugging::rpc_client::execute<opp::debugging::PutEnvelopeResponse>(*rpc_client, debugging::rpc_client::api_paths::opp_envelope, req);
 
-      ilog("external_debugging_pplugin: send_envelope: delivered epoch={} endpoints={} batch_op={} "
+      ilog("external_debugging_plugin: send_envelope: delivered epoch={} endpoints={} batch_op={} "
            "({} bytes) -> key={} existed={}",
            epoch_index, opp::debugging::DebugOutpostEndpointsType_Name(endpoints_type), batch_op_name.to_string(),
            envelope_data.size(), res.key(), res.data_existed());
@@ -56,6 +68,7 @@ struct external_debugging_plugin::impl {
    // ------------------------------------------------------------------
    bool validate_server() {
       try {
+         fc::task::deadline_scope request_deadline(next_request_deadline());
          rpc_client->send_http(rpc::http_verb::GET, debugging::rpc_client::api_paths::ping);
          return true;
       } catch (const fc::exception& e) {
@@ -79,9 +92,26 @@ void external_debugging_plugin::set_program_options(options_description& cli, op
    opts(option_name_ext_debugging_server, bpo::value<std::string>(),
         "URL of the external debugging server (e.g. http://localhost:9876). "
         "If not provided, OPP tracking is disabled.");
+   opts(option_name_ext_debugging_max_pending_envelopes,
+        bpo::value<uint32_t>()->default_value(default_max_pending_envelopes),
+        "Maximum debugging envelopes waiting behind the active server request.");
+   opts(option_name_ext_debugging_request_timeout_ms, bpo::value<uint32_t>()->default_value(default_request_timeout_ms),
+        "Maximum time in milliseconds for each debugging-server request.");
 }
 
 void external_debugging_plugin::plugin_initialize(const variables_map& options) {
+   if (options.contains(option_name_ext_debugging_max_pending_envelopes)) {
+      _impl->max_pending_envelopes = options[option_name_ext_debugging_max_pending_envelopes].as<uint32_t>();
+   }
+   if (options.contains(option_name_ext_debugging_request_timeout_ms)) {
+      _impl->request_timeout_ms = options[option_name_ext_debugging_request_timeout_ms].as<uint32_t>();
+   }
+
+   SYS_ASSERT(_impl->max_pending_envelopes > 0, chain::plugin_config_exception, "--{} must be greater than 0",
+              option_name_ext_debugging_max_pending_envelopes);
+   SYS_ASSERT(_impl->request_timeout_ms > 0, chain::plugin_config_exception, "--{} must be greater than 0",
+              option_name_ext_debugging_request_timeout_ms);
+
    if (options.contains(option_name_ext_debugging_server)) {
       _impl->server_url = options[option_name_ext_debugging_server].as<std::string>();
       _impl->enabled = true;
@@ -97,15 +127,15 @@ void external_debugging_plugin::plugin_startup() {
    // Create RPC client pointed at the OPP base path —
    // json_rpc_client::call() POSTs JSON-RPC 2.0 to this URL
    auto rpc_url = _impl->server_url + debugging::rpc_client::api_paths::opp_base;
-   _impl->rpc_client = std::make_unique<rpc::json_rpc_client>(fc::url(rpc_url));
+   _impl->rpc_client =
+      std::make_unique<rpc::json_rpc_client>(fc::url(rpc_url), std::nullopt, rpc::endpoint_refresh_policy::never);
 
    // Validate server connectivity
    FC_ASSERT(_impl->validate_server(), "External debugging server not reachable at {}", _impl->server_url);
 
-   // Start async event delivery queue
-   _impl->event_queue = fc::parallel::worker_task_queue<opp::debugging::DebugEnvelopeEvent>::create(
-      {.max_threads = 1},
-      [impl = _impl.get()](opp::debugging::DebugEnvelopeEvent& event) {
+   // Start the bounded asynchronous event sink
+   _impl->event_sink = std::make_shared<external_debugging::debug_envelope_event_sink>(
+      _impl->max_pending_envelopes, [impl = _impl.get()](opp::debugging::DebugEnvelopeEvent& event) {
          std::vector<char>& event_data = std::get<3>(event);
          opp::Envelope envelope;
          if (!envelope.ParseFromArray(event_data.data(), event_data.size())) {
@@ -123,28 +153,28 @@ void external_debugging_plugin::plugin_startup() {
 
          try {
             impl->send_envelope(event);
-
-         } FC_LOG_AND_DROP("external_debugging_plugin: error sending envelope to {}: {}", impl->server_url, event_json);
+         }
+         FC_LOG_AND_DROP("external_debugging_plugin: error sending envelope to {}: {}", impl->server_url, event_json);
       });
 
    // Connect to batch_operator_plugin signal
    auto& bo_plug = app().get_plugin<batch_operator_plugin>();
-   _impl->bo_signal_connection.emplace(bo_plug.debugging_opp_envelope().connect(
-      [impl = _impl.get()](const opp::debugging::DebugEnvelopeEvent& event) { impl->event_queue->push(event); }));
+   _impl->bo_signal_connection.emplace(
+      bo_plug.debugging_opp_envelope().connect(external_debugging::make_debug_envelope_slot(_impl->event_sink)));
 
    ilog("external_debugging_plugin: connected to batch_operator_plugin, "
-        "forwarding to {}",
-        _impl->server_url);
+        "forwarding to {} with pending_capacity={} request_timeout_ms={}",
+        _impl->server_url, _impl->max_pending_envelopes, _impl->request_timeout_ms);
 }
 
 void external_debugging_plugin::plugin_shutdown() {
    // Disconnect signal first
    _impl->bo_signal_connection.reset();
 
-   // Stop the event delivery queue (drains workers and joins)
-   if (_impl->event_queue) {
-      _impl->event_queue->stop();
-      _impl->event_queue.reset();
+   // Stop the event delivery sink (joins the active worker)
+   if (_impl->event_sink) {
+      _impl->event_sink->stop();
+      _impl->event_sink.reset();
    }
 
    ilog("external_debugging_plugin: shutdown complete");

--- a/plugins/external_debugging_plugin/test/main.cpp
+++ b/plugins/external_debugging_plugin/test/main.cpp
@@ -1,0 +1,2 @@
+#define BOOST_TEST_MODULE external_debugging_plugin
+#include <boost/test/included/unit_test.hpp>

--- a/plugins/external_debugging_plugin/test/test_external_debugging_plugin.cpp
+++ b/plugins/external_debugging_plugin/test/test_external_debugging_plugin.cpp
@@ -1,0 +1,136 @@
+#include <atomic>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <boost/test/unit_test.hpp>
+#include <cstdint>
+#include <latch>
+#include <memory>
+#include <set>
+#include <string>
+#include <sysio/chain/exceptions.hpp>
+#include <sysio/external_debugging_plugin/debug_envelope_event_sink.hpp>
+#include <sysio/external_debugging_plugin/external_debugging_plugin.hpp>
+#include <thread>
+#include <vector>
+
+namespace {
+
+/** Parse external-debugging configuration arguments through the plugin's public option surface. */
+boost::program_options::variables_map parse_options(sysio::external_debugging_plugin& plugin,
+                                                    const std::vector<std::string>& arguments) {
+   boost::program_options::options_description cli, cfg;
+   plugin.set_program_options(cli, cfg);
+
+   boost::program_options::variables_map options;
+   boost::program_options::store(boost::program_options::command_line_parser(arguments).options(cfg).run(), options);
+   boost::program_options::notify(options);
+   return options;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(external_debugging_plugin_tests)
+
+BOOST_AUTO_TEST_CASE(backpressure_options_are_registered) {
+   sysio::external_debugging_plugin plugin;
+   boost::program_options::options_description cli, cfg;
+   plugin.set_program_options(cli, cfg);
+
+   std::set<std::string> option_names;
+   for (const auto& option : cfg.options()) {
+      option_names.insert(option->long_name());
+   }
+
+   BOOST_TEST(option_names.contains("ext-debugging-server"));
+   BOOST_TEST(option_names.contains("ext-debugging-max-pending-envelopes"));
+   BOOST_TEST(option_names.contains("ext-debugging-request-timeout-ms"));
+}
+
+BOOST_AUTO_TEST_CASE(backpressure_defaults_are_bounded) {
+   sysio::external_debugging_plugin plugin;
+   const auto options = parse_options(plugin, {});
+
+   BOOST_TEST(options["ext-debugging-max-pending-envelopes"].as<uint32_t>() == 16u);
+   BOOST_TEST(options["ext-debugging-request-timeout-ms"].as<uint32_t>() == 5'000u);
+   BOOST_CHECK_NO_THROW(plugin.plugin_initialize(options));
+}
+
+BOOST_AUTO_TEST_CASE(zero_pending_capacity_is_rejected) {
+   sysio::external_debugging_plugin plugin;
+   const auto options = parse_options(plugin, {"--ext-debugging-max-pending-envelopes=0"});
+
+   BOOST_CHECK_THROW(plugin.plugin_initialize(options), sysio::chain::plugin_config_exception);
+}
+
+BOOST_AUTO_TEST_CASE(zero_request_timeout_is_rejected) {
+   sysio::external_debugging_plugin plugin;
+   const auto options = parse_options(plugin, {"--ext-debugging-request-timeout-ms=0"});
+
+   BOOST_CHECK_THROW(plugin.plugin_initialize(options), sysio::chain::plugin_config_exception);
+}
+
+BOOST_AUTO_TEST_CASE(debugging_server_hostname_remains_accepted) {
+   sysio::external_debugging_plugin plugin;
+   const auto options = parse_options(plugin, {"--ext-debugging-server=http://localhost:9876"});
+
+   BOOST_CHECK_NO_THROW(plugin.plugin_initialize(options));
+}
+
+BOOST_AUTO_TEST_CASE(event_sink_bounds_pending_envelopes_and_counts_drops) {
+   constexpr std::size_t pending_capacity = 2;
+   std::atomic<int> processed{0};
+   std::latch callback_started(1);
+   std::latch release_callback(1);
+
+   auto sink = std::make_shared<sysio::external_debugging::debug_envelope_event_sink>(
+      pending_capacity, [&](sysio::opp::debugging::DebugEnvelopeEvent&) {
+         callback_started.count_down();
+         release_callback.wait();
+         ++processed;
+      });
+   const sysio::opp::debugging::DebugEnvelopeEvent event{};
+
+   sink->enqueue(event);
+   callback_started.wait();
+   sink->enqueue(event);
+   sink->enqueue(event);
+   sink->enqueue(event);
+
+   BOOST_TEST(sink->pending_envelopes() == pending_capacity);
+   BOOST_TEST(sink->dropped_envelopes() == 1u);
+
+   std::thread stopper([&] { sink->stop(); });
+   while (sink->running())
+      std::this_thread::yield();
+   release_callback.count_down();
+   stopper.join();
+
+   BOOST_TEST(processed.load() == 1);
+   BOOST_TEST(sink->pending_envelopes() == 0u);
+   BOOST_TEST(sink->dropped_envelopes() == 3u);
+}
+
+/// The production slot owns the sink independently of the plugin's member so
+/// an in-flight emission remains safe after shutdown releases its owner.
+BOOST_AUTO_TEST_CASE(event_slot_retains_stopped_sink_through_owner_release) {
+   std::atomic<int> processed{0};
+   auto sink = std::make_shared<sysio::external_debugging::debug_envelope_event_sink>(
+      1, [&](sysio::opp::debugging::DebugEnvelopeEvent&) { ++processed; });
+   std::weak_ptr<sysio::external_debugging::debug_envelope_event_sink> weak_sink = sink;
+   auto slot = sysio::external_debugging::make_debug_envelope_slot(sink);
+
+   sink->stop();
+   sink.reset();
+   BOOST_TEST(!weak_sink.expired());
+
+   slot(sysio::opp::debugging::DebugEnvelopeEvent{});
+   BOOST_TEST(processed.load() == 0);
+   auto retained_sink = weak_sink.lock();
+   BOOST_REQUIRE(retained_sink);
+   BOOST_TEST(retained_sink->dropped_envelopes() == 1u);
+   retained_sink.reset();
+   slot = {};
+   BOOST_TEST(weak_sink.expired());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- bound the external debugging sink to a configurable number of pending OPP envelopes
- apply a configurable deadline to debugging-server validation and envelope delivery requests
- make queue admission, drop accounting, and shutdown safe under concurrent signal delivery
- preserve hostname configurations while preventing runtime requests from re-entering potentially unbounded DNS resolution

Jira: [SEC-67](https://wire-network.atlassian.net/browse/SEC-67)

## Root cause

The batch-operator debugging signal fed full OPP envelopes into an unbounded worker queue. If the optional debugging server accepted a connection but stopped responding, the single delivery worker remained occupied while subsequent envelopes accumulated without a memory bound.

## Changes

- add `--ext-debugging-max-pending-envelopes` with a default of 16 waiting envelopes
- add `--ext-debugging-request-timeout-ms` with a default of 5000 milliseconds
- add optional bounded admission and `try_push` support to `worker_task_queue` without changing existing unbounded callers
- introduce a dedicated debugging event sink that logs/counts rejected and shutdown-discarded envelopes
- disconnect, stop, join, and discard pending work safely during plugin shutdown
- add a JSON-RPC endpoint refresh policy; the debugging client resolves its configured hostname at startup and reuses that endpoint set for bounded runtime behavior
- add queue, transport policy, configuration, backpressure, drop-accounting, and shutdown-lifetime tests

## Operational impact

- the default memory bound is 16 waiting envelopes plus at most one active delivery
- a stalled debugging-server request releases the worker after five seconds by default
- existing hostname URLs such as `localhost` remain valid
- DNS changes to the debugging hostname require restarting `nodeop`
- both new limits are configurable and reject zero values

## Validation

- Release build targets: `test_fc`, `test_external_debugging_plugin`, and `nodeop`
- `test_fc`, `test_batch_operator_plugin`, and `test_external_debugging_plugin`: 3/3 passed
- focused `worker_task_queue_tests`: 12/12 passed
- `git diff --check`
- final review-specific agent pass: no remaining actionable findings


[SEC-67]: https://wire-network.atlassian.net/browse/SEC-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ