### PR TITLE
Batch_operator: drop the operator-side bootstrap push

### DIFF
--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -480,8 +480,12 @@ struct batch_operator_plugin::impl {
       // operator signs with its own account authority, so an operator-side push
       // fails unconditionally with `missing authority of sysio.msgch` before the
       // epoch check — it never advanced anything, it only produced boot-window
-      // error-log noise. From epoch 1 onward, `advance` re-arms itself via
-      // `evalcons` consensus; batch operators never trigger it.
+      // error-log noise. From epoch 1 onward batch operators still TRIGGER
+      // advancement — the elected operator's poll cranks `msgch::chkcons`
+      // (see poll_epoch_state), which sends the inline `sysio.epoch::advance`
+      // (again under msgch's own authority) once the per-outpost consensus
+      // recorded during `evalcons` dispatch and the epoch time gate are met —
+      // but they never AUTHORIZE bootstrap or advance directly.
 
       if (!is_elected) {
          if (epoch_index != current_epoch) {

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -64,7 +64,6 @@ namespace {
       constexpr auto table_outenvelopes  = "outenvelopes";
       constexpr auto action_deliver      = "deliver";
       constexpr auto action_chkcons      = "chkcons";
-      constexpr auto action_bootstrap    = "bootstrap";
       /// Field names on `envelope_entry` / `outbound_envelope` rows.
       namespace field {
          constexpr auto chain_code     = "chain_code";
@@ -474,19 +473,15 @@ struct batch_operator_plugin::impl {
       auto [ok, epoch_index] = parse_epoch_state();
       if (!ok) return;
 
-      // Genesis bootstrap: if epoch has never been advanced (epoch == 0),
-      // trigger the first advance via msgch::bootstrap.
-      // Post-genesis: advance is triggered by evalcons consensus, not by batch operators.
-      if (epoch_index == 0) {
-         try {
-            push_action(msgch::account, msgch::action_bootstrap, operator_account,
-                        fc::mutable_variant_object());
-            auto [ok2, epoch_index2] = parse_epoch_state();
-            if (ok2) epoch_index = epoch_index2;
-         } catch (const fc::exception& e) {
-            dlog("batch_operator: bootstrap skipped — {}", e.to_string());
-         }
-      }
+      // The genesis advance (epoch 0 -> 1) is a SYSTEM responsibility, not a
+      // batch operator's: `sysio.msgch::bootstrap` gates on
+      // `require_auth(get_self())`, so only the holder of `sysio.msgch`'s own
+      // authority (the genesis / bootstrap process) can trigger it. A batch
+      // operator signs with its own account authority, so an operator-side push
+      // fails unconditionally with `missing authority of sysio.msgch` before the
+      // epoch check — it never advanced anything, it only produced boot-window
+      // error-log noise. From epoch 1 onward, `advance` re-arms itself via
+      // `evalcons` consensus; batch operators never trigger it.
 
       if (!is_elected) {
          if (epoch_index != current_epoch) {


### PR DESCRIPTION
## Stacked on #522

Base is `fix/chain-plugin-sync-gate-channel` (#522, the sync-gate replacement for #520). This restacks #521 — the same single commit, cherry-picked unchanged — onto the new base; GitHub will retarget this to `master` once #522 merges.

## Problem

`batch_operator_plugin::do_poll_epoch_state` pushed `sysio.msgch::bootstrap` at epoch 0 to trigger the genesis advance — signed with the operator's own account authority. But `msgch::bootstrap` gates on `require_auth(get_self())` (i.e. `sysio.msgch`'s own authority), so the chain rejected the push unconditionally with `missing authority of sysio.msgch (3090004)`, before the `check(epoch == 0)` ever ran. It never advanced anything — it only emitted boot-window error-log noise.

The genesis advance is a system responsibility: only the holder of `sysio.msgch`'s authority (the genesis/bootstrap process; the harness in test clusters) can trigger it. From epoch 1 onward batch operators still trigger advancement — the elected operator's poll cranks `msgch::chkcons`, which sends the inline `sysio.epoch::advance` under msgch's own authority once the per-outpost consensus recorded during `evalcons` dispatch and the epoch time gate are met — but they never authorize `bootstrap` or `advance` directly.

## Change

Remove the `epoch == 0` bootstrap-push block from `do_poll_epoch_state` and the now-orphan `action_bootstrap` constant. One file.
