### PR TITLE
outpost_solana_client_plugin: --solana-outpost-program-name + required token custody

### DIFF
--- a/plugins/outpost_solana_client_plugin/README.md
+++ b/plugins/outpost_solana_client_plugin/README.md
@@ -78,6 +78,18 @@ Loads one or more Anchor IDL JSON files for use with `solana_program_client`:
 --solana-idl-file /path/to/counter.json /path/to/another_program.json
 ```
 
+#### `--solana-outpost-program-name` (optional, default `opp_outpost`)
+
+Anchor IDL program name of the Solana OPP outpost. When an outpost client is
+constructed, the loaded `--solana-idl-file` set is filtered to programs whose
+IDL name matches this value. The default targets the standalone `opp_outpost`
+program; the clean-room outpost implementation is hosted inside the
+`liqsol-core` program, whose generated IDL is named `liqsol_core`:
+
+```
+--solana-outpost-program-name liqsol_core
+```
+
 ### Full Example
 
 ```bash

--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin.hpp
@@ -11,9 +11,12 @@
 namespace sysio {
 using namespace fc::network::solana;
 
-/// Program name used in the Anchor IDL for the Solana OPP outpost. Shared
-/// between the outpost_solana_client_plugin and the batch_operator_plugin so
-/// both speak a single constant when locating the program's IDL entry.
+/// Default program name used in the Anchor IDL for the Solana OPP outpost.
+/// Shared between the outpost_solana_client_plugin and the batch_operator_plugin
+/// so both speak a single constant when locating the program's IDL entry.
+/// Overridable at runtime via `--solana-outpost-program-name`: the clean-room
+/// outpost implementation is hosted inside the `liqsol_core` program, whose
+/// generated IDL carries that name instead of `opp_outpost`.
 inline constexpr const char* OPP_SOLANA_OUTPOST_PROGRAM_NAME = "opp_outpost";
 
 /// Interval between successive `getSignaturesForAddress` + log-scan attempts
@@ -45,6 +48,23 @@ struct solana_client_entry_t {
 
 using solana_client_entry_ptr = std::shared_ptr<solana_client_entry_t>;
 
+/**
+ * @brief Filter loaded IDL definitions down to the OPP outpost program.
+ *
+ * Walks `idl_files` (shaped like `outpost_solana_client_plugin::get_idl_files()`)
+ * and returns every program definition whose IDL name equals `program_name`, so
+ * an outpost client is never constructed around an unrelated IDL.
+ *
+ * @param idl_files    Loaded IDL files: one `(path, programs)` pair per file.
+ * @param program_name IDL program name to match — the configured
+ *                     `--solana-outpost-program-name` (default
+ *                     `OPP_SOLANA_OUTPOST_PROGRAM_NAME`).
+ * @return Matching program definitions (empty when none match).
+ */
+std::vector<fc::network::solana::idl::program> filter_outpost_program_idls(
+   const std::vector<std::pair<std::filesystem::path, std::vector<fc::network::solana::idl::program>>>& idl_files,
+   std::string_view program_name);
+
 /// Typed program client for the Solana OPP outpost program. Mirrors the
 /// Ethereum `opp_contract_client` / `opp_inbound_contract_client` pattern —
 /// each `solana_program_tx_fn<RT, Args...>` is a strongly-typed wrapper that
@@ -54,8 +74,10 @@ using solana_client_entry_ptr = std::shared_ptr<solana_client_entry_t>;
 /// list, so the static PDAs are pre-derived from the program ID at construction
 /// and injected via account_overrides on every call.
 ///
-/// These signatures must stay in sync with `wire-solana/programs/opp-outpost/`
-/// (see its generated IDL at `wire-solana/target/idl/opp_outpost.json`).
+/// These signatures must stay in sync with the Solana OPP outpost program —
+/// since the clean-room rewrite it is hosted inside
+/// `wire-solana/programs/liqsol-core/` (`src/instructions/opp/`; generated IDL
+/// at `wire-solana/target/idl/liqsol_core.json`).
 struct opp_solana_outpost_client : fc::network::solana::solana_program_client {
    // Pre-computed static PDAs (deterministic from program_id).
    fc::network::solana::solana_public_key config_pda;
@@ -351,7 +373,8 @@ public:
     * @brief Build an `outpost_client` concrete for a Solana outpost.
     *
     * Resolves the shared chain-connection entry by id, filters the plugin's
-    * loaded IDLs down to those matching `OPP_SOLANA_OUTPOST_PROGRAM_NAME`,
+    * loaded IDLs down to those matching the configured
+    * `--solana-outpost-program-name` (default `OPP_SOLANA_OUTPOST_PROGRAM_NAME`),
     * and constructs an `outpost_solana_client` bound to the given program id.
     *
     * @param sol_client_id  Id passed to `--outpost-solana-client`.

--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
@@ -80,9 +80,13 @@ private:
       uint8_t                                custody_decimals = 0;
    };
 
-   /// Resolve the pinned terminal-finalization facts stored on a per-reserve
-   /// PDA. Reserve-backed effects must not infer native-vs-SPL or decimals
-   /// from mutable `OutpostConfig` rows after the reserve has been created.
+   /// Resolve the terminal-finalization facts for a per-reserve PDA:
+   /// `creator` from the `Reserve` account, custody (mint / decimals) from
+   /// the `OutpostConfig` maps keyed by `token_code`. The clean-room outpost
+   /// program resolves custody from `config.token_addresses_by_code` at
+   /// dispatch time (`Reserve` carries no custody fields), so the relay
+   /// mirrors that lookup to stay account-consistent with the on-chain
+   /// handlers.
    std::optional<reserve_terminal_info>
    reserve_info_for_codes(uint64_t token_code, uint64_t reserve_code);
 
@@ -97,6 +101,27 @@ private:
 using outpost_solana_client_ptr = std::shared_ptr<outpost_solana_client>;
 
 namespace outpost_solana_client_detail {
+
+/// Custody binding for a `token_code`, resolved from the outpost's
+/// `OutpostConfig` maps. The clean-room program pins custody on the config
+/// (`token_addresses_by_code` / `precision_by_token_code`) instead of
+/// denormalizing it onto each `Reserve` account.
+struct token_custody_info {
+   /// SPL mint for the token, or the all-zero system-program key when the
+   /// token is native lamports (the on-chain zero-marker convention).
+   fc::network::solana::solana_public_key mint;
+   /// Chain-native decimals for the token.
+   uint8_t decimals = 0;
+};
+
+/// Resolve `token_code`'s custody binding from a decoded `OutpostConfig`
+/// account object. BOTH entries are required — same contract as
+/// wire-ethereum's `ReserveManager` (`WIRE_TokenPrecisionUnset`) and the
+/// program's own `PrecisionUnconfigured` / `TokenCodeNotConfigured` gates:
+/// a missing address or precision entry throws instead of silently
+/// defaulting. Native custody is expressed by an EXPLICIT zero-mint entry.
+token_custody_info resolve_token_custody(const fc::variant_object& outpost_config,
+                                         uint64_t token_code);
 
 /// Append `key` to `metas`, or merge its writable flag into the existing
 /// entry when an earlier terminal effect already required the same account.

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
@@ -362,6 +362,46 @@ extract_inbound_reserve_create_cancelled_seeds(const std::vector<char>& envelope
    return seeds;
 }
 
+token_custody_info resolve_token_custody(const fc::variant_object& outpost_config,
+                                         uint64_t token_code) {
+   token_custody_info custody;
+   bool address_found   = false;
+   bool precision_found = false;
+
+   if (outpost_config.contains("token_addresses_by_code")) {
+      for (const auto& entry_v : outpost_config["token_addresses_by_code"].get_array()) {
+         const auto& entry = entry_v.get_object();
+         if (entry["token_code"].as_uint64() == token_code) {
+            custody.mint =
+               fc::network::solana::solana_public_key::from_base58_string(entry["mint"].as_string());
+            address_found = true;
+            break;
+         }
+      }
+   }
+   FC_ASSERT(address_found,
+             "token address binding unconfigured for token_code {} — the outpost's "
+             "token_addresses_by_code map must carry an explicit entry (zero mint = native)",
+             token_code);
+
+   if (outpost_config.contains("precision_by_token_code")) {
+      for (const auto& entry_v : outpost_config["precision_by_token_code"].get_array()) {
+         const auto& entry = entry_v.get_object();
+         if (entry["token_code"].as_uint64() == token_code) {
+            custody.decimals  = static_cast<uint8_t>(entry["decimals"].as_uint64());
+            precision_found = true;
+            break;
+         }
+      }
+   }
+   FC_ASSERT(precision_found,
+             "token precision unconfigured for token_code {} — required, same as "
+             "wire-ethereum's WIRE_TokenPrecisionUnset and the program's PrecisionUnconfigured",
+             token_code);
+
+   return custody;
+}
+
 } // namespace outpost_solana_client_detail
 
 outpost_solana_client::outpost_solana_client(
@@ -377,8 +417,7 @@ outpost_solana_client::outpost_solana_client(
    FC_ASSERT(_entry && _entry->client,
              "solana_client_entry must carry a client");
    FC_ASSERT(!program_idls.empty(),
-             "Solana outpost requires at least one IDL for program '{}'",
-             OPP_SOLANA_OUTPOST_PROGRAM_NAME);
+             "Solana outpost requires at least one program IDL");
 
    _program_client = std::make_shared<opp_solana_outpost_client>(
       _entry->client, _program_id, program_idls);
@@ -413,13 +452,24 @@ outpost_solana_client::reserve_info_for_codes(uint64_t token_code, uint64_t rese
    const auto reserve_v = _program_client->decode_account_info_data("Reserve", account_info->data);
    const auto& reserve = reserve_v.get_object();
    FC_ASSERT(reserve.contains("creator"), "Reserve account missing creator field");
-   FC_ASSERT(reserve.contains("custody_mint"), "Reserve account missing custody_mint field");
-   FC_ASSERT(reserve.contains("custody_decimals"), "Reserve account missing custody_decimals field");
+
+   // Custody (mint / decimals) lives on the OutpostConfig maps keyed by
+   // token_code — the clean-room program resolves it there at dispatch time,
+   // so the relay mirrors that lookup to stay account-consistent with the
+   // on-chain handlers.
+   const auto config_info = _entry->client->get_account_info(_program_client->config_pda);
+   FC_ASSERT(config_info.has_value() && !config_info->data.empty(),
+             "OutpostConfig account missing at {} — outpost not initialized",
+             _program_client->config_pda.to_string(fc::yield_function_t{}));
+   const auto config_v =
+      _program_client->decode_account_info_data("OutpostConfig", config_info->data);
+   const auto custody =
+      outpost_solana_client_detail::resolve_token_custody(config_v.get_object(), token_code);
 
    return reserve_terminal_info{
       fc::network::solana::solana_public_key::from_base58_string(reserve["creator"].as_string()),
-      fc::network::solana::solana_public_key::from_base58_string(reserve["custody_mint"].as_string()),
-      static_cast<uint8_t>(reserve["custody_decimals"].as_uint64())
+      custody.mint,
+      custody.decimals
    };
 }
 

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
@@ -7,8 +7,9 @@
 namespace sysio {
 
 namespace {
-constexpr auto option_name_client = "outpost-solana-client";
-constexpr auto option_idl_file    = "solana-idl-file";
+constexpr auto option_name_client          = "outpost-solana-client";
+constexpr auto option_idl_file             = "solana-idl-file";
+constexpr auto option_outpost_program_name = "solana-outpost-program-name";
 
 [[maybe_unused]] inline fc::logger& logger() {
    static fc::logger log{"outpost_solana_client_plugin"};
@@ -20,8 +21,18 @@ class outpost_solana_client_plugin_impl {
    std::map<std::string, solana_client_entry_ptr> _clients{};
    using file_idl_programs_t = std::pair<std::filesystem::path, std::vector<fc::network::solana::idl::program>>;
    std::vector<file_idl_programs_t> _idl_files{};
+   std::string _outpost_program_name{OPP_SOLANA_OUTPOST_PROGRAM_NAME};
 
 public:
+   void set_outpost_program_name(std::string name) {
+      FC_ASSERT(!name.empty(), "--{} cannot be empty", option_outpost_program_name);
+      _outpost_program_name = std::move(name);
+   }
+
+   const std::string& outpost_program_name() const {
+      return _outpost_program_name;
+   }
+
    std::vector<file_idl_programs_t> load_idl_files(const std::vector<std::filesystem::path>& file_names) {
       static std::mutex mutex;
       std::scoped_lock lock(mutex);
@@ -68,6 +79,8 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
       auto& idl_files = options.at(option_idl_file).as<std::vector<std::filesystem::path>>();
       my->load_idl_files(idl_files);
    }
+   my->set_outpost_program_name(options.at(option_outpost_program_name).as<std::string>());
+   ilog("Solana OPP outpost program name: {}", my->outpost_program_name());
    FC_ASSERT(options.count(option_name_client),
              "At least one solana client argument is required {}",
              option_name_client);
@@ -109,7 +122,13 @@ void outpost_solana_client_plugin::set_program_options(options_description& cli,
       "Format: `<sol-client-id>,<sig-provider-id>,<rpc-url>`")(
       option_idl_file,
       boost::program_options::value<std::vector<std::filesystem::path>>()->multitoken(),
-      "Solana program IDL file(s). Expects each file to be a JSON IDL (Anchor format) program definition.");
+      "Solana program IDL file(s). Expects each file to be a JSON IDL (Anchor format) program definition.")(
+      option_outpost_program_name,
+      boost::program_options::value<std::string>()->default_value(OPP_SOLANA_OUTPOST_PROGRAM_NAME),
+      "Anchor IDL program name of the Solana OPP outpost. The loaded --solana-idl-file set is filtered to "
+      "programs with this name when constructing outpost clients. The default targets the standalone "
+      "opp_outpost program; pass liqsol_core when the outpost interface is hosted inside the liqsol-core "
+      "program (clean-room layout).");
 }
 
 void outpost_solana_client_plugin::plugin_shutdown() {
@@ -140,22 +159,32 @@ outpost_solana_client_plugin::create_outpost_client(const std::string& sol_clien
 
    auto program_key = fc::crypto::solana::solana_public_key::from_base58_string(program_id);
 
-   // Filter the loaded IDL set down to programs whose name matches the OPP
-   // outpost program so we don't construct a client around an unrelated IDL.
+   // Filter the loaded IDL set down to programs whose name matches the
+   // configured OPP outpost program name so we don't construct a client
+   // around an unrelated IDL.
+   auto program_idls = filter_outpost_program_idls(my->get_idl_files(), my->outpost_program_name());
+   FC_ASSERT(!program_idls.empty(),
+             "IDL for program '{}' not loaded — pass --solana-idl-file (and --{} when the outpost "
+             "IDL uses a different program name)",
+             my->outpost_program_name(),
+             option_outpost_program_name);
+
+   return std::make_shared<outpost_solana_client>(
+      entry, program_key, std::move(program_idls), chain_code, chain_id);
+}
+
+std::vector<fc::network::solana::idl::program> filter_outpost_program_idls(
+   const std::vector<std::pair<std::filesystem::path, std::vector<fc::network::solana::idl::program>>>& idl_files,
+   std::string_view program_name) {
    std::vector<fc::network::solana::idl::program> program_idls;
-   for (auto& [path, programs] : my->get_idl_files()) {
+   for (auto& [path, programs] : idl_files) {
       for (auto& p : programs) {
-         if (p.name == OPP_SOLANA_OUTPOST_PROGRAM_NAME) {
+         if (p.name == program_name) {
             program_idls.push_back(p);
          }
       }
    }
-   FC_ASSERT(!program_idls.empty(),
-             "IDL for program '{}' not loaded — pass --solana-idl-file",
-             OPP_SOLANA_OUTPOST_PROGRAM_NAME);
-
-   return std::make_shared<outpost_solana_client>(
-      entry, program_key, std::move(program_idls), chain_code, chain_id);
+   return program_idls;
 }
 
 } // namespace sysio

--- a/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
@@ -291,6 +291,92 @@ BOOST_AUTO_TEST_CASE(can_load_opp_outpost_idl) try {
    BOOST_CHECK(has_emit);
 } FC_LOG_AND_RETHROW();
 
+BOOST_AUTO_TEST_CASE(filter_outpost_program_idls_selects_configured_name) try {
+   std::vector<std::pair<std::filesystem::path, std::vector<idl::program>>> idl_files;
+   idl_files.emplace_back("counter.json",
+                          std::vector<idl::program>{load_idl_fixture(counter_anchor_idl_fixture)});
+   idl_files.emplace_back("outpost.json",
+                          std::vector<idl::program>{load_idl_fixture(opp_outpost_idl_fixture)});
+
+   // The default constant selects the standalone outpost program's IDL only.
+   auto defaults =
+      sysio::filter_outpost_program_idls(idl_files, sysio::OPP_SOLANA_OUTPOST_PROGRAM_NAME);
+   BOOST_REQUIRE_EQUAL(defaults.size(), 1u);
+   BOOST_CHECK_EQUAL(defaults.front().name, "opp_outpost");
+
+   // A configured `--solana-outpost-program-name` override (e.g. liqsol_core
+   // hosting the outpost interface) selects by the overridden name instead.
+   auto counter = sysio::filter_outpost_program_idls(idl_files, "counter_anchor");
+   BOOST_REQUIRE_EQUAL(counter.size(), 1u);
+   BOOST_CHECK_EQUAL(counter.front().name, "counter_anchor");
+
+   // No loaded IDL with the configured name -> empty (create_outpost_client
+   // FC_ASSERTs on this with a remediation message).
+   BOOST_CHECK(sysio::filter_outpost_program_idls(idl_files, "liqsol_core").empty());
+   BOOST_CHECK(sysio::filter_outpost_program_idls({}, sysio::OPP_SOLANA_OUTPOST_PROGRAM_NAME).empty());
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(outpost_program_name_default_is_opp_outpost) try {
+   // The option default is back-compat load-bearing: pre-cleanroom deployments
+   // pass no --solana-outpost-program-name and must keep matching opp_outpost.
+   BOOST_CHECK_EQUAL(std::string{sysio::OPP_SOLANA_OUTPOST_PROGRAM_NAME}, "opp_outpost");
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(resolve_token_custody_reads_outpost_config_maps) try {
+   using sysio::outpost_solana_client_detail::resolve_token_custody;
+
+   const auto spl_mint      = measurement_pubkey(77);
+   const auto native_marker = system::program_ids::SYSTEM_PROGRAM;
+
+   fc::variants addresses;
+   addresses.push_back(fc::mutable_variant_object("token_code", 111)(
+      "mint", spl_mint.to_string(fc::yield_function_t{})));
+   addresses.push_back(fc::mutable_variant_object("token_code", 222)(
+      "mint", native_marker.to_string(fc::yield_function_t{})));
+   fc::variants precisions;
+   precisions.push_back(fc::mutable_variant_object("token_code", 111)("decimals", 6));
+   precisions.push_back(fc::mutable_variant_object("token_code", 222)("decimals", 9));
+
+   const fc::variant_object config =
+      fc::mutable_variant_object("token_addresses_by_code", std::move(addresses))(
+         "precision_by_token_code", std::move(precisions));
+
+   // SPL binding: configured mint + configured decimals.
+   const auto spl = resolve_token_custody(config, 111);
+   BOOST_CHECK(spl.mint == spl_mint);
+   BOOST_CHECK_EQUAL(static_cast<unsigned>(spl.decimals), 6u);
+
+   // Explicit zero-mint binding (the harness registers native SOL this way):
+   // native custody + its configured precision.
+   const auto native = resolve_token_custody(config, 222);
+   BOOST_CHECK(native.mint == native_marker);
+   BOOST_CHECK_EQUAL(static_cast<unsigned>(native.decimals), 9u);
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(resolve_token_custody_requires_both_config_entries) try {
+   using sysio::outpost_solana_client_detail::resolve_token_custody;
+
+   const auto spl_mint = measurement_pubkey(78);
+   fc::variants addresses;
+   addresses.push_back(fc::mutable_variant_object("token_code", 111)(
+      "mint", spl_mint.to_string(fc::yield_function_t{})));
+
+   // Address bound but precision missing -> throws (wire-ethereum
+   // WIRE_TokenPrecisionUnset parity; program PrecisionUnconfigured parity).
+   const fc::variant_object address_only =
+      fc::mutable_variant_object("token_addresses_by_code", addresses)(
+         "precision_by_token_code", fc::variants{});
+   BOOST_CHECK_THROW(resolve_token_custody(address_only, 111), fc::assert_exception);
+
+   // Unknown token_code entirely -> throws on the address requirement.
+   BOOST_CHECK_THROW(resolve_token_custody(address_only, 999), fc::assert_exception);
+
+   // Config carrying no maps at all -> throws.
+   BOOST_CHECK_THROW(
+      resolve_token_custody(fc::variant_object{fc::mutable_variant_object{}}, 111),
+      fc::assert_exception);
+} FC_LOG_AND_RETHROW();
+
 BOOST_AUTO_TEST_CASE(opp_outpost_epoch_in_has_chunked_args) try {
    auto prog = load_idl_fixture(opp_outpost_idl_fixture);
 

--- a/tests/fixtures/sec-94-solana-terminal-budget.json
+++ b/tests/fixtures/sec-94-solana-terminal-budget.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "description": "SEC-94 terminal epoch_in legacy-transaction budget fixture. The dynamic accounts are modeled as distinct remaining_accounts, which upper-bounds packet/account-key growth when shared programs dedupe with the static IDL accounts.",
-  "program": "opp_outpost",
+  "program": "liqsol_core",
   "instruction": "epoch_in",
-  "program_id": "2FcAgnSdn29VXZ3eF2jS4U4KzGaYm5M9Wha1CtArm9EU",
+  "program_id": "5nBtmutQLrRKBUxNfHJPDjiW5u8id6QM9Hhjg1D1g1XH",
   "legacy_packet_limit_bytes": 1232,
   "runtime_account_limit": 64,
   "legacy_account_key_limit": 256,


### PR DESCRIPTION
## Summary

Chained onto #511 (`feature/packaging-deb-rpm-portable`) — this PR carries ONLY the Solana-outpost plugin change on top of the packaging branch.

- **New `--solana-outpost-program-name` option** (default `opp_outpost`) on `outpost_solana_client_plugin` selects which program IDL hosts the OPP outpost. The wire-solana cleanroom moved the outpost interface inside the `liqsol_core` Anchor program, so the wire-tools-ts harness passes `liqsol_core`; IDL filtering (`filter_outpost_program_idls`) and the create-client assert carry the configured name.
- **`resolve_token_custody`**: mint + decimals resolve from `OutpostConfig.token_addresses_by_code` / `precision_by_token_code` and **both entries are REQUIRED** (parity with wire-ethereum's `WIRE_TokenPrecisionUnset` and the program's `PrecisionUnconfigured`); the zero mint is the native marker. `reserve_info_for_codes` reads custody from config at dispatch time (cleanroom `Reserve`s carry no custody fields).
- **SEC-94 terminal-budget fixture** identity updated to `liqsol_core` (measurements byte-identical: account count, discriminator, and args are unchanged; numbers verified equal to wire-solana's copy).
- Plugin tests: IDL-name filtering, default constant, custody resolution + required-entry throws — **29/29 green**.

## Merge order

**Merge this repo's chain before (or with) the wire-tools-ts companion** — an updated harness against an older nodeop fails with `Unknown option: --solana-outpost-program-name`.

## Companions

- `Wire-Network/wire-solana` PR #374 (cleanroom parity port; held for the e2e gate)
- `Wire-Network/wire-tools-ts` branch `fix/solana-opp-integration` (harness retarget; PR follows the green e2e run)

## Validation

- Plugin unit tests 29/29; contracts_unit_test + test_fc green on the pre-rebase base (master); nodeop `--help` exposes the option.
- All 13 wire-tools-ts flows green locally against this plugin change.
- The chained combination (this branch = packaging + this commit) is validated by the cross-repo `e2e-tests` dispatch over `fix/solana-opp-integration` in wire-sysio/wire-tools-ts/wire-solana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
