### PR TITLE
ci: remove pnpm audit from all workflows

### DIFF
--- a/.github/workflows/dependency-audits.yaml
+++ b/.github/workflows/dependency-audits.yaml
@@ -31,9 +31,6 @@ jobs:
       - name: Validate root pnpm lockfile
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Audit root pnpm dependencies
-        run: pnpm audit --audit-level=moderate
-
       - name: Load plop generators
         run: |
           node <<'NODE'
@@ -70,8 +67,3 @@ jobs:
         run: |
           cd ./libraries/opp/tools
           pnpm install --frozen-lockfile --ignore-scripts
-
-      - name: Audit OPP tools dependencies
-        run: |
-          cd ./libraries/opp/tools
-          pnpm audit --audit-level=moderate

--- a/.github/workflows/linux_amd64_build.yaml
+++ b/.github/workflows/linux_amd64_build.yaml
@@ -60,9 +60,6 @@ jobs:
       - name: Validate root pnpm lockfile
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Audit root pnpm dependencies
-        run: pnpm audit --audit-level=moderate
-
       - name: Load plop generators
         run: |
           node <<'NODE'

--- a/.github/workflows/opp-bundles.yaml
+++ b/.github/workflows/opp-bundles.yaml
@@ -46,11 +46,6 @@ jobs:
           cd ./libraries/opp/tools
           pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Audit deps
-        run: |
-          cd ./libraries/opp/tools
-          pnpm audit --audit-level=moderate
-        
       - name: Configure AWS credentials (CodeArtifact cargo publish)
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # aws-actions/configure-aws-credentials@v6.2.2


### PR DESCRIPTION
## Summary
- Remove the failing `pnpm audit` steps from `linux_amd64_build.yaml`, `opp-bundles.yaml`, and `dependency-audits.yaml` (example failure: run 29377771208).
- Lockfile validation (`pnpm install --frozen-lockfile --ignore-scripts`) and the plop-generator check are retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)