### PR TITLE
batch_operator: drop the operator-side bootstrap push

### DIFF
--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -63,7 +63,6 @@ namespace {
       constexpr auto table_outenvelopes  = "outenvelopes";
       constexpr auto action_deliver      = "deliver";
       constexpr auto action_chkcons      = "chkcons";
-      constexpr auto action_bootstrap    = "bootstrap";
       /// Field names on `envelope_entry` / `outbound_envelope` rows.
       namespace field {
          constexpr auto chain_code     = "chain_code";
@@ -470,19 +469,15 @@ struct batch_operator_plugin::impl {
       auto [ok, epoch_index] = parse_epoch_state();
       if (!ok) return;
 
-      // Genesis bootstrap: if epoch has never been advanced (epoch == 0),
-      // trigger the first advance via msgch::bootstrap.
-      // Post-genesis: advance is triggered by evalcons consensus, not by batch operators.
-      if (epoch_index == 0) {
-         try {
-            push_action(msgch::account, msgch::action_bootstrap, operator_account,
-                        fc::mutable_variant_object());
-            auto [ok2, epoch_index2] = parse_epoch_state();
-            if (ok2) epoch_index = epoch_index2;
-         } catch (const fc::exception& e) {
-            dlog("batch_operator: bootstrap skipped — {}", e.to_string());
-         }
-      }
+      // The genesis advance (epoch 0 -> 1) is a SYSTEM responsibility, not a
+      // batch operator's: `sysio.msgch::bootstrap` gates on
+      // `require_auth(get_self())`, so only the holder of `sysio.msgch`'s own
+      // authority (the genesis / bootstrap process) can trigger it. A batch
+      // operator signs with its own account authority, so an operator-side push
+      // fails unconditionally with `missing authority of sysio.msgch` before the
+      // epoch check — it never advanced anything, it only produced boot-window
+      // error-log noise. From epoch 1 onward, `advance` re-arms itself via
+      // `evalcons` consensus; batch operators never trigger it.
 
       if (!is_elected) {
          if (epoch_index != current_epoch) {


### PR DESCRIPTION
## Stacked on #520

Base is `fix/chain-plugin-sync-gate` (PR #520 — the chain_plugin sync gate). This PR is the **one-file follow-up** the sync-gate PR called out as out-of-scope. Review #520 first; GitHub will auto-retarget this to `master` once #520 merges.

## Problem

`batch_operator_plugin::do_poll_epoch_state` pushed `sysio.msgch::bootstrap` at epoch 0 to trigger the genesis advance — signed with the **operator's own account authority**. But `msgch::bootstrap` gates on `require_auth(get_self())` (i.e. `sysio.msgch`'s own authority), so the chain rejected the push **unconditionally** with `missing authority of sysio.msgch (3090004)`, before the `check(epoch == 0)` ever ran. It never advanced anything — it only emitted boot-window error-log noise (3 lines/run on the 9-op clusters).

The genesis advance is a **system responsibility**: only the holder of `sysio.msgch`'s authority (the genesis / bootstrap process; the harness in test clusters) can trigger it. From epoch 1 onward, `advance` re-arms itself via `evalcons` consensus — batch operators never trigger it.

## Change

Remove the `epoch == 0` bootstrap-push block from `do_poll_epoch_state` and the now-orphan `action_bootstrap` constant. One file, +9/−14.

## Verification

On top of #520:

- **Unit sweep 7/7 green** — `unit_test` 1507/1507, `contracts_unit_test`, `plugin_test`, `test_fc`, and the `test_chain_plugin` / `test_underwriter_plugin` / `test_batch_operator_plugin` binaries.
- **Full 13-flow suite: 13/13 SUCCEEDED** (fresh cluster per flow, canonical runner + heartbeat monitor, 8 concurrent).
  - `msgch::bootstrap 3090004` signature = **0 across all 13 clusters** (was 3× on the 9-op runs of the parent branch — this is exactly what the change removes).
  - `3060002/3060003` (the sync-gate target) still **0 across all 13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
