### PR TITLE
SEC-139: Pin Solana RPC clients by genesis hash

### DIFF
--- a/docs/outbound-http-transport.md
+++ b/docs/outbound-http-transport.md
@@ -55,6 +55,24 @@ closed before reuse, which keeps the reuse window below common provider keep-ali
 peer-closed sockets retained by the process. A non-blocking socket peek also rejects a cached connection when a
 peer FIN/reset or unexpected unread bytes are already observable.
 
+## Per-connection validation
+
+The asynchronous client and blocking adapter accept an optional generic validator for fixed-endpoint clients. Before
+the first ordinary request on each newly established connection, the transport sends one bounded, single-attempt
+validation request to that same endpoint. The response predicate either admits the connection or throws to reject
+and close it. An admitted connection must remain persistent; if the peer closes the validation response, the
+transport rejects it because no subsequent operation can be bound to that observation.
+
+Validation state belongs to the live HTTP/TLS connection and is discarded when it closes. A replacement or fallback
+connection therefore validates independently before carrying ordinary work. The attempt, success, and failure
+lifecycle callbacks are non-blocking telemetry hooks; they cannot change the single-attempt policy and must not
+throw from completion callbacks. The initiating ordinary request's already-started total deadline caps the
+validation deadline, so validation cannot extend that request's overall budget.
+
+For a connection-affine continuation, validation precedes the initial call. The hook and follow-up then use the same
+already-admitted connection; the continuation mechanism does not trigger another validation between its two legs.
+This keeps endpoint admission generic and independent from higher-level JSON-RPC or chain-specific policy.
+
 ## Connection-affine continuations
 
 The asynchronous client and blocking compatibility adapter expose a generic one-step continuation hook. The

--- a/docs/solana-cluster-identity.md
+++ b/docs/solana-cluster-identity.md
@@ -33,7 +33,6 @@ outpost-solana-cluster-identity = <client-id>,<expected-genesis-hash>
 Optional policy:
 
 ```ini
-outpost-solana-cluster-identity-max-age-ms = 30000
 outpost-solana-cluster-identity-probe-timeout-ms = 5000
 ```
 
@@ -54,8 +53,14 @@ and publishes no clients unless all probes match.
 - Signing always performs a fresh bounded probe immediately before invoking
   the local signer. Transaction submission performs its verification and
   `sendTransaction` call on one exact connection.
-- The configured maximum age bounds reported verification freshness. Every
-  protected JSON-RPC operation is stricter and performs a peer-bound preflight.
+- Operation-gate queueing shares the configured RPC total-timeout budget.
+  Startup and signing gate waits share the identity-probe timeout, so a stalled
+  concurrent operation cannot create an unbounded wait.
+- Solana clients always honor an earlier active task deadline. The lower-level
+  transport inheritance switch cannot disable these fail-closed client budgets.
+- Verification age is telemetry showing time since the latest successful
+  probe. It is not an authorization cache; every protected JSON-RPC operation
+  performs a new peer-bound preflight.
 - A follow-up transport failure cannot reuse the completed preflight. The next
   operation independently re-resolves when needed and reverifies.
 - Timeout, RPC, and malformed-response failures block the current operation
@@ -87,7 +92,8 @@ Recommended initial alerts:
 - any client with `status="mismatch"`;
 - sustained `status="error"` or increasing verification failures;
 - increasing blocked signing or submission operations;
-- verification age above the configured maximum plus normal scrape delay.
+- unexpectedly old verification age while protected operations should be
+  active.
 
 Metric labels are bounded to configured client IDs and closed enum values.
 Expected/observed hashes and endpoint URLs are deliberately excluded.

--- a/docs/solana-cluster-identity.md
+++ b/docs/solana-cluster-identity.md
@@ -53,11 +53,11 @@ and publishes no clients unless all probes match.
   covers successful fallback between multiple DNS addresses.
 - Signing always performs a fresh bounded probe immediately before invoking
   the local signer. Transaction submission performs its verification and
-  `sendTransaction` call on one transport session.
-- The configured maximum age remains an upper bound on reusable identity
-  evidence; the per-session JSON-RPC check is intentionally stricter.
-- A JSON-RPC transport failure invalidates the verified transport session. The
-  next operation re-resolves and reverifies before continuing.
+  `sendTransaction` call on one exact connection.
+- The configured maximum age bounds reported verification freshness. Every
+  protected JSON-RPC operation is stricter and performs a peer-bound preflight.
+- A follow-up transport failure cannot reuse the completed preflight. The next
+  operation independently re-resolves when needed and reverifies.
 - Timeout, RPC, and malformed-response failures block the current operation
   but can recover after a later matching probe.
 - An identity mismatch is sticky for the process lifetime. All later protected
@@ -74,7 +74,6 @@ The Prometheus plugin exports:
 
 - `nodeop_solana_cluster_identity{client_id,mode,status,reason}`
 - `nodeop_solana_cluster_identity_verification_age_seconds`
-- `nodeop_solana_cluster_identity_transport_session_id`
 - `nodeop_solana_cluster_identity_verification_attempts_total`
 - `nodeop_solana_cluster_identity_verification_successes_total`
 - `nodeop_solana_cluster_identity_verification_mismatches_total`

--- a/docs/solana-cluster-identity.md
+++ b/docs/solana-cluster-identity.md
@@ -1,0 +1,102 @@
+# Solana Cluster Identity Operations
+
+`outpost_solana_client_plugin` can pin each signing-capable Solana RPC client
+to an expected genesis hash. This prevents a reachable but incorrect RPC
+cluster from receiving reads, signatures, or submitted transactions.
+
+## Initial backward-compatible rollout
+
+The initial release intentionally supports two modes:
+
+1. **Legacy unpinned:** configure no
+   `--outpost-solana-cluster-identity` entries. Existing nodeop and
+   `wire-tools-ts` configurations continue to start unchanged. Nodeop emits a
+   security warning for every client and reports the unpinned state in
+   Prometheus.
+2. **Strict pinned:** configure at least one identity entry. Every configured
+   Solana client must then have exactly one entry. Startup rejects partial
+   coverage, duplicates, unknown client IDs, empty values, and hashes that are
+   not canonical base58 encodings of exactly 32 bytes.
+
+There is no mixed mode within one process. This makes a missing entry visible
+at startup instead of silently leaving only some signing paths unprotected.
+
+## Configuration
+
+For each existing client:
+
+```ini
+outpost-solana-client = <client-id>,<signature-provider-id>,<rpc-url>
+outpost-solana-cluster-identity = <client-id>,<expected-genesis-hash>
+```
+
+Optional policy:
+
+```ini
+outpost-solana-cluster-identity-max-age-ms = 30000
+outpost-solana-cluster-identity-probe-timeout-ms = 5000
+```
+
+Obtain the expected hash from an independently trusted deployment manifest or
+control-plane source. Do not generate configuration by asking the same RPC URL
+that nodeop will pin: that would make a redirected endpoint self-attesting.
+
+Roll out all identity entries for a node in one configuration change. A pinned
+node performs a bounded `getGenesisHash` probe for every client during startup
+and publishes no clients unless all probes match.
+
+## Runtime behavior
+
+- Every protected JSON-RPC request first calls `getGenesisHash` on the same
+  HTTP/TLS connection. The protected request is not written unless that peer
+  returns the configured identity and permits connection reuse. This also
+  covers successful fallback between multiple DNS addresses.
+- Signing always performs a fresh bounded probe immediately before invoking
+  the local signer. Transaction submission performs its verification and
+  `sendTransaction` call on one transport session.
+- The configured maximum age remains an upper bound on reusable identity
+  evidence; the per-session JSON-RPC check is intentionally stricter.
+- A JSON-RPC transport failure invalidates the verified transport session. The
+  next operation re-resolves and reverifies before continuing.
+- Timeout, RPC, and malformed-response failures block the current operation
+  but can recover after a later matching probe.
+- An identity mismatch is sticky for the process lifetime. All later protected
+  operations fail without probing or signing. Investigate the endpoint and
+  restart only after correcting configuration or routing.
+
+Logs identify the configured client, sanitized endpoint, status, reason, and
+operation. Query strings, URL user information, signer identifiers, account
+payloads, and transaction data are omitted.
+
+## Prometheus and alerts
+
+The Prometheus plugin exports:
+
+- `nodeop_solana_cluster_identity{client_id,mode,status,reason}`
+- `nodeop_solana_cluster_identity_verification_age_seconds`
+- `nodeop_solana_cluster_identity_transport_session_id`
+- `nodeop_solana_cluster_identity_verification_attempts_total`
+- `nodeop_solana_cluster_identity_verification_successes_total`
+- `nodeop_solana_cluster_identity_verification_mismatches_total`
+- `nodeop_solana_cluster_identity_verification_failures_total`
+- `nodeop_solana_cluster_identity_verification_recoveries_total`
+- `nodeop_solana_cluster_identity_blocked_operations_total{operation}`
+
+Recommended initial alerts:
+
+- any production client with `mode="unpinned"`;
+- any client with `status="mismatch"`;
+- sustained `status="error"` or increasing verification failures;
+- increasing blocked signing or submission operations;
+- verification age above the configured maximum plus normal scrape delay.
+
+Metric labels are bounded to configured client IDs and closed enum values.
+Expected/observed hashes and endpoint URLs are deliberately excluded.
+
+## Follow-up enforcement
+
+This compatibility window does not complete mandatory enforcement. Before
+removing legacy mode, deployment tooling (including `wire-tools-ts`) must
+provision an independently sourced identity for every generated Solana client
+configuration. The enforcement release should then reject startup when the
+option is absent.

--- a/docs/solana-cluster-identity.md
+++ b/docs/solana-cluster-identity.md
@@ -1,8 +1,12 @@
 # Solana Cluster Identity Operations
 
 `outpost_solana_client_plugin` can pin each signing-capable Solana RPC client
-to an expected genesis hash. This prevents a reachable but incorrect RPC
-cluster from receiving reads, signatures, or submitted transactions.
+to an expected genesis hash. This detects benign routing and configuration
+errors before a connection receives ordinary reads or submitted transactions.
+It is not endpoint authentication: the genesis hash is public, so a malicious
+RPC service can claim the expected value, and a request-routing proxy can select
+different backends behind one persistent connection. TLS endpoint
+authentication and trusted network routing remain required.
 
 ## Initial backward-compatible rollout
 
@@ -41,28 +45,39 @@ control-plane source. Do not generate configuration by asking the same RPC URL
 that nodeop will pin: that would make a redirected endpoint self-attesting.
 
 Roll out all identity entries for a node in one configuration change. A pinned
-node performs a bounded `getGenesisHash` probe for every client during startup
-and publishes no clients unless all probes match.
+node validates every client's first persistent RPC connection and performs a
+separate ordinary `getGenesisHash` cross-check during startup. The plugin
+publishes no clients unless all startup checks match.
 
 ## Runtime behavior
 
-- Every protected JSON-RPC request first calls `getGenesisHash` on the same
-  HTTP/TLS connection. The protected request is not written unless that peer
-  returns the configured identity and permits connection reuse. This also
-  covers successful fallback between multiple DNS addresses.
-- Signing always performs a fresh bounded probe immediately before invoking
-  the local signer. Transaction submission performs its verification and
-  `sendTransaction` call on one exact connection.
-- Operation-gate queueing shares the configured RPC total-timeout budget.
-  Startup and signing gate waits share the identity-probe timeout, so a stalled
-  concurrent operation cannot create an unbounded wait.
-- Solana clients always honor an earlier active task deadline. The lower-level
-  transport inheritance switch cannot disable these fail-closed client budgets.
+- Every new HTTP/TLS connection calls `getGenesisHash` before its first
+  ordinary JSON-RPC request. The connection is admitted only when that peer
+  returns the configured identity and preserves the connection for reuse.
+  Healthy persistent connections are validated once; replacements and
+  successful fallback to another resolved address are validated independently.
+- Protected JSON-RPC operations can use only an admitted live connection.
+  There is no process-wide cached authorization or per-operation identity
+  re-probe, so one failed connection does not authorize a later replacement.
+  Later callers may reuse the same admitted persistent connection, but its
+  validation never transfers to a different connection.
+- Signing remains local. In pinned mode, a transaction can be signed only when
+  its recent blockhash came from `getLatestBlockhash` over an admitted
+  connection. This binds the transaction to validated provisioning data
+  without adding network I/O to the signing method. Unpinned signing preserves
+  the legacy local-only behavior.
+- The identity validation request has its own bounded timeout. An endpoint
+  that answers the validation and then closes the connection is incompatible
+  with pinned mode because no ordinary request can be safely bound to that
+  validation.
+- Solana clients honor cancellation and an earlier active task deadline while
+  queued as well as during transport work. The lower-level transport
+  inheritance switch cannot disable these fail-closed client budgets.
 - Verification age is telemetry showing time since the latest successful
-  probe. It is not an authorization cache; every protected JSON-RPC operation
-  performs a new peer-bound preflight.
-- A follow-up transport failure cannot reuse the completed preflight. The next
-  operation independently re-resolves when needed and reverifies.
+  connection admission. It is not an authorization TTL; authorization lives
+  only on the admitted connection and disappears when that connection closes.
+- A transport failure cannot transfer admission to a replacement connection.
+  The next connection independently re-resolves when needed and revalidates.
 - Timeout, RPC, and malformed-response failures block the current operation
   but can recover after a later matching probe.
 - An identity mismatch is sticky for the process lifetime. All later protected
@@ -83,8 +98,10 @@ The Prometheus plugin exports:
 - `nodeop_solana_cluster_identity_verification_successes_total`
 - `nodeop_solana_cluster_identity_verification_mismatches_total`
 - `nodeop_solana_cluster_identity_verification_failures_total`
+- `nodeop_solana_cluster_identity_verification_cancellations_total`
 - `nodeop_solana_cluster_identity_verification_recoveries_total`
 - `nodeop_solana_cluster_identity_blocked_operations_total{operation}`
+- `nodeop_solana_cluster_identity_protected_operation_failures_total{operation}`
 
 Recommended initial alerts:
 
@@ -92,8 +109,13 @@ Recommended initial alerts:
 - any client with `status="mismatch"`;
 - sustained `status="error"` or increasing verification failures;
 - increasing blocked signing or submission operations;
-- unexpectedly old verification age while protected operations should be
-  active.
+- increasing protected-operation failures.
+
+Cancellation increases indicate local shutdown or load-shedding activity, not
+an endpoint identity failure. Verification age is the age of the last
+connection admission. It may grow indefinitely while a healthy persistent
+connection remains in use, so it is diagnostic context rather than a
+standalone freshness alert.
 
 Metric labels are bounded to configured client IDs and closed enum values.
 Expected/observed hashes and endpoint URLs are deliberately excluded.

--- a/libraries/libfc-test/include/fc-test/scripted_json_rpc_server.hpp
+++ b/libraries/libfc-test/include/fc-test/scripted_json_rpc_server.hpp
@@ -6,9 +6,11 @@
 
 #include <fc/io/json.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <sstream>
@@ -33,7 +35,11 @@ struct scripted_json_rpc_response {
 
    kind        response_kind = kind::result;
    fc::variant payload;
+   std::optional<int64_t> response_id;
    std::chrono::microseconds delay{0};
+   std::shared_ptr<std::atomic_bool> release_gate;
+   bool keep_alive = true;
+   bool reset_after_response = false;
 
    /** Return a successful JSON-RPC result. */
    static scripted_json_rpc_response result(fc::variant value) {
@@ -48,6 +54,17 @@ struct scripted_json_rpc_response {
          .response_kind = kind::result,
          .payload = std::move(value),
          .delay = delay,
+      };
+   }
+
+   /** Return a successful result after the caller releases a shared gate. */
+   static scripted_json_rpc_response gated_result(
+      fc::variant value,
+      std::shared_ptr<std::atomic_bool> release_gate) {
+      return {
+         .response_kind = kind::result,
+         .payload = std::move(value),
+         .release_gate = std::move(release_gate),
       };
    }
 
@@ -83,6 +100,13 @@ struct scripted_json_rpc_response {
  */
 class scripted_json_rpc_server {
 public:
+   /** One request observed by the scripted endpoint. */
+   struct request_record {
+      std::string method;
+      size_t connection = 0;
+      std::optional<int64_t> id;
+   };
+
    explicit scripted_json_rpc_server(std::vector<scripted_json_rpc_response> responses)
       : scripted_json_rpc_server(std::move(responses), "127.0.0.1", 0, false) {}
 
@@ -115,6 +139,11 @@ public:
       _stopping_changed.notify_all();
 
       boost::system::error_code error;
+      {
+         std::scoped_lock socket_lock(_socket_mutex);
+         if (_active_socket)
+            _active_socket->shutdown(tcp::socket::shutdown_both, error);
+      }
       boost::asio::io_context wake_io;
       tcp::socket wake_socket(wake_io);
       wake_socket.connect(
@@ -125,6 +154,12 @@ public:
          _worker.join();
       }
       _acceptor.close(error);
+      {
+         std::scoped_lock socket_lock(_socket_mutex);
+         if (_active_socket)
+            _active_socket->close(error);
+         _active_socket.reset();
+      }
    }
 
    /** Return the loopback URL selected for this server. */
@@ -152,6 +187,15 @@ public:
       return _request_methods;
    }
 
+   /** Return how many TCP connections accepted a request. */
+   size_t connection_count() const noexcept { return _connection_count.load(); }
+
+   /** Return request methods and their accepted connection number. */
+   std::vector<request_record> requests() const {
+      std::lock_guard lock(_mutex);
+      return _requests;
+   }
+
 private:
    using tcp = boost::asio::ip::tcp;
 
@@ -161,47 +205,67 @@ private:
       return _stopping;
    }
 
+   /** Serialize worker-side socket options and close against destructor shutdown. */
+   void close_socket(const std::shared_ptr<tcp::socket>& socket,
+                     boost::system::error_code& error,
+                     bool reset_connection = false) {
+      std::scoped_lock socket_lock(_socket_mutex);
+      if (reset_connection)
+         socket->set_option(boost::asio::socket_base::linger(true, 0), error);
+      socket->close(error);
+   }
+
    /** Consume scripted responses sequentially on the worker thread. */
    void serve() {
       size_t response_index = 0;
       while (!stopping()) {
          boost::system::error_code error;
-         tcp::socket socket(_io);
-         _acceptor.accept(socket, error);
+         auto socket = std::make_shared<tcp::socket>(_io);
+         _acceptor.accept(*socket, error);
          if (error || stopping()) {
             return;
          }
+         {
+            std::scoped_lock socket_lock(_socket_mutex);
+            _active_socket = socket;
+         }
+         const auto connection = _connection_count.fetch_add(1) + 1;
 
          boost::beast::flat_buffer request_buffer;
          while (!stopping()) {
             boost::beast::http::request<boost::beast::http::string_body> request;
-            boost::beast::http::read(socket, request_buffer, request, error);
+            boost::beast::http::read(*socket, request_buffer, request, error);
             if (error) {
                break;
             }
+
+            if (response_index >= _responses.size()) {
+               close_socket(socket, error);
+               break;
+            }
+            const auto response = _responses[response_index++];
+            const bool script_complete = response_index >= _responses.size();
 
             fc::variant request_variant;
             try {
                request_variant = fc::json::from_string(request.body());
                const auto& request_object = request_variant.get_object();
                const auto method = request_object["method"].as_string();
+               std::optional<int64_t> id;
+               if (request_object.contains("id"))
+                  id = request_object["id"].as_int64();
                {
                   std::lock_guard lock(_mutex);
                   _request_methods.push_back(method);
+                  _requests.push_back({.method = method, .connection = connection, .id = id});
                }
             } catch (...) {
-               break;
+               if (response.response_kind != scripted_json_rpc_response::kind::raw_body)
+                  break;
             }
 
-            if (response_index >= _responses.size()) {
-               socket.close(error);
-               break;
-            }
-            const auto response = _responses[response_index++];
-            const bool script_complete = response_index >= _responses.size();
             if (response.response_kind == scripted_json_rpc_response::kind::close_connection) {
-               socket.set_option(boost::asio::socket_base::linger(true, 0), error);
-               socket.close(error);
+               close_socket(socket, error, true);
                if (_stop_after_script && script_complete) {
                   _acceptor.close(error);
                   return;
@@ -211,7 +275,17 @@ private:
             if (response.response_kind == scripted_json_rpc_response::kind::hang) {
                std::unique_lock lock(_mutex);
                _stopping_changed.wait(lock, [this] { return _stopping; });
-               socket.close(error);
+               lock.unlock();
+               close_socket(socket, error);
+               return;
+            }
+            while (response.release_gate &&
+                   !response.release_gate->load(std::memory_order_acquire) &&
+                   !stopping()) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            if (stopping()) {
+               close_socket(socket, error);
                return;
             }
             if (response.delay.count() > 0) {
@@ -219,30 +293,41 @@ private:
             }
 
             std::string response_body;
-            if (response.response_kind == scripted_json_rpc_response::kind::raw_body) {
-               response_body = response.payload.as_string();
-            } else {
-               const auto& request_object = request_variant.get_object();
-               fc::mutable_variant_object envelope;
-               envelope("jsonrpc", "2.0")("id", request_object["id"]);
-               if (response.response_kind == scripted_json_rpc_response::kind::result) {
-                  envelope("result", response.payload);
+            try {
+               if (response.response_kind == scripted_json_rpc_response::kind::raw_body) {
+                  response_body = response.payload.as_string();
                } else {
-                  envelope("error", response.payload);
+                  const auto& request_object = request_variant.get_object();
+                  if (request_object.contains("id")) {
+                     fc::mutable_variant_object envelope;
+                     envelope("jsonrpc", "2.0")(
+                        "id",
+                        response.response_id ? fc::variant(*response.response_id) : request_object["id"]);
+                     if (response.response_kind == scripted_json_rpc_response::kind::result) {
+                        envelope("result", response.payload);
+                     } else {
+                        envelope("error", response.payload);
+                     }
+                     response_body = fc::json::to_string(fc::variant(envelope), fc::json::yield_function_t{});
+                  }
                }
-               response_body =
-                  fc::json::to_string(fc::variant(envelope), fc::json::yield_function_t{});
+            } catch (...) {
+               close_socket(socket, error);
+               break;
             }
 
             boost::beast::http::response<boost::beast::http::string_body> http_response{
                boost::beast::http::status::ok, request.version()};
             http_response.set(boost::beast::http::field::content_type, "application/json");
             http_response.body() = std::move(response_body);
-            http_response.keep_alive(request.keep_alive() && !(_stop_after_script && script_complete));
+            http_response.keep_alive(
+               request.keep_alive() && response.keep_alive && !(_stop_after_script && script_complete));
             http_response.prepare_payload();
-            boost::beast::http::write(socket, http_response, error);
+            boost::beast::http::write(*socket, http_response, error);
+            if (!error && response.reset_after_response)
+               close_socket(socket, error, true);
             if (error || !http_response.keep_alive()) {
-               socket.close(error);
+               close_socket(socket, error);
             }
             if (_stop_after_script && script_complete) {
                _acceptor.close(error);
@@ -251,6 +336,11 @@ private:
             if (error || !http_response.keep_alive()) {
                break;
             }
+         }
+         {
+            std::scoped_lock socket_lock(_socket_mutex);
+            if (_active_socket == socket)
+               _active_socket.reset();
          }
       }
    }
@@ -265,6 +355,10 @@ private:
    bool                                     _stopping = false;
    bool                                     _stop_after_script = false;
    std::vector<std::string>                 _request_methods;
+   std::vector<request_record>               _requests;
+   std::atomic_size_t                        _connection_count{0};
+   mutable std::mutex                        _socket_mutex;
+   std::shared_ptr<tcp::socket>              _active_socket;
    std::thread                              _worker;
 };
 

--- a/libraries/libfc-test/include/fc-test/scripted_json_rpc_server.hpp
+++ b/libraries/libfc-test/include/fc-test/scripted_json_rpc_server.hpp
@@ -1,0 +1,271 @@
+#pragma once
+
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+
+#include <fc/io/json.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace fc::test {
+
+/**
+ * One deterministic response consumed by {@link scripted_json_rpc_server}.
+ */
+struct scripted_json_rpc_response {
+   enum class kind {
+      result,
+      error,
+      raw_body,
+      close_connection,
+      hang
+   };
+
+   kind        response_kind = kind::result;
+   fc::variant payload;
+   std::chrono::microseconds delay{0};
+
+   /** Return a successful JSON-RPC result. */
+   static scripted_json_rpc_response result(fc::variant value) {
+      return {.response_kind = kind::result, .payload = std::move(value)};
+   }
+
+   /** Return a successful result after a deterministic server-side delay. */
+   static scripted_json_rpc_response delayed_result(
+      fc::variant value,
+      std::chrono::microseconds delay) {
+      return {
+         .response_kind = kind::result,
+         .payload = std::move(value),
+         .delay = delay,
+      };
+   }
+
+   /** Return a JSON-RPC error object supplied as `payload`. */
+   static scripted_json_rpc_response error(fc::variant value) {
+      return {.response_kind = kind::error, .payload = std::move(value)};
+   }
+
+   /** Return a complete caller-supplied HTTP response body. */
+   static scripted_json_rpc_response raw(std::string body) {
+      return {.response_kind = kind::raw_body, .payload = fc::variant(std::move(body))};
+   }
+
+   /** Accept and then close the connection without an HTTP response. */
+   static scripted_json_rpc_response close() {
+      return {.response_kind = kind::close_connection};
+   }
+
+   /** Accept the request and withhold a response until server destruction. */
+   static scripted_json_rpc_response hanging() {
+      return {.response_kind = kind::hang};
+   }
+};
+
+/**
+ * Loopback JSON-RPC server that consumes a fixed response script.
+ *
+ * Each accepted request consumes one script entry. Successful and error
+ * responses copy the request ID into their JSON-RPC envelope, allowing a
+ * long-lived client to issue multiple calls. Request methods are retained for
+ * assertions. The hanging response cooperates with destruction so deadline
+ * tests cannot strand a worker thread.
+ */
+class scripted_json_rpc_server {
+public:
+   explicit scripted_json_rpc_server(std::vector<scripted_json_rpc_response> responses)
+      : scripted_json_rpc_server(std::move(responses), "127.0.0.1", 0, false) {}
+
+   /**
+    * Bind a caller-selected loopback address/port.
+    *
+    * `stop_after_script` is useful for deterministic DNS-fallback tests: the
+    * server closes its listener after the final response so a later connect
+    * attempt advances to the next resolved address.
+    */
+   scripted_json_rpc_server(std::vector<scripted_json_rpc_response> responses,
+                            const std::string& bind_address,
+                            uint16_t port,
+                            bool stop_after_script)
+      : _responses(std::move(responses))
+      , _acceptor(_io, tcp::endpoint(boost::asio::ip::make_address(bind_address), port))
+      , _port(_acceptor.local_endpoint().port())
+      , _bind_address(bind_address)
+      , _stop_after_script(stop_after_script)
+      , _worker([this] { serve(); }) {}
+
+   scripted_json_rpc_server(const scripted_json_rpc_server&) = delete;
+   scripted_json_rpc_server& operator=(const scripted_json_rpc_server&) = delete;
+
+   ~scripted_json_rpc_server() {
+      {
+         std::lock_guard lock(_mutex);
+         _stopping = true;
+      }
+      _stopping_changed.notify_all();
+
+      boost::system::error_code error;
+      boost::asio::io_context wake_io;
+      tcp::socket wake_socket(wake_io);
+      wake_socket.connect(
+         tcp::endpoint(boost::asio::ip::make_address(_bind_address), _port),
+         error);
+      wake_socket.close(error);
+      if (_worker.joinable()) {
+         _worker.join();
+      }
+      _acceptor.close(error);
+   }
+
+   /** Return the loopback URL selected for this server. */
+   std::string url() const {
+      return "http://127.0.0.1:" + std::to_string(_port);
+   }
+
+   /** Return a URL using a hostname that resolves to this server's port. */
+   std::string url_for_host(const std::string& host) const {
+      return "http://" + host + ":" + std::to_string(_port);
+   }
+
+   /** Return the selected TCP port. */
+   uint16_t port() const noexcept { return _port; }
+
+   /** Return the number of fully parsed requests received so far. */
+   size_t request_count() const {
+      std::lock_guard lock(_mutex);
+      return _request_methods.size();
+   }
+
+   /** Return a copy of received JSON-RPC method names in request order. */
+   std::vector<std::string> request_methods() const {
+      std::lock_guard lock(_mutex);
+      return _request_methods;
+   }
+
+private:
+   using tcp = boost::asio::ip::tcp;
+
+   /** Return whether destruction requested the server loop to stop. */
+   bool stopping() const {
+      std::lock_guard lock(_mutex);
+      return _stopping;
+   }
+
+   /** Consume scripted responses sequentially on the worker thread. */
+   void serve() {
+      size_t response_index = 0;
+      while (!stopping()) {
+         boost::system::error_code error;
+         tcp::socket socket(_io);
+         _acceptor.accept(socket, error);
+         if (error || stopping()) {
+            return;
+         }
+
+         boost::beast::flat_buffer request_buffer;
+         while (!stopping()) {
+            boost::beast::http::request<boost::beast::http::string_body> request;
+            boost::beast::http::read(socket, request_buffer, request, error);
+            if (error) {
+               break;
+            }
+
+            fc::variant request_variant;
+            try {
+               request_variant = fc::json::from_string(request.body());
+               const auto& request_object = request_variant.get_object();
+               const auto method = request_object["method"].as_string();
+               {
+                  std::lock_guard lock(_mutex);
+                  _request_methods.push_back(method);
+               }
+            } catch (...) {
+               break;
+            }
+
+            if (response_index >= _responses.size()) {
+               socket.close(error);
+               break;
+            }
+            const auto response = _responses[response_index++];
+            const bool script_complete = response_index >= _responses.size();
+            if (response.response_kind == scripted_json_rpc_response::kind::close_connection) {
+               socket.set_option(boost::asio::socket_base::linger(true, 0), error);
+               socket.close(error);
+               if (_stop_after_script && script_complete) {
+                  _acceptor.close(error);
+                  return;
+               }
+               break;
+            }
+            if (response.response_kind == scripted_json_rpc_response::kind::hang) {
+               std::unique_lock lock(_mutex);
+               _stopping_changed.wait(lock, [this] { return _stopping; });
+               socket.close(error);
+               return;
+            }
+            if (response.delay.count() > 0) {
+               std::this_thread::sleep_for(response.delay);
+            }
+
+            std::string response_body;
+            if (response.response_kind == scripted_json_rpc_response::kind::raw_body) {
+               response_body = response.payload.as_string();
+            } else {
+               const auto& request_object = request_variant.get_object();
+               fc::mutable_variant_object envelope;
+               envelope("jsonrpc", "2.0")("id", request_object["id"]);
+               if (response.response_kind == scripted_json_rpc_response::kind::result) {
+                  envelope("result", response.payload);
+               } else {
+                  envelope("error", response.payload);
+               }
+               response_body =
+                  fc::json::to_string(fc::variant(envelope), fc::json::yield_function_t{});
+            }
+
+            boost::beast::http::response<boost::beast::http::string_body> http_response{
+               boost::beast::http::status::ok, request.version()};
+            http_response.set(boost::beast::http::field::content_type, "application/json");
+            http_response.body() = std::move(response_body);
+            http_response.keep_alive(request.keep_alive() && !(_stop_after_script && script_complete));
+            http_response.prepare_payload();
+            boost::beast::http::write(socket, http_response, error);
+            if (error || !http_response.keep_alive()) {
+               socket.close(error);
+            }
+            if (_stop_after_script && script_complete) {
+               _acceptor.close(error);
+               return;
+            }
+            if (error || !http_response.keep_alive()) {
+               break;
+            }
+         }
+      }
+   }
+
+   std::vector<scripted_json_rpc_response> _responses;
+   boost::asio::io_context                  _io;
+   tcp::acceptor                            _acceptor;
+   uint16_t                                 _port;
+   std::string                              _bind_address;
+   mutable std::mutex                       _mutex;
+   std::condition_variable                  _stopping_changed;
+   bool                                     _stopping = false;
+   bool                                     _stop_after_script = false;
+   std::vector<std::string>                 _request_methods;
+   std::thread                              _worker;
+};
+
+} // namespace fc::test

--- a/libraries/libfc-test/include/fc-test/solana_utils.hpp
+++ b/libraries/libfc-test/include/fc-test/solana_utils.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <fc/crypto/base58.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace fc::test {
+
+/**
+ * Return a deterministic canonical base58 value with Solana's 32-byte hash shape.
+ *
+ * This helper is suitable for genesis hashes, recent blockhashes, and public
+ * keys in tests that do not need cryptographically meaningful contents.
+ */
+inline std::string solana_hash(uint8_t seed) {
+   const std::vector<char> bytes(32, static_cast<char>(seed));
+   return fc::to_base58(bytes, fc::yield_function_t{});
+}
+
+} // namespace fc::test

--- a/libraries/libfc/include/fc/network/http/http_client.hpp
+++ b/libraries/libfc/include/fc/network/http/http_client.hpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <array>
+#include <exception>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -222,6 +223,29 @@ struct response {
 };
 
 /**
+ * Generic validation performed once for every newly established connection.
+ *
+ * The validation request must target the same endpoint as ordinary requests.
+ * A connection enters the idle pool only after the bounded response is
+ * accepted and the peer keeps the connection alive. Validation state belongs
+ * to the connection and is discarded when that connection closes.
+ */
+struct connection_validation {
+   /// Bounded request sent before the first ordinary request on a connection.
+   request validation_request;
+   /// Single-attempt limits and deadlines for the validation request.
+   request_options options;
+   /// Accept the complete validation response or throw to reject the connection.
+   std::function<void(const response&)> validate_response;
+   /// Observe the start of one connection-validation attempt; must not block.
+   std::function<void()> on_attempt;
+   /// Observe one accepted, persistent connection; must not throw.
+   std::function<void()> on_success;
+   /// Observe one rejected validation attempt; must not throw.
+   std::function<void(std::exception_ptr, std::optional<failure_kind>)> on_failure;
+};
+
+/**
  * One request selected by a connection-affine continuation hook.
  *
  * The request must target the same transport endpoint as the completed
@@ -329,6 +353,10 @@ class client {
 public:
    explicit client(boost::asio::any_io_executor executor,
                    transport_options options = {});
+   /** Construct a client that validates every newly established connection before use. */
+   client(boost::asio::any_io_executor executor,
+          transport_options options,
+          std::optional<connection_validation> validation);
    ~client();
 
    client(const client&) = delete;
@@ -387,6 +415,10 @@ private:
    client(boost::asio::any_io_executor executor,
           transport_options options,
           detail::resolver_start_fn resolver_start);
+   client(boost::asio::any_io_executor executor,
+          transport_options options,
+          std::optional<connection_validation> validation,
+          detail::resolver_start_fn resolver_start);
 
    std::shared_ptr<class client_impl> _impl;
 };
@@ -412,6 +444,9 @@ async_download_atomic(
 class transport {
 public:
    explicit transport(transport_options options = {});
+   /** Construct a blocking adapter that validates every newly established connection before use. */
+   transport(transport_options options,
+             std::optional<connection_validation> validation);
    ~transport();
 
    transport(const transport&) = delete;
@@ -456,6 +491,9 @@ private:
    friend struct transport_test_access;
 
    transport(transport_options options,
+             detail::resolver_start_fn resolver_start);
+   transport(transport_options options,
+             std::optional<connection_validation> validation,
              detail::resolver_start_fn resolver_start);
 
    std::unique_ptr<class transport_impl> _impl;

--- a/libraries/libfc/include/fc/network/json_rpc/json_rpc_client.hpp
+++ b/libraries/libfc/include/fc/network/json_rpc/json_rpc_client.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
+#include <exception>
 #include <fc/io/json.hpp>
 #include <fc/network/http/http_client.hpp>
 #include <fc/network/url.hpp>
@@ -25,6 +27,30 @@ enum class http_verb { GET, PUT, POST, DELETE_ };
 /// Control whether connection failures invalidate the client's startup DNS result.
 enum class endpoint_refresh_policy { on_connection_failure, never };
 
+/**
+ * JSON-RPC method and result predicate used to validate each new connection.
+ *
+ * The validator runs before the first ordinary request on a connection. Its
+ * successful state is discarded with that connection. Lifecycle observers
+ * support domain telemetry without leaking domain concepts into HTTP policy.
+ */
+struct connection_validation {
+   /// Validation method sent before the first ordinary request.
+   std::string method;
+   /// Validation method parameters.
+   fc::variant params = variants{};
+   /// Upper bound for one validation call.
+   std::optional<fc::microseconds> total_timeout_cap;
+   /// Accept the extracted JSON-RPC result or throw to reject the connection.
+   std::function<void(const fc::variant&)> validate_result;
+   /// Observe one validation attempt; may throw to reject before network I/O.
+   std::function<void()> on_attempt;
+   /// Observe one accepted persistent connection; must not throw.
+   std::function<void()> on_success;
+   /// Observe one rejected validation attempt; must not throw.
+   std::function<void(std::exception_ptr, std::optional<fc::http::failure_kind>)> on_failure;
+};
+
 /** Shared transport and per-request policy for one JSON-RPC client. */
 struct client_options {
    /// TLS trust, explicit proxy, and DNS-cache configuration.
@@ -33,6 +59,8 @@ struct client_options {
    };
    /// Caller-specific deadlines, byte ceilings, cancellation, and retry policy.
    fc::http::request_options request;
+   /// Optional validator run once on every newly established connection.
+   std::optional<connection_validation> connection_validator;
 };
 
 /** Replay behavior for one JSON-RPC call. */
@@ -91,6 +119,10 @@ public:
    explicit json_rpc_client(fc::url url, const std::optional<std::string>& user_agent = std::nullopt,
                             endpoint_refresh_policy refresh_policy = endpoint_refresh_policy::on_connection_failure,
                             client_options options = {});
+   /** Move a client while preserving its transport and next request ID. */
+   json_rpc_client(json_rpc_client&& other);
+   /** Move-assign a client while preserving its transport and next request ID. */
+   json_rpc_client& operator=(json_rpc_client&& other);
 
    // -----------------------------------------------------------------------
    //  JSON-RPC 2.0 methods (unchanged, backwards compatible)
@@ -146,9 +178,18 @@ public:
 private:
    fc::url _url;
    std::string _user_agent;
-   std::int64_t _next_id;
+   std::atomic<std::int64_t> _next_id;
    client_options _options;
    fc::http::transport _transport;
+
+   /** Reserve one request ID safely across concurrent synchronous callers. */
+   std::int64_t next_request_id();
+
+   /** Build the generic HTTP validator for this fixed JSON-RPC endpoint. */
+   static std::optional<fc::http::connection_validation>
+   make_http_connection_validation(const fc::url& url,
+                                   const std::string& user_agent,
+                                   const client_options& options);
 
    /** Build and perform one call with an explicit replay policy. */
    variant call_with_policy(const std::string& method, const fc::variant& params, call_options options);

--- a/libraries/libfc/include/fc/network/solana/solana_client.hpp
+++ b/libraries/libfc/include/fc/network/solana/solana_client.hpp
@@ -103,7 +103,6 @@ enum class solana_cluster_identity_reason {
    malformed_observed_identity,
    identity_mismatch,
    verification_stale,
-   transport_session_changed,
    verification_recovered
 };
 
@@ -145,7 +144,6 @@ struct solana_cluster_identity_snapshot {
    std::optional<std::string> observed_genesis_hash;
    std::optional<fc::time_point> verified_at;
    std::optional<fc::microseconds> verification_age;
-   std::uint64_t transport_session_id = 0;
    std::uint64_t verification_attempts = 0;
    std::uint64_t verification_successes = 0;
    std::uint64_t verification_mismatches = 0;
@@ -637,8 +635,7 @@ public:
     * @param url_source The URL of the Solana RPC node
     * @param rpc_options authenticated transport and bounded request policy
     */
-   solana_client(const signature_provider_ptr& sig_provider,
-                 const std::variant<std::string, fc::url>& url_source,
+   solana_client(const signature_provider_ptr& sig_provider, const std::variant<std::string, fc::url>& url_source,
                  client_options rpc_options = {});
 
    /**
@@ -654,8 +651,7 @@ public:
     *                        and freshness policy.
     */
    solana_client(const signature_provider_ptr& sig_provider, const std::variant<std::string, fc::url>& url_source,
-                 solana_cluster_identity_config identity_config,
-                 client_options rpc_options = {});
+                 solana_cluster_identity_config identity_config, client_options rpc_options = {});
 
    /**
     * @brief Execute a raw JSON-RPC method call
@@ -1096,7 +1092,6 @@ private:
    solana_cluster_identity_reason _cluster_identity_reason;
    std::optional<solana_genesis_hash> _last_observed_genesis_hash;
    std::optional<fc::time_point> _last_verified_at;
-   std::uint64_t _verified_transport_session_id = 0;
    std::uint64_t _verification_attempts = 0;
    std::uint64_t _verification_successes = 0;
    std::uint64_t _verification_mismatches = 0;
@@ -1129,8 +1124,7 @@ private:
    /** Validate and record one `getGenesisHash` result. */
    void record_cluster_identity_observation_locked(solana_cluster_identity_operation operation,
                                                    const fc::variant& observed_result,
-                                                   solana_cluster_identity_status previous_status,
-                                                   solana_cluster_identity_reason previous_reason);
+                                                   solana_cluster_identity_status previous_status);
    /** Reverify pinned identity when required or block the protected operation. */
    void ensure_cluster_verified_locked(solana_cluster_identity_operation operation, bool force_fresh);
    /** Publish verification state without holding the RPC gate during later scrapes. */

--- a/libraries/libfc/include/fc/network/solana/solana_client.hpp
+++ b/libraries/libfc/include/fc/network/solana/solana_client.hpp
@@ -91,7 +91,7 @@ solana_genesis_hash parse_solana_genesis_hash(const std::string& value);
 enum class solana_cluster_identity_mode { unpinned, pinned };
 
 /// Durable verification status for a signing-capable Solana client.
-enum class solana_cluster_identity_status { unpinned, unverified, verified, mismatch, error, stale };
+enum class solana_cluster_identity_status { unpinned, unverified, verified, mismatch, error };
 
 /// Stable reason codes exposed through sanitized logs and metrics.
 enum class solana_cluster_identity_reason {
@@ -102,7 +102,6 @@ enum class solana_cluster_identity_reason {
    rpc_error,
    malformed_observed_identity,
    identity_mismatch,
-   verification_stale,
    verification_recovered
 };
 
@@ -123,9 +122,7 @@ enum class solana_cluster_identity_operation {
 struct solana_cluster_identity_config {
    std::string client_id;
    solana_genesis_hash expected_genesis_hash;
-   fc::microseconds maximum_verification_age = fc::seconds(30);
    fc::microseconds probe_timeout = fc::seconds(5);
-   std::function<fc::time_point()> verification_clock = [] { return fc::time_point::now(); };
 };
 
 /**
@@ -633,7 +630,9 @@ public:
     *
     * @param sig_provider Signature provider for signing transactions (ED25519)
     * @param url_source The URL of the Solana RPC node
-    * @param rpc_options authenticated transport and bounded request policy
+    * @param rpc_options authenticated transport and bounded request policy.
+    *                    Solana clients always inherit active task deadlines so
+    *                    their internal operation budgets remain enforceable.
     */
    solana_client(const signature_provider_ptr& sig_provider, const std::variant<std::string, fc::url>& url_source,
                  client_options rpc_options = {});
@@ -647,11 +646,13 @@ public:
     *
     * @param sig_provider Signature provider for signing transactions.
     * @param url_source Configured Solana RPC endpoint.
-    * @param identity_config Independently sourced expected cluster identity
-    *                        and freshness policy.
+    * @param rpc_options authenticated transport and bounded request policy.
+    *                    Solana clients always inherit active task deadlines so
+    *                    their internal operation budgets remain enforceable.
+    * @param identity_config Independently sourced expected cluster identity.
     */
    solana_client(const signature_provider_ptr& sig_provider, const std::variant<std::string, fc::url>& url_source,
-                 solana_cluster_identity_config identity_config, client_options rpc_options = {});
+                 client_options rpc_options, solana_cluster_identity_config identity_config);
 
    /**
     * @brief Execute a raw JSON-RPC method call
@@ -1082,6 +1083,8 @@ private:
    const solana_public_key _pubkey;
    const std::optional<solana_cluster_identity_config> _cluster_identity;
    const std::string _sanitized_endpoint;
+   /// Configured whole-operation budget, including operation-gate queueing.
+   const std::optional<fc::microseconds> _rpc_total_timeout;
    json_rpc_client _client;
    /// Serializes JSON-RPC, verification state changes, signing, and submission.
    mutable std::timed_mutex _operation_mutex;
@@ -1115,26 +1118,26 @@ private:
    /** Acquire the serialized operation gate within the caller's active deadline. */
    operation_lock lock_operation() const;
    /** Execute one RPC method while the operation gate is already held. */
-   fc::variant execute_locked(const std::string& method, const fc::variant& params);
-   /** Return whether a probe is required after applying sticky/stale state transitions. */
-   bool cluster_verification_required_locked(solana_cluster_identity_operation operation, bool force_fresh);
+   fc::variant execute_locked(const std::string& method, const fc::variant& params, bool idempotent);
+   /** Reject an operation after a sticky cluster-identity mismatch. */
+   void throw_if_cluster_identity_mismatched_locked(solana_cluster_identity_operation operation);
    /** Record one transport-level probe failure without exposing request data. */
    void record_cluster_verification_failure_locked(solana_cluster_identity_operation operation,
                                                    solana_cluster_identity_reason reason);
-   /** Validate and record one `getGenesisHash` result. */
-   void record_cluster_identity_observation_locked(solana_cluster_identity_operation operation,
-                                                   const fc::variant& observed_result,
+   /** Record one already parsed `getGenesisHash` result and return whether it matched. */
+   bool record_cluster_identity_observation_locked(solana_cluster_identity_operation operation,
+                                                   const solana_genesis_hash& observed,
                                                    solana_cluster_identity_status previous_status);
-   /** Reverify pinned identity when required or block the protected operation. */
-   void ensure_cluster_verified_locked(solana_cluster_identity_operation operation, bool force_fresh);
+   /** Perform a fresh standalone verification or block the protected operation. */
+   void ensure_cluster_verified_locked(solana_cluster_identity_operation operation);
    /** Publish verification state without holding the RPC gate during later scrapes. */
    void publish_cluster_identity_snapshot_locked();
    /** Call `getGenesisHash` without recursively entering the public verification gate. */
    fc::variant fetch_genesis_hash_unchecked_locked();
    /** Count one operation rejected before RPC or signing. */
    void record_blocked_operation_locked(solana_cluster_identity_operation operation);
-   /** Map raw RPC names onto the closed telemetry operation vocabulary. */
-   static solana_cluster_identity_operation operation_for_rpc_method(const std::string& method);
+   /** Map RPC names and replay semantics onto the closed telemetry operation vocabulary. */
+   static solana_cluster_identity_operation operation_for_rpc_method(const std::string& method, bool idempotent);
 };
 
 //=============================================================================

--- a/libraries/libfc/include/fc/network/solana/solana_client.hpp
+++ b/libraries/libfc/include/fc/network/solana/solana_client.hpp
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <array>
+#include <boost/core/demangle.hpp>
+#include <cstdint>
 #include <fc-lite/threadsafe_map.hpp>
-
 #include <fc/crypto/signature_provider.hpp>
 #include <fc/network/json_rpc/json_rpc_client.hpp>
 #include <fc/network/solana/solana_borsh.hpp>
@@ -10,10 +12,10 @@
 #include <fc/network/solana/solana_system_programs.hpp>
 #include <fc/network/solana/solana_types.hpp>
 #include <fc/task/retry.hpp>
-
-#include <boost/core/demangle.hpp>
+#include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <typeinfo>
@@ -42,11 +44,11 @@ struct solana_confirm_options {
    /// mis-confirmation. Use `confirmed` when the caller needs reorg-
    /// resistance within the same tx, `finalized` only for cross-chain
    /// checkpoints where the wait cost is acceptable.
-   commitment_t              commitment = commitment_t::processed;
+   commitment_t commitment = commitment_t::processed;
 
    /// Retry / backoff / deadline envelope — shared with the Ethereum client.
    /// See `fc::task::retry_options` for per-field semantics.
-   fc::task::retry_options   retry      = fc::task::retry_option_defaults;
+   fc::task::retry_options retry = fc::task::retry_option_defaults;
 };
 
 inline constexpr solana_confirm_options solana_confirm_option_defaults{};
@@ -60,6 +62,97 @@ inline constexpr size_t max_idl_type_nesting_depth = 32;
  * @brief Maximum materialized elements for an IDL vector whose element encoding can consume zero bytes.
  */
 inline constexpr uint32_t max_zero_sized_idl_vector_elements = 64u * 1024u;
+
+/**
+ * Canonical Solana cluster genesis hash.
+ *
+ * `parse_solana_genesis_hash` is the only supported construction path from
+ * text. It rejects non-canonical base58 and any decoded length other than 32
+ * bytes so configuration and RPC observations share identical validation.
+ */
+struct solana_genesis_hash {
+   std::array<uint8_t, 32> bytes{};
+   std::string canonical;
+
+   bool operator==(const solana_genesis_hash&) const = default;
+};
+
+/**
+ * Parse a canonical base58-encoded 32-byte Solana genesis hash.
+ *
+ * @param value Operator configuration or RPC result to validate.
+ * @return Parsed bytes and their canonical base58 representation.
+ * @throws fc::exception when the value is empty, malformed, non-canonical, or
+ *         does not decode to exactly 32 bytes.
+ */
+solana_genesis_hash parse_solana_genesis_hash(const std::string& value);
+
+/// Runtime mode for the staged Solana cluster-identity rollout.
+enum class solana_cluster_identity_mode { unpinned, pinned };
+
+/// Durable verification status for a signing-capable Solana client.
+enum class solana_cluster_identity_status { unpinned, unverified, verified, mismatch, error, stale };
+
+/// Stable reason codes exposed through sanitized logs and metrics.
+enum class solana_cluster_identity_reason {
+   none,
+   missing_expected_identity,
+   malformed_expected_identity,
+   rpc_timeout,
+   rpc_error,
+   malformed_observed_identity,
+   identity_mismatch,
+   verification_stale,
+   transport_session_changed,
+   verification_recovered
+};
+
+/// Bounded protected-operation categories used in verification telemetry.
+enum class solana_cluster_identity_operation {
+   startup,
+   rpc_read,
+   transaction_build,
+   simulation,
+   fee_estimation,
+   signing,
+   submission
+};
+
+/**
+ * Operator-supplied pinning configuration for one Solana client.
+ */
+struct solana_cluster_identity_config {
+   std::string client_id;
+   solana_genesis_hash expected_genesis_hash;
+   fc::microseconds maximum_verification_age = fc::seconds(30);
+   fc::microseconds probe_timeout = fc::seconds(5);
+   std::function<fc::time_point()> verification_clock = [] { return fc::time_point::now(); };
+};
+
+/**
+ * Sanitized point-in-time verification state for logs and metrics.
+ *
+ * RPC credentials, signature-provider identifiers, transactions, and account
+ * payloads are deliberately absent.
+ */
+struct solana_cluster_identity_snapshot {
+   std::string client_id;
+   std::string sanitized_endpoint;
+   solana_cluster_identity_mode mode = solana_cluster_identity_mode::unpinned;
+   solana_cluster_identity_status status = solana_cluster_identity_status::unpinned;
+   solana_cluster_identity_reason reason = solana_cluster_identity_reason::missing_expected_identity;
+   std::optional<std::string> expected_genesis_hash;
+   std::optional<std::string> observed_genesis_hash;
+   std::optional<fc::time_point> verified_at;
+   std::optional<fc::microseconds> verification_age;
+   std::uint64_t transport_session_id = 0;
+   std::uint64_t verification_attempts = 0;
+   std::uint64_t verification_successes = 0;
+   std::uint64_t verification_mismatches = 0;
+   std::uint64_t verification_failures = 0;
+   std::uint64_t verification_recoveries = 0;
+   std::map<solana_cluster_identity_operation, std::uint64_t> blocked_operations;
+};
 
 class solana_client;
 using solana_client_ptr = std::shared_ptr<solana_client>;
@@ -281,11 +374,9 @@ public:
     * @return Confirmed transaction signature.
     * @throws fc::timeout_exception on deadline expiry; fc::exception on tx error.
     */
-   std::string execute_tx_and_confirm(const idl::instruction& instr,
-                                      const std::vector<account_meta>& accounts,
+   std::string execute_tx_and_confirm(const idl::instruction& instr, const std::vector<account_meta>& accounts,
                                       const program_invoke_data_items& params = {},
-                                      const solana_confirm_options& opts =
-                                         solana_confirm_option_defaults);
+                                      const solana_confirm_options& opts = solana_confirm_option_defaults);
 
    /**
     * @brief Same as `execute_tx_and_confirm` above, but prepends the supplied
@@ -305,12 +396,10 @@ public:
     * @return Confirmed transaction signature.
     * @throws fc::timeout_exception on deadline expiry; fc::exception on tx error.
     */
-   std::string execute_tx_and_confirm(const idl::instruction& instr,
-                                      const std::vector<account_meta>& accounts,
+   std::string execute_tx_and_confirm(const idl::instruction& instr, const std::vector<account_meta>& accounts,
                                       const program_invoke_data_items& params,
                                       const std::vector<instruction>& pre_instructions,
-                                      const solana_confirm_options& opts =
-                                         solana_confirm_option_defaults);
+                                      const solana_confirm_options& opts = solana_confirm_option_defaults);
 
    /**
     * @brief Resolve accounts for an instruction based on IDL
@@ -376,9 +465,8 @@ protected:
     * @param opts Commitment + retry envelope captured into the callable
     */
    template <typename RT, typename... Args>
-   solana_program_tx_fn<RT, Args...> create_tx_and_confirm(
-      const idl::instruction&  instr,
-      solana_confirm_options   opts = solana_confirm_option_defaults);
+   solana_program_tx_fn<RT, Args...>
+   create_tx_and_confirm(const idl::instruction& instr, solana_confirm_options opts = solana_confirm_option_defaults);
 
    /**
     * @brief Creates a typed account data getter function
@@ -393,7 +481,8 @@ protected:
     * @return Callable function object that fetches and decodes the account data
     */
    template <typename RT>
-   solana_program_account_data_fn<RT> create_account_data_get(const std::string& idl_type_name, const solana_public_key& pda);
+   solana_program_account_data_fn<RT> create_account_data_get(const std::string& idl_type_name,
+                                                              const solana_public_key& pda);
 
    /**
     * @brief Encode a value to Borsh format using IDL type information
@@ -444,7 +533,7 @@ protected:
     * @return Pair of (pubkey, bump)
     */
    std::pair<solana_public_key, uint8_t> derive_pda(const std::vector<idl::pda_seed>& pda_seeds,
-                                          const program_invoke_data_items& params = {});
+                                                    const program_invoke_data_items& params = {});
 
    /**
     * @brief Decode a value from Borsh-encoded data using IDL type information
@@ -553,6 +642,22 @@ public:
                  client_options rpc_options = {});
 
    /**
+    * Construct a cluster-pinned client and verify it before returning.
+    *
+    * The JSON-RPC transport, expected hash, and initial observation are bound
+    * into this instance. Construction throws before the client can be exposed
+    * when the bounded startup probe does not produce an exact canonical match.
+    *
+    * @param sig_provider Signature provider for signing transactions.
+    * @param url_source Configured Solana RPC endpoint.
+    * @param identity_config Independently sourced expected cluster identity
+    *                        and freshness policy.
+    */
+   solana_client(const signature_provider_ptr& sig_provider, const std::variant<std::string, fc::url>& url_source,
+                 solana_cluster_identity_config identity_config,
+                 client_options rpc_options = {});
+
+   /**
     * @brief Execute a raw JSON-RPC method call
     */
    fc::variant execute(const std::string& method, const fc::variant& params);
@@ -565,6 +670,16 @@ public:
     * `execute`.
     */
    fc::variant execute_idempotent(const std::string& method, const fc::variant& params);
+
+   /**
+    * Return sanitized cluster-verification state and counters.
+    */
+   solana_cluster_identity_snapshot get_cluster_identity_snapshot() const;
+
+   /**
+    * Return true when this client enforces an operator-supplied genesis hash.
+    */
+   bool cluster_identity_pinning_enabled() const noexcept { return _cluster_identity.has_value(); }
 
    /**
     * @brief Get the signer's public key
@@ -583,7 +698,7 @@ public:
     * @return Account info or nullopt if account doesn't exist
     */
    std::optional<account_info> get_account_info(const pubkey_compat_t& address,
-                                                 commitment_t commitment = commitment_t::confirmed);
+                                                commitment_t commitment = commitment_t::confirmed);
 
    /**
     * @brief Get account balance in lamports
@@ -594,7 +709,7 @@ public:
     * @brief Get multiple accounts in a single request
     */
    std::vector<std::optional<account_info>> get_multiple_accounts(const std::vector<solana_public_key>& addresses,
-                                                                   commitment_t commitment = commitment_t::confirmed);
+                                                                  commitment_t commitment = commitment_t::confirmed);
 
    //=========================================================================
    // Block Methods
@@ -724,7 +839,7 @@ public:
     * @return Fee in lamports or nullopt if blockhash expired
     */
    std::optional<uint64_t> get_fee_for_message(const std::string& message_base64,
-                                                commitment_t commitment = commitment_t::confirmed);
+                                               commitment_t commitment = commitment_t::confirmed);
 
    /**
     * @brief Get recent prioritization fees
@@ -737,7 +852,8 @@ public:
 
    fc::variant get_inflation_governor(commitment_t commitment = commitment_t::confirmed);
    fc::variant get_inflation_rate();
-   fc::variant get_inflation_reward(const std::vector<solana_public_key>& addresses, std::optional<uint64_t> epoch = std::nullopt);
+   fc::variant get_inflation_reward(const std::vector<solana_public_key>& addresses,
+                                    std::optional<uint64_t> epoch = std::nullopt);
 
    //=========================================================================
    // Supply Methods
@@ -757,13 +873,13 @@ public:
    //=========================================================================
 
    fc::variant get_token_account_balance(const pubkey_compat_t& token_account,
-                                          commitment_t commitment = commitment_t::confirmed);
+                                         commitment_t commitment = commitment_t::confirmed);
    fc::variant get_token_accounts_by_delegate(const pubkey_compat_t& delegate, const fc::variant& filter,
-                                               commitment_t commitment = commitment_t::confirmed);
+                                              commitment_t commitment = commitment_t::confirmed);
    fc::variant get_token_accounts_by_owner(const pubkey_compat_t& owner, const fc::variant& filter,
-                                            commitment_t commitment = commitment_t::confirmed);
-   fc::variant get_token_largest_accounts(const pubkey_compat_t& mint,
                                            commitment_t commitment = commitment_t::confirmed);
+   fc::variant get_token_largest_accounts(const pubkey_compat_t& mint,
+                                          commitment_t commitment = commitment_t::confirmed);
    fc::variant get_token_supply(const pubkey_compat_t& mint, commitment_t commitment = commitment_t::confirmed);
 
    //=========================================================================
@@ -784,9 +900,9 @@ public:
     * @brief Get signatures for an address
     */
    std::vector<fc::variant> get_signatures_for_address(const pubkey_compat_t& address,
-                                                        std::optional<std::string> before = std::nullopt,
-                                                        std::optional<std::string> until = std::nullopt,
-                                                        size_t limit = 1000);
+                                                       std::optional<std::string> before = std::nullopt,
+                                                       std::optional<std::string> until = std::nullopt,
+                                                       size_t limit = 1000);
 
    /**
     * @brief Get signature statuses
@@ -849,7 +965,8 @@ public:
    /**
     * @brief Get minimum balance for rent exemption
     */
-   uint64_t get_minimum_balance_for_rent_exemption(size_t data_length, commitment_t commitment = commitment_t::confirmed);
+   uint64_t get_minimum_balance_for_rent_exemption(size_t data_length,
+                                                   commitment_t commitment = commitment_t::confirmed);
 
    //=========================================================================
    // Performance Methods
@@ -908,8 +1025,7 @@ public:
     * @param commitment Commitment level to wait for
     * @return Transaction signature
     */
-   std::string send_and_confirm_transaction(const transaction& tx,
-                                             commitment_t commitment = commitment_t::confirmed);
+   std::string send_and_confirm_transaction(const transaction& tx, commitment_t commitment = commitment_t::confirmed);
 
    /**
     * @brief Submit a signed transaction and await confirmation with
@@ -930,8 +1046,7 @@ public:
     * @return Confirmed transaction signature.
     */
    std::string send_transaction_and_confirm(const transaction& tx,
-                                             const solana_confirm_options& opts =
-                                                solana_confirm_option_defaults);
+                                            const solana_confirm_options& opts = solana_confirm_option_defaults);
 
    //=========================================================================
    // Program Client Support
@@ -969,7 +1084,27 @@ public:
 private:
    const signature_provider_ptr _signature_provider;
    const solana_public_key _pubkey;
+   const std::optional<solana_cluster_identity_config> _cluster_identity;
+   const std::string _sanitized_endpoint;
    json_rpc_client _client;
+   /// Serializes JSON-RPC, verification state changes, signing, and submission.
+   mutable std::timed_mutex _operation_mutex;
+   /// Protects the published non-blocking telemetry snapshot.
+   mutable std::mutex _snapshot_mutex;
+
+   solana_cluster_identity_status _cluster_identity_status;
+   solana_cluster_identity_reason _cluster_identity_reason;
+   std::optional<solana_genesis_hash> _last_observed_genesis_hash;
+   std::optional<fc::time_point> _last_verified_at;
+   std::uint64_t _verified_transport_session_id = 0;
+   std::uint64_t _verification_attempts = 0;
+   std::uint64_t _verification_successes = 0;
+   std::uint64_t _verification_mismatches = 0;
+   std::uint64_t _verification_failures = 0;
+   std::uint64_t _verification_recoveries = 0;
+   std::map<solana_cluster_identity_operation, std::uint64_t> _blocked_operations;
+   /// Latest immutable-by-convention state copied for logs and metric scrapes.
+   solana_cluster_identity_snapshot _published_identity_snapshot;
 
    using program_key_t = std::pair<solana_public_key, std::string>;
    fc::threadsafe_map<program_key_t, std::shared_ptr<solana_program_client>> _programs_map{};
@@ -979,6 +1114,33 @@ private:
     * @brief Build config object for RPC calls
     */
    fc::variant build_config(commitment_t commitment, const std::optional<fc::variant_object>& extra = std::nullopt);
+
+   using operation_lock = std::unique_lock<std::timed_mutex>;
+
+   /** Acquire the serialized operation gate within the caller's active deadline. */
+   operation_lock lock_operation() const;
+   /** Execute one RPC method while the operation gate is already held. */
+   fc::variant execute_locked(const std::string& method, const fc::variant& params);
+   /** Return whether a probe is required after applying sticky/stale state transitions. */
+   bool cluster_verification_required_locked(solana_cluster_identity_operation operation, bool force_fresh);
+   /** Record one transport-level probe failure without exposing request data. */
+   void record_cluster_verification_failure_locked(solana_cluster_identity_operation operation,
+                                                   solana_cluster_identity_reason reason);
+   /** Validate and record one `getGenesisHash` result. */
+   void record_cluster_identity_observation_locked(solana_cluster_identity_operation operation,
+                                                   const fc::variant& observed_result,
+                                                   solana_cluster_identity_status previous_status,
+                                                   solana_cluster_identity_reason previous_reason);
+   /** Reverify pinned identity when required or block the protected operation. */
+   void ensure_cluster_verified_locked(solana_cluster_identity_operation operation, bool force_fresh);
+   /** Publish verification state without holding the RPC gate during later scrapes. */
+   void publish_cluster_identity_snapshot_locked();
+   /** Call `getGenesisHash` without recursively entering the public verification gate. */
+   fc::variant fetch_genesis_hash_unchecked_locked();
+   /** Count one operation rejected before RPC or signing. */
+   void record_blocked_operation_locked(solana_cluster_identity_operation operation);
+   /** Map raw RPC names onto the closed telemetry operation vocabulary. */
+   static solana_cluster_identity_operation operation_for_rpc_method(const std::string& method);
 };
 
 //=============================================================================
@@ -1036,8 +1198,8 @@ solana_program_tx_fn<RT, Args...> solana_program_client::create_tx(const idl::in
 }
 
 template <typename RT, typename... Args>
-solana_program_tx_fn<RT, Args...> solana_program_client::create_tx_and_confirm(
-   const idl::instruction& instr, solana_confirm_options opts) {
+solana_program_tx_fn<RT, Args...> solana_program_client::create_tx_and_confirm(const idl::instruction& instr,
+                                                                               solana_confirm_options opts) {
    auto idl_map = _idl_map.writeable();
    if (!idl_map.contains(instr.name)) {
       idl_map[instr.name] = instr;
@@ -1049,8 +1211,7 @@ solana_program_tx_fn<RT, Args...> solana_program_client::create_tx_and_confirm(
 
       // Execute + await confirmation. Throws on timeout or RPC-reported
       // tx failure, so callers never see a "success" for a dropped tx.
-      std::string signature = execute_tx_and_confirm(
-         idl, resolve_accounts(idl, params), params, opts);
+      std::string signature = execute_tx_and_confirm(idl, resolve_accounts(idl, params), params, opts);
 
       // Result coercion matches create_tx above so callers of either
       // factory see identical return-type behaviour.
@@ -1067,7 +1228,7 @@ solana_program_tx_fn<RT, Args...> solana_program_client::create_tx_and_confirm(
 
 template <typename RT>
 RT solana_program_client::get_account_data(const std::string& account_name, const solana_public_key& address,
-                                            commitment_t commitment) {
+                                           commitment_t commitment) {
    // Fetch account info from the network
    auto account_info = client->get_account_info(address, commitment);
    FC_ASSERT(account_info.has_value(), "Account not found: {}", address.to_string(fc::yield_function_t{}));
@@ -1086,7 +1247,7 @@ RT solana_program_client::get_account_data(const std::string& account_name, cons
 
 template <typename RT>
 solana_program_account_data_fn<RT> solana_program_client::create_account_data_get(const std::string& idl_type_name,
-                                                                                    const solana_public_key& pda) {
+                                                                                  const solana_public_key& pda) {
    // Capture type name and address by value for the lambda
    std::string type_name = idl_type_name;
    solana_public_key address = pda;
@@ -1109,4 +1270,4 @@ solana_program_account_data_fn<RT> solana_program_client::create_account_data_ge
    };
 }
 
-}  // namespace fc::network::solana
+} // namespace fc::network::solana

--- a/libraries/libfc/include/fc/network/solana/solana_client.hpp
+++ b/libraries/libfc/include/fc/network/solana/solana_client.hpp
@@ -3,7 +3,9 @@
 
 #include <array>
 #include <boost/core/demangle.hpp>
+#include <chrono>
 #include <cstdint>
+#include <deque>
 #include <fc-lite/threadsafe_map.hpp>
 #include <fc/crypto/signature_provider.hpp>
 #include <fc/network/json_rpc/json_rpc_client.hpp>
@@ -17,6 +19,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <string>
 #include <typeinfo>
 #include <variant>
@@ -145,8 +148,10 @@ struct solana_cluster_identity_snapshot {
    std::uint64_t verification_successes = 0;
    std::uint64_t verification_mismatches = 0;
    std::uint64_t verification_failures = 0;
+   std::uint64_t verification_cancellations = 0;
    std::uint64_t verification_recoveries = 0;
    std::map<solana_cluster_identity_operation, std::uint64_t> blocked_operations;
+   std::map<solana_cluster_identity_operation, std::uint64_t> protected_operation_failures;
 };
 
 class solana_client;
@@ -655,7 +660,10 @@ public:
                  client_options rpc_options, solana_cluster_identity_config identity_config);
 
    /**
-    * @brief Execute a raw JSON-RPC method call
+    * Execute a raw non-idempotent JSON-RPC method call.
+    *
+    * Unknown non-idempotent calls are conservatively classified as
+    * submissions. Read-only callers should use `execute_idempotent`.
     */
    fc::variant execute(const std::string& method, const fc::variant& params);
 
@@ -1083,26 +1091,33 @@ private:
    const solana_public_key _pubkey;
    const std::optional<solana_cluster_identity_config> _cluster_identity;
    const std::string _sanitized_endpoint;
-   /// Configured whole-operation budget, including operation-gate queueing.
+   /// Configured per-RPC budget, further bounded by an active task deadline.
    const std::optional<fc::microseconds> _rpc_total_timeout;
+   /// Blocking-adapter cancellation predicate used while waiting for the pinned RPC gate.
+   const std::function<bool()> _rpc_cancel_check;
    json_rpc_client _client;
-   /// Serializes JSON-RPC, verification state changes, signing, and submission.
-   mutable std::timed_mutex _operation_mutex;
-   /// Protects the published non-blocking telemetry snapshot.
-   mutable std::mutex _snapshot_mutex;
+   /// Serializes pinned calls through their final identity-result cross-check.
+   mutable std::timed_mutex _rpc_mutex;
+   /// Protects cluster identity state without serializing local signing.
+   mutable std::mutex _identity_mutex;
 
    solana_cluster_identity_status _cluster_identity_status;
    solana_cluster_identity_reason _cluster_identity_reason;
    std::optional<solana_genesis_hash> _last_observed_genesis_hash;
    std::optional<fc::time_point> _last_verified_at;
+   std::optional<std::chrono::steady_clock::time_point> _last_verified_monotonic;
    std::uint64_t _verification_attempts = 0;
    std::uint64_t _verification_successes = 0;
    std::uint64_t _verification_mismatches = 0;
    std::uint64_t _verification_failures = 0;
+   std::uint64_t _verification_cancellations = 0;
    std::uint64_t _verification_recoveries = 0;
    std::map<solana_cluster_identity_operation, std::uint64_t> _blocked_operations;
-   /// Latest immutable-by-convention state copied for logs and metric scrapes.
-   solana_cluster_identity_snapshot _published_identity_snapshot;
+   std::map<solana_cluster_identity_operation, std::uint64_t> _protected_operation_failures;
+   solana_cluster_identity_status _validation_previous_status = solana_cluster_identity_status::unverified;
+   bool _validation_failure_recorded = false;
+   std::deque<solana_public_key> _verified_blockhash_order;
+   std::set<solana_public_key> _verified_blockhashes;
 
    using program_key_t = std::pair<solana_public_key, std::string>;
    fc::threadsafe_map<program_key_t, std::shared_ptr<solana_program_client>> _programs_map{};
@@ -1113,12 +1128,17 @@ private:
     */
    fc::variant build_config(commitment_t commitment, const std::optional<fc::variant_object>& extra = std::nullopt);
 
-   using operation_lock = std::unique_lock<std::timed_mutex>;
-
-   /** Acquire the serialized operation gate within the caller's active deadline. */
-   operation_lock lock_operation() const;
-   /** Execute one RPC method while the operation gate is already held. */
-   fc::variant execute_locked(const std::string& method, const fc::variant& params, bool idempotent);
+   /** Force task-deadline inheritance and install the per-connection validator. */
+   client_options configure_rpc_options(client_options options);
+   using rpc_lock = std::unique_lock<std::timed_mutex>;
+   /** Acquire the pinned RPC gate within the caller's active deadline. */
+   rpc_lock lock_rpc() const;
+   /** Execute one RPC with explicit replay and telemetry semantics. */
+   fc::variant execute_rpc(const std::string& method, const fc::variant& params, bool idempotent,
+                           solana_cluster_identity_operation operation);
+   /** Execute one typed read-only RPC with stale-connection recovery. */
+   fc::variant execute_idempotent(const std::string& method, const fc::variant& params,
+                                  solana_cluster_identity_operation operation);
    /** Reject an operation after a sticky cluster-identity mismatch. */
    void throw_if_cluster_identity_mismatched_locked(solana_cluster_identity_operation operation);
    /** Record one transport-level probe failure without exposing request data. */
@@ -1128,16 +1148,28 @@ private:
    bool record_cluster_identity_observation_locked(solana_cluster_identity_operation operation,
                                                    const solana_genesis_hash& observed,
                                                    solana_cluster_identity_status previous_status);
-   /** Perform a fresh standalone verification or block the protected operation. */
-   void ensure_cluster_verified_locked(solana_cluster_identity_operation operation);
-   /** Publish verification state without holding the RPC gate during later scrapes. */
-   void publish_cluster_identity_snapshot_locked();
-   /** Call `getGenesisHash` without recursively entering the public verification gate. */
-   fc::variant fetch_genesis_hash_unchecked_locked();
    /** Count one operation rejected before RPC or signing. */
    void record_blocked_operation_locked(solana_cluster_identity_operation operation);
-   /** Map RPC names and replay semantics onto the closed telemetry operation vocabulary. */
-   static solana_cluster_identity_operation operation_for_rpc_method(const std::string& method, bool idempotent);
+   /** Begin one connection validation for the active protected operation. */
+   void begin_connection_validation();
+   /** Validate one connection's JSON-RPC identity result. */
+   void validate_connection_identity(const fc::variant& result);
+   /** Record one successfully validated persistent connection. */
+   void record_connection_validation_success();
+   /** Classify one rejected connection validation without throwing. */
+   void record_connection_validation_failure(std::exception_ptr failure,
+                                             std::optional<fc::http::failure_kind> transport_failure) noexcept;
+   /** Validate the public getGenesisHash result independently of its connection preflight. */
+   solana_genesis_hash validate_returned_genesis_hash(const fc::variant& result,
+                                                      solana_cluster_identity_operation operation);
+   /** Count one protected RPC that failed after admission. */
+   void record_protected_operation_failure(solana_cluster_identity_operation operation);
+   /** Remember a blockhash obtained through a validated RPC connection. */
+   void remember_verified_blockhash(const solana_public_key& blockhash);
+   /** Require pinned signing input to carry a blockhash observed by this client. */
+   void require_verified_blockhash_for_signing(const solana_public_key& blockhash);
+   /** Return whether sticky mismatch currently requires immediate abort. */
+   bool cluster_identity_mismatched() const;
 };
 
 //=============================================================================

--- a/libraries/libfc/include/fc/task/retry.hpp
+++ b/libraries/libfc/include/fc/task/retry.hpp
@@ -76,6 +76,7 @@ T retry_until(std::string_view                          op_label,
    const auto deadline_abs = fc::task::clamp_to_current_deadline(start_time + opts.total_timeout);
    const auto budget       = std::max(fc::microseconds(), deadline_abs - start_time);
    auto       backoff      = opts.initial_backoff;
+   fc::task::deadline_scope retry_deadline(deadline_abs);
 
    while (true) {
       if (fc::time_point::now() >= deadline_abs) {

--- a/libraries/libfc/src/network/http/http_client.cpp
+++ b/libraries/libfc/src/network/http/http_client.cpp
@@ -1095,6 +1095,7 @@ struct connection_state {
    }
 
    stream_variant stream;
+   bool validation_complete = false;
 };
 
 /** Monotonic clock used for connection-pool residence time. */
@@ -1324,9 +1325,11 @@ public:
    explicit client_impl(
       asio::any_io_executor executor,
       transport_options options_in,
+      std::optional<connection_validation> validation_in = std::nullopt,
       detail::resolver_start_fn resolver_start_in = {})
       : strand(asio::make_strand(std::move(executor)))
       , options(std::move(options_in))
+      , validation(std::move(validation_in))
       , tls_context(asio::ssl::context::tls_client)
       , resolver_start(std::move(resolver_start_in)) {
       FC_ASSERT(
@@ -1336,6 +1339,14 @@ public:
       FC_ASSERT(
          options.max_idle_connection_age.count() > 0,
          "Outbound HTTP idle connection age must be positive");
+      if (validation) {
+         FC_ASSERT(
+            static_cast<bool>(validation->validate_response),
+            "Outbound HTTP connection validation requires a response validator");
+         FC_ASSERT(
+            validation->options.retry.max_attempts == 1,
+            "Outbound HTTP connection validation must be single-attempt");
+      }
       tls_context.set_verify_mode(asio::ssl::verify_peer);
       error_code error;
       tls_context.set_default_verify_paths(error);
@@ -1400,6 +1411,7 @@ public:
 
    asio::strand<asio::any_io_executor> strand;
    transport_options options;
+   std::optional<connection_validation> validation;
    asio::ssl::context tls_context;
    detail::resolver_start_fn resolver_start;
    std::optional<std::string> proxy_host;
@@ -2433,6 +2445,14 @@ public:
       connection_affinity affinity = {},
       bool retain_connection = false);
 
+   /** Validate one newly opened connection before its first ordinary request. */
+   asio::awaitable<void>
+   validate_connection(
+      const target_info& target,
+      const std::shared_ptr<connection_state>& connection,
+      const std::shared_ptr<request_control>& control,
+      const std::optional<time_point>& request_total_deadline);
+
    asio::awaitable<void>
    async_warm_up(
       url target,
@@ -2640,6 +2660,84 @@ public:
    bool reading = false;
 };
 
+asio::awaitable<void>
+client_impl::validate_connection(
+   const target_info& target,
+   const std::shared_ptr<connection_state>& connection,
+   const std::shared_ptr<request_control>& control,
+   const std::optional<time_point>& request_total_deadline) {
+   FC_ASSERT(validation, "Outbound HTTP connection validation is not configured");
+   FC_ASSERT(!connection->validation_complete, "Outbound HTTP connection was already validated");
+
+   try {
+      if (validation->on_attempt)
+         validation->on_attempt();
+
+      auto validation_options = validation->options;
+      if (request_total_deadline) {
+         const auto remaining = *request_total_deadline - time_point::now();
+         if (remaining.count() <= 0) {
+            throw transport_failure(
+               failure_kind::timeout_total,
+               "request deadline expired before connection validation");
+         }
+         validation_options.timeouts.total =
+            validation_options.timeouts.total
+               ? std::min(*validation_options.timeouts.total, remaining)
+               : std::optional(remaining);
+      }
+
+      auto reader = co_await async_open(
+         validation->validation_request,
+         std::move(validation_options),
+         control,
+         {},
+         connection_affinity{
+            .connection = connection,
+            .connection_key = target.connection_key,
+         },
+         true);
+
+      response validation_response{
+         .status = reader->value_head.status,
+         .reason = reader->value_head.reason,
+      };
+      std::array<char, body_read_buffer_bytes> body_buffer{};
+      while (!reader->complete.load(std::memory_order_acquire)) {
+         const auto bytes = co_await reader->read_some(asio::buffer(body_buffer));
+         validation_response.body.append(body_buffer.data(), bytes);
+      }
+
+      validation->validate_response(validation_response);
+      if (!connection->open()) {
+         throw transport_failure(
+            failure_kind::connect,
+            "connection validation response did not preserve a persistent connection");
+      }
+      if (validation->on_success)
+         validation->on_success();
+      connection->validation_complete = true;
+   } catch (...) {
+      connection->close();
+      const auto failure = std::current_exception();
+      std::optional<failure_kind> transport_kind;
+      try {
+         std::rethrow_exception(failure);
+      } catch (const transport_failure& transport_error) {
+         transport_kind = transport_error.kind;
+      } catch (...) {
+      }
+      if (validation->on_failure) {
+         try {
+            validation->on_failure(failure, transport_kind);
+         } catch (...) {
+            // Observation cannot replace the validation failure seen by the caller.
+         }
+      }
+      std::rethrow_exception(failure);
+   }
+}
+
 asio::awaitable<std::shared_ptr<response_reader_impl>>
 client_impl::async_open(
    request req,
@@ -2708,6 +2806,9 @@ client_impl::async_open(
             connection = std::move(acquired.first);
             reused = acquired.second;
          }
+
+         if (!affinity && validation && !connection->validation_complete)
+            co_await validate_connection(target, connection, control, total_deadline);
 
          auto request_message = build_request(req, target);
          if (on_phase)
@@ -2914,18 +3015,45 @@ async_close_retained_response(
    co_return;
 }
 
-client::client(asio::any_io_executor executor,
-               transport_options options)
-   : client(std::move(executor), std::move(options), {}) {}
+client::client(
+   asio::any_io_executor executor,
+   transport_options options)
+   : client(
+        std::move(executor),
+        std::move(options),
+        std::nullopt,
+        {}) {}
+
+client::client(
+   asio::any_io_executor executor,
+   transport_options options,
+   std::optional<connection_validation> validation)
+   : client(
+        std::move(executor),
+        std::move(options),
+        std::move(validation),
+        {}) {}
 
 client::client(
    asio::any_io_executor executor,
    transport_options options,
    detail::resolver_start_fn resolver_start)
+   : client(
+        std::move(executor),
+        std::move(options),
+        std::nullopt,
+        std::move(resolver_start)) {}
+
+client::client(
+   asio::any_io_executor executor,
+   transport_options options,
+   std::optional<connection_validation> validation,
+   detail::resolver_start_fn resolver_start)
    : _impl(
         std::make_shared<client_impl>(
            std::move(executor),
            std::move(options),
+           std::move(validation),
            std::move(resolver_start))) {}
 
 client::~client() = default;

--- a/libraries/libfc/src/network/http/http_client_legacy.cpp
+++ b/libraries/libfc/src/network/http/http_client_legacy.cpp
@@ -44,10 +44,12 @@ class transport_impl {
 public:
    explicit transport_impl(
       transport_options options,
+      std::optional<connection_validation> validation = std::nullopt,
       detail::resolver_start_fn resolver_start = {})
       : async_client(
            io.get_executor(),
            std::move(options),
+           std::move(validation),
            std::move(resolver_start))
       , poll_timer(io) {}
 
@@ -372,15 +374,37 @@ private:
    std::timed_mutex use_mutex;
 };
 
-transport::transport(transport_options options)
-   : transport(std::move(options), {}) {}
+transport::transport(
+   transport_options options)
+   : transport(
+        std::move(options),
+        std::nullopt,
+        {}) {}
+
+transport::transport(
+   transport_options options,
+   std::optional<connection_validation> validation)
+   : transport(
+        std::move(options),
+        std::move(validation),
+        {}) {}
 
 transport::transport(
    transport_options options,
    detail::resolver_start_fn resolver_start)
+   : transport(
+        std::move(options),
+        std::nullopt,
+        std::move(resolver_start)) {}
+
+transport::transport(
+   transport_options options,
+   std::optional<connection_validation> validation,
+   detail::resolver_start_fn resolver_start)
    : _impl(
         std::make_unique<transport_impl>(
            std::move(options),
+           std::move(validation),
            std::move(resolver_start))) {}
 
 transport::~transport() = default;

--- a/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
+++ b/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
@@ -16,6 +16,7 @@ constexpr std::string_view https_scheme = "https";
 constexpr std::string_view default_http_path = "/";
 constexpr uint32_t single_attempt = 1;
 constexpr uint32_t stale_connection_max_attempts = 2;
+constexpr int64_t connection_validation_request_id = 0;
 constexpr uint32_t ok_status =
    static_cast<uint32_t>(
       boost::beast::http::status::ok);
@@ -38,6 +39,16 @@ fc::http::request_options stale_connection_retry_options(fc::http::request_optio
    return options;
 }
 
+/** Apply one optional upper bound to a request's total timeout. */
+void cap_total_timeout(fc::http::request_options& options,
+                       const std::optional<fc::microseconds>& cap,
+                       std::string_view operation) {
+   if (!cap)
+      return;
+   FC_ASSERT(cap->count() > 0, "{} total timeout cap must be positive", std::string(operation));
+   options.timeouts.total = options.timeouts.total ? std::min(*options.timeouts.total, *cap) : cap;
+}
+
 /** Apply a per-call replay policy and optional total-timeout cap. */
 fc::http::request_options request_options_for(fc::http::request_options options, const call_options& call) {
    switch (call.replay) {
@@ -49,11 +60,7 @@ fc::http::request_options request_options_for(fc::http::request_options options,
       break;
    }
 
-   if (call.total_timeout_cap) {
-      FC_ASSERT(call.total_timeout_cap->count() > 0, "JSON-RPC total timeout cap must be positive");
-      options.timeouts.total =
-         options.timeouts.total ? std::min(*options.timeouts.total, *call.total_timeout_cap) : call.total_timeout_cap;
-   }
+   cap_total_timeout(options, call.total_timeout_cap, "JSON-RPC call");
    return options;
 }
 
@@ -65,17 +72,7 @@ request_options_for(
    options =
       non_replaying_request_options(
          std::move(options));
-   if (call.total_timeout_cap) {
-      FC_ASSERT(
-         call.total_timeout_cap->count() > 0,
-         "JSON-RPC total timeout cap must be positive");
-      options.timeouts.total =
-         options.timeouts.total
-            ? std::min(
-                 *options.timeouts.total,
-                 *call.total_timeout_cap)
-            : call.total_timeout_cap;
-   }
+   cap_total_timeout(options, call.total_timeout_cap, "JSON-RPC follow-up");
    return options;
 }
 
@@ -133,6 +130,17 @@ variant make_call_payload(
    return variant(std::move(object));
 }
 
+/** Build one JSON-RPC POST request for a complete payload. */
+fc::http::request make_http_request(const fc::url& url, const std::string& user_agent, const variant& payload) {
+   return fc::http::request{
+      .method = fc::http::request_method::post,
+      .target = url,
+      .body = fc::json::to_string(payload, fc::json::yield_function_t{}),
+      .content_type = "application/json",
+      .user_agent = user_agent,
+   };
+}
+
 } // namespace
 
 json_rpc_error::json_rpc_error(const std::string& message)
@@ -164,10 +172,69 @@ json_rpc_client::json_rpc_client(fc::url url, const std::optional<std::string>& 
    , _user_agent(user_agent.value_or(BOOST_BEAST_VERSION_STRING))
    , _next_id(1)
    , _options(normalize_options(refresh_policy, std::move(options)))
-   , _transport(_options.transport) {
+   , _transport(_options.transport, make_http_connection_validation(_url, _user_agent, _options)) {
    const auto scheme = _url.proto();
    FC_ASSERT(scheme == http_scheme || scheme == https_scheme, "Unsupported JSON-RPC URL scheme: {}", scheme);
    FC_ASSERT(_url.host() && !_url.host()->empty(), "JSON-RPC URL is missing host");
+}
+
+json_rpc_client::json_rpc_client(json_rpc_client&& other)
+   : _url(std::move(other._url))
+   , _user_agent(std::move(other._user_agent))
+   , _next_id(other._next_id.load(std::memory_order_relaxed))
+   , _options(std::move(other._options))
+   , _transport(std::move(other._transport)) {}
+
+json_rpc_client& json_rpc_client::operator=(json_rpc_client&& other) {
+   if (this == &other)
+      return *this;
+   _url = std::move(other._url);
+   _user_agent = std::move(other._user_agent);
+   _next_id.store(other._next_id.load(std::memory_order_relaxed), std::memory_order_relaxed);
+   _options = std::move(other._options);
+   _transport = std::move(other._transport);
+   return *this;
+}
+
+std::int64_t json_rpc_client::next_request_id() {
+   const auto id = _next_id.fetch_add(1, std::memory_order_relaxed);
+   FC_ASSERT(id > connection_validation_request_id, "JSON-RPC request id space exhausted");
+   return id;
+}
+
+std::optional<fc::http::connection_validation>
+json_rpc_client::make_http_connection_validation(const fc::url& url,
+                                                 const std::string& user_agent,
+                                                 const client_options& options) {
+   if (!options.connection_validator)
+      return std::nullopt;
+
+   const auto& validator = *options.connection_validator;
+   FC_ASSERT(!validator.method.empty(), "JSON-RPC connection validator method must not be empty");
+   FC_ASSERT(static_cast<bool>(validator.validate_result),
+             "JSON-RPC connection validator requires a result predicate");
+
+   auto request_options = non_replaying_request_options(options.request);
+   cap_total_timeout(request_options, validator.total_timeout_cap, "JSON-RPC connection validation");
+
+   return fc::http::connection_validation{
+      .validation_request =
+         make_http_request(
+            url,
+            user_agent,
+            make_call_payload(validator.method, validator.params, connection_validation_request_id)),
+      .options = std::move(request_options),
+      .validate_response =
+         [validate_result = validator.validate_result](const fc::http::response& response) {
+            require_ok(response, "JSON-RPC connection validation");
+            FC_ASSERT(!response.body.empty(), "Empty HTTP body, expected JSON-RPC connection validation response");
+            validate_result(
+               extract_call_result(fc::json::from_string(response.body), connection_validation_request_id));
+         },
+      .on_attempt = validator.on_attempt,
+      .on_success = validator.on_success,
+      .on_failure = validator.on_failure,
+   };
 }
 
 variant json_rpc_client::call(const std::string& method, const fc::variant& params) {
@@ -182,17 +249,11 @@ variant json_rpc_client::call_then(const std::string& method, const fc::variant&
                                    call_options first_call_options, const continuation_hook& continue_with) {
    FC_ASSERT(static_cast<bool>(continue_with), "JSON-RPC continuation hook must be configured");
 
-   const auto initial_id = _next_id++;
-   const auto next_id = _next_id++;
+   const auto initial_id = next_request_id();
+   const auto next_id = next_request_id();
 
    const auto make_request = [&](const variant& payload) {
-      return fc::http::request{
-         .method = fc::http::request_method::post,
-         .target = _url,
-         .body = fc::json::to_string(payload, fc::json::yield_function_t{}),
-         .content_type = "application/json",
-         .user_agent = _user_agent,
-      };
+      return make_http_request(_url, _user_agent, payload);
    };
 
    const auto response = _transport.perform_then(
@@ -224,7 +285,7 @@ variant json_rpc_client::call_then(const std::string& method, const fc::variant&
 }
 
 variant json_rpc_client::call_with_policy(const std::string& method, const fc::variant& params, call_options options) {
-   const auto id = _next_id++;
+   const auto id = next_request_id();
    variant response =
       send_json(
          make_call_payload(method, params, id),
@@ -309,14 +370,7 @@ fc::variant json_rpc_client::call_batch(const std::vector<fc::variant>& requests
 
 variant json_rpc_client::send_json(const variant& payload, bool expect_json_body,
                                    fc::http::request_options request_options) {
-   const auto body = fc::json::to_string(payload, fc::json::yield_function_t{});
-   fc::http::request request{
-      .method = fc::http::request_method::post,
-      .target = _url,
-      .body = body,
-      .content_type = "application/json",
-      .user_agent = _user_agent,
-   };
+   auto request = make_http_request(_url, _user_agent, payload);
    const auto response = _transport.perform(request, std::move(request_options));
    require_ok(response, "JSON-RPC request");
 

--- a/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
+++ b/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
@@ -213,7 +213,7 @@ variant json_rpc_client::call_then(const std::string& method, const fc::variant&
                   make_call_payload(
                      std::move(next.method),
                      std::move(next.params),
-                  next_id)),
+                     next_id)),
             .options = request_options_for(_options.request, next.options),
          };
       });

--- a/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
+++ b/libraries/libfc/src/network/json_rpc/json_rpc_client.cpp
@@ -213,7 +213,7 @@ variant json_rpc_client::call_then(const std::string& method, const fc::variant&
                   make_call_payload(
                      std::move(next.method),
                      std::move(next.params),
-                     next_id)),
+                  next_id)),
             .options = request_options_for(_options.request, next.options),
          };
       });

--- a/libraries/libfc/src/network/solana/solana_client.cpp
+++ b/libraries/libfc/src/network/solana/solana_client.cpp
@@ -1033,10 +1033,16 @@ fc::variant solana_client::execute_locked(const std::string& method, const fc::v
    } catch (const fc::timeout_exception&) {
       if (!observation_received) {
          record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
+      } else if (_cluster_identity_status == solana_cluster_identity_status::verified &&
+                 _client.last_transport_session_id() == 0) {
+         record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
       }
       throw;
    } catch (const std::exception&) {
       if (!observation_received) {
+         record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
+      } else if (_cluster_identity_status == solana_cluster_identity_status::verified &&
+                 _client.last_transport_session_id() == 0) {
          record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
       }
       throw;
@@ -1118,10 +1124,9 @@ void solana_client::record_cluster_identity_observation_locked(
       ++_verification_mismatches;
       record_blocked_operation_locked(operation);
       elog("Solana cluster identity mismatch "
-           "(client_id={},endpoint={},expected_genesis_hash={},observed_genesis_hash={},"
-           "status={},reason={},operation={})",
-           _cluster_identity->client_id, _sanitized_endpoint, _cluster_identity->expected_genesis_hash.canonical,
-           observed.canonical, magic_enum::enum_name(_cluster_identity_status),
+           "(client_id={},endpoint={},status={},reason={},operation={})",
+           _cluster_identity->client_id, _sanitized_endpoint,
+           magic_enum::enum_name(_cluster_identity_status),
            magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
       publish_cluster_identity_snapshot_locked();
       FC_THROW("Solana cluster identity mismatch for client '{}'", _cluster_identity->client_id);
@@ -1140,8 +1145,8 @@ void solana_client::record_cluster_identity_observation_locked(
    if (recovered) {
       ++_verification_recoveries;
       wlog("Solana cluster identity verification recovered "
-           "(client_id={},endpoint={},observed_genesis_hash={},status={},reason={},operation={})",
-           _cluster_identity->client_id, _sanitized_endpoint, observed.canonical,
+           "(client_id={},endpoint={},status={},reason={},operation={})",
+           _cluster_identity->client_id, _sanitized_endpoint,
            magic_enum::enum_name(_cluster_identity_status), magic_enum::enum_name(_cluster_identity_reason),
            magic_enum::enum_name(operation));
    }

--- a/libraries/libfc/src/network/solana/solana_client.cpp
+++ b/libraries/libfc/src/network/solana/solana_client.cpp
@@ -32,13 +32,23 @@ std::string sanitize_endpoint(const std::variant<std::string, fc::url>& source) 
 }
 
 /**
- * Construct a transport while the configured startup deadline is active.
+ * Make the transport honor both caller deadlines and deadlines installed
+ * internally by solana_client. Pinned safety budgets cannot be made optional.
  */
-json_rpc_client create_pinned_rpc_client(const std::variant<std::string, fc::url>& source,
-                                         fc::microseconds probe_timeout, client_options rpc_options) {
-   FC_ASSERT(probe_timeout.count() > 0, "Solana cluster identity probe timeout must be positive");
-   fc::task::deadline_scope deadline(fc::task::clamp_to_current_deadline(fc::time_point::now() + probe_timeout));
-   return json_rpc_client::create(source, std::move(rpc_options));
+client_options enforce_solana_deadline_inheritance(client_options options) {
+   options.request.timeouts.inherit_task_deadline = true;
+   return options;
+}
+
+/** Return the configured whole-operation deadline bounded by the caller. */
+fc::time_point operation_deadline(std::optional<fc::microseconds> configured_timeout) {
+   if (!configured_timeout)
+      return fc::task::current_deadline().value_or(fc::time_point::maximum());
+
+   FC_ASSERT(configured_timeout->count() > 0, "Solana client operation timeout must be positive");
+   auto deadline = fc::time_point::now();
+   deadline.safe_add(*configured_timeout);
+   return fc::task::clamp_to_current_deadline(deadline);
 }
 
 /**
@@ -935,7 +945,8 @@ solana_client::solana_client(const signature_provider_ptr& sig_provider,
    , _pubkey(from_fc_public_key(_signature_provider->public_key))
    , _cluster_identity(std::nullopt)
    , _sanitized_endpoint(sanitize_endpoint(url_source))
-   , _client(json_rpc_client::create(url_source, std::move(rpc_options)))
+   , _rpc_total_timeout(rpc_options.request.timeouts.total)
+   , _client(json_rpc_client::create(url_source, enforce_solana_deadline_inheritance(std::move(rpc_options))))
    , _cluster_identity_status(solana_cluster_identity_status::unpinned)
    , _cluster_identity_reason(solana_cluster_identity_reason::missing_expected_identity) {
    publish_cluster_identity_snapshot_locked();
@@ -943,30 +954,31 @@ solana_client::solana_client(const signature_provider_ptr& sig_provider,
 
 solana_client::solana_client(const signature_provider_ptr& sig_provider,
                              const std::variant<std::string, fc::url>& url_source,
-                             solana_cluster_identity_config identity_config, client_options rpc_options)
+                             client_options rpc_options, solana_cluster_identity_config identity_config)
    : _signature_provider(sig_provider)
    , _pubkey(from_fc_public_key(_signature_provider->public_key))
    , _cluster_identity(std::move(identity_config))
    , _sanitized_endpoint(sanitize_endpoint(url_source))
-   , _client(create_pinned_rpc_client(url_source, _cluster_identity->probe_timeout, std::move(rpc_options)))
+   , _rpc_total_timeout(rpc_options.request.timeouts.total)
+   , _client(json_rpc_client::create(url_source, enforce_solana_deadline_inheritance(std::move(rpc_options))))
    , _cluster_identity_status(solana_cluster_identity_status::unverified)
    , _cluster_identity_reason(solana_cluster_identity_reason::none) {
    FC_ASSERT(!_cluster_identity->client_id.empty(), "Solana cluster identity client id must not be empty");
-   FC_ASSERT(_cluster_identity->maximum_verification_age.count() > 0,
-             "Solana cluster identity maximum verification age must be positive");
-   FC_ASSERT(static_cast<bool>(_cluster_identity->verification_clock),
-             "Solana cluster identity verification clock must be configured");
    const auto reparsed = parse_solana_genesis_hash(_cluster_identity->expected_genesis_hash.canonical);
    FC_ASSERT(reparsed == _cluster_identity->expected_genesis_hash,
              "Solana expected genesis hash bytes do not match their canonical representation");
 
+   fc::task::deadline_scope operation_scope(
+      operation_deadline(_cluster_identity->probe_timeout));
    auto operation_guard = lock_operation();
-   ensure_cluster_verified_locked(solana_cluster_identity_operation::startup, true);
+   ensure_cluster_verified_locked(solana_cluster_identity_operation::startup);
 }
 
 fc::variant solana_client::execute(const std::string& method, const fc::variant& params) {
+   fc::task::deadline_scope operation_scope(
+      operation_deadline(_rpc_total_timeout));
    auto operation_guard = lock_operation();
-   return execute_locked(method, params);
+   return execute_locked(method, params, false);
 }
 
 solana_client::operation_lock solana_client::lock_operation() const {
@@ -988,8 +1000,9 @@ solana_client::operation_lock solana_client::lock_operation() const {
    return lock;
 }
 
-solana_cluster_identity_operation solana_client::operation_for_rpc_method(const std::string& method) {
-   if (method == "sendTransaction") {
+solana_cluster_identity_operation solana_client::operation_for_rpc_method(const std::string& method,
+                                                                          bool idempotent) {
+   if (method == "sendTransaction" || method == "requestAirdrop") {
       return solana_cluster_identity_operation::submission;
    }
    if (method == "getLatestBlockhash") {
@@ -1001,45 +1014,77 @@ solana_cluster_identity_operation solana_client::operation_for_rpc_method(const 
    if (method == "getFeeForMessage" || method == "getRecentPrioritizationFees") {
       return solana_cluster_identity_operation::fee_estimation;
    }
-   return solana_cluster_identity_operation::rpc_read;
+   return idempotent ? solana_cluster_identity_operation::rpc_read
+                     : solana_cluster_identity_operation::submission;
 }
 
-fc::variant solana_client::execute_locked(const std::string& method, const fc::variant& params) {
-   const auto operation = operation_for_rpc_method(method);
+fc::variant solana_client::execute_locked(const std::string& method, const fc::variant& params, bool idempotent) {
+   const auto operation = operation_for_rpc_method(method, idempotent);
    if (!_cluster_identity) {
       return _client.call(method, params);
    }
 
    // Every protected RPC is preceded by getGenesisHash on the exact same
    // opaque HTTP/TLS connection. Cached evidence remains telemetry only.
-   (void)cluster_verification_required_locked(operation, true);
+   throw_if_cluster_identity_mismatched_locked(operation);
    const auto previous_status = _cluster_identity_status;
    ++_verification_attempts;
 
-   bool observation_received = false;
+   enum class probe_result { none, matched, mismatch, malformed };
+   probe_result result = probe_result::none;
+   std::optional<solana_genesis_hash> observed;
    try {
-      return _client.call_then("getGenesisHash", fc::variants{},
-                               continuation_options{
-                                  .initial_timeout = _cluster_identity->probe_timeout,
-                                  .initial_idempotent = true,
-                               },
-                               [&](const fc::variant& observed_result) {
-                                  observation_received = true;
-                                  record_cluster_identity_observation_locked(operation, observed_result,
-                                                                             previous_status);
-                                  return continuation_call{
-                                     .method = method,
-                                     .params = params,
-                                  };
-                               });
-   } catch (const fc::timeout_exception&) {
-      if (!observation_received) {
-         record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
-      }
-      throw;
-   } catch (const std::exception&) {
-      if (!observation_received) {
-         record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
+      auto protected_result =
+         _client.call_then("getGenesisHash", fc::variants{},
+                           call_options{
+                              .replay = replay_policy::stale_reused_connection_once,
+                              .total_timeout_cap = _cluster_identity->probe_timeout,
+                           },
+                           [&](const fc::variant& observed_result) {
+                              // Keep the connection-affine hook bounded and non-blocking:
+                              // parse, compare, and select the follow-up only.
+                              try {
+                                 FC_ASSERT(observed_result.is_string(),
+                                           "Solana getGenesisHash result must be a string");
+                                 observed = parse_solana_genesis_hash(observed_result.as_string());
+                              } catch (const std::exception&) {
+                                 result = probe_result::malformed;
+                                 throw;
+                              }
+                              if (*observed != _cluster_identity->expected_genesis_hash) {
+                                 result = probe_result::mismatch;
+                                 FC_THROW("Solana cluster identity mismatch for client '{}'",
+                                          _cluster_identity->client_id);
+                              }
+                              result = probe_result::matched;
+                              return continuation_call{
+                                 .method = method,
+                                 .params = params,
+                              };
+                           });
+      FC_ASSERT(result == probe_result::matched && observed,
+                "Solana cluster identity continuation completed without a matching observation");
+      FC_ASSERT(record_cluster_identity_observation_locked(operation, *observed, previous_status),
+                "Solana cluster identity observation changed after a matching continuation");
+      return protected_result;
+   } catch (...) {
+      if (result == probe_result::matched || result == probe_result::mismatch) {
+         FC_ASSERT(observed, "Solana cluster identity result is missing its parsed observation");
+         const bool matched =
+            record_cluster_identity_observation_locked(operation, *observed, previous_status);
+         FC_ASSERT(matched == (result == probe_result::matched),
+                   "Solana cluster identity observation classification changed after the continuation");
+      } else if (result == probe_result::malformed) {
+         record_cluster_verification_failure_locked(
+            operation, solana_cluster_identity_reason::malformed_observed_identity);
+      } else {
+         try {
+            throw;
+         } catch (const fc::timeout_exception&) {
+            record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
+         } catch (const std::exception&) {
+            record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
+         }
       }
       throw;
    }
@@ -1053,12 +1098,7 @@ void solana_client::record_blocked_operation_locked(solana_cluster_identity_oper
    ++_blocked_operations[operation];
 }
 
-bool solana_client::cluster_verification_required_locked(solana_cluster_identity_operation operation,
-                                                         bool force_fresh) {
-   if (!_cluster_identity) {
-      return false;
-   }
-
+void solana_client::throw_if_cluster_identity_mismatched_locked(solana_cluster_identity_operation operation) {
    if (_cluster_identity_status == solana_cluster_identity_status::mismatch) {
       record_blocked_operation_locked(operation);
       publish_cluster_identity_snapshot_locked();
@@ -1067,15 +1107,6 @@ bool solana_client::cluster_verification_required_locked(solana_cluster_identity
                _cluster_identity->client_id, magic_enum::enum_name(_cluster_identity_status),
                magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
    }
-
-   const auto now = _cluster_identity->verification_clock();
-   if (_cluster_identity_status == solana_cluster_identity_status::verified && _last_verified_at &&
-       now - *_last_verified_at >= _cluster_identity->maximum_verification_age) {
-      _cluster_identity_status = solana_cluster_identity_status::stale;
-      _cluster_identity_reason = solana_cluster_identity_reason::verification_stale;
-   }
-
-   return force_fresh || _cluster_identity_status != solana_cluster_identity_status::verified;
 }
 
 void solana_client::record_cluster_verification_failure_locked(solana_cluster_identity_operation operation,
@@ -1091,19 +1122,9 @@ void solana_client::record_cluster_verification_failure_locked(solana_cluster_id
    publish_cluster_identity_snapshot_locked();
 }
 
-void solana_client::record_cluster_identity_observation_locked(solana_cluster_identity_operation operation,
-                                                               const fc::variant& observed_result,
+bool solana_client::record_cluster_identity_observation_locked(solana_cluster_identity_operation operation,
+                                                               const solana_genesis_hash& observed,
                                                                solana_cluster_identity_status previous_status) {
-   solana_genesis_hash observed;
-   try {
-      FC_ASSERT(observed_result.is_string(), "Solana getGenesisHash result must be a string");
-      observed = parse_solana_genesis_hash(observed_result.as_string());
-   } catch (const std::exception&) {
-      record_cluster_verification_failure_locked(operation,
-                                                 solana_cluster_identity_reason::malformed_observed_identity);
-      throw;
-   }
-
    _last_observed_genesis_hash = observed;
    if (observed != _cluster_identity->expected_genesis_hash) {
       _cluster_identity_status = solana_cluster_identity_status::mismatch;
@@ -1115,14 +1136,14 @@ void solana_client::record_cluster_identity_observation_locked(solana_cluster_id
            _cluster_identity->client_id, _sanitized_endpoint, magic_enum::enum_name(_cluster_identity_status),
            magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
       publish_cluster_identity_snapshot_locked();
-      FC_THROW("Solana cluster identity mismatch for client '{}'", _cluster_identity->client_id);
+      return false;
    }
 
    const bool recovered = previous_status == solana_cluster_identity_status::error;
    _cluster_identity_status = solana_cluster_identity_status::verified;
    _cluster_identity_reason =
       recovered ? solana_cluster_identity_reason::verification_recovered : solana_cluster_identity_reason::none;
-   _last_verified_at = _cluster_identity->verification_clock();
+   _last_verified_at = fc::time_point::now();
    ++_verification_successes;
 
    if (recovered) {
@@ -1133,20 +1154,22 @@ void solana_client::record_cluster_identity_observation_locked(solana_cluster_id
            magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
    }
    publish_cluster_identity_snapshot_locked();
+   return true;
 }
 
-void solana_client::ensure_cluster_verified_locked(solana_cluster_identity_operation operation, bool force_fresh) {
-   if (!cluster_verification_required_locked(operation, force_fresh)) {
+void solana_client::ensure_cluster_verified_locked(solana_cluster_identity_operation operation) {
+   if (!_cluster_identity)
       return;
-   }
+
+   throw_if_cluster_identity_mismatched_locked(operation);
 
    const auto previous_status = _cluster_identity_status;
    ++_verification_attempts;
 
    fc::variant observed_result;
    try {
-      fc::task::deadline_scope probe_deadline(
-         fc::task::clamp_to_current_deadline(fc::time_point::now() + _cluster_identity->probe_timeout));
+      // The constructor/signing caller already installed the saturating probe
+      // deadline before acquiring the operation gate.
       observed_result = fetch_genesis_hash_unchecked_locked();
    } catch (const fc::timeout_exception&) {
       record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
@@ -1156,7 +1179,18 @@ void solana_client::ensure_cluster_verified_locked(solana_cluster_identity_opera
       throw;
    }
 
-   record_cluster_identity_observation_locked(operation, observed_result, previous_status);
+   solana_genesis_hash observed;
+   try {
+      FC_ASSERT(observed_result.is_string(), "Solana getGenesisHash result must be a string");
+      observed = parse_solana_genesis_hash(observed_result.as_string());
+   } catch (const std::exception&) {
+      record_cluster_verification_failure_locked(operation,
+                                                 solana_cluster_identity_reason::malformed_observed_identity);
+      throw;
+   }
+   if (!record_cluster_identity_observation_locked(operation, observed, previous_status)) {
+      FC_THROW("Solana cluster identity mismatch for client '{}'", _cluster_identity->client_id);
+   }
 }
 
 void solana_client::publish_cluster_identity_snapshot_locked() {
@@ -1191,18 +1225,19 @@ solana_cluster_identity_snapshot solana_client::get_cluster_identity_snapshot() 
    }
 
    if (snapshot.verified_at) {
-      const auto now = _cluster_identity ? _cluster_identity->verification_clock() : fc::time_point::now();
-      snapshot.verification_age = now - *snapshot.verified_at;
+      snapshot.verification_age = fc::time_point::now() - *snapshot.verified_at;
    }
    return snapshot;
 }
 
 fc::variant solana_client::execute_idempotent(const std::string& method, const fc::variant& params) {
+   fc::task::deadline_scope operation_scope(
+      operation_deadline(_rpc_total_timeout));
    auto operation_guard = lock_operation();
    if (!_cluster_identity) {
       return _client.call_idempotent(method, params);
    }
-   return execute_locked(method, params);
+   return execute_locked(method, params, true);
 }
 
 fc::variant solana_client::build_config(commitment_t commitment, const std::optional<fc::variant_object>& extra) {
@@ -1941,8 +1976,13 @@ transaction solana_client::create_transaction(const std::vector<instruction>& in
 }
 
 transaction solana_client::sign_transaction(transaction& tx) {
+   fc::task::deadline_scope operation_scope(
+      operation_deadline(
+         _cluster_identity
+            ? std::optional(_cluster_identity->probe_timeout)
+            : _rpc_total_timeout));
    auto operation_guard = lock_operation();
-   ensure_cluster_verified_locked(solana_cluster_identity_operation::signing, true);
+   ensure_cluster_verified_locked(solana_cluster_identity_operation::signing);
 
    auto msg_bytes = tx.msg.serialize();
 

--- a/libraries/libfc/src/network/solana/solana_client.cpp
+++ b/libraries/libfc/src/network/solana/solana_client.cpp
@@ -35,8 +35,7 @@ std::string sanitize_endpoint(const std::variant<std::string, fc::url>& source) 
  * Construct a transport while the configured startup deadline is active.
  */
 json_rpc_client create_pinned_rpc_client(const std::variant<std::string, fc::url>& source,
-                                         fc::microseconds probe_timeout,
-                                         client_options rpc_options) {
+                                         fc::microseconds probe_timeout, client_options rpc_options) {
    FC_ASSERT(probe_timeout.count() > 0, "Solana cluster identity probe timeout must be positive");
    fc::task::deadline_scope deadline(fc::task::clamp_to_current_deadline(fc::time_point::now() + probe_timeout));
    return json_rpc_client::create(source, std::move(rpc_options));
@@ -168,7 +167,11 @@ std::optional<size_t> min_borsh_encoded_size(const idl::idl_type& type, const id
 } // namespace
 
 solana_genesis_hash parse_solana_genesis_hash(const std::string& value) {
+   constexpr size_t maximum_encoded_genesis_hash_bytes = 44;
+
    FC_ASSERT(!value.empty(), "Solana genesis hash must not be empty");
+   FC_ASSERT(value.size() <= maximum_encoded_genesis_hash_bytes, "Solana genesis hash must not exceed {} encoded bytes",
+             maximum_encoded_genesis_hash_bytes);
 
    std::vector<char> decoded;
    try {
@@ -927,8 +930,7 @@ std::vector<account_meta> solana_program_client::resolve_accounts(const idl::ins
 //=============================================================================
 
 solana_client::solana_client(const signature_provider_ptr& sig_provider,
-                             const std::variant<std::string, fc::url>& url_source,
-                             client_options rpc_options)
+                             const std::variant<std::string, fc::url>& url_source, client_options rpc_options)
    : _signature_provider(sig_provider)
    , _pubkey(from_fc_public_key(_signature_provider->public_key))
    , _cluster_identity(std::nullopt)
@@ -941,16 +943,12 @@ solana_client::solana_client(const signature_provider_ptr& sig_provider,
 
 solana_client::solana_client(const signature_provider_ptr& sig_provider,
                              const std::variant<std::string, fc::url>& url_source,
-                             solana_cluster_identity_config identity_config,
-                             client_options rpc_options)
+                             solana_cluster_identity_config identity_config, client_options rpc_options)
    : _signature_provider(sig_provider)
    , _pubkey(from_fc_public_key(_signature_provider->public_key))
    , _cluster_identity(std::move(identity_config))
    , _sanitized_endpoint(sanitize_endpoint(url_source))
-   , _client(create_pinned_rpc_client(
-        url_source,
-        _cluster_identity->probe_timeout,
-        std::move(rpc_options)))
+   , _client(create_pinned_rpc_client(url_source, _cluster_identity->probe_timeout, std::move(rpc_options)))
    , _cluster_identity_status(solana_cluster_identity_status::unverified)
    , _cluster_identity_reason(solana_cluster_identity_reason::none) {
    FC_ASSERT(!_cluster_identity->client_id.empty(), "Solana cluster identity client id must not be empty");
@@ -1013,36 +1011,34 @@ fc::variant solana_client::execute_locked(const std::string& method, const fc::v
    }
 
    // Every protected RPC is preceded by getGenesisHash on the exact same
-   // HTTP/TLS connection. A cached observation can describe telemetry and
-   // signing freshness, but it cannot authorize a new transport session.
+   // opaque HTTP/TLS connection. Cached evidence remains telemetry only.
    (void)cluster_verification_required_locked(operation, true);
    const auto previous_status = _cluster_identity_status;
-   const auto previous_reason = _cluster_identity_reason;
    ++_verification_attempts;
 
    bool observation_received = false;
    try {
-      return _client.call_after_verification(
-         "getGenesisHash", fc::variants{},
-         [&](const fc::variant& observed_result) {
-            observation_received = true;
-            record_cluster_identity_observation_locked(operation, observed_result, previous_status, previous_reason);
-         },
-         _cluster_identity->probe_timeout,
-         method, params);
+      return _client.call_then("getGenesisHash", fc::variants{},
+                               continuation_options{
+                                  .initial_timeout = _cluster_identity->probe_timeout,
+                                  .initial_idempotent = true,
+                               },
+                               [&](const fc::variant& observed_result) {
+                                  observation_received = true;
+                                  record_cluster_identity_observation_locked(operation, observed_result,
+                                                                             previous_status);
+                                  return continuation_call{
+                                     .method = method,
+                                     .params = params,
+                                  };
+                               });
    } catch (const fc::timeout_exception&) {
       if (!observation_received) {
-         record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
-      } else if (_cluster_identity_status == solana_cluster_identity_status::verified &&
-                 _client.last_transport_session_id() == 0) {
          record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
       }
       throw;
    } catch (const std::exception&) {
       if (!observation_received) {
-         record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
-      } else if (_cluster_identity_status == solana_cluster_identity_status::verified &&
-                 _client.last_transport_session_id() == 0) {
          record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
       }
       throw;
@@ -1073,13 +1069,6 @@ bool solana_client::cluster_verification_required_locked(solana_cluster_identity
    }
 
    const auto now = _cluster_identity->verification_clock();
-   const auto current_transport_session_id = _client.last_transport_session_id();
-   if (_cluster_identity_status == solana_cluster_identity_status::verified &&
-       _verified_transport_session_id != current_transport_session_id) {
-      _cluster_identity_status = solana_cluster_identity_status::stale;
-      _cluster_identity_reason = solana_cluster_identity_reason::transport_session_changed;
-   }
-
    if (_cluster_identity_status == solana_cluster_identity_status::verified && _last_verified_at &&
        now - *_last_verified_at >= _cluster_identity->maximum_verification_age) {
       _cluster_identity_status = solana_cluster_identity_status::stale;
@@ -1102,18 +1091,16 @@ void solana_client::record_cluster_verification_failure_locked(solana_cluster_id
    publish_cluster_identity_snapshot_locked();
 }
 
-void solana_client::record_cluster_identity_observation_locked(
-   solana_cluster_identity_operation operation,
-   const fc::variant& observed_result,
-   solana_cluster_identity_status previous_status,
-   solana_cluster_identity_reason previous_reason) {
+void solana_client::record_cluster_identity_observation_locked(solana_cluster_identity_operation operation,
+                                                               const fc::variant& observed_result,
+                                                               solana_cluster_identity_status previous_status) {
    solana_genesis_hash observed;
    try {
       FC_ASSERT(observed_result.is_string(), "Solana getGenesisHash result must be a string");
       observed = parse_solana_genesis_hash(observed_result.as_string());
    } catch (const std::exception&) {
-      record_cluster_verification_failure_locked(
-         operation, solana_cluster_identity_reason::malformed_observed_identity);
+      record_cluster_verification_failure_locked(operation,
+                                                 solana_cluster_identity_reason::malformed_observed_identity);
       throw;
    }
 
@@ -1125,30 +1112,25 @@ void solana_client::record_cluster_identity_observation_locked(
       record_blocked_operation_locked(operation);
       elog("Solana cluster identity mismatch "
            "(client_id={},endpoint={},status={},reason={},operation={})",
-           _cluster_identity->client_id, _sanitized_endpoint,
-           magic_enum::enum_name(_cluster_identity_status),
+           _cluster_identity->client_id, _sanitized_endpoint, magic_enum::enum_name(_cluster_identity_status),
            magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
       publish_cluster_identity_snapshot_locked();
       FC_THROW("Solana cluster identity mismatch for client '{}'", _cluster_identity->client_id);
    }
 
-   const bool recovered = previous_status == solana_cluster_identity_status::error ||
-                          (previous_status == solana_cluster_identity_status::stale &&
-                           previous_reason == solana_cluster_identity_reason::transport_session_changed);
+   const bool recovered = previous_status == solana_cluster_identity_status::error;
    _cluster_identity_status = solana_cluster_identity_status::verified;
    _cluster_identity_reason =
       recovered ? solana_cluster_identity_reason::verification_recovered : solana_cluster_identity_reason::none;
    _last_verified_at = _cluster_identity->verification_clock();
-   _verified_transport_session_id = _client.last_transport_session_id();
    ++_verification_successes;
 
    if (recovered) {
       ++_verification_recoveries;
       wlog("Solana cluster identity verification recovered "
            "(client_id={},endpoint={},status={},reason={},operation={})",
-           _cluster_identity->client_id, _sanitized_endpoint,
-           magic_enum::enum_name(_cluster_identity_status), magic_enum::enum_name(_cluster_identity_reason),
-           magic_enum::enum_name(operation));
+           _cluster_identity->client_id, _sanitized_endpoint, magic_enum::enum_name(_cluster_identity_status),
+           magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
    }
    publish_cluster_identity_snapshot_locked();
 }
@@ -1159,7 +1141,6 @@ void solana_client::ensure_cluster_verified_locked(solana_cluster_identity_opera
    }
 
    const auto previous_status = _cluster_identity_status;
-   const auto previous_reason = _cluster_identity_reason;
    ++_verification_attempts;
 
    fc::variant observed_result;
@@ -1175,7 +1156,7 @@ void solana_client::ensure_cluster_verified_locked(solana_cluster_identity_opera
       throw;
    }
 
-   record_cluster_identity_observation_locked(operation, observed_result, previous_status, previous_reason);
+   record_cluster_identity_observation_locked(operation, observed_result, previous_status);
 }
 
 void solana_client::publish_cluster_identity_snapshot_locked() {
@@ -1191,7 +1172,6 @@ void solana_client::publish_cluster_identity_snapshot_locked() {
          _last_observed_genesis_hash ? std::optional(_last_observed_genesis_hash->canonical) : std::nullopt,
       .verified_at = _last_verified_at,
       .verification_age = std::nullopt,
-      .transport_session_id = _client.last_transport_session_id(),
       .verification_attempts = _verification_attempts,
       .verification_successes = _verification_successes,
       .verification_mismatches = _verification_mismatches,
@@ -1210,13 +1190,6 @@ solana_cluster_identity_snapshot solana_client::get_cluster_identity_snapshot() 
       snapshot = _published_identity_snapshot;
    }
 
-   const auto current_transport_session_id = _client.last_transport_session_id();
-   if (snapshot.status == solana_cluster_identity_status::verified &&
-       snapshot.transport_session_id != current_transport_session_id) {
-      snapshot.status = solana_cluster_identity_status::stale;
-      snapshot.reason = solana_cluster_identity_reason::transport_session_changed;
-   }
-   snapshot.transport_session_id = current_transport_session_id;
    if (snapshot.verified_at) {
       const auto now = _cluster_identity ? _cluster_identity->verification_clock() : fc::time_point::now();
       snapshot.verification_age = now - *snapshot.verified_at;

--- a/libraries/libfc/src/network/solana/solana_client.cpp
+++ b/libraries/libfc/src/network/solana/solana_client.cpp
@@ -19,6 +19,48 @@ namespace fc::network::solana {
 
 namespace {
 
+constexpr std::string_view rpc_method_get_genesis_hash = "getGenesisHash";
+constexpr size_t maximum_encoded_genesis_hash_bytes = 44;
+constexpr size_t maximum_verified_blockhashes = 256;
+
+/** Protected-operation context observed by connection-validation callbacks. */
+struct identity_operation_context {
+   const solana_client* client = nullptr;
+   solana_cluster_identity_operation operation = solana_cluster_identity_operation::rpc_read;
+   bool connection_validation_failed = false;
+};
+
+thread_local std::optional<identity_operation_context> active_identity_operation;
+
+/** Install one thread-local protected-operation context for a synchronous RPC. */
+class identity_operation_scope {
+public:
+   identity_operation_scope(const solana_client* client, solana_cluster_identity_operation operation)
+      : _previous(active_identity_operation) {
+      active_identity_operation = identity_operation_context{.client = client, .operation = operation};
+   }
+
+   identity_operation_scope(const identity_operation_scope&) = delete;
+   identity_operation_scope& operator=(const identity_operation_scope&) = delete;
+
+   ~identity_operation_scope() { active_identity_operation = _previous; }
+
+private:
+   std::optional<identity_operation_context> _previous;
+};
+
+/** Return the operation that caused this client's current connection validation. */
+identity_operation_context& current_identity_operation_context(const solana_client* client) {
+   FC_ASSERT(active_identity_operation && active_identity_operation->client == client,
+             "Solana connection validation has no active protected operation");
+   return *active_identity_operation;
+}
+
+/** Return the operation that caused this client's current connection validation. */
+solana_cluster_identity_operation current_identity_operation(const solana_client* client) {
+   return current_identity_operation_context(client).operation;
+}
+
 /**
  * Return a credential-free endpoint label.
  *
@@ -177,29 +219,26 @@ std::optional<size_t> min_borsh_encoded_size(const idl::idl_type& type, const id
 } // namespace
 
 solana_genesis_hash parse_solana_genesis_hash(const std::string& value) {
-   constexpr size_t maximum_encoded_genesis_hash_bytes = 44;
-
    FC_ASSERT(!value.empty(), "Solana genesis hash must not be empty");
    FC_ASSERT(value.size() <= maximum_encoded_genesis_hash_bytes, "Solana genesis hash must not exceed {} encoded bytes",
              maximum_encoded_genesis_hash_bytes);
 
-   std::vector<char> decoded;
+   solana_public_key decoded;
    try {
-      decoded = fc::from_base58(value);
+      decoded = solana_public_key::from_base58_string(value);
    } catch (const fc::exception&) {
       FC_THROW("Solana genesis hash is not valid base58");
    } catch (const std::exception&) {
       FC_THROW("Solana genesis hash is not valid base58");
    }
 
-   FC_ASSERT(decoded.size() == 32, "Solana genesis hash must decode to exactly 32 bytes, got {}", decoded.size());
-   const auto canonical = fc::to_base58(decoded, fc::yield_function_t{});
+   const auto canonical = decoded.to_string(fc::yield_function_t{});
    FC_ASSERT(canonical == value, "Solana genesis hash must use canonical base58 encoding");
 
-   solana_genesis_hash result;
-   std::ranges::transform(decoded, result.bytes.begin(), [](char byte) { return static_cast<uint8_t>(byte); });
-   result.canonical = canonical;
-   return result;
+   return solana_genesis_hash{
+      .bytes = decoded.serialize(),
+      .canonical = canonical,
+   };
 }
 
 //=============================================================================
@@ -946,11 +985,10 @@ solana_client::solana_client(const signature_provider_ptr& sig_provider,
    , _cluster_identity(std::nullopt)
    , _sanitized_endpoint(sanitize_endpoint(url_source))
    , _rpc_total_timeout(rpc_options.request.timeouts.total)
-   , _client(json_rpc_client::create(url_source, enforce_solana_deadline_inheritance(std::move(rpc_options))))
+   , _rpc_cancel_check(rpc_options.request.cancel_check)
+   , _client(json_rpc_client::create(url_source, configure_rpc_options(std::move(rpc_options))))
    , _cluster_identity_status(solana_cluster_identity_status::unpinned)
-   , _cluster_identity_reason(solana_cluster_identity_reason::missing_expected_identity) {
-   publish_cluster_identity_snapshot_locked();
-}
+   , _cluster_identity_reason(solana_cluster_identity_reason::missing_expected_identity) {}
 
 solana_client::solana_client(const signature_provider_ptr& sig_provider,
                              const std::variant<std::string, fc::url>& url_source,
@@ -960,7 +998,8 @@ solana_client::solana_client(const signature_provider_ptr& sig_provider,
    , _cluster_identity(std::move(identity_config))
    , _sanitized_endpoint(sanitize_endpoint(url_source))
    , _rpc_total_timeout(rpc_options.request.timeouts.total)
-   , _client(json_rpc_client::create(url_source, enforce_solana_deadline_inheritance(std::move(rpc_options))))
+   , _rpc_cancel_check(rpc_options.request.cancel_check)
+   , _client(json_rpc_client::create(url_source, configure_rpc_options(std::move(rpc_options))))
    , _cluster_identity_status(solana_cluster_identity_status::unverified)
    , _cluster_identity_reason(solana_cluster_identity_reason::none) {
    FC_ASSERT(!_cluster_identity->client_id.empty(), "Solana cluster identity client id must not be empty");
@@ -968,130 +1007,104 @@ solana_client::solana_client(const signature_provider_ptr& sig_provider,
    FC_ASSERT(reparsed == _cluster_identity->expected_genesis_hash,
              "Solana expected genesis hash bytes do not match their canonical representation");
 
-   fc::task::deadline_scope operation_scope(
-      operation_deadline(_cluster_identity->probe_timeout));
-   auto operation_guard = lock_operation();
-   ensure_cluster_verified_locked(solana_cluster_identity_operation::startup);
+   const auto startup_timeout =
+      _rpc_total_timeout
+         ? std::min(*_rpc_total_timeout, _cluster_identity->probe_timeout)
+         : _cluster_identity->probe_timeout;
+   fc::task::deadline_scope operation_scope(operation_deadline(startup_timeout));
+   (void)execute_idempotent(std::string(rpc_method_get_genesis_hash), fc::variants{},
+                            solana_cluster_identity_operation::startup);
+}
+
+client_options solana_client::configure_rpc_options(client_options options) {
+   // Solana installs internal validation deadlines through task scopes. A
+   // caller cannot disable inheritance and thereby make those probes unbounded.
+   options = enforce_solana_deadline_inheritance(std::move(options));
+   FC_ASSERT(options.request.timeouts.inherit_task_deadline,
+             "Solana RPC must inherit active task deadlines");
+   if (!_cluster_identity)
+      return options;
+
+   options.connection_validator = connection_validation{
+      .method = std::string(rpc_method_get_genesis_hash),
+      .params = fc::variants{},
+      .total_timeout_cap = _cluster_identity->probe_timeout,
+      .validate_result = [this](const fc::variant& result) { validate_connection_identity(result); },
+      .on_attempt = [this] { begin_connection_validation(); },
+      .on_success = [this] { record_connection_validation_success(); },
+      .on_failure = [this](std::exception_ptr failure, std::optional<fc::http::failure_kind> transport_failure) {
+         record_connection_validation_failure(std::move(failure), transport_failure);
+      },
+   };
+   return options;
 }
 
 fc::variant solana_client::execute(const std::string& method, const fc::variant& params) {
-   fc::task::deadline_scope operation_scope(
-      operation_deadline(_rpc_total_timeout));
-   auto operation_guard = lock_operation();
-   return execute_locked(method, params, false);
+   return execute_rpc(method, params, false, solana_cluster_identity_operation::submission);
 }
 
-solana_client::operation_lock solana_client::lock_operation() const {
-   operation_lock lock(_operation_mutex, std::defer_lock);
+solana_client::rpc_lock solana_client::lock_rpc() const {
+   rpc_lock lock(_rpc_mutex, std::defer_lock);
    const auto deadline = fc::task::current_deadline();
-   if (!deadline || *deadline == fc::time_point::maximum()) {
+   if ((!deadline || *deadline == fc::time_point::maximum()) && !_rpc_cancel_check) {
       lock.lock();
       return lock;
    }
 
-   const auto now = fc::time_point::now();
-   if (now >= *deadline) {
-      FC_THROW_EXCEPTION(fc::timeout_exception, "Timed out waiting for the Solana client operation gate");
-   }
-   const auto remaining = *deadline - now;
-   if (!lock.try_lock_for(std::chrono::microseconds(remaining.count()))) {
-      FC_THROW_EXCEPTION(fc::timeout_exception, "Timed out waiting for the Solana client operation gate");
+   constexpr auto cancellation_poll_interval = std::chrono::milliseconds(10);
+   while (!lock.owns_lock()) {
+      bool cancelled = false;
+      try {
+         cancelled = _rpc_cancel_check && _rpc_cancel_check();
+      } catch (...) {
+         cancelled = true;
+      }
+      if (cancelled)
+         FC_THROW_EXCEPTION(fc::canceled_exception, "Solana RPC cancelled while waiting for the pinned RPC gate");
+
+      auto wait_for = cancellation_poll_interval;
+      if (deadline && *deadline != fc::time_point::maximum()) {
+         const auto remaining = *deadline - fc::time_point::now();
+         if (remaining.count() <= 0)
+            FC_THROW_EXCEPTION(fc::timeout_exception, "Timed out waiting for the Solana pinned RPC gate");
+         wait_for = std::min(wait_for,
+                             std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::microseconds(remaining.count())));
+         if (wait_for.count() <= 0)
+            wait_for = std::chrono::milliseconds(1);
+      }
+      (void)lock.try_lock_for(wait_for);
    }
    return lock;
 }
 
-solana_cluster_identity_operation solana_client::operation_for_rpc_method(const std::string& method,
-                                                                          bool idempotent) {
-   if (method == "sendTransaction" || method == "requestAirdrop") {
-      return solana_cluster_identity_operation::submission;
-   }
-   if (method == "getLatestBlockhash") {
-      return solana_cluster_identity_operation::transaction_build;
-   }
-   if (method == "simulateTransaction") {
-      return solana_cluster_identity_operation::simulation;
-   }
-   if (method == "getFeeForMessage" || method == "getRecentPrioritizationFees") {
-      return solana_cluster_identity_operation::fee_estimation;
-   }
-   return idempotent ? solana_cluster_identity_operation::rpc_read
-                     : solana_cluster_identity_operation::submission;
-}
+fc::variant solana_client::execute_rpc(const std::string& method, const fc::variant& params, bool idempotent,
+                                       solana_cluster_identity_operation operation) {
+   fc::task::deadline_scope operation_scope(operation_deadline(_rpc_total_timeout));
+   if (!_cluster_identity)
+      return idempotent ? _client.call_idempotent(method, params) : _client.call(method, params);
 
-fc::variant solana_client::execute_locked(const std::string& method, const fc::variant& params, bool idempotent) {
-   const auto operation = operation_for_rpc_method(method, idempotent);
-   if (!_cluster_identity) {
-      return _client.call(method, params);
+   // Keep the pre-send mismatch check and an ordinary getGenesisHash
+   // cross-check in one serialized region. A caller queued behind a newly
+   // discovered mismatch must observe the sticky state before network I/O.
+   auto rpc_guard = lock_rpc();
+   {
+      std::lock_guard identity_guard(_identity_mutex);
+      throw_if_cluster_identity_mismatched_locked(operation);
    }
 
-   // Every protected RPC is preceded by getGenesisHash on the exact same
-   // opaque HTTP/TLS connection. Cached evidence remains telemetry only.
-   throw_if_cluster_identity_mismatched_locked(operation);
-   const auto previous_status = _cluster_identity_status;
-   ++_verification_attempts;
-
-   enum class probe_result { none, matched, mismatch, malformed };
-   probe_result result = probe_result::none;
-   std::optional<solana_genesis_hash> observed;
+   identity_operation_scope identity_scope(this, operation);
    try {
-      auto protected_result =
-         _client.call_then("getGenesisHash", fc::variants{},
-                           call_options{
-                              .replay = replay_policy::stale_reused_connection_once,
-                              .total_timeout_cap = _cluster_identity->probe_timeout,
-                           },
-                           [&](const fc::variant& observed_result) {
-                              // Keep the connection-affine hook bounded and non-blocking:
-                              // parse, compare, and select the follow-up only.
-                              try {
-                                 FC_ASSERT(observed_result.is_string(),
-                                           "Solana getGenesisHash result must be a string");
-                                 observed = parse_solana_genesis_hash(observed_result.as_string());
-                              } catch (const std::exception&) {
-                                 result = probe_result::malformed;
-                                 throw;
-                              }
-                              if (*observed != _cluster_identity->expected_genesis_hash) {
-                                 result = probe_result::mismatch;
-                                 FC_THROW("Solana cluster identity mismatch for client '{}'",
-                                          _cluster_identity->client_id);
-                              }
-                              result = probe_result::matched;
-                              return continuation_call{
-                                 .method = method,
-                                 .params = params,
-                              };
-                           });
-      FC_ASSERT(result == probe_result::matched && observed,
-                "Solana cluster identity continuation completed without a matching observation");
-      FC_ASSERT(record_cluster_identity_observation_locked(operation, *observed, previous_status),
-                "Solana cluster identity observation changed after a matching continuation");
-      return protected_result;
+      auto result = idempotent ? _client.call_idempotent(method, params) : _client.call(method, params);
+      if (method == rpc_method_get_genesis_hash)
+         (void)validate_returned_genesis_hash(result, operation);
+      return result;
    } catch (...) {
-      if (result == probe_result::matched || result == probe_result::mismatch) {
-         FC_ASSERT(observed, "Solana cluster identity result is missing its parsed observation");
-         const bool matched =
-            record_cluster_identity_observation_locked(operation, *observed, previous_status);
-         FC_ASSERT(matched == (result == probe_result::matched),
-                   "Solana cluster identity observation classification changed after the continuation");
-      } else if (result == probe_result::malformed) {
-         record_cluster_verification_failure_locked(
-            operation, solana_cluster_identity_reason::malformed_observed_identity);
-      } else {
-         try {
-            throw;
-         } catch (const fc::timeout_exception&) {
-            record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
-         } catch (const std::exception&) {
-            record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
-         }
-      }
+      if (!current_identity_operation_context(this).connection_validation_failed &&
+          !cluster_identity_mismatched())
+         record_protected_operation_failure(operation);
       throw;
    }
-}
-
-fc::variant solana_client::fetch_genesis_hash_unchecked_locked() {
-   return _client.call("getGenesisHash", fc::variants{});
 }
 
 void solana_client::record_blocked_operation_locked(solana_cluster_identity_operation operation) {
@@ -1101,7 +1114,6 @@ void solana_client::record_blocked_operation_locked(solana_cluster_identity_oper
 void solana_client::throw_if_cluster_identity_mismatched_locked(solana_cluster_identity_operation operation) {
    if (_cluster_identity_status == solana_cluster_identity_status::mismatch) {
       record_blocked_operation_locked(operation);
-      publish_cluster_identity_snapshot_locked();
       FC_THROW("Solana cluster identity verification blocked client '{}' "
                "(status={}, reason={}, operation={})",
                _cluster_identity->client_id, magic_enum::enum_name(_cluster_identity_status),
@@ -1119,7 +1131,6 @@ void solana_client::record_cluster_verification_failure_locked(solana_cluster_id
         "(client_id={},endpoint={},status={},reason={},operation={})",
         _cluster_identity->client_id, _sanitized_endpoint, magic_enum::enum_name(_cluster_identity_status),
         magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
-   publish_cluster_identity_snapshot_locked();
 }
 
 bool solana_client::record_cluster_identity_observation_locked(solana_cluster_identity_operation operation,
@@ -1131,11 +1142,12 @@ bool solana_client::record_cluster_identity_observation_locked(solana_cluster_id
       _cluster_identity_reason = solana_cluster_identity_reason::identity_mismatch;
       ++_verification_mismatches;
       record_blocked_operation_locked(operation);
+      _verified_blockhash_order.clear();
+      _verified_blockhashes.clear();
       elog("Solana cluster identity mismatch "
            "(client_id={},endpoint={},status={},reason={},operation={})",
            _cluster_identity->client_id, _sanitized_endpoint, magic_enum::enum_name(_cluster_identity_status),
            magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
-      publish_cluster_identity_snapshot_locked();
       return false;
    }
 
@@ -1144,6 +1156,7 @@ bool solana_client::record_cluster_identity_observation_locked(solana_cluster_id
    _cluster_identity_reason =
       recovered ? solana_cluster_identity_reason::verification_recovered : solana_cluster_identity_reason::none;
    _last_verified_at = fc::time_point::now();
+   _last_verified_monotonic = std::chrono::steady_clock::now();
    ++_verification_successes;
 
    if (recovered) {
@@ -1153,47 +1166,166 @@ bool solana_client::record_cluster_identity_observation_locked(solana_cluster_id
            _cluster_identity->client_id, _sanitized_endpoint, magic_enum::enum_name(_cluster_identity_status),
            magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
    }
-   publish_cluster_identity_snapshot_locked();
    return true;
 }
 
-void solana_client::ensure_cluster_verified_locked(solana_cluster_identity_operation operation) {
-   if (!_cluster_identity)
-      return;
-
+void solana_client::begin_connection_validation() {
+   const auto operation = current_identity_operation(this);
+   std::lock_guard identity_guard(_identity_mutex);
    throw_if_cluster_identity_mismatched_locked(operation);
-
-   const auto previous_status = _cluster_identity_status;
+   _validation_previous_status = _cluster_identity_status;
+   _validation_failure_recorded = false;
    ++_verification_attempts;
+}
 
-   fc::variant observed_result;
-   try {
-      // The constructor/signing caller already installed the saturating probe
-      // deadline before acquiring the operation gate.
-      observed_result = fetch_genesis_hash_unchecked_locked();
-   } catch (const fc::timeout_exception&) {
-      record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
-      throw;
-   } catch (const std::exception&) {
-      record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
-      throw;
-   }
-
+void solana_client::validate_connection_identity(const fc::variant& result) {
+   const auto operation = current_identity_operation(this);
    solana_genesis_hash observed;
    try {
-      FC_ASSERT(observed_result.is_string(), "Solana getGenesisHash result must be a string");
-      observed = parse_solana_genesis_hash(observed_result.as_string());
-   } catch (const std::exception&) {
-      record_cluster_verification_failure_locked(operation,
-                                                 solana_cluster_identity_reason::malformed_observed_identity);
+      FC_ASSERT(result.is_string(), "Solana getGenesisHash result must be a string");
+      observed = parse_solana_genesis_hash(result.as_string());
+   } catch (...) {
+      std::lock_guard identity_guard(_identity_mutex);
+      record_cluster_verification_failure_locked(
+         operation,
+         solana_cluster_identity_reason::malformed_observed_identity);
+      _validation_failure_recorded = true;
       throw;
    }
-   if (!record_cluster_identity_observation_locked(operation, observed, previous_status)) {
+
+   bool matched = false;
+   {
+      std::lock_guard identity_guard(_identity_mutex);
+      _last_observed_genesis_hash = observed;
+      matched = observed == _cluster_identity->expected_genesis_hash;
+      if (!matched) {
+         (void)record_cluster_identity_observation_locked(operation, observed, _validation_previous_status);
+         _validation_failure_recorded = true;
+      }
+   }
+   if (!matched)
       FC_THROW("Solana cluster identity mismatch for client '{}'", _cluster_identity->client_id);
+}
+
+void solana_client::record_connection_validation_success() {
+   const auto operation = current_identity_operation(this);
+   std::lock_guard identity_guard(_identity_mutex);
+   FC_ASSERT(record_cluster_identity_observation_locked(
+                operation,
+                _cluster_identity->expected_genesis_hash,
+                _validation_previous_status),
+             "Accepted Solana connection validation no longer matches the configured identity");
+   _validation_failure_recorded = false;
+}
+
+void solana_client::record_connection_validation_failure(
+   std::exception_ptr failure,
+   std::optional<fc::http::failure_kind> transport_failure) noexcept {
+   try {
+      auto& operation_context = current_identity_operation_context(this);
+      operation_context.connection_validation_failed = true;
+      const auto operation = operation_context.operation;
+
+      bool cancellation_observed =
+         transport_failure == fc::http::failure_kind::cancelled;
+      solana_cluster_identity_reason reason = solana_cluster_identity_reason::rpc_error;
+      if (transport_failure == fc::http::failure_kind::timeout_connect ||
+          transport_failure == fc::http::failure_kind::timeout_header ||
+          transport_failure == fc::http::failure_kind::timeout_read ||
+          transport_failure == fc::http::failure_kind::timeout_idle ||
+          transport_failure == fc::http::failure_kind::timeout_total) {
+         reason = solana_cluster_identity_reason::rpc_timeout;
+      } else if (!cancellation_observed) {
+         try {
+            if (failure)
+               std::rethrow_exception(failure);
+         } catch (const fc::canceled_exception&) {
+            cancellation_observed = true;
+         } catch (const fc::timeout_exception&) {
+            reason = solana_cluster_identity_reason::rpc_timeout;
+         } catch (...) {
+            reason = solana_cluster_identity_reason::rpc_error;
+         }
+      }
+
+      std::lock_guard identity_guard(_identity_mutex);
+      if (_validation_failure_recorded || _cluster_identity_status == solana_cluster_identity_status::mismatch)
+         return;
+      if (cancellation_observed) {
+         ++_verification_cancellations;
+         _validation_failure_recorded = true;
+         return;
+      }
+      record_cluster_verification_failure_locked(operation, reason);
+      _validation_failure_recorded = true;
+   } catch (...) {
+      // Telemetry observation must never replace the connection failure.
    }
 }
 
-void solana_client::publish_cluster_identity_snapshot_locked() {
+solana_genesis_hash
+solana_client::validate_returned_genesis_hash(const fc::variant& result,
+                                              solana_cluster_identity_operation operation) {
+   solana_genesis_hash observed;
+   try {
+      FC_ASSERT(result.is_string(), "Solana getGenesisHash result must be a string");
+      observed = parse_solana_genesis_hash(result.as_string());
+   } catch (...) {
+      throw;
+   }
+
+   {
+      std::lock_guard identity_guard(_identity_mutex);
+      if (observed != _cluster_identity->expected_genesis_hash) {
+         (void)record_cluster_identity_observation_locked(operation, observed, _cluster_identity_status);
+         FC_THROW("Solana cluster identity mismatch for client '{}'", _cluster_identity->client_id);
+      }
+   }
+   return observed;
+}
+
+void solana_client::record_protected_operation_failure(solana_cluster_identity_operation operation) {
+   if (!_cluster_identity)
+      return;
+   std::lock_guard identity_guard(_identity_mutex);
+   ++_protected_operation_failures[operation];
+}
+
+void solana_client::remember_verified_blockhash(const solana_public_key& blockhash) {
+   if (!_cluster_identity)
+      return;
+   std::lock_guard identity_guard(_identity_mutex);
+   if (!_verified_blockhashes.emplace(blockhash).second)
+      return;
+   _verified_blockhash_order.push_back(blockhash);
+   while (_verified_blockhash_order.size() > maximum_verified_blockhashes) {
+      _verified_blockhashes.erase(_verified_blockhash_order.front());
+      _verified_blockhash_order.pop_front();
+   }
+}
+
+void solana_client::require_verified_blockhash_for_signing(const solana_public_key& blockhash) {
+   if (!_cluster_identity)
+      return;
+   std::lock_guard identity_guard(_identity_mutex);
+   throw_if_cluster_identity_mismatched_locked(solana_cluster_identity_operation::signing);
+   if (!_verified_blockhashes.contains(blockhash)) {
+      record_blocked_operation_locked(solana_cluster_identity_operation::signing);
+      FC_THROW("Solana pinned client '{}' refuses to sign a transaction whose blockhash was not obtained "
+               "through this client's validated RPC connection",
+               _cluster_identity->client_id);
+   }
+}
+
+bool solana_client::cluster_identity_mismatched() const {
+   if (!_cluster_identity)
+      return false;
+   std::lock_guard identity_guard(_identity_mutex);
+   return _cluster_identity_status == solana_cluster_identity_status::mismatch;
+}
+
+solana_cluster_identity_snapshot solana_client::get_cluster_identity_snapshot() const {
+   std::lock_guard identity_guard(_identity_mutex);
    solana_cluster_identity_snapshot snapshot{
       .client_id = _cluster_identity ? _cluster_identity->client_id : std::string{},
       .sanitized_endpoint = _sanitized_endpoint,
@@ -1210,34 +1342,26 @@ void solana_client::publish_cluster_identity_snapshot_locked() {
       .verification_successes = _verification_successes,
       .verification_mismatches = _verification_mismatches,
       .verification_failures = _verification_failures,
+      .verification_cancellations = _verification_cancellations,
       .verification_recoveries = _verification_recoveries,
       .blocked_operations = _blocked_operations,
+      .protected_operation_failures = _protected_operation_failures,
    };
-   std::lock_guard snapshot_guard(_snapshot_mutex);
-   _published_identity_snapshot = std::move(snapshot);
-}
-
-solana_cluster_identity_snapshot solana_client::get_cluster_identity_snapshot() const {
-   solana_cluster_identity_snapshot snapshot;
-   {
-      std::lock_guard snapshot_guard(_snapshot_mutex);
-      snapshot = _published_identity_snapshot;
-   }
-
-   if (snapshot.verified_at) {
-      snapshot.verification_age = fc::time_point::now() - *snapshot.verified_at;
+   if (_last_verified_monotonic) {
+      const auto elapsed = std::chrono::steady_clock::now() - *_last_verified_monotonic;
+      const auto elapsed_microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+      snapshot.verification_age = fc::microseconds(std::max<int64_t>(0, elapsed_microseconds));
    }
    return snapshot;
 }
 
 fc::variant solana_client::execute_idempotent(const std::string& method, const fc::variant& params) {
-   fc::task::deadline_scope operation_scope(
-      operation_deadline(_rpc_total_timeout));
-   auto operation_guard = lock_operation();
-   if (!_cluster_identity) {
-      return _client.call_idempotent(method, params);
-   }
-   return execute_locked(method, params, true);
+   return execute_idempotent(method, params, solana_cluster_identity_operation::rpc_read);
+}
+
+fc::variant solana_client::execute_idempotent(const std::string& method, const fc::variant& params,
+                                              solana_cluster_identity_operation operation) {
+   return execute_rpc(method, params, true, operation);
 }
 
 fc::variant solana_client::build_config(commitment_t commitment, const std::optional<fc::variant_object>& extra) {
@@ -1410,12 +1534,16 @@ std::optional<int64_t> solana_client::get_block_time(uint64_t slot) {
 
 blockhash_info solana_client::get_latest_blockhash(commitment_t commitment) {
    fc::variants params{build_config(commitment)};
-   auto result = execute_idempotent("getLatestBlockhash", params);
+   auto result = execute_idempotent(
+      "getLatestBlockhash",
+      params,
+      solana_cluster_identity_operation::transaction_build);
 
    auto value = result.get_object()["value"].get_object();
    blockhash_info info;
    info.blockhash = value["blockhash"].as_string();
    info.last_valid_block_height = value["lastValidBlockHeight"].as_uint64();
+   remember_verified_blockhash(solana_public_key::from_base58_string(info.blockhash));
    return info;
 }
 
@@ -1436,7 +1564,8 @@ fc::variant solana_client::get_cluster_nodes() {
 
 std::string solana_client::get_genesis_hash() {
    fc::variants params;
-   return execute_idempotent("getGenesisHash", params).as_string();
+   auto result = execute_idempotent(std::string(rpc_method_get_genesis_hash), params);
+   return result.as_string();
 }
 
 std::string solana_client::get_health() {
@@ -1508,7 +1637,8 @@ fc::variant solana_client::get_epoch_schedule() {
 
 std::optional<uint64_t> solana_client::get_fee_for_message(const std::string& message_base64, commitment_t commitment) {
    fc::variants params{message_base64, build_config(commitment)};
-   auto result = execute_idempotent("getFeeForMessage", params);
+   auto result =
+      execute_idempotent("getFeeForMessage", params, solana_cluster_identity_operation::fee_estimation);
 
    auto value = result.get_object()["value"];
    if (value.is_null())
@@ -1526,7 +1656,10 @@ std::vector<fc::variant> solana_client::get_recent_prioritization_fees(const std
    if (!addr_list.empty())
       params.push_back(addr_list);
 
-   auto result = execute_idempotent("getRecentPrioritizationFees", params);
+   auto result = execute_idempotent(
+      "getRecentPrioritizationFees",
+      params,
+      solana_cluster_identity_operation::fee_estimation);
    return result.get_array();
 }
 
@@ -1728,7 +1861,12 @@ std::string solana_client::send_transaction(const std::string& tx_base64, bool s
    config("preflightCommitment", to_string(preflight_commitment));
 
    fc::variants params{tx_base64, config};
-   return execute("sendTransaction", params).as_string();
+   return execute_rpc(
+             "sendTransaction",
+             params,
+             false,
+             solana_cluster_identity_operation::submission)
+      .as_string();
 }
 
 fc::variant solana_client::simulate_transaction(const transaction& tx, commitment_t commitment) {
@@ -1742,13 +1880,18 @@ fc::variant solana_client::simulate_transaction(const transaction& tx, commitmen
    config("sigVerify", false);
 
    fc::variants params{tx_base64, config};
-   return execute_idempotent("simulateTransaction", params);
+   return execute_idempotent("simulateTransaction", params, solana_cluster_identity_operation::simulation);
 }
 
 std::string solana_client::request_airdrop(const pubkey_compat_t& address, uint64_t lamports, commitment_t commitment) {
    auto addr = to_pubkey(address);
    fc::variants params{addr.to_string(fc::yield_function_t{}), lamports, build_config(commitment)};
-   return execute("requestAirdrop", params).as_string();
+   return execute_rpc(
+             "requestAirdrop",
+             params,
+             false,
+             solana_cluster_identity_operation::submission)
+      .as_string();
 }
 
 //=============================================================================
@@ -1976,13 +2119,8 @@ transaction solana_client::create_transaction(const std::vector<instruction>& in
 }
 
 transaction solana_client::sign_transaction(transaction& tx) {
-   fc::task::deadline_scope operation_scope(
-      operation_deadline(
-         _cluster_identity
-            ? std::optional(_cluster_identity->probe_timeout)
-            : _rpc_total_timeout));
-   auto operation_guard = lock_operation();
-   ensure_cluster_verified_locked(solana_cluster_identity_operation::signing);
+   fc::task::deadline_scope operation_scope(operation_deadline(_rpc_total_timeout));
+   require_verified_blockhash_for_signing(tx.msg.recent_blockhash);
 
    auto msg_bytes = tx.msg.serialize();
 
@@ -2002,39 +2140,18 @@ transaction solana_client::sign_transaction(transaction& tx) {
 }
 
 std::string solana_client::send_and_confirm_transaction(const transaction& tx, commitment_t commitment) {
-   // Send the transaction
-   std::string sig = send_transaction(tx, false, commitment);
-
-   // Poll for confirmation
-   const int max_retries = 60; // 60 seconds max
-   for (int i = 0; i < max_retries; ++i) {
-      auto statuses = get_signature_statuses({sig}, false);
-      if (!statuses.value.empty() && statuses.value[0].has_value()) {
-         auto& status = *statuses.value[0];
-
-         // Check for error
-         if (status.err.has_value()) {
-            FC_THROW("Transaction failed: {}", *status.err);
-         }
-
-         // Check if confirmed at requested level
-         if (commitment == commitment_t::processed && !status.confirmation_status.empty()) {
-            return sig;
-         }
-         if (commitment == commitment_t::confirmed &&
-             (status.confirmation_status == "confirmed" || status.confirmation_status == "finalized")) {
-            return sig;
-         }
-         if (commitment == commitment_t::finalized && status.confirmation_status == "finalized") {
-            return sig;
-         }
-      }
-
-      // Wait 1 second before next poll
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-   }
-
-   FC_THROW("Transaction confirmation timeout");
+   return send_transaction_and_confirm(
+      tx,
+      solana_confirm_options{
+         .commitment = commitment,
+         .retry =
+            fc::task::retry_options{
+               .initial_backoff = fc::seconds(1),
+               .max_backoff = fc::seconds(1),
+               .total_timeout = fc::seconds(60),
+               .growth_factor = 1.0,
+            },
+      });
 }
 
 namespace {
@@ -2067,7 +2184,16 @@ std::string solana_client::send_transaction_and_confirm(const transaction& tx, c
 
    return fc::task::retry_until<std::string>("solana:send_transaction_and_confirm", opts.retry,
                                              [this, sig, target = opts.commitment]() -> std::optional<std::string> {
-                                                auto statuses = get_signature_statuses({sig}, false);
+                                                rpc_response<std::vector<std::optional<signature_status>>> statuses;
+                                                try {
+                                                   statuses = get_signature_statuses({sig}, false);
+                                                } catch (const fc::canceled_exception&) {
+                                                   throw;
+                                                } catch (const fc::exception&) {
+                                                   if (cluster_identity_mismatched())
+                                                      throw;
+                                                   return std::nullopt;
+                                                }
                                                 if (statuses.value.empty() || !statuses.value[0].has_value()) {
                                                    return std::nullopt; // cluster hasn't observed the tx yet — retry
                                                 }

--- a/libraries/libfc/src/network/solana/solana_client.cpp
+++ b/libraries/libfc/src/network/solana/solana_client.cpp
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+#include <chrono>
+#include <fc/crypto/base58.hpp>
 #include <fc/crypto/base64.hpp>
 #include <fc/crypto/signer.hpp>
 #include <fc/int256.hpp>
@@ -6,15 +8,39 @@
 #include <fc/log/logger.hpp>
 #include <fc/network/solana/solana_borsh.hpp>
 #include <fc/network/solana/solana_client.hpp>
+#include <fc/task/deadline.hpp>
 #include <fc/task/retry.hpp>
-#include <magic_enum/magic_enum.hpp>
 #include <limits>
+#include <magic_enum/magic_enum.hpp>
 #include <optional>
 #include <thread>
 
 namespace fc::network::solana {
 
 namespace {
+
+/**
+ * Return a credential-free endpoint label.
+ *
+ * Hosted RPC API keys commonly appear in URL userinfo, query strings, or path
+ * segments, so telemetry deliberately retains only scheme, host, and port.
+ */
+std::string sanitize_endpoint(const std::variant<std::string, fc::url>& source) {
+   const fc::url endpoint =
+      std::holds_alternative<std::string>(source) ? fc::url(std::get<std::string>(source)) : std::get<fc::url>(source);
+   return fc::http::sanitized_endpoint(endpoint);
+}
+
+/**
+ * Construct a transport while the configured startup deadline is active.
+ */
+json_rpc_client create_pinned_rpc_client(const std::variant<std::string, fc::url>& source,
+                                         fc::microseconds probe_timeout,
+                                         client_options rpc_options) {
+   FC_ASSERT(probe_timeout.count() > 0, "Solana cluster identity probe timeout must be positive");
+   fc::task::deadline_scope deadline(fc::task::clamp_to_current_deadline(fc::time_point::now() + probe_timeout));
+   return json_rpc_client::create(source, std::move(rpc_options));
+}
 
 /**
  * @brief Checked size_t addition for conservative Borsh size estimates.
@@ -38,20 +64,17 @@ std::optional<size_t> checked_mul_size(size_t lhs, size_t rhs) {
  * @brief Return the next nested IDL type depth or reject excessive recursion.
  */
 size_t next_idl_type_depth(size_t type_depth) {
-   FC_ASSERT(type_depth < max_idl_type_nesting_depth,
-             "Solana IDL type nesting exceeds maximum depth {}",
+   FC_ASSERT(type_depth < max_idl_type_nesting_depth, "Solana IDL type nesting exceeds maximum depth {}",
              max_idl_type_nesting_depth);
    return type_depth + 1;
 }
 
-std::optional<size_t> min_borsh_encoded_size(const idl::idl_type& type, const idl::program* program,
-                                             size_t type_depth);
+std::optional<size_t> min_borsh_encoded_size(const idl::idl_type& type, const idl::program* program, size_t type_depth);
 
 /**
  * @brief Smallest Borsh byte count for a field sequence.
  */
-std::optional<size_t> min_borsh_fields_encoded_size(const std::vector<idl::field>& fields,
-                                                    const idl::program* program,
+std::optional<size_t> min_borsh_fields_encoded_size(const std::vector<idl::field>& fields, const idl::program* program,
                                                     size_t type_depth) {
    size_t total = 0;
    for (const auto& field : fields) {
@@ -133,8 +156,7 @@ std::optional<size_t> min_borsh_encoded_size(const idl::idl_type& type, const id
          return std::nullopt;
 
       if (type_def->is_struct() && type_def->struct_fields)
-         return min_borsh_fields_encoded_size(*type_def->struct_fields, program,
-                                              next_idl_type_depth(type_depth));
+         return min_borsh_fields_encoded_size(*type_def->struct_fields, program, next_idl_type_depth(type_depth));
 
       if (type_def->is_enum() && type_def->enum_variants)
          return sizeof(uint8_t);
@@ -143,7 +165,29 @@ std::optional<size_t> min_borsh_encoded_size(const idl::idl_type& type, const id
    return std::nullopt;
 }
 
-}  // namespace
+} // namespace
+
+solana_genesis_hash parse_solana_genesis_hash(const std::string& value) {
+   FC_ASSERT(!value.empty(), "Solana genesis hash must not be empty");
+
+   std::vector<char> decoded;
+   try {
+      decoded = fc::from_base58(value);
+   } catch (const fc::exception&) {
+      FC_THROW("Solana genesis hash is not valid base58");
+   } catch (const std::exception&) {
+      FC_THROW("Solana genesis hash is not valid base58");
+   }
+
+   FC_ASSERT(decoded.size() == 32, "Solana genesis hash must decode to exactly 32 bytes, got {}", decoded.size());
+   const auto canonical = fc::to_base58(decoded, fc::yield_function_t{});
+   FC_ASSERT(canonical == value, "Solana genesis hash must use canonical base58 encoding");
+
+   solana_genesis_hash result;
+   std::ranges::transform(decoded, result.bytes.begin(), [](char byte) { return static_cast<uint8_t>(byte); });
+   result.canonical = canonical;
+   return result;
+}
 
 //=============================================================================
 // solana_program_data_client implementation
@@ -517,8 +561,7 @@ fc::variant solana_program_client::decode_type(borsh::decoder& decoder, const id
    return decode_type(decoder, type, 0);
 }
 
-fc::variant solana_program_client::decode_type(borsh::decoder& decoder, const idl::idl_type& type,
-                                               size_t type_depth) {
+fc::variant solana_program_client::decode_type(borsh::decoder& decoder, const idl::idl_type& type, size_t type_depth) {
    if (type.is_primitive()) {
       switch (type.get_primitive()) {
       case idl::primitive_type::bool_t:
@@ -577,17 +620,16 @@ fc::variant solana_program_client::decode_type(borsh::decoder& decoder, const id
       const auto element_depth = next_idl_type_depth(type_depth);
       const auto min_element_size = min_borsh_encoded_size(*type.vec_element, _program.get(), element_depth);
       if (!min_element_size) {
-         FC_ASSERT(len == 0,
-                   "Borsh decoder: cannot safely bound vector element type '{}' before allocation",
+         FC_ASSERT(len == 0, "Borsh decoder: cannot safely bound vector element type '{}' before allocation",
                    type.vec_element->to_string());
       } else if (*min_element_size == 0) {
          FC_ASSERT(len <= max_zero_sized_idl_vector_elements,
-                   "Borsh decoder: zero-sized vector length {} for element type '{}' exceeds decode cap {}",
-                   len, type.vec_element->to_string(), max_zero_sized_idl_vector_elements);
+                   "Borsh decoder: zero-sized vector length {} for element type '{}' exceeds decode cap {}", len,
+                   type.vec_element->to_string(), max_zero_sized_idl_vector_elements);
       } else {
          FC_ASSERT(len <= decoder.remaining() / *min_element_size,
-                   "Borsh decoder: vector length {} for element type '{}' exceeds remaining {} bytes",
-                   len, type.vec_element->to_string(), decoder.remaining());
+                   "Borsh decoder: vector length {} for element type '{}' exceeds remaining {} bytes", len,
+                   type.vec_element->to_string(), decoder.remaining());
       }
 
       fc::variants arr;
@@ -735,9 +777,9 @@ std::string solana_program_client::execute_tx(const idl::instruction& instr, con
 }
 
 std::string solana_program_client::execute_tx_and_confirm(const idl::instruction& instr,
-                                                           const std::vector<account_meta>& accounts,
-                                                           const program_invoke_data_items& params,
-                                                           const solana_confirm_options& opts) {
+                                                          const std::vector<account_meta>& accounts,
+                                                          const program_invoke_data_items& params,
+                                                          const solana_confirm_options& opts) {
    // Delegate to the pre-instructions overload with an empty prefix so we
    // have a single tx-build path; both overloads stay source-compatible
    // for every existing caller.
@@ -745,16 +787,15 @@ std::string solana_program_client::execute_tx_and_confirm(const idl::instruction
 }
 
 std::string solana_program_client::execute_tx_and_confirm(const idl::instruction& instr,
-                                                           const std::vector<account_meta>& accounts,
-                                                           const program_invoke_data_items& params,
-                                                           const std::vector<instruction>& pre_instructions,
-                                                           const solana_confirm_options& opts) {
+                                                          const std::vector<account_meta>& accounts,
+                                                          const program_invoke_data_items& params,
+                                                          const std::vector<instruction>& pre_instructions,
+                                                          const solana_confirm_options& opts) {
    auto idl_instruction = build_instruction(instr, accounts, params);
 
    std::vector<instruction> all_instructions;
    all_instructions.reserve(pre_instructions.size() + 1);
-   all_instructions.insert(all_instructions.end(),
-                           pre_instructions.begin(), pre_instructions.end());
+   all_instructions.insert(all_instructions.end(), pre_instructions.begin(), pre_instructions.end());
    all_instructions.push_back(std::move(idl_instruction));
 
    auto tx = client->create_transaction(all_instructions, client->get_pubkey());
@@ -854,10 +895,10 @@ std::vector<account_meta> solana_program_client::resolve_accounts(const idl::ins
       // a built-in table so callers don't have to override every instruction.
       else {
          static const std::map<std::string, solana_public_key> well_known = {
-            {"system_program",             system::program_ids::SYSTEM_PROGRAM},
-            {"token_program",              system::program_ids::TOKEN_PROGRAM},
-            {"associated_token_program",   system::program_ids::ASSOCIATED_TOKEN_PROGRAM},
-            {"compute_budget_program",     system::program_ids::COMPUTE_BUDGET_PROGRAM},
+            {"system_program",           system::program_ids::SYSTEM_PROGRAM          },
+            {"token_program",            system::program_ids::TOKEN_PROGRAM           },
+            {"associated_token_program", system::program_ids::ASSOCIATED_TOKEN_PROGRAM},
+            {"compute_budget_program",   system::program_ids::COMPUTE_BUDGET_PROGRAM  },
          };
          auto it = well_known.find(acct.name);
          if (it != well_known.end()) {
@@ -890,14 +931,300 @@ solana_client::solana_client(const signature_provider_ptr& sig_provider,
                              client_options rpc_options)
    : _signature_provider(sig_provider)
    , _pubkey(from_fc_public_key(_signature_provider->public_key))
-   , _client(json_rpc_client::create(url_source, std::move(rpc_options))) {}
+   , _cluster_identity(std::nullopt)
+   , _sanitized_endpoint(sanitize_endpoint(url_source))
+   , _client(json_rpc_client::create(url_source, std::move(rpc_options)))
+   , _cluster_identity_status(solana_cluster_identity_status::unpinned)
+   , _cluster_identity_reason(solana_cluster_identity_reason::missing_expected_identity) {
+   publish_cluster_identity_snapshot_locked();
+}
+
+solana_client::solana_client(const signature_provider_ptr& sig_provider,
+                             const std::variant<std::string, fc::url>& url_source,
+                             solana_cluster_identity_config identity_config,
+                             client_options rpc_options)
+   : _signature_provider(sig_provider)
+   , _pubkey(from_fc_public_key(_signature_provider->public_key))
+   , _cluster_identity(std::move(identity_config))
+   , _sanitized_endpoint(sanitize_endpoint(url_source))
+   , _client(create_pinned_rpc_client(
+        url_source,
+        _cluster_identity->probe_timeout,
+        std::move(rpc_options)))
+   , _cluster_identity_status(solana_cluster_identity_status::unverified)
+   , _cluster_identity_reason(solana_cluster_identity_reason::none) {
+   FC_ASSERT(!_cluster_identity->client_id.empty(), "Solana cluster identity client id must not be empty");
+   FC_ASSERT(_cluster_identity->maximum_verification_age.count() > 0,
+             "Solana cluster identity maximum verification age must be positive");
+   FC_ASSERT(static_cast<bool>(_cluster_identity->verification_clock),
+             "Solana cluster identity verification clock must be configured");
+   const auto reparsed = parse_solana_genesis_hash(_cluster_identity->expected_genesis_hash.canonical);
+   FC_ASSERT(reparsed == _cluster_identity->expected_genesis_hash,
+             "Solana expected genesis hash bytes do not match their canonical representation");
+
+   auto operation_guard = lock_operation();
+   ensure_cluster_verified_locked(solana_cluster_identity_operation::startup, true);
+}
 
 fc::variant solana_client::execute(const std::string& method, const fc::variant& params) {
-   return _client.call(method, params);
+   auto operation_guard = lock_operation();
+   return execute_locked(method, params);
+}
+
+solana_client::operation_lock solana_client::lock_operation() const {
+   operation_lock lock(_operation_mutex, std::defer_lock);
+   const auto deadline = fc::task::current_deadline();
+   if (!deadline || *deadline == fc::time_point::maximum()) {
+      lock.lock();
+      return lock;
+   }
+
+   const auto now = fc::time_point::now();
+   if (now >= *deadline) {
+      FC_THROW_EXCEPTION(fc::timeout_exception, "Timed out waiting for the Solana client operation gate");
+   }
+   const auto remaining = *deadline - now;
+   if (!lock.try_lock_for(std::chrono::microseconds(remaining.count()))) {
+      FC_THROW_EXCEPTION(fc::timeout_exception, "Timed out waiting for the Solana client operation gate");
+   }
+   return lock;
+}
+
+solana_cluster_identity_operation solana_client::operation_for_rpc_method(const std::string& method) {
+   if (method == "sendTransaction") {
+      return solana_cluster_identity_operation::submission;
+   }
+   if (method == "getLatestBlockhash") {
+      return solana_cluster_identity_operation::transaction_build;
+   }
+   if (method == "simulateTransaction") {
+      return solana_cluster_identity_operation::simulation;
+   }
+   if (method == "getFeeForMessage" || method == "getRecentPrioritizationFees") {
+      return solana_cluster_identity_operation::fee_estimation;
+   }
+   return solana_cluster_identity_operation::rpc_read;
+}
+
+fc::variant solana_client::execute_locked(const std::string& method, const fc::variant& params) {
+   const auto operation = operation_for_rpc_method(method);
+   if (!_cluster_identity) {
+      return _client.call(method, params);
+   }
+
+   // Every protected RPC is preceded by getGenesisHash on the exact same
+   // HTTP/TLS connection. A cached observation can describe telemetry and
+   // signing freshness, but it cannot authorize a new transport session.
+   (void)cluster_verification_required_locked(operation, true);
+   const auto previous_status = _cluster_identity_status;
+   const auto previous_reason = _cluster_identity_reason;
+   ++_verification_attempts;
+
+   bool observation_received = false;
+   try {
+      return _client.call_after_verification(
+         "getGenesisHash", fc::variants{},
+         [&](const fc::variant& observed_result) {
+            observation_received = true;
+            record_cluster_identity_observation_locked(operation, observed_result, previous_status, previous_reason);
+         },
+         _cluster_identity->probe_timeout,
+         method, params);
+   } catch (const fc::timeout_exception&) {
+      if (!observation_received) {
+         record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
+      }
+      throw;
+   } catch (const std::exception&) {
+      if (!observation_received) {
+         record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
+      }
+      throw;
+   }
+}
+
+fc::variant solana_client::fetch_genesis_hash_unchecked_locked() {
+   return _client.call("getGenesisHash", fc::variants{});
+}
+
+void solana_client::record_blocked_operation_locked(solana_cluster_identity_operation operation) {
+   ++_blocked_operations[operation];
+}
+
+bool solana_client::cluster_verification_required_locked(solana_cluster_identity_operation operation,
+                                                         bool force_fresh) {
+   if (!_cluster_identity) {
+      return false;
+   }
+
+   if (_cluster_identity_status == solana_cluster_identity_status::mismatch) {
+      record_blocked_operation_locked(operation);
+      publish_cluster_identity_snapshot_locked();
+      FC_THROW("Solana cluster identity verification blocked client '{}' "
+               "(status={}, reason={}, operation={})",
+               _cluster_identity->client_id, magic_enum::enum_name(_cluster_identity_status),
+               magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
+   }
+
+   const auto now = _cluster_identity->verification_clock();
+   const auto current_transport_session_id = _client.last_transport_session_id();
+   if (_cluster_identity_status == solana_cluster_identity_status::verified &&
+       _verified_transport_session_id != current_transport_session_id) {
+      _cluster_identity_status = solana_cluster_identity_status::stale;
+      _cluster_identity_reason = solana_cluster_identity_reason::transport_session_changed;
+   }
+
+   if (_cluster_identity_status == solana_cluster_identity_status::verified && _last_verified_at &&
+       now - *_last_verified_at >= _cluster_identity->maximum_verification_age) {
+      _cluster_identity_status = solana_cluster_identity_status::stale;
+      _cluster_identity_reason = solana_cluster_identity_reason::verification_stale;
+   }
+
+   return force_fresh || _cluster_identity_status != solana_cluster_identity_status::verified;
+}
+
+void solana_client::record_cluster_verification_failure_locked(solana_cluster_identity_operation operation,
+                                                               solana_cluster_identity_reason reason) {
+   _cluster_identity_status = solana_cluster_identity_status::error;
+   _cluster_identity_reason = reason;
+   ++_verification_failures;
+   record_blocked_operation_locked(operation);
+   wlog("Solana cluster identity verification failed "
+        "(client_id={},endpoint={},status={},reason={},operation={})",
+        _cluster_identity->client_id, _sanitized_endpoint, magic_enum::enum_name(_cluster_identity_status),
+        magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
+   publish_cluster_identity_snapshot_locked();
+}
+
+void solana_client::record_cluster_identity_observation_locked(
+   solana_cluster_identity_operation operation,
+   const fc::variant& observed_result,
+   solana_cluster_identity_status previous_status,
+   solana_cluster_identity_reason previous_reason) {
+   solana_genesis_hash observed;
+   try {
+      FC_ASSERT(observed_result.is_string(), "Solana getGenesisHash result must be a string");
+      observed = parse_solana_genesis_hash(observed_result.as_string());
+   } catch (const std::exception&) {
+      record_cluster_verification_failure_locked(
+         operation, solana_cluster_identity_reason::malformed_observed_identity);
+      throw;
+   }
+
+   _last_observed_genesis_hash = observed;
+   if (observed != _cluster_identity->expected_genesis_hash) {
+      _cluster_identity_status = solana_cluster_identity_status::mismatch;
+      _cluster_identity_reason = solana_cluster_identity_reason::identity_mismatch;
+      ++_verification_mismatches;
+      record_blocked_operation_locked(operation);
+      elog("Solana cluster identity mismatch "
+           "(client_id={},endpoint={},expected_genesis_hash={},observed_genesis_hash={},"
+           "status={},reason={},operation={})",
+           _cluster_identity->client_id, _sanitized_endpoint, _cluster_identity->expected_genesis_hash.canonical,
+           observed.canonical, magic_enum::enum_name(_cluster_identity_status),
+           magic_enum::enum_name(_cluster_identity_reason), magic_enum::enum_name(operation));
+      publish_cluster_identity_snapshot_locked();
+      FC_THROW("Solana cluster identity mismatch for client '{}'", _cluster_identity->client_id);
+   }
+
+   const bool recovered = previous_status == solana_cluster_identity_status::error ||
+                          (previous_status == solana_cluster_identity_status::stale &&
+                           previous_reason == solana_cluster_identity_reason::transport_session_changed);
+   _cluster_identity_status = solana_cluster_identity_status::verified;
+   _cluster_identity_reason =
+      recovered ? solana_cluster_identity_reason::verification_recovered : solana_cluster_identity_reason::none;
+   _last_verified_at = _cluster_identity->verification_clock();
+   _verified_transport_session_id = _client.last_transport_session_id();
+   ++_verification_successes;
+
+   if (recovered) {
+      ++_verification_recoveries;
+      wlog("Solana cluster identity verification recovered "
+           "(client_id={},endpoint={},observed_genesis_hash={},status={},reason={},operation={})",
+           _cluster_identity->client_id, _sanitized_endpoint, observed.canonical,
+           magic_enum::enum_name(_cluster_identity_status), magic_enum::enum_name(_cluster_identity_reason),
+           magic_enum::enum_name(operation));
+   }
+   publish_cluster_identity_snapshot_locked();
+}
+
+void solana_client::ensure_cluster_verified_locked(solana_cluster_identity_operation operation, bool force_fresh) {
+   if (!cluster_verification_required_locked(operation, force_fresh)) {
+      return;
+   }
+
+   const auto previous_status = _cluster_identity_status;
+   const auto previous_reason = _cluster_identity_reason;
+   ++_verification_attempts;
+
+   fc::variant observed_result;
+   try {
+      fc::task::deadline_scope probe_deadline(
+         fc::task::clamp_to_current_deadline(fc::time_point::now() + _cluster_identity->probe_timeout));
+      observed_result = fetch_genesis_hash_unchecked_locked();
+   } catch (const fc::timeout_exception&) {
+      record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_timeout);
+      throw;
+   } catch (const std::exception&) {
+      record_cluster_verification_failure_locked(operation, solana_cluster_identity_reason::rpc_error);
+      throw;
+   }
+
+   record_cluster_identity_observation_locked(operation, observed_result, previous_status, previous_reason);
+}
+
+void solana_client::publish_cluster_identity_snapshot_locked() {
+   solana_cluster_identity_snapshot snapshot{
+      .client_id = _cluster_identity ? _cluster_identity->client_id : std::string{},
+      .sanitized_endpoint = _sanitized_endpoint,
+      .mode = _cluster_identity ? solana_cluster_identity_mode::pinned : solana_cluster_identity_mode::unpinned,
+      .status = _cluster_identity_status,
+      .reason = _cluster_identity_reason,
+      .expected_genesis_hash =
+         _cluster_identity ? std::optional(_cluster_identity->expected_genesis_hash.canonical) : std::nullopt,
+      .observed_genesis_hash =
+         _last_observed_genesis_hash ? std::optional(_last_observed_genesis_hash->canonical) : std::nullopt,
+      .verified_at = _last_verified_at,
+      .verification_age = std::nullopt,
+      .transport_session_id = _client.last_transport_session_id(),
+      .verification_attempts = _verification_attempts,
+      .verification_successes = _verification_successes,
+      .verification_mismatches = _verification_mismatches,
+      .verification_failures = _verification_failures,
+      .verification_recoveries = _verification_recoveries,
+      .blocked_operations = _blocked_operations,
+   };
+   std::lock_guard snapshot_guard(_snapshot_mutex);
+   _published_identity_snapshot = std::move(snapshot);
+}
+
+solana_cluster_identity_snapshot solana_client::get_cluster_identity_snapshot() const {
+   solana_cluster_identity_snapshot snapshot;
+   {
+      std::lock_guard snapshot_guard(_snapshot_mutex);
+      snapshot = _published_identity_snapshot;
+   }
+
+   const auto current_transport_session_id = _client.last_transport_session_id();
+   if (snapshot.status == solana_cluster_identity_status::verified &&
+       snapshot.transport_session_id != current_transport_session_id) {
+      snapshot.status = solana_cluster_identity_status::stale;
+      snapshot.reason = solana_cluster_identity_reason::transport_session_changed;
+   }
+   snapshot.transport_session_id = current_transport_session_id;
+   if (snapshot.verified_at) {
+      const auto now = _cluster_identity ? _cluster_identity->verification_clock() : fc::time_point::now();
+      snapshot.verification_age = now - *snapshot.verified_at;
+   }
+   return snapshot;
 }
 
 fc::variant solana_client::execute_idempotent(const std::string& method, const fc::variant& params) {
-   return _client.call_idempotent(method, params);
+   auto operation_guard = lock_operation();
+   if (!_cluster_identity) {
+      return _client.call_idempotent(method, params);
+   }
+   return execute_locked(method, params);
 }
 
 fc::variant solana_client::build_config(commitment_t commitment, const std::optional<fc::variant_object>& extra) {
@@ -1584,29 +1911,23 @@ transaction solana_client::create_transaction(const std::vector<instruction>& in
    for (const auto& m : readonly_non_signers)
       tx.msg.account_keys.push_back(m.key);
 
-   FC_ASSERT(
-      tx.msg.account_keys.size() <= limits::LEGACY_ACCOUNT_KEY_LIMIT,
-      "Solana legacy transaction has {} account keys, exceeding the {} key uint8_t instruction-index limit",
-      tx.msg.account_keys.size(),
-      limits::LEGACY_ACCOUNT_KEY_LIMIT);
+   FC_ASSERT(tx.msg.account_keys.size() <= limits::LEGACY_ACCOUNT_KEY_LIMIT,
+             "Solana legacy transaction has {} account keys, exceeding the {} key uint8_t instruction-index limit",
+             tx.msg.account_keys.size(), limits::LEGACY_ACCOUNT_KEY_LIMIT);
 
    const auto max_u8_count = static_cast<size_t>(std::numeric_limits<uint8_t>::max());
-   FC_ASSERT(
-      writable_signers.size() + readonly_signers.size() <= max_u8_count,
-      "Solana legacy transaction has {} required signatures, exceeding the uint8_t header limit",
-      writable_signers.size() + readonly_signers.size());
-   FC_ASSERT(
-      readonly_signers.size() <= max_u8_count,
-      "Solana legacy transaction has {} readonly signers, exceeding the uint8_t header limit",
-      readonly_signers.size());
-   FC_ASSERT(
-      readonly_non_signers.size() <= max_u8_count,
-      "Solana legacy transaction has {} readonly unsigned accounts, exceeding the uint8_t header limit",
-      readonly_non_signers.size());
+   FC_ASSERT(writable_signers.size() + readonly_signers.size() <= max_u8_count,
+             "Solana legacy transaction has {} required signatures, exceeding the uint8_t header limit",
+             writable_signers.size() + readonly_signers.size());
+   FC_ASSERT(readonly_signers.size() <= max_u8_count,
+             "Solana legacy transaction has {} readonly signers, exceeding the uint8_t header limit",
+             readonly_signers.size());
+   FC_ASSERT(readonly_non_signers.size() <= max_u8_count,
+             "Solana legacy transaction has {} readonly unsigned accounts, exceeding the uint8_t header limit",
+             readonly_non_signers.size());
 
    // Set header
-   tx.msg.header.num_required_signatures =
-      static_cast<uint8_t>(writable_signers.size() + readonly_signers.size());
+   tx.msg.header.num_required_signatures = static_cast<uint8_t>(writable_signers.size() + readonly_signers.size());
    tx.msg.header.num_readonly_signed_accounts = static_cast<uint8_t>(readonly_signers.size());
    tx.msg.header.num_readonly_unsigned_accounts = static_cast<uint8_t>(readonly_non_signers.size());
 
@@ -1617,11 +1938,8 @@ transaction solana_client::create_transaction(const std::vector<instruction>& in
    }
 
    const auto checked_u8_index = [](size_t index, const char* label) -> uint8_t {
-      FC_ASSERT(
-         index < limits::LEGACY_ACCOUNT_KEY_LIMIT,
-         "Solana {} index {} exceeds the uint8_t instruction-index limit",
-         label,
-         index);
+      FC_ASSERT(index < limits::LEGACY_ACCOUNT_KEY_LIMIT,
+                "Solana {} index {} exceeds the uint8_t instruction-index limit", label, index);
       return static_cast<uint8_t>(index);
    };
 
@@ -1645,6 +1963,9 @@ transaction solana_client::create_transaction(const std::vector<instruction>& in
 }
 
 transaction solana_client::sign_transaction(transaction& tx) {
+   auto operation_guard = lock_operation();
+   ensure_cluster_verified_locked(solana_cluster_identity_operation::signing, true);
+
    auto msg_bytes = tx.msg.serialize();
 
    fc::crypto::sol_client_signer signer(*_signature_provider);
@@ -1699,52 +2020,51 @@ std::string solana_client::send_and_confirm_transaction(const transaction& tx, c
 }
 
 namespace {
-   /// True when `confirmation_status` string from `getSignatureStatuses` is
-   /// at least as advanced as the requested `target`. Commitment ordering is
-   /// `processed < confirmed < finalized`; an RPC reporting "finalized"
-   /// satisfies every lesser target. Empty status string means the cluster
-   /// has not observed the tx yet — never sufficient.
-   bool has_reached_commitment(const std::string& confirmation_status, commitment_t target) {
-      if (confirmation_status.empty()) return false;
+/// True when `confirmation_status` string from `getSignatureStatuses` is
+/// at least as advanced as the requested `target`. Commitment ordering is
+/// `processed < confirmed < finalized`; an RPC reporting "finalized"
+/// satisfies every lesser target. Empty status string means the cluster
+/// has not observed the tx yet — never sufficient.
+bool has_reached_commitment(const std::string& confirmation_status, commitment_t target) {
+   if (confirmation_status.empty())
+      return false;
 
-      // Map the RPC's string back to the enum. Unknown strings are treated
-      // as "not yet confirmed" — safer than guessing.
-      auto observed = magic_enum::enum_cast<commitment_t>(confirmation_status);
-      if (!observed.has_value()) return false;
+   // Map the RPC's string back to the enum. Unknown strings are treated
+   // as "not yet confirmed" — safer than guessing.
+   auto observed = magic_enum::enum_cast<commitment_t>(confirmation_status);
+   if (!observed.has_value())
+      return false;
 
-      // Enum declaration order (processed=0, confirmed=1, finalized=2) encodes
-      // the monotonic commitment strength we compare against.
-      return magic_enum::enum_integer(*observed) >= magic_enum::enum_integer(target);
-   }
+   // Enum declaration order (processed=0, confirmed=1, finalized=2) encodes
+   // the monotonic commitment strength we compare against.
+   return magic_enum::enum_integer(*observed) >= magic_enum::enum_integer(target);
+}
 } // namespace
 
-std::string solana_client::send_transaction_and_confirm(const transaction& tx,
-                                                         const solana_confirm_options& opts) {
+std::string solana_client::send_transaction_and_confirm(const transaction& tx, const solana_confirm_options& opts) {
    // Submit once — send_transaction is fire-and-forget by design. We wrap
    // the poll-until-confirmed step in `fc::task::retry_until` so backoff +
    // deadline semantics are shared with the Ethereum client.
    const std::string sig = send_transaction(tx, /*skip_preflight=*/false, opts.commitment);
 
-   return fc::task::retry_until<std::string>(
-      "solana:send_transaction_and_confirm",
-      opts.retry,
-      [this, sig, target = opts.commitment]() -> std::optional<std::string> {
-         auto statuses = get_signature_statuses({sig}, false);
-         if (statuses.value.empty() || !statuses.value[0].has_value()) {
-            return std::nullopt; // cluster hasn't observed the tx yet — retry
-         }
-         const auto& s = *statuses.value[0];
-         if (s.err.has_value()) {
-            // Fatal: the tx ran and failed. No amount of waiting fixes that;
-            // propagate so the caller's retry logic (at the batch-op layer)
-            // can re-submit with a fresh blockhash / nonce.
-            FC_THROW("Transaction failed: {}", *s.err);
-         }
-         if (has_reached_commitment(s.confirmation_status, target)) {
-            return sig; // done — reached the requested commitment level
-         }
-         return std::nullopt; // seen, not yet at target commitment — retry
-      });
+   return fc::task::retry_until<std::string>("solana:send_transaction_and_confirm", opts.retry,
+                                             [this, sig, target = opts.commitment]() -> std::optional<std::string> {
+                                                auto statuses = get_signature_statuses({sig}, false);
+                                                if (statuses.value.empty() || !statuses.value[0].has_value()) {
+                                                   return std::nullopt; // cluster hasn't observed the tx yet — retry
+                                                }
+                                                const auto& s = *statuses.value[0];
+                                                if (s.err.has_value()) {
+                                                   // Fatal: the tx ran and failed. No amount of waiting fixes that;
+                                                   // propagate so the caller's retry logic (at the batch-op layer)
+                                                   // can re-submit with a fresh blockhash / nonce.
+                                                   FC_THROW("Transaction failed: {}", *s.err);
+                                                }
+                                                if (has_reached_commitment(s.confirmation_status, target)) {
+                                                   return sig; // done — reached the requested commitment level
+                                                }
+                                                return std::nullopt; // seen, not yet at target commitment — retry
+                                             });
 }
 
 } // namespace fc::network::solana

--- a/libraries/libfc/test/network/solana/test_solana_client.cpp
+++ b/libraries/libfc/test/network/solana/test_solana_client.cpp
@@ -273,21 +273,14 @@ fc::crypto::signature_provider_ptr test_solana_signature_provider() {
    return provider;
 }
 
-/** Build pinning configuration with an optional deterministic test clock. */
+/** Build pinning configuration with a bounded probe timeout. */
 solana_cluster_identity_config test_identity_config(const std::string& expected_hash,
-                                                    fc::microseconds maximum_age = fc::seconds(30),
-                                                    fc::microseconds probe_timeout = fc::seconds(1),
-                                                    std::shared_ptr<fc::time_point> clock = {}) {
-   solana_cluster_identity_config config{
+                                                    fc::microseconds probe_timeout = fc::seconds(1)) {
+   return solana_cluster_identity_config{
       .client_id = "client-a",
       .expected_genesis_hash = parse_solana_genesis_hash(expected_hash),
-      .maximum_verification_age = maximum_age,
       .probe_timeout = probe_timeout,
    };
-   if (clock) {
-      config.verification_clock = [clock] { return *clock; };
-   }
-   return config;
 }
 
 /** Build the smallest transaction that the configured provider can sign. */
@@ -330,15 +323,64 @@ BOOST_AUTO_TEST_CASE(test_genesis_hash_requires_canonical_base58_and_exact_lengt
 }
 
 BOOST_AUTO_TEST_CASE(test_legacy_client_performs_no_identity_probe) {
-   fc::test::scripted_json_rpc_server server({});
-   solana_client client(test_solana_signature_provider(), server.url());
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("ok"),
+   });
+   // Keep the legacy three-argument brace form source-compatible.
+   solana_client client(test_solana_signature_provider(), server.url(), {});
+
+   auto tx = test_signable_transaction(client);
+   const auto empty_signature = tx.signatures.front();
+   client.sign_transaction(tx);
+   BOOST_CHECK(tx.signatures.front() != empty_signature);
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
 
    const auto snapshot = client.get_cluster_identity_snapshot();
    BOOST_CHECK(!client.cluster_identity_pinning_enabled());
    BOOST_CHECK(snapshot.mode == solana_cluster_identity_mode::unpinned);
    BOOST_CHECK(snapshot.status == solana_cluster_identity_status::unpinned);
    BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::missing_expected_identity);
-   BOOST_CHECK_EQUAL(server.request_count(), 0u);
+   BOOST_CHECK_EQUAL(snapshot.verification_attempts, 0u);
+   const std::vector<std::string> expected_methods{"getHealth"};
+   BOOST_CHECK(server.request_methods() == expected_methods);
+}
+
+BOOST_AUTO_TEST_CASE(test_internal_probe_deadline_survives_disabled_task_inheritance) {
+   const auto expected = test_genesis_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::hanging(),
+   });
+   client_options rpc_options;
+   rpc_options.request.timeouts.total = std::nullopt;
+   rpc_options.request.timeouts.header = std::nullopt;
+   rpc_options.request.timeouts.read = std::nullopt;
+   rpc_options.request.timeouts.idle = std::nullopt;
+   rpc_options.request.timeouts.inherit_task_deadline = false;
+
+   const auto started = std::chrono::steady_clock::now();
+   BOOST_CHECK_THROW(
+      solana_client(test_solana_signature_provider(), server.url(), std::move(rpc_options),
+                    test_identity_config(expected, fc::milliseconds(50))),
+      fc::timeout_exception);
+   const auto elapsed = std::chrono::steady_clock::now() - started;
+   BOOST_CHECK_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 250);
+}
+
+BOOST_AUTO_TEST_CASE(test_solana_client_always_honors_ambient_task_deadline) {
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::delayed_result("ok", std::chrono::milliseconds(125)),
+   });
+   client_options rpc_options;
+   rpc_options.request.timeouts.connect = std::nullopt;
+   rpc_options.request.timeouts.header = std::nullopt;
+   rpc_options.request.timeouts.read = std::nullopt;
+   rpc_options.request.timeouts.idle = std::nullopt;
+   rpc_options.request.timeouts.total = std::nullopt;
+   rpc_options.request.timeouts.inherit_task_deadline = false;
+   solana_client client(test_solana_signature_provider(), server.url(), std::move(rpc_options));
+
+   fc::task::deadline_scope caller_deadline(fc::time_point::now() + fc::milliseconds(50));
+   BOOST_CHECK_THROW(client.get_health(), fc::timeout_exception);
 }
 
 BOOST_AUTO_TEST_CASE(test_pinned_client_permits_read_sign_and_submit_after_matching_probes) {
@@ -351,7 +393,8 @@ BOOST_AUTO_TEST_CASE(test_pinned_client_permits_read_sign_and_submit_after_match
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result("tx-signature"),
    });
-   solana_client client(test_solana_signature_provider(), server.url(), test_identity_config(expected));
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
 
    const auto account = client.get_account_info(make_test_pubkey(12));
    BOOST_CHECK(!account);
@@ -382,7 +425,8 @@ BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_startup_mismatch) {
       fc::test::scripted_json_rpc_response::result(observed),
    });
 
-   BOOST_CHECK_THROW(solana_client(test_solana_signature_provider(), server.url(), test_identity_config(expected)),
+   BOOST_CHECK_THROW(solana_client(test_solana_signature_provider(), server.url(), client_options{},
+                                   test_identity_config(expected)),
                      fc::exception);
    BOOST_CHECK_EQUAL(server.request_count(), 1u);
 }
@@ -394,7 +438,8 @@ BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_oversized_observed_identity) {
       fc::test::scripted_json_rpc_response::result(std::string(4096, 'z')),
    });
 
-   BOOST_CHECK_EXCEPTION(solana_client(test_solana_signature_provider(), server.url(), test_identity_config(expected)),
+   BOOST_CHECK_EXCEPTION(solana_client(test_solana_signature_provider(), server.url(), client_options{},
+                                       test_identity_config(expected)),
                          fc::exception, [](const fc::exception& error) {
                             return error.to_detail_string().find("must not exceed 44 encoded bytes") !=
                                    std::string::npos;
@@ -410,7 +455,8 @@ BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_signing_and_remains_sticky) {
       fc::test::scripted_json_rpc_response::result(wrong_cluster),
       fc::test::scripted_json_rpc_response::result(expected),
    });
-   solana_client client(test_solana_signature_provider(), server.url(), test_identity_config(expected));
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
 
    auto tx = test_signable_transaction(client);
    const auto empty_signature = tx.signatures.front();
@@ -431,13 +477,12 @@ BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_signing_and_remains_sticky) {
 BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_protected_account_read) {
    const auto expected = test_genesis_hash(1);
    const auto wrong_cluster = test_genesis_hash(2);
-   auto clock = std::make_shared<fc::time_point>(fc::time_point::now());
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(wrong_cluster),
    });
-   solana_client client(test_solana_signature_provider(), server.url(),
-                        test_identity_config(expected, fc::milliseconds(10), fc::seconds(1), clock));
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
 
    BOOST_CHECK_THROW(client.get_account_info(make_test_pubkey(15)), fc::exception);
    const auto methods = server.request_methods();
@@ -446,9 +491,24 @@ BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_protected_account_read) {
    BOOST_CHECK_EQUAL(methods[1], "getGenesisHash");
 }
 
-BOOST_AUTO_TEST_CASE(test_rpc_verification_is_peer_bound_even_while_cached_identity_is_fresh) {
+BOOST_AUTO_TEST_CASE(test_runtime_mismatch_classifies_airdrop_as_submission) {
    const auto expected = test_genesis_hash(1);
-   auto clock = std::make_shared<fc::time_point>(fc::time_point::now());
+   const auto wrong_cluster = test_genesis_hash(2);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(wrong_cluster),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
+
+   BOOST_CHECK_THROW(client.request_airdrop(make_test_pubkey(16), 1), fc::exception);
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK_EQUAL(snapshot.blocked_operations.at(solana_cluster_identity_operation::submission), 1u);
+   BOOST_CHECK(!snapshot.blocked_operations.contains(solana_cluster_identity_operation::rpc_read));
+}
+
+BOOST_AUTO_TEST_CASE(test_rpc_verification_is_peer_bound_for_every_call) {
+   const auto expected = test_genesis_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
@@ -458,18 +518,15 @@ BOOST_AUTO_TEST_CASE(test_rpc_verification_is_peer_bound_even_while_cached_ident
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result("ok"),
    });
-   solana_client client(test_solana_signature_provider(), server.url(),
-                        test_identity_config(expected, fc::milliseconds(10), fc::seconds(1), clock));
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
 
-   *clock += fc::microseconds(9'999);
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
    BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 2);
 
-   *clock += fc::microseconds(1);
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
    BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 3);
 
-   *clock += fc::microseconds(10'001);
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
    BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 4);
 }
@@ -483,9 +540,16 @@ BOOST_AUTO_TEST_CASE(test_followup_transport_failure_requires_a_new_peer_bound_p
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result("ok"),
    });
-   solana_client client(test_solana_signature_provider(), server.url(), test_identity_config(expected));
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
 
    BOOST_CHECK_THROW(client.get_health(), fc::exception);
+   const auto failed_followup_snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(failed_followup_snapshot.status == solana_cluster_identity_status::verified);
+   BOOST_CHECK(failed_followup_snapshot.reason == solana_cluster_identity_reason::none);
+   BOOST_CHECK_EQUAL(failed_followup_snapshot.verification_successes, 2u);
+   BOOST_CHECK_EQUAL(failed_followup_snapshot.verification_failures, 0u);
+
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
 
    const auto snapshot = client.get_cluster_identity_snapshot();
@@ -494,14 +558,44 @@ BOOST_AUTO_TEST_CASE(test_followup_transport_failure_requires_a_new_peer_bound_p
    BOOST_CHECK_EQUAL(snapshot.verification_recoveries, 0u);
 }
 
+BOOST_AUTO_TEST_CASE(test_probe_error_recovers_after_a_later_matching_probe) {
+   const auto expected = test_genesis_hash(1);
+   const auto rpc_error =
+      fc::mutable_variant_object()("code", -32000)("message", "temporary probe failure");
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::error(rpc_error),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result("ok"),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
+
+   BOOST_CHECK_THROW(client.get_health(), fc::network::json_rpc::json_rpc_error);
+   auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::error);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::rpc_error);
+   BOOST_CHECK_EQUAL(snapshot.verification_failures, 1u);
+   BOOST_CHECK_EQUAL(snapshot.verification_recoveries, 0u);
+
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
+   snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::verified);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::verification_recovered);
+   BOOST_CHECK_EQUAL(snapshot.verification_attempts, 3u);
+   BOOST_CHECK_EQUAL(snapshot.verification_successes, 2u);
+   BOOST_CHECK_EQUAL(snapshot.verification_failures, 1u);
+   BOOST_CHECK_EQUAL(snapshot.verification_recoveries, 1u);
+}
+
 BOOST_AUTO_TEST_CASE(test_hanging_runtime_probe_times_out_before_signing) {
    const auto expected = test_genesis_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::hanging(),
    });
-   solana_client client(test_solana_signature_provider(), server.url(),
-                        test_identity_config(expected, fc::seconds(30), fc::milliseconds(50)));
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected, fc::milliseconds(50)));
 
    auto tx = test_signable_transaction(client);
    const auto empty_signature = tx.signatures.front();
@@ -516,8 +610,6 @@ BOOST_AUTO_TEST_CASE(test_hanging_runtime_probe_times_out_before_signing) {
 BOOST_AUTO_TEST_CASE(test_concurrent_reads_each_bind_identity_to_their_exact_connection) {
    constexpr size_t caller_count = 4;
    const auto expected = test_genesis_hash(1);
-   auto clock = std::make_shared<fc::time_point>(fc::time_point::now());
-
    std::vector<fc::test::scripted_json_rpc_response> responses{
       fc::test::scripted_json_rpc_response::result(expected),
    };
@@ -526,10 +618,8 @@ BOOST_AUTO_TEST_CASE(test_concurrent_reads_each_bind_identity_to_their_exact_con
       responses.push_back(fc::test::scripted_json_rpc_response::result("ok"));
    }
    fc::test::scripted_json_rpc_server server(std::move(responses));
-   auto client =
-      std::make_shared<solana_client>(test_solana_signature_provider(), server.url(),
-                                      test_identity_config(expected, fc::milliseconds(10), fc::seconds(1), clock));
-   *clock += fc::milliseconds(10);
+   auto client = std::make_shared<solana_client>(test_solana_signature_provider(), server.url(), client_options{},
+                                                 test_identity_config(expected));
 
    std::vector<std::future<std::string>> reads;
    for (size_t i = 0; i < caller_count; ++i) {
@@ -546,17 +636,56 @@ BOOST_AUTO_TEST_CASE(test_concurrent_reads_each_bind_identity_to_their_exact_con
 
 BOOST_AUTO_TEST_CASE(test_operation_gate_uses_real_clock_for_task_deadline) {
    const auto expected = test_genesis_hash(1);
-   auto freshness_clock = std::make_shared<fc::time_point>(fc::time_point::now() + fc::seconds(60));
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result("ok"),
    });
-   solana_client client(test_solana_signature_provider(), server.url(),
-                        test_identity_config(expected, fc::seconds(30), fc::seconds(1), freshness_clock));
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected, fc::seconds(1)));
 
    fc::task::deadline_scope deadline(fc::time_point::now() + fc::milliseconds(500));
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
+}
+
+BOOST_AUTO_TEST_CASE(test_operation_gate_contention_uses_rpc_total_without_task_deadline) {
+   const auto expected = test_genesis_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::hanging(),
+   });
+   client_options rpc_options;
+   rpc_options.request.timeouts.total = fc::milliseconds(50);
+   rpc_options.request.timeouts.inherit_task_deadline = false;
+   solana_client client(
+      test_solana_signature_provider(),
+      server.url(),
+      std::move(rpc_options),
+      test_identity_config(expected, fc::milliseconds(500)));
+
+   auto signing = std::async(
+      std::launch::async,
+      [&client] {
+         auto tx = test_signable_transaction(client);
+         client.sign_transaction(tx);
+      });
+   const auto request_deadline =
+      std::chrono::steady_clock::now() +
+      std::chrono::seconds(1);
+   while (server.request_count() < 2 &&
+          std::chrono::steady_clock::now() < request_deadline) {
+      std::this_thread::yield();
+   }
+   BOOST_REQUIRE_EQUAL(server.request_count(), 2u);
+
+   const auto started = std::chrono::steady_clock::now();
+   BOOST_CHECK_THROW(client.get_health(), fc::timeout_exception);
+   const auto elapsed =
+      std::chrono::steady_clock::now() - started;
+   BOOST_CHECK_LT(
+      std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(),
+      250);
+   BOOST_CHECK_THROW(signing.get(), fc::timeout_exception);
 }
 
 BOOST_AUTO_TEST_CASE(test_probe_timeout_does_not_cap_verified_protected_response) {
@@ -566,8 +695,8 @@ BOOST_AUTO_TEST_CASE(test_probe_timeout_does_not_cap_verified_protected_response
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::delayed_result("ok", std::chrono::milliseconds(125)),
    });
-   solana_client client(test_solana_signature_provider(), server.url(),
-                        test_identity_config(expected, fc::seconds(30), fc::milliseconds(50)));
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected, fc::milliseconds(50)));
 
    fc::task::deadline_scope deadline(fc::time_point::now() + fc::seconds(1));
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
@@ -575,15 +704,13 @@ BOOST_AUTO_TEST_CASE(test_probe_timeout_does_not_cap_verified_protected_response
 
 BOOST_AUTO_TEST_CASE(test_malformed_runtime_identity_blocks_raw_execute) {
    const auto expected = test_genesis_hash(1);
-   auto clock = std::make_shared<fc::time_point>(fc::time_point::now());
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(fc::variant()),
    });
-   solana_client client(test_solana_signature_provider(), server.url(),
-                        test_identity_config(expected, fc::milliseconds(10), fc::seconds(1), clock));
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
 
-   *clock += fc::milliseconds(10);
    BOOST_CHECK_THROW(client.execute("getHealth", fc::variants{}), fc::exception);
    const auto snapshot = client.get_cluster_identity_snapshot();
    BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::malformed_observed_identity);

--- a/libraries/libfc/test/network/solana/test_solana_client.cpp
+++ b/libraries/libfc/test/network/solana/test_solana_client.cpp
@@ -557,9 +557,11 @@ BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_protected_account_read) {
 BOOST_AUTO_TEST_CASE(test_runtime_mismatch_classifies_airdrop_as_submission) {
    const auto expected = fc::test::solana_hash(1);
    const auto wrong_cluster = fc::test::solana_hash(2);
+   auto close_after_startup = fc::test::scripted_json_rpc_response::result(expected);
+   close_after_startup.keep_alive = false;
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
-      resetting_result(expected),
+      std::move(close_after_startup),
       fc::test::scripted_json_rpc_response::result(wrong_cluster),
    });
    solana_client client(test_solana_signature_provider(), server.url(), client_options{},
@@ -567,6 +569,9 @@ BOOST_AUTO_TEST_CASE(test_runtime_mismatch_classifies_airdrop_as_submission) {
 
    BOOST_CHECK_THROW(client.request_airdrop(make_test_pubkey(16), 1), fc::exception);
    const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::mismatch);
+   BOOST_CHECK_EQUAL(snapshot.verification_mismatches, 1u);
+   BOOST_REQUIRE(snapshot.blocked_operations.contains(solana_cluster_identity_operation::submission));
    BOOST_CHECK_EQUAL(snapshot.blocked_operations.at(solana_cluster_identity_operation::submission), 1u);
    BOOST_CHECK(!snapshot.blocked_operations.contains(solana_cluster_identity_operation::rpc_read));
 }

--- a/libraries/libfc/test/network/solana/test_solana_client.cpp
+++ b/libraries/libfc/test/network/solana/test_solana_client.cpp
@@ -323,6 +323,10 @@ BOOST_AUTO_TEST_CASE(test_genesis_hash_requires_canonical_base58_and_exact_lengt
    std::vector<char> long_bytes(33, 1);
    BOOST_CHECK_THROW(parse_solana_genesis_hash(fc::to_base58(short_bytes, fc::yield_function_t{})), fc::exception);
    BOOST_CHECK_THROW(parse_solana_genesis_hash(fc::to_base58(long_bytes, fc::yield_function_t{})), fc::exception);
+   BOOST_CHECK_EXCEPTION(
+      parse_solana_genesis_hash(std::string(45, 'z')), fc::exception, [](const fc::exception& error) {
+         return error.to_detail_string().find("must not exceed 44 encoded bytes") != std::string::npos;
+      });
 }
 
 BOOST_AUTO_TEST_CASE(test_legacy_client_performs_no_identity_probe) {
@@ -380,6 +384,21 @@ BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_startup_mismatch) {
 
    BOOST_CHECK_THROW(solana_client(test_solana_signature_provider(), server.url(), test_identity_config(expected)),
                      fc::exception);
+   BOOST_CHECK_EQUAL(server.request_count(), 1u);
+}
+
+/// An oversized RPC identity is rejected before the quadratic base58 decoder.
+BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_oversized_observed_identity) {
+   const auto expected = test_genesis_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(std::string(4096, 'z')),
+   });
+
+   BOOST_CHECK_EXCEPTION(solana_client(test_solana_signature_provider(), server.url(), test_identity_config(expected)),
+                         fc::exception, [](const fc::exception& error) {
+                            return error.to_detail_string().find("must not exceed 44 encoded bytes") !=
+                                   std::string::npos;
+                         });
    BOOST_CHECK_EQUAL(server.request_count(), 1u);
 }
 
@@ -455,7 +474,7 @@ BOOST_AUTO_TEST_CASE(test_rpc_verification_is_peer_bound_even_while_cached_ident
    BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 4);
 }
 
-BOOST_AUTO_TEST_CASE(test_transport_failure_invalidates_identity_and_matching_probe_recovers) {
+BOOST_AUTO_TEST_CASE(test_followup_transport_failure_requires_a_new_peer_bound_probe) {
    const auto expected = test_genesis_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
@@ -471,8 +490,8 @@ BOOST_AUTO_TEST_CASE(test_transport_failure_invalidates_identity_and_matching_pr
 
    const auto snapshot = client.get_cluster_identity_snapshot();
    BOOST_CHECK(snapshot.status == solana_cluster_identity_status::verified);
-   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::verification_recovered);
-   BOOST_CHECK_EQUAL(snapshot.verification_recoveries, 1u);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::none);
+   BOOST_CHECK_EQUAL(snapshot.verification_recoveries, 0u);
 }
 
 BOOST_AUTO_TEST_CASE(test_hanging_runtime_probe_times_out_before_signing) {
@@ -494,7 +513,7 @@ BOOST_AUTO_TEST_CASE(test_hanging_runtime_probe_times_out_before_signing) {
    BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::rpc_timeout);
 }
 
-BOOST_AUTO_TEST_CASE(test_concurrent_reads_each_bind_identity_to_their_transport_session) {
+BOOST_AUTO_TEST_CASE(test_concurrent_reads_each_bind_identity_to_their_exact_connection) {
    constexpr size_t caller_count = 4;
    const auto expected = test_genesis_hash(1);
    auto clock = std::make_shared<fc::time_point>(fc::time_point::now());
@@ -527,8 +546,7 @@ BOOST_AUTO_TEST_CASE(test_concurrent_reads_each_bind_identity_to_their_transport
 
 BOOST_AUTO_TEST_CASE(test_operation_gate_uses_real_clock_for_task_deadline) {
    const auto expected = test_genesis_hash(1);
-   auto freshness_clock =
-      std::make_shared<fc::time_point>(fc::time_point::now() + fc::seconds(60));
+   auto freshness_clock = std::make_shared<fc::time_point>(fc::time_point::now() + fc::seconds(60));
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
@@ -546,8 +564,7 @@ BOOST_AUTO_TEST_CASE(test_probe_timeout_does_not_cap_verified_protected_response
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
-      fc::test::scripted_json_rpc_response::delayed_result(
-         "ok", std::chrono::milliseconds(125)),
+      fc::test::scripted_json_rpc_response::delayed_result("ok", std::chrono::milliseconds(125)),
    });
    solana_client client(test_solana_signature_provider(), server.url(),
                         test_identity_config(expected, fc::seconds(30), fc::milliseconds(50)));

--- a/libraries/libfc/test/network/solana/test_solana_client.cpp
+++ b/libraries/libfc/test/network/solana/test_solana_client.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <fc-test/crypto_utils.hpp>
 #include <fc-test/scripted_json_rpc_server.hpp>
+#include <fc-test/solana_utils.hpp>
 #include <fc/crypto/sha256.hpp>
 #include <fc/crypto/signature_provider.hpp>
 #include <fc/exception/exception.hpp>
@@ -35,6 +36,7 @@ constexpr std::string_view empty_vec_account_name = "EmptyVecAccount";
 constexpr std::string_view nested_account_name = "NestedAccount";
 constexpr std::string_view cyclic_account_name = "CyclicAccount";
 constexpr std::string_view idl_depth_error = "Solana IDL type nesting exceeds maximum depth";
+thread_local bool cancel_current_rpc_wait = false;
 
 /**
  * @brief Construct a deterministic Solana public key for serialization tests.
@@ -255,12 +257,6 @@ bool is_idl_depth_exception(const fc::assert_exception& error) {
    return error.to_detail_string().find(idl_depth_error) != std::string::npos;
 }
 
-/** Return a deterministic canonical 32-byte Solana genesis hash. */
-std::string test_genesis_hash(uint8_t seed) {
-   std::vector<char> bytes(32, static_cast<char>(seed));
-   return fc::to_base58(bytes, fc::yield_function_t{});
-}
-
 /** Build the local Solana signature provider used by protected-sign tests. */
 fc::crypto::signature_provider_ptr test_solana_signature_provider() {
    const auto fixture = fc::test::load_keygen_fixture("solana", 1);
@@ -284,18 +280,59 @@ solana_cluster_identity_config test_identity_config(const std::string& expected_
 }
 
 /** Build the smallest transaction that the configured provider can sign. */
-transaction test_signable_transaction(const solana_client& client) {
+transaction test_signable_transaction(const solana_client& client,
+                                      solana_public_key recent_blockhash = make_test_pubkey(777)) {
    transaction tx;
    tx.msg.header.num_required_signatures = 1;
    tx.msg.account_keys.push_back(client.get_pubkey());
-   tx.msg.recent_blockhash = make_test_pubkey(777);
+   tx.msg.recent_blockhash = recent_blockhash;
    tx.signatures.resize(1);
    return tx;
+}
+
+/** Return a valid getLatestBlockhash result. */
+fc::variant blockhash_response(const std::string& blockhash) {
+   return fc::mutable_variant_object()(
+      "context",
+      fc::mutable_variant_object()("slot", 1))(
+      "value",
+      fc::mutable_variant_object()("blockhash", blockhash)("lastValidBlockHeight", 100));
+}
+
+/** Return a successful response that resets its connection after writing. */
+fc::test::scripted_json_rpc_response resetting_result(fc::variant value) {
+   auto response = fc::test::scripted_json_rpc_response::result(std::move(value));
+   response.reset_after_response = true;
+   return response;
 }
 
 /** Return a valid getAccountInfo response for an account that does not exist. */
 fc::variant account_not_found_response() {
    return fc::mutable_variant_object()("context", fc::mutable_variant_object()("slot", 1))("value", fc::variant());
+}
+
+/** Return one successful getSignatureStatuses result at the requested commitment. */
+fc::variant signature_status_response(std::string confirmation_status) {
+   return fc::mutable_variant_object()(
+      "context",
+      fc::mutable_variant_object()("slot", 1))(
+      "value",
+      fc::variants{
+         fc::mutable_variant_object()("slot", 1)("confirmations", 1)("err", fc::variant())(
+            "confirmationStatus", std::move(confirmation_status)),
+      });
+}
+
+/** Return one on-chain transaction failure from getSignatureStatuses. */
+fc::variant failed_signature_status_response(std::string error) {
+   return fc::mutable_variant_object()(
+      "context",
+      fc::mutable_variant_object()("slot", 1))(
+      "value",
+      fc::variants{
+         fc::mutable_variant_object()("slot", 1)("confirmations", 1)("err", std::move(error))(
+            "confirmationStatus", "processed"),
+      });
 }
 
 } // namespace
@@ -305,7 +342,7 @@ fc::variant account_not_found_response() {
 //=============================================================================
 
 BOOST_AUTO_TEST_CASE(test_genesis_hash_requires_canonical_base58_and_exact_length) {
-   const auto canonical = test_genesis_hash(7);
+   const auto canonical = fc::test::solana_hash(7);
    const auto parsed = parse_solana_genesis_hash(canonical);
    BOOST_CHECK_EQUAL(parsed.canonical, canonical);
 
@@ -346,7 +383,7 @@ BOOST_AUTO_TEST_CASE(test_legacy_client_performs_no_identity_probe) {
 }
 
 BOOST_AUTO_TEST_CASE(test_internal_probe_deadline_survives_disabled_task_inheritance) {
-   const auto expected = test_genesis_hash(1);
+   const auto expected = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::hanging(),
    });
@@ -384,22 +421,25 @@ BOOST_AUTO_TEST_CASE(test_solana_client_always_honors_ambient_task_deadline) {
 }
 
 BOOST_AUTO_TEST_CASE(test_pinned_client_permits_read_sign_and_submit_after_matching_probes) {
-   const auto expected = test_genesis_hash(1);
+   const auto expected = fc::test::solana_hash(1);
+   const auto blockhash = fc::test::solana_hash(3);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(blockhash_response(blockhash)),
       fc::test::scripted_json_rpc_response::result(account_not_found_response()),
-      fc::test::scripted_json_rpc_response::result(expected),
-      fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result("tx-signature"),
    });
    solana_client client(test_solana_signature_provider(), server.url(), client_options{},
                         test_identity_config(expected));
 
+   const auto latest_blockhash = client.get_latest_blockhash();
    const auto account = client.get_account_info(make_test_pubkey(12));
    BOOST_CHECK(!account);
 
-   auto tx = test_signable_transaction(client);
+   auto tx = test_signable_transaction(
+      client,
+      solana_public_key::from_base58_string(latest_blockhash.blockhash));
    const auto empty_signature = tx.signatures.front();
    client.sign_transaction(tx);
    BOOST_CHECK(tx.signatures.front() != empty_signature);
@@ -407,20 +447,20 @@ BOOST_AUTO_TEST_CASE(test_pinned_client_permits_read_sign_and_submit_after_match
 
    const auto methods = server.request_methods();
    const std::vector<std::string> expected_methods{
-      "getGenesisHash", "getGenesisHash", "getAccountInfo", "getGenesisHash", "getGenesisHash", "sendTransaction",
+      "getGenesisHash", "getGenesisHash", "getLatestBlockhash", "getAccountInfo", "sendTransaction",
    };
    BOOST_CHECK(methods == expected_methods);
 
    const auto snapshot = client.get_cluster_identity_snapshot();
    BOOST_CHECK(snapshot.status == solana_cluster_identity_status::verified);
-   BOOST_CHECK_EQUAL(snapshot.verification_attempts, 4u);
-   BOOST_CHECK_EQUAL(snapshot.verification_successes, 4u);
+   BOOST_CHECK_EQUAL(snapshot.verification_attempts, 1u);
+   BOOST_CHECK_EQUAL(snapshot.verification_successes, 1u);
    BOOST_CHECK_EQUAL(snapshot.verification_mismatches, 0u);
 }
 
 BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_startup_mismatch) {
-   const auto expected = test_genesis_hash(1);
-   const auto observed = test_genesis_hash(2);
+   const auto expected = fc::test::solana_hash(1);
+   const auto observed = fc::test::solana_hash(2);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(observed),
    });
@@ -431,9 +471,24 @@ BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_startup_mismatch) {
    BOOST_CHECK_EQUAL(server.request_count(), 1u);
 }
 
+BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_nonpersistent_rpc_transport_at_startup) {
+   const auto expected = fc::test::solana_hash(1);
+   auto closing_validation = fc::test::scripted_json_rpc_response::result(expected);
+   closing_validation.keep_alive = false;
+   fc::test::scripted_json_rpc_server server({std::move(closing_validation)});
+
+   BOOST_CHECK_EXCEPTION(
+      solana_client(test_solana_signature_provider(), server.url(), client_options{}, test_identity_config(expected)),
+      fc::exception,
+      [](const fc::exception& error) {
+         return error.to_detail_string().find("did not preserve a persistent connection") != std::string::npos;
+      });
+   BOOST_CHECK_EQUAL(server.request_count(), 1u);
+}
+
 /// An oversized RPC identity is rejected before the quadratic base58 decoder.
 BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_oversized_observed_identity) {
-   const auto expected = test_genesis_hash(1);
+   const auto expected = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(std::string(4096, 'z')),
    });
@@ -448,24 +503,30 @@ BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_oversized_observed_identity) {
 }
 
 BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_signing_and_remains_sticky) {
-   const auto expected = test_genesis_hash(1);
-   const auto wrong_cluster = test_genesis_hash(2);
+   const auto expected = fc::test::solana_hash(1);
+   const auto wrong_cluster = fc::test::solana_hash(2);
+   const auto blockhash = fc::test::solana_hash(3);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
-      fc::test::scripted_json_rpc_response::result(wrong_cluster),
       fc::test::scripted_json_rpc_response::result(expected),
+      resetting_result(blockhash_response(blockhash)),
+      fc::test::scripted_json_rpc_response::result(wrong_cluster),
    });
    solana_client client(test_solana_signature_provider(), server.url(), client_options{},
                         test_identity_config(expected));
 
-   auto tx = test_signable_transaction(client);
+   const auto latest_blockhash = client.get_latest_blockhash();
+   auto tx = test_signable_transaction(
+      client,
+      solana_public_key::from_base58_string(latest_blockhash.blockhash));
    const auto empty_signature = tx.signatures.front();
+   BOOST_CHECK_THROW(client.get_health(), fc::exception);
    BOOST_CHECK_THROW(client.sign_transaction(tx), fc::exception);
    BOOST_CHECK(tx.signatures.front() == empty_signature);
 
    BOOST_CHECK_THROW(client.sign_transaction(tx), fc::exception);
    BOOST_CHECK(tx.signatures.front() == empty_signature);
-   BOOST_CHECK_EQUAL(server.request_count(), 2u);
+   BOOST_CHECK_EQUAL(server.request_count(), 4u);
 
    const auto snapshot = client.get_cluster_identity_snapshot();
    BOOST_CHECK(snapshot.status == solana_cluster_identity_status::mismatch);
@@ -475,10 +536,11 @@ BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_signing_and_remains_sticky) {
 }
 
 BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_protected_account_read) {
-   const auto expected = test_genesis_hash(1);
-   const auto wrong_cluster = test_genesis_hash(2);
+   const auto expected = fc::test::solana_hash(1);
+   const auto wrong_cluster = fc::test::solana_hash(2);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
+      resetting_result(expected),
       fc::test::scripted_json_rpc_response::result(wrong_cluster),
    });
    solana_client client(test_solana_signature_provider(), server.url(), client_options{},
@@ -486,16 +548,18 @@ BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_protected_account_read) {
 
    BOOST_CHECK_THROW(client.get_account_info(make_test_pubkey(15)), fc::exception);
    const auto methods = server.request_methods();
-   BOOST_REQUIRE_EQUAL(methods.size(), 2u);
+   BOOST_REQUIRE_EQUAL(methods.size(), 3u);
    BOOST_CHECK_EQUAL(methods[0], "getGenesisHash");
    BOOST_CHECK_EQUAL(methods[1], "getGenesisHash");
+   BOOST_CHECK_EQUAL(methods[2], "getGenesisHash");
 }
 
 BOOST_AUTO_TEST_CASE(test_runtime_mismatch_classifies_airdrop_as_submission) {
-   const auto expected = test_genesis_hash(1);
-   const auto wrong_cluster = test_genesis_hash(2);
+   const auto expected = fc::test::solana_hash(1);
+   const auto wrong_cluster = fc::test::solana_hash(2);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
+      resetting_result(expected),
       fc::test::scripted_json_rpc_response::result(wrong_cluster),
    });
    solana_client client(test_solana_signature_provider(), server.url(), client_options{},
@@ -507,15 +571,13 @@ BOOST_AUTO_TEST_CASE(test_runtime_mismatch_classifies_airdrop_as_submission) {
    BOOST_CHECK(!snapshot.blocked_operations.contains(solana_cluster_identity_operation::rpc_read));
 }
 
-BOOST_AUTO_TEST_CASE(test_rpc_verification_is_peer_bound_for_every_call) {
-   const auto expected = test_genesis_hash(1);
+BOOST_AUTO_TEST_CASE(test_rpc_verification_runs_once_per_persistent_connection) {
+   const auto expected = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result("ok"),
-      fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result("ok"),
-      fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result("ok"),
    });
    solana_client client(test_solana_signature_provider(), server.url(), client_options{},
@@ -525,16 +587,45 @@ BOOST_AUTO_TEST_CASE(test_rpc_verification_is_peer_bound_for_every_call) {
    BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 2);
 
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
-   BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 3);
+   BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 2);
 
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
-   BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 4);
+   BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 2);
+   BOOST_CHECK_EQUAL(server.connection_count(), 1u);
 }
 
-BOOST_AUTO_TEST_CASE(test_followup_transport_failure_requires_a_new_peer_bound_probe) {
-   const auto expected = test_genesis_hash(1);
+BOOST_AUTO_TEST_CASE(test_each_replacement_connection_is_validated_before_use) {
+   const auto expected = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      resetting_result("first"),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result("second"),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
+
+   BOOST_CHECK_EQUAL(client.get_health(), "first");
+   BOOST_CHECK_EQUAL(client.get_health(), "second");
+
+   const auto requests = server.requests();
+   BOOST_REQUIRE_EQUAL(requests.size(), 5u);
+   BOOST_CHECK_EQUAL(requests[0].connection, requests[1].connection);
+   BOOST_CHECK_EQUAL(requests[1].connection, requests[2].connection);
+   BOOST_CHECK_NE(requests[2].connection, requests[3].connection);
+   BOOST_CHECK_EQUAL(requests[3].connection, requests[4].connection);
+
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK_EQUAL(snapshot.verification_attempts, 2u);
+   BOOST_CHECK_EQUAL(snapshot.verification_successes, 2u);
+}
+
+BOOST_AUTO_TEST_CASE(test_protected_transport_failure_is_not_reported_as_total_success) {
+   const auto expected = fc::test::solana_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      resetting_result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::close(),
       fc::test::scripted_json_rpc_response::result(expected),
@@ -549,21 +640,26 @@ BOOST_AUTO_TEST_CASE(test_followup_transport_failure_requires_a_new_peer_bound_p
    BOOST_CHECK(failed_followup_snapshot.reason == solana_cluster_identity_reason::none);
    BOOST_CHECK_EQUAL(failed_followup_snapshot.verification_successes, 2u);
    BOOST_CHECK_EQUAL(failed_followup_snapshot.verification_failures, 0u);
+   BOOST_CHECK_EQUAL(
+      failed_followup_snapshot.protected_operation_failures.at(solana_cluster_identity_operation::rpc_read),
+      1u);
 
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
 
    const auto snapshot = client.get_cluster_identity_snapshot();
    BOOST_CHECK(snapshot.status == solana_cluster_identity_status::verified);
    BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::none);
+   BOOST_CHECK_EQUAL(snapshot.verification_successes, 3u);
    BOOST_CHECK_EQUAL(snapshot.verification_recoveries, 0u);
 }
 
 BOOST_AUTO_TEST_CASE(test_probe_error_recovers_after_a_later_matching_probe) {
-   const auto expected = test_genesis_hash(1);
+   const auto expected = fc::test::solana_hash(1);
    const auto rpc_error =
       fc::mutable_variant_object()("code", -32000)("message", "temporary probe failure");
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
+      resetting_result(expected),
       fc::test::scripted_json_rpc_response::error(rpc_error),
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result("ok"),
@@ -588,33 +684,96 @@ BOOST_AUTO_TEST_CASE(test_probe_error_recovers_after_a_later_matching_probe) {
    BOOST_CHECK_EQUAL(snapshot.verification_recoveries, 1u);
 }
 
-BOOST_AUTO_TEST_CASE(test_hanging_runtime_probe_times_out_before_signing) {
-   const auto expected = test_genesis_hash(1);
+BOOST_AUTO_TEST_CASE(test_runtime_connection_validation_timeout_is_classified) {
+   const auto expected = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
+      resetting_result(expected),
       fc::test::scripted_json_rpc_response::hanging(),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected, fc::milliseconds(50)));
+
+   BOOST_CHECK_THROW(client.get_health(), fc::timeout_exception);
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::error);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::rpc_timeout);
+   BOOST_CHECK_EQUAL(snapshot.verification_failures, 1u);
+   BOOST_CHECK(!snapshot.protected_operation_failures.contains(
+      solana_cluster_identity_operation::rpc_read));
+}
+
+BOOST_AUTO_TEST_CASE(test_runtime_connection_validation_cancellation_is_classified) {
+   const auto expected = fc::test::solana_hash(1);
+   std::atomic_bool cancellation_requested{false};
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      resetting_result(expected),
+      fc::test::scripted_json_rpc_response::delayed_result(expected, std::chrono::milliseconds(250)),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result("ok"),
+   });
+   client_options rpc_options;
+   rpc_options.request.cancel_check = [&cancellation_requested] {
+      return cancellation_requested.load(std::memory_order_acquire);
+   };
+   solana_client client(test_solana_signature_provider(), server.url(), std::move(rpc_options),
+                        test_identity_config(expected));
+
+   auto read = std::async(std::launch::async, [&client] { return client.get_health(); });
+   const auto request_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+   while (server.request_count() < 3 && std::chrono::steady_clock::now() < request_deadline)
+      std::this_thread::yield();
+   BOOST_REQUIRE_EQUAL(server.request_count(), 3u);
+   cancellation_requested.store(true, std::memory_order_release);
+   BOOST_CHECK_THROW(read.get(), fc::exception);
+
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::verified);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::none);
+   BOOST_CHECK_EQUAL(snapshot.verification_failures, 0u);
+   BOOST_CHECK_EQUAL(snapshot.verification_cancellations, 1u);
+   BOOST_CHECK_EQUAL(snapshot.verification_recoveries, 0u);
+   BOOST_CHECK(!snapshot.protected_operation_failures.contains(
+      solana_cluster_identity_operation::rpc_read));
+
+   cancellation_requested.store(false, std::memory_order_release);
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
+   const auto recovered_snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(recovered_snapshot.status == solana_cluster_identity_status::verified);
+   BOOST_CHECK(recovered_snapshot.reason == solana_cluster_identity_reason::none);
+   BOOST_CHECK_EQUAL(recovered_snapshot.verification_successes, 2u);
+   BOOST_CHECK_EQUAL(recovered_snapshot.verification_recoveries, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(test_pinned_signing_requires_verified_blockhash_provenance) {
+   const auto expected = fc::test::solana_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
    });
    solana_client client(test_solana_signature_provider(), server.url(), client_options{},
                         test_identity_config(expected, fc::milliseconds(50)));
 
    auto tx = test_signable_transaction(client);
    const auto empty_signature = tx.signatures.front();
-   BOOST_CHECK_THROW(client.sign_transaction(tx), fc::timeout_exception);
+   BOOST_CHECK_THROW(client.sign_transaction(tx), fc::exception);
    BOOST_CHECK(tx.signatures.front() == empty_signature);
+   BOOST_CHECK_EQUAL(server.request_count(), 2u);
 
    const auto snapshot = client.get_cluster_identity_snapshot();
-   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::error);
-   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::rpc_timeout);
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::verified);
+   BOOST_CHECK_EQUAL(snapshot.blocked_operations.at(solana_cluster_identity_operation::signing), 1u);
 }
 
-BOOST_AUTO_TEST_CASE(test_concurrent_reads_each_bind_identity_to_their_exact_connection) {
+BOOST_AUTO_TEST_CASE(test_concurrent_reads_share_one_validated_persistent_connection) {
    constexpr size_t caller_count = 4;
-   const auto expected = test_genesis_hash(1);
+   const auto expected = fc::test::solana_hash(1);
    std::vector<fc::test::scripted_json_rpc_response> responses{
+      fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
    };
    for (size_t i = 0; i < caller_count; ++i) {
-      responses.push_back(fc::test::scripted_json_rpc_response::result(expected));
       responses.push_back(fc::test::scripted_json_rpc_response::result("ok"));
    }
    fc::test::scripted_json_rpc_server server(std::move(responses));
@@ -630,12 +789,13 @@ BOOST_AUTO_TEST_CASE(test_concurrent_reads_each_bind_identity_to_their_exact_con
    }
 
    const auto methods = server.request_methods();
-   BOOST_CHECK_EQUAL(std::ranges::count(methods, "getGenesisHash"), caller_count + 1);
+   BOOST_CHECK_EQUAL(std::ranges::count(methods, "getGenesisHash"), 2u);
    BOOST_CHECK_EQUAL(std::ranges::count(methods, "getHealth"), caller_count);
+   BOOST_CHECK_EQUAL(server.connection_count(), 1u);
 }
 
-BOOST_AUTO_TEST_CASE(test_operation_gate_uses_real_clock_for_task_deadline) {
-   const auto expected = test_genesis_hash(1);
+BOOST_AUTO_TEST_CASE(test_pinned_rpc_honors_ambient_task_deadline) {
+   const auto expected = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
@@ -648,48 +808,254 @@ BOOST_AUTO_TEST_CASE(test_operation_gate_uses_real_clock_for_task_deadline) {
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
 }
 
-BOOST_AUTO_TEST_CASE(test_operation_gate_contention_uses_rpc_total_without_task_deadline) {
-   const auto expected = test_genesis_hash(1);
+BOOST_AUTO_TEST_CASE(test_pinned_rpc_gate_contention_honors_ambient_deadline_without_sending) {
+   const auto expected = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::hanging(),
    });
    client_options rpc_options;
-   rpc_options.request.timeouts.total = fc::milliseconds(50);
-   rpc_options.request.timeouts.inherit_task_deadline = false;
-   solana_client client(
-      test_solana_signature_provider(),
-      server.url(),
-      std::move(rpc_options),
-      test_identity_config(expected, fc::milliseconds(500)));
+   rpc_options.request.timeouts.total = std::nullopt;
+   solana_client client(test_solana_signature_provider(), server.url(), std::move(rpc_options),
+                        test_identity_config(expected, fc::seconds(1)));
 
-   auto signing = std::async(
-      std::launch::async,
+   auto holding_call = std::async(std::launch::async, [&client] {
+      fc::task::deadline_scope deadline(fc::time_point::now() + fc::milliseconds(250));
+      return client.get_health();
+   });
+   const auto request_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+   while (server.request_count() < 3 && std::chrono::steady_clock::now() < request_deadline)
+      std::this_thread::yield();
+   BOOST_REQUIRE_EQUAL(server.request_count(), 3u);
+
+   const auto started = std::chrono::steady_clock::now();
+   BOOST_CHECK_THROW(
       [&client] {
-         auto tx = test_signable_transaction(client);
-         client.sign_transaction(tx);
-      });
+         fc::task::deadline_scope deadline(fc::time_point::now() + fc::milliseconds(50));
+         (void)client.get_health();
+      }(),
+      fc::timeout_exception);
+   const auto elapsed = std::chrono::steady_clock::now() - started;
+
+   BOOST_CHECK_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 200);
+   BOOST_CHECK_EQUAL(server.request_count(), 3u);
+   BOOST_CHECK_THROW(holding_call.get(), fc::timeout_exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_pinned_rpc_gate_contention_honors_cancellation_without_sending) {
+   const auto expected = fc::test::solana_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::hanging(),
+   });
+   client_options rpc_options;
+   rpc_options.request.timeouts.total = std::nullopt;
+   rpc_options.request.cancel_check = [] { return cancel_current_rpc_wait; };
+   solana_client client(test_solana_signature_provider(), server.url(), std::move(rpc_options),
+                        test_identity_config(expected, fc::seconds(1)));
+
+   auto holding_call = std::async(std::launch::async, [&client] {
+      fc::task::deadline_scope deadline(fc::time_point::now() + fc::milliseconds(250));
+      return client.get_health();
+   });
+   const auto request_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+   while (server.request_count() < 3 && std::chrono::steady_clock::now() < request_deadline)
+      std::this_thread::yield();
+   BOOST_REQUIRE_EQUAL(server.request_count(), 3u);
+
+   const auto started = std::chrono::steady_clock::now();
+   auto cancelled_call = std::async(std::launch::async, [&client] {
+      cancel_current_rpc_wait = true;
+      return client.get_health();
+   });
+   BOOST_CHECK_THROW(cancelled_call.get(), fc::canceled_exception);
+   const auto elapsed = std::chrono::steady_clock::now() - started;
+
+   BOOST_CHECK_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 200);
+   BOOST_CHECK_EQUAL(server.request_count(), 3u);
+   BOOST_CHECK_THROW(holding_call.get(), fc::timeout_exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_unpinned_local_signing_is_not_blocked_by_a_hanging_rpc) {
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::hanging(),
+   });
+   client_options rpc_options;
+   rpc_options.request.timeouts.total = fc::milliseconds(100);
+   rpc_options.request.timeouts.inherit_task_deadline = false;
+   solana_client client(test_solana_signature_provider(), server.url(), std::move(rpc_options));
+
+   auto read = std::async(std::launch::async, [&client] { return client.get_health(); });
    const auto request_deadline =
       std::chrono::steady_clock::now() +
       std::chrono::seconds(1);
-   while (server.request_count() < 2 &&
+   while (server.request_count() < 1 &&
           std::chrono::steady_clock::now() < request_deadline) {
       std::this_thread::yield();
    }
-   BOOST_REQUIRE_EQUAL(server.request_count(), 2u);
+   BOOST_REQUIRE_EQUAL(server.request_count(), 1u);
 
+   auto tx = test_signable_transaction(client);
    const auto started = std::chrono::steady_clock::now();
-   BOOST_CHECK_THROW(client.get_health(), fc::timeout_exception);
+   client.sign_transaction(tx);
    const auto elapsed =
       std::chrono::steady_clock::now() - started;
    BOOST_CHECK_LT(
       std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(),
-      250);
-   BOOST_CHECK_THROW(signing.get(), fc::timeout_exception);
+      50);
+   BOOST_CHECK_THROW(read.get(), fc::timeout_exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_confirmation_poll_retries_transient_rpc_exception_after_single_submission) {
+   const auto rpc_error =
+      fc::mutable_variant_object()("code", -32000)("message", "temporary confirmation failure");
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("tx-signature"),
+      fc::test::scripted_json_rpc_response::error(rpc_error),
+      fc::test::scripted_json_rpc_response::result(signature_status_response("processed")),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{});
+   auto tx = test_signable_transaction(client);
+   solana_confirm_options options;
+   options.retry.initial_backoff = fc::milliseconds(1);
+   options.retry.max_backoff = fc::milliseconds(1);
+   options.retry.total_timeout = fc::seconds(1);
+
+   BOOST_CHECK_EQUAL(client.send_transaction_and_confirm(tx, options), "tx-signature");
+   const std::vector<std::string> expected_methods{
+      "sendTransaction",
+      "getSignatureStatuses",
+      "getSignatureStatuses",
+   };
+   BOOST_CHECK(server.request_methods() == expected_methods);
+}
+
+BOOST_AUTO_TEST_CASE(test_legacy_confirmation_poll_retries_transient_rpc_exception_after_single_submission) {
+   const auto rpc_error =
+      fc::mutable_variant_object()("code", -32000)("message", "temporary confirmation failure");
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("tx-signature"),
+      fc::test::scripted_json_rpc_response::error(rpc_error),
+      fc::test::scripted_json_rpc_response::result(signature_status_response("processed")),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{});
+   auto tx = test_signable_transaction(client);
+
+   BOOST_CHECK_EQUAL(
+      client.send_and_confirm_transaction(tx, commitment_t::processed),
+      "tx-signature");
+   const std::vector<std::string> expected_methods{
+      "sendTransaction",
+      "getSignatureStatuses",
+      "getSignatureStatuses",
+   };
+   BOOST_CHECK(server.request_methods() == expected_methods);
+}
+
+BOOST_AUTO_TEST_CASE(test_legacy_confirmation_propagates_on_chain_failure_without_poll_retry) {
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("tx-signature"),
+      fc::test::scripted_json_rpc_response::result(failed_signature_status_response("program failure")),
+      fc::test::scripted_json_rpc_response::result(signature_status_response("processed")),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{});
+   auto tx = test_signable_transaction(client);
+
+   BOOST_CHECK_THROW(
+      client.send_and_confirm_transaction(tx, commitment_t::processed),
+      fc::exception);
+   const std::vector<std::string> expected_methods{
+      "sendTransaction",
+      "getSignatureStatuses",
+   };
+   BOOST_CHECK(server.request_methods() == expected_methods);
+}
+
+BOOST_AUTO_TEST_CASE(test_legacy_confirmation_honors_short_ambient_deadline_without_resubmission) {
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("tx-signature"),
+      fc::test::scripted_json_rpc_response::hanging(),
+   });
+   client_options rpc_options;
+   rpc_options.request.timeouts.total = fc::seconds(5);
+   solana_client client(test_solana_signature_provider(), server.url(), std::move(rpc_options));
+   auto tx = test_signable_transaction(client);
+
+   const auto start = fc::time_point::now();
+   BOOST_CHECK_THROW(
+      [&] {
+         fc::task::deadline_scope deadline(fc::time_point::now() + fc::milliseconds(100));
+         client.send_and_confirm_transaction(tx, commitment_t::processed);
+      }(),
+      fc::timeout_exception);
+   const auto elapsed = fc::time_point::now() - start;
+
+   BOOST_CHECK_LT(elapsed.count(), fc::seconds(2).count());
+   const std::vector<std::string> expected_methods{
+      "sendTransaction",
+      "getSignatureStatuses",
+   };
+   BOOST_CHECK(server.request_methods() == expected_methods);
+}
+
+BOOST_AUTO_TEST_CASE(test_confirmation_total_timeout_bounds_hanging_status_poll_without_ambient_deadline) {
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("tx-signature"),
+      fc::test::scripted_json_rpc_response::hanging(),
+   });
+   client_options rpc_options;
+   rpc_options.request.timeouts.total = std::nullopt;
+   solana_client client(test_solana_signature_provider(), server.url(), std::move(rpc_options));
+   auto tx = test_signable_transaction(client);
+   solana_confirm_options options;
+   options.retry.initial_backoff = fc::milliseconds(1);
+   options.retry.max_backoff = fc::milliseconds(1);
+   options.retry.total_timeout = fc::milliseconds(100);
+
+   const auto start = fc::time_point::now();
+   BOOST_CHECK_THROW(client.send_transaction_and_confirm(tx, options), fc::timeout_exception);
+   const auto elapsed = fc::time_point::now() - start;
+
+   BOOST_CHECK_LT(elapsed.count(), fc::seconds(2).count());
+   const std::vector<std::string> expected_methods{
+      "sendTransaction",
+      "getSignatureStatuses",
+   };
+   BOOST_CHECK(server.request_methods() == expected_methods);
+}
+
+BOOST_AUTO_TEST_CASE(test_pinned_confirmation_revalidates_after_transport_failure_without_resubmission) {
+   const auto expected = fc::test::solana_hash(1);
+   auto submission = fc::test::scripted_json_rpc_response::result("tx-signature");
+   submission.reset_after_response = true;
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      std::move(submission),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::close(),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(signature_status_response("processed")),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
+   auto tx = test_signable_transaction(client);
+   solana_confirm_options options;
+   options.retry.initial_backoff = fc::milliseconds(1);
+   options.retry.max_backoff = fc::milliseconds(1);
+   options.retry.total_timeout = fc::seconds(1);
+
+   BOOST_CHECK_EQUAL(client.send_transaction_and_confirm(tx, options), "tx-signature");
+   const auto methods = server.request_methods();
+   BOOST_CHECK_EQUAL(std::ranges::count(methods, "sendTransaction"), 1u);
+   BOOST_CHECK_EQUAL(std::ranges::count(methods, "getSignatureStatuses"), 2u);
+   BOOST_CHECK_EQUAL(std::ranges::count(methods, "getGenesisHash"), 4u);
 }
 
 BOOST_AUTO_TEST_CASE(test_probe_timeout_does_not_cap_verified_protected_response) {
-   const auto expected = test_genesis_hash(1);
+   const auto expected = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
       fc::test::scripted_json_rpc_response::result(expected),
@@ -702,18 +1068,96 @@ BOOST_AUTO_TEST_CASE(test_probe_timeout_does_not_cap_verified_protected_response
    BOOST_CHECK_EQUAL(client.get_health(), "ok");
 }
 
-BOOST_AUTO_TEST_CASE(test_malformed_runtime_identity_blocks_raw_execute) {
-   const auto expected = test_genesis_hash(1);
+BOOST_AUTO_TEST_CASE(test_malformed_runtime_identity_blocks_read) {
+   const auto expected = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(expected),
+      resetting_result(expected),
       fc::test::scripted_json_rpc_response::result(fc::variant()),
    });
    solana_client client(test_solana_signature_provider(), server.url(), client_options{},
                         test_identity_config(expected));
 
-   BOOST_CHECK_THROW(client.execute("getHealth", fc::variants{}), fc::exception);
+   BOOST_CHECK_THROW(client.execute_idempotent("getHealth", fc::variants{}), fc::exception);
    const auto snapshot = client.get_cluster_identity_snapshot();
    BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::malformed_observed_identity);
+}
+
+BOOST_AUTO_TEST_CASE(test_public_genesis_hash_result_is_cross_checked_after_connection_validation) {
+   const auto expected = fc::test::solana_hash(1);
+   const auto wrong_cluster = fc::test::solana_hash(2);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(wrong_cluster),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
+
+   BOOST_CHECK_THROW(client.get_genesis_hash(), fc::exception);
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::mismatch);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::identity_mismatch);
+   BOOST_CHECK_THROW(client.get_health(), fc::exception);
+   BOOST_CHECK_EQUAL(server.request_count(), 3u);
+}
+
+BOOST_AUTO_TEST_CASE(test_queued_protected_call_observes_public_genesis_mismatch_before_send) {
+   const auto expected = fc::test::solana_hash(1);
+   const auto wrong_cluster = fc::test::solana_hash(2);
+   auto release_mismatch = std::make_shared<std::atomic_bool>(false);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::gated_result(wrong_cluster, release_mismatch),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
+
+   auto mismatch = std::async(std::launch::async, [&client] { return client.get_genesis_hash(); });
+   const auto mismatch_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+   while (server.request_count() < 3 && std::chrono::steady_clock::now() < mismatch_deadline)
+      std::this_thread::yield();
+   BOOST_REQUIRE_EQUAL(server.request_count(), 3u);
+
+   std::promise<void> queued_started;
+   auto queued_started_future = queued_started.get_future();
+   auto queued = std::async(std::launch::async, [&client, &queued_started] {
+      queued_started.set_value();
+      return client.get_health();
+   });
+   queued_started_future.wait();
+   release_mismatch->store(true, std::memory_order_release);
+
+   BOOST_CHECK_THROW(mismatch.get(), fc::exception);
+   BOOST_CHECK_THROW(queued.get(), fc::exception);
+   BOOST_CHECK_EQUAL(server.request_count(), 3u);
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::mismatch);
+   BOOST_CHECK_EQUAL(snapshot.blocked_operations.at(solana_cluster_identity_operation::rpc_read), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(test_malformed_public_genesis_hash_is_an_ordinary_failure_on_an_admitted_connection) {
+   const auto expected = fc::test::solana_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(fc::variant()),
+      fc::test::scripted_json_rpc_response::result("ok"),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), client_options{},
+                        test_identity_config(expected));
+
+   BOOST_CHECK_THROW(client.get_genesis_hash(), fc::exception);
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::verified);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::none);
+   BOOST_CHECK_EQUAL(
+      snapshot.protected_operation_failures.at(solana_cluster_identity_operation::rpc_read),
+      1u);
+   BOOST_CHECK_EQUAL(server.connection_count(), 1u);
+   BOOST_CHECK_EQUAL(server.request_count(), 4u);
 }
 
 //=============================================================================

--- a/libraries/libfc/test/network/solana/test_solana_client.cpp
+++ b/libraries/libfc/test/network/solana/test_solana_client.cpp
@@ -1,15 +1,23 @@
 // SPDX-License-Identifier: MIT
+#include <atomic>
 #include <boost/test/unit_test.hpp>
+#include <chrono>
+#include <fc-test/crypto_utils.hpp>
+#include <fc-test/scripted_json_rpc_server.hpp>
 #include <fc/crypto/sha256.hpp>
+#include <fc/crypto/signature_provider.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/network/solana/solana_borsh.hpp>
 #include <fc/network/solana/solana_client.hpp>
 #include <fc/network/solana/solana_idl.hpp>
 #include <fc/network/solana/solana_system_programs.hpp>
 #include <fc/network/solana/solana_types.hpp>
-
+#include <fc/task/deadline.hpp>
+#include <future>
 #include <limits>
+#include <memory>
 #include <string_view>
+#include <thread>
 
 using namespace fc::network::solana;
 using namespace fc::crypto::solana;
@@ -182,8 +190,7 @@ idl::program make_nested_defined_account_idl(size_t defined_type_count) {
    idl::account account;
    account.name = nested_account_name;
    account.discriminator = nested_account_discriminator;
-   account.fields.push_back(
-      {std::string(nested_field_name), idl::idl_type::make_defined(type_name(0))});
+   account.fields.push_back({std::string(nested_field_name), idl::idl_type::make_defined(type_name(0))});
    program.accounts.push_back(std::move(account));
 
    for (size_t index = 0; index < defined_type_count; ++index) {
@@ -227,13 +234,15 @@ idl::program make_cyclic_defined_account_idl(bool vector_root) {
    idl::type_def cycle_a;
    cycle_a.name = cycle_a_name;
    cycle_a.struct_fields = std::vector<idl::field>{
-      {std::string(cyclic_field_name), idl::idl_type::make_defined(std::string(cycle_b_name))}};
+      {std::string(cyclic_field_name), idl::idl_type::make_defined(std::string(cycle_b_name))}
+   };
    program.types.push_back(std::move(cycle_a));
 
    idl::type_def cycle_b;
    cycle_b.name = cycle_b_name;
    cycle_b.struct_fields = std::vector<idl::field>{
-      {std::string(cyclic_field_name), idl::idl_type::make_defined(std::string(cycle_a_name))}};
+      {std::string(cyclic_field_name), idl::idl_type::make_defined(std::string(cycle_a_name))}
+   };
    program.types.push_back(std::move(cycle_b));
 
    return program;
@@ -246,7 +255,322 @@ bool is_idl_depth_exception(const fc::assert_exception& error) {
    return error.to_detail_string().find(idl_depth_error) != std::string::npos;
 }
 
+/** Return a deterministic canonical 32-byte Solana genesis hash. */
+std::string test_genesis_hash(uint8_t seed) {
+   std::vector<char> bytes(32, static_cast<char>(seed));
+   return fc::to_base58(bytes, fc::yield_function_t{});
+}
+
+/** Build the local Solana signature provider used by protected-sign tests. */
+fc::crypto::signature_provider_ptr test_solana_signature_provider() {
+   const auto fixture = fc::test::load_keygen_fixture("solana", 1);
+   auto provider = std::make_shared<fc::crypto::signature_provider_t>();
+   provider->target_chain = fc::crypto::chain_kind_solana;
+   provider->key_type = fc::crypto::chain_key_type_solana;
+   provider->key_name = "test-solana-provider";
+   provider->public_key = fc::crypto::from_native_string_to_public_key(provider->key_type, fixture.public_key);
+   provider->private_key = fc::crypto::from_native_string_to_private_key(provider->key_type, fixture.private_key);
+   return provider;
+}
+
+/** Build pinning configuration with an optional deterministic test clock. */
+solana_cluster_identity_config test_identity_config(const std::string& expected_hash,
+                                                    fc::microseconds maximum_age = fc::seconds(30),
+                                                    fc::microseconds probe_timeout = fc::seconds(1),
+                                                    std::shared_ptr<fc::time_point> clock = {}) {
+   solana_cluster_identity_config config{
+      .client_id = "client-a",
+      .expected_genesis_hash = parse_solana_genesis_hash(expected_hash),
+      .maximum_verification_age = maximum_age,
+      .probe_timeout = probe_timeout,
+   };
+   if (clock) {
+      config.verification_clock = [clock] { return *clock; };
+   }
+   return config;
+}
+
+/** Build the smallest transaction that the configured provider can sign. */
+transaction test_signable_transaction(const solana_client& client) {
+   transaction tx;
+   tx.msg.header.num_required_signatures = 1;
+   tx.msg.account_keys.push_back(client.get_pubkey());
+   tx.msg.recent_blockhash = make_test_pubkey(777);
+   tx.signatures.resize(1);
+   return tx;
+}
+
+/** Return a valid getAccountInfo response for an account that does not exist. */
+fc::variant account_not_found_response() {
+   return fc::mutable_variant_object()("context", fc::mutable_variant_object()("slot", 1))("value", fc::variant());
+}
+
 } // namespace
+
+//=============================================================================
+// Cluster identity pinning tests
+//=============================================================================
+
+BOOST_AUTO_TEST_CASE(test_genesis_hash_requires_canonical_base58_and_exact_length) {
+   const auto canonical = test_genesis_hash(7);
+   const auto parsed = parse_solana_genesis_hash(canonical);
+   BOOST_CHECK_EQUAL(parsed.canonical, canonical);
+
+   BOOST_CHECK_THROW(parse_solana_genesis_hash("0" + canonical), fc::exception);
+   BOOST_CHECK_THROW(parse_solana_genesis_hash(" " + canonical), fc::exception);
+
+   std::vector<char> short_bytes(31, 1);
+   std::vector<char> long_bytes(33, 1);
+   BOOST_CHECK_THROW(parse_solana_genesis_hash(fc::to_base58(short_bytes, fc::yield_function_t{})), fc::exception);
+   BOOST_CHECK_THROW(parse_solana_genesis_hash(fc::to_base58(long_bytes, fc::yield_function_t{})), fc::exception);
+}
+
+BOOST_AUTO_TEST_CASE(test_legacy_client_performs_no_identity_probe) {
+   fc::test::scripted_json_rpc_server server({});
+   solana_client client(test_solana_signature_provider(), server.url());
+
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(!client.cluster_identity_pinning_enabled());
+   BOOST_CHECK(snapshot.mode == solana_cluster_identity_mode::unpinned);
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::unpinned);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::missing_expected_identity);
+   BOOST_CHECK_EQUAL(server.request_count(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(test_pinned_client_permits_read_sign_and_submit_after_matching_probes) {
+   const auto expected = test_genesis_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(account_not_found_response()),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result("tx-signature"),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), test_identity_config(expected));
+
+   const auto account = client.get_account_info(make_test_pubkey(12));
+   BOOST_CHECK(!account);
+
+   auto tx = test_signable_transaction(client);
+   const auto empty_signature = tx.signatures.front();
+   client.sign_transaction(tx);
+   BOOST_CHECK(tx.signatures.front() != empty_signature);
+   BOOST_CHECK_EQUAL(client.send_transaction(tx), "tx-signature");
+
+   const auto methods = server.request_methods();
+   const std::vector<std::string> expected_methods{
+      "getGenesisHash", "getGenesisHash", "getAccountInfo", "getGenesisHash", "getGenesisHash", "sendTransaction",
+   };
+   BOOST_CHECK(methods == expected_methods);
+
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::verified);
+   BOOST_CHECK_EQUAL(snapshot.verification_attempts, 4u);
+   BOOST_CHECK_EQUAL(snapshot.verification_successes, 4u);
+   BOOST_CHECK_EQUAL(snapshot.verification_mismatches, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(test_pinned_client_rejects_startup_mismatch) {
+   const auto expected = test_genesis_hash(1);
+   const auto observed = test_genesis_hash(2);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(observed),
+   });
+
+   BOOST_CHECK_THROW(solana_client(test_solana_signature_provider(), server.url(), test_identity_config(expected)),
+                     fc::exception);
+   BOOST_CHECK_EQUAL(server.request_count(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_signing_and_remains_sticky) {
+   const auto expected = test_genesis_hash(1);
+   const auto wrong_cluster = test_genesis_hash(2);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(wrong_cluster),
+      fc::test::scripted_json_rpc_response::result(expected),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), test_identity_config(expected));
+
+   auto tx = test_signable_transaction(client);
+   const auto empty_signature = tx.signatures.front();
+   BOOST_CHECK_THROW(client.sign_transaction(tx), fc::exception);
+   BOOST_CHECK(tx.signatures.front() == empty_signature);
+
+   BOOST_CHECK_THROW(client.sign_transaction(tx), fc::exception);
+   BOOST_CHECK(tx.signatures.front() == empty_signature);
+   BOOST_CHECK_EQUAL(server.request_count(), 2u);
+
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::mismatch);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::identity_mismatch);
+   BOOST_CHECK_EQUAL(snapshot.verification_mismatches, 1u);
+   BOOST_CHECK_EQUAL(snapshot.blocked_operations.at(solana_cluster_identity_operation::signing), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(test_runtime_mismatch_blocks_protected_account_read) {
+   const auto expected = test_genesis_hash(1);
+   const auto wrong_cluster = test_genesis_hash(2);
+   auto clock = std::make_shared<fc::time_point>(fc::time_point::now());
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(wrong_cluster),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(),
+                        test_identity_config(expected, fc::milliseconds(10), fc::seconds(1), clock));
+
+   BOOST_CHECK_THROW(client.get_account_info(make_test_pubkey(15)), fc::exception);
+   const auto methods = server.request_methods();
+   BOOST_REQUIRE_EQUAL(methods.size(), 2u);
+   BOOST_CHECK_EQUAL(methods[0], "getGenesisHash");
+   BOOST_CHECK_EQUAL(methods[1], "getGenesisHash");
+}
+
+BOOST_AUTO_TEST_CASE(test_rpc_verification_is_peer_bound_even_while_cached_identity_is_fresh) {
+   const auto expected = test_genesis_hash(1);
+   auto clock = std::make_shared<fc::time_point>(fc::time_point::now());
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result("ok"),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result("ok"),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result("ok"),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(),
+                        test_identity_config(expected, fc::milliseconds(10), fc::seconds(1), clock));
+
+   *clock += fc::microseconds(9'999);
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
+   BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 2);
+
+   *clock += fc::microseconds(1);
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
+   BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 3);
+
+   *clock += fc::microseconds(10'001);
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
+   BOOST_CHECK_EQUAL(std::ranges::count(server.request_methods(), "getGenesisHash"), 4);
+}
+
+BOOST_AUTO_TEST_CASE(test_transport_failure_invalidates_identity_and_matching_probe_recovers) {
+   const auto expected = test_genesis_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::close(),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result("ok"),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(), test_identity_config(expected));
+
+   BOOST_CHECK_THROW(client.get_health(), fc::exception);
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
+
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::verified);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::verification_recovered);
+   BOOST_CHECK_EQUAL(snapshot.verification_recoveries, 1u);
+}
+
+BOOST_AUTO_TEST_CASE(test_hanging_runtime_probe_times_out_before_signing) {
+   const auto expected = test_genesis_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::hanging(),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(),
+                        test_identity_config(expected, fc::seconds(30), fc::milliseconds(50)));
+
+   auto tx = test_signable_transaction(client);
+   const auto empty_signature = tx.signatures.front();
+   BOOST_CHECK_THROW(client.sign_transaction(tx), fc::timeout_exception);
+   BOOST_CHECK(tx.signatures.front() == empty_signature);
+
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.status == solana_cluster_identity_status::error);
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::rpc_timeout);
+}
+
+BOOST_AUTO_TEST_CASE(test_concurrent_reads_each_bind_identity_to_their_transport_session) {
+   constexpr size_t caller_count = 4;
+   const auto expected = test_genesis_hash(1);
+   auto clock = std::make_shared<fc::time_point>(fc::time_point::now());
+
+   std::vector<fc::test::scripted_json_rpc_response> responses{
+      fc::test::scripted_json_rpc_response::result(expected),
+   };
+   for (size_t i = 0; i < caller_count; ++i) {
+      responses.push_back(fc::test::scripted_json_rpc_response::result(expected));
+      responses.push_back(fc::test::scripted_json_rpc_response::result("ok"));
+   }
+   fc::test::scripted_json_rpc_server server(std::move(responses));
+   auto client =
+      std::make_shared<solana_client>(test_solana_signature_provider(), server.url(),
+                                      test_identity_config(expected, fc::milliseconds(10), fc::seconds(1), clock));
+   *clock += fc::milliseconds(10);
+
+   std::vector<std::future<std::string>> reads;
+   for (size_t i = 0; i < caller_count; ++i) {
+      reads.push_back(std::async(std::launch::async, [client] { return client->get_health(); }));
+   }
+   for (auto& read : reads) {
+      BOOST_CHECK_EQUAL(read.get(), "ok");
+   }
+
+   const auto methods = server.request_methods();
+   BOOST_CHECK_EQUAL(std::ranges::count(methods, "getGenesisHash"), caller_count + 1);
+   BOOST_CHECK_EQUAL(std::ranges::count(methods, "getHealth"), caller_count);
+}
+
+BOOST_AUTO_TEST_CASE(test_operation_gate_uses_real_clock_for_task_deadline) {
+   const auto expected = test_genesis_hash(1);
+   auto freshness_clock =
+      std::make_shared<fc::time_point>(fc::time_point::now() + fc::seconds(60));
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result("ok"),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(),
+                        test_identity_config(expected, fc::seconds(30), fc::seconds(1), freshness_clock));
+
+   fc::task::deadline_scope deadline(fc::time_point::now() + fc::milliseconds(500));
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
+}
+
+BOOST_AUTO_TEST_CASE(test_probe_timeout_does_not_cap_verified_protected_response) {
+   const auto expected = test_genesis_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::delayed_result(
+         "ok", std::chrono::milliseconds(125)),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(),
+                        test_identity_config(expected, fc::seconds(30), fc::milliseconds(50)));
+
+   fc::task::deadline_scope deadline(fc::time_point::now() + fc::seconds(1));
+   BOOST_CHECK_EQUAL(client.get_health(), "ok");
+}
+
+BOOST_AUTO_TEST_CASE(test_malformed_runtime_identity_blocks_raw_execute) {
+   const auto expected = test_genesis_hash(1);
+   auto clock = std::make_shared<fc::time_point>(fc::time_point::now());
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(expected),
+      fc::test::scripted_json_rpc_response::result(fc::variant()),
+   });
+   solana_client client(test_solana_signature_provider(), server.url(),
+                        test_identity_config(expected, fc::milliseconds(10), fc::seconds(1), clock));
+
+   *clock += fc::milliseconds(10);
+   BOOST_CHECK_THROW(client.execute("getHealth", fc::variants{}), fc::exception);
+   const auto snapshot = client.get_cluster_identity_snapshot();
+   BOOST_CHECK(snapshot.reason == solana_cluster_identity_reason::malformed_observed_identity);
+}
 
 //=============================================================================
 // Pubkey Tests
@@ -876,10 +1200,10 @@ BOOST_AUTO_TEST_CASE(test_is_on_curve) {
    };
 
    // Verify is_on_curve matches expected Solana behavior — ADL finds fc::crypto::ed::is_on_curve
-   BOOST_CHECK(fc::crypto::ed::is_on_curve(compute_pda(255))); // ON curve
-   BOOST_CHECK(fc::crypto::ed::is_on_curve(compute_pda(254))); // ON curve
+   BOOST_CHECK(fc::crypto::ed::is_on_curve(compute_pda(255)));  // ON curve
+   BOOST_CHECK(fc::crypto::ed::is_on_curve(compute_pda(254)));  // ON curve
    BOOST_CHECK(!fc::crypto::ed::is_on_curve(compute_pda(253))); // NOT on curve - valid PDA
-   BOOST_CHECK(fc::crypto::ed::is_on_curve(compute_pda(252))); // ON curve
+   BOOST_CHECK(fc::crypto::ed::is_on_curve(compute_pda(252)));  // ON curve
 }
 
 BOOST_AUTO_TEST_CASE(test_pda_derivation_anchor_counter) {
@@ -1256,7 +1580,8 @@ BOOST_AUTO_TEST_CASE(test_borsh_encode_decode_struct_roundtrip) {
    BOOST_CHECK_EQUAL(dec.read_u64(), 12345678901234567890ULL);
    BOOST_CHECK_EQUAL(dec.read_bool(), true);
    BOOST_CHECK_EQUAL(dec.read_string(), "hello world");
-   BOOST_CHECK_EQUAL(dec.read_pubkey().to_string(fc::yield_function_t{}), "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+   BOOST_CHECK_EQUAL(dec.read_pubkey().to_string(fc::yield_function_t{}),
+                     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 }
 
 BOOST_AUTO_TEST_CASE(test_borsh_encode_decode_vec_and_option) {
@@ -1477,8 +1802,7 @@ BOOST_AUTO_TEST_CASE(test_anchor_idl_account_vec_checks_remaining_byte_boundary)
       one_past_data[vec_account_discriminator.size() + index] =
          static_cast<uint8_t>((one_past_length >> (index * 8)) & 0xff);
 
-   BOOST_CHECK_THROW(client.decode_account_data(one_past_data, std::string(vec_account_name)),
-                     fc::assert_exception);
+   BOOST_CHECK_THROW(client.decode_account_data(one_past_data, std::string(vec_account_name)), fc::assert_exception);
 }
 
 BOOST_AUTO_TEST_CASE(test_anchor_idl_account_vec_decodes_dynamic_elements) {
@@ -1529,8 +1853,7 @@ BOOST_AUTO_TEST_CASE(test_anchor_idl_account_zero_sized_vec_accepts_materializat
    auto prog = parse_empty_struct_vec_account_idl();
    test_solana_program_client client({prog});
 
-   std::vector<uint8_t> account_data(empty_vec_account_discriminator.begin(),
-                                     empty_vec_account_discriminator.end());
+   std::vector<uint8_t> account_data(empty_vec_account_discriminator.begin(), empty_vec_account_discriminator.end());
    append_u32_le(account_data, max_zero_sized_idl_vector_elements);
 
    auto result = client.decode_account_data(account_data, std::string(empty_vec_account_name)).get_object();
@@ -1545,8 +1868,7 @@ BOOST_AUTO_TEST_CASE(test_anchor_idl_account_zero_sized_vec_rejects_one_past_mat
    auto prog = parse_empty_struct_vec_account_idl();
    test_solana_program_client client({prog});
 
-   std::vector<uint8_t> account_data(empty_vec_account_discriminator.begin(),
-                                     empty_vec_account_discriminator.end());
+   std::vector<uint8_t> account_data(empty_vec_account_discriminator.begin(), empty_vec_account_discriminator.end());
    append_u32_le(account_data, max_zero_sized_idl_vector_elements + 1);
 
    BOOST_CHECK_THROW(client.decode_account_data(account_data, std::string(empty_vec_account_name)),

--- a/libraries/libfc/test/network/test_json_rpc_client.cpp
+++ b/libraries/libfc/test/network/test_json_rpc_client.cpp
@@ -831,12 +831,8 @@ BOOST_AUTO_TEST_CASE(continuation_followup_has_independent_total_timeout) {
 
 /// An idempotent call retries once when its cached connection has gone stale.
 BOOST_AUTO_TEST_CASE(idempotent_call_recovers_from_a_stale_cached_connection) {
-   reusable_json_rpc_server server(
-      reusable_json_rpc_server::behavior::stale_after_first_response);
-   fc::network::json_rpc::json_rpc_client client(
-      fc::url(
-         "http://127.0.0.1:" +
-         std::to_string(server.port())));
+   reusable_json_rpc_server server(reusable_json_rpc_server::behavior::stale_after_first_response);
+   fc::network::json_rpc::json_rpc_client client(fc::url("http://127.0.0.1:" + std::to_string(server.port())));
 
    BOOST_CHECK_EQUAL(
       client.call_idempotent("wire_first_probe").as_string(),

--- a/libraries/libfc/test/network/test_json_rpc_client.cpp
+++ b/libraries/libfc/test/network/test_json_rpc_client.cpp
@@ -5,19 +5,17 @@
 
 #include <fc/network/json_rpc/json_rpc_client.hpp>
 #include <fc/task/deadline.hpp>
+#include <fc-test/scripted_json_rpc_server.hpp>
 
-#include <boost/asio.hpp>
-#include <boost/beast/core/flat_buffer.hpp>
-#include <boost/beast/http.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <atomic>
 #include <chrono>
+#include <future>
 #include <optional>
-#include <sstream>
+#include <set>
 #include <string>
-#include <string_view>
-#include <thread>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -25,495 +23,9 @@ using namespace std::chrono_literals;
 
 namespace {
 
-using tcp = boost::asio::ip::tcp;
-
 constexpr size_t OVERSIZED_RESPONSE_BODY_BYTES = 2 * 1024 * 1024;
-
-/**
- * HTTP endpoint that reads one request and deliberately withholds the response.
- */
-class hanging_http_server {
-public:
-   /**
-    * Start listening on a loopback port and launch the accept worker.
-    */
-   hanging_http_server()
-      : _acceptor(_io, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0))
-      , _port(_acceptor.local_endpoint().port())
-      , _worker([this] { serve(); }) {}
-
-   hanging_http_server(const hanging_http_server&) = delete;
-   hanging_http_server& operator=(const hanging_http_server&) = delete;
-
-   /**
-    * Stop the worker without waiting for the client's read timeout.
-    */
-   ~hanging_http_server() {
-      _stop = true;
-      boost::system::error_code ec;
-      _acceptor.close(ec);
-      unblock_accept();
-      if (_worker.joinable()) {
-         _worker.join();
-      }
-   }
-
-   /**
-    * Return the TCP port assigned by the OS.
-    */
-   uint16_t port() const { return _port; }
-
-private:
-   /**
-    * Connect once to the listening socket so a blocked accept can observe shutdown.
-    */
-   void unblock_accept() {
-      boost::asio::io_context io;
-      tcp::socket socket(io);
-      boost::system::error_code ec;
-      socket.connect(tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), _port), ec);
-   }
-
-   /**
-    * Accept a single client, consume the request header, and then hang.
-    */
-   void serve() {
-      boost::system::error_code ec;
-      tcp::socket socket(_io);
-      _acceptor.accept(socket, ec);
-      if (ec) {
-         return;
-      }
-
-      boost::asio::streambuf request;
-      boost::asio::read_until(socket, request, "\r\n\r\n", ec);
-      while (!_stop.load()) {
-         std::this_thread::sleep_for(10ms);
-      }
-      socket.close(ec);
-   }
-
-   boost::asio::io_context _io;
-   tcp::acceptor           _acceptor;
-   uint16_t                _port;
-   std::atomic_bool        _stop{false};
-   std::thread             _worker;
-};
-
-/**
- * HTTP endpoint that replies to one request with a caller-supplied response body.
- */
-class fixed_response_http_server {
-public:
-   /**
-    * Start listening on a loopback port and launch the response worker.
-    */
-   explicit fixed_response_http_server(std::string response_body)
-      : _acceptor(_io, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0))
-      , _port(_acceptor.local_endpoint().port())
-      , _response_body(std::move(response_body))
-      , _worker([this] { serve(); }) {}
-
-   fixed_response_http_server(const fixed_response_http_server&) = delete;
-   fixed_response_http_server& operator=(const fixed_response_http_server&) = delete;
-
-   /**
-    * Stop the worker if the client failed before accepting the response.
-    */
-   ~fixed_response_http_server() {
-      boost::system::error_code ec;
-      _acceptor.close(ec);
-      unblock_accept();
-      if (_worker.joinable()) {
-         _worker.join();
-      }
-   }
-
-   /**
-    * Return the TCP port assigned by the OS.
-    */
-   uint16_t port() const { return _port; }
-
-private:
-   /**
-    * Connect once to the listening socket so a blocked accept can observe shutdown.
-    */
-   void unblock_accept() {
-      boost::asio::io_context io;
-      tcp::socket socket(io);
-      boost::system::error_code ec;
-      socket.connect(tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), _port), ec);
-   }
-
-   /**
-    * Accept a single client, consume its request header, and write the response.
-    */
-   void serve() {
-      boost::system::error_code ec;
-      tcp::socket socket(_io);
-      _acceptor.accept(socket, ec);
-      if (ec) {
-         return;
-      }
-
-      boost::asio::streambuf request;
-      boost::asio::read_until(socket, request, "\r\n\r\n", ec);
-      if (ec) {
-         return;
-      }
-
-      std::ostringstream response;
-      response << "HTTP/1.1 200 OK\r\n"
-               << "Content-Type: application/json\r\n"
-               << "Content-Length: " << _response_body.size() << "\r\n"
-               << "Connection: close\r\n\r\n"
-               << _response_body;
-      const auto response_text = response.str();
-      boost::asio::write(socket, boost::asio::buffer(response_text), ec);
-      socket.close(ec);
-   }
-
-   boost::asio::io_context _io;
-   tcp::acceptor           _acceptor;
-   uint16_t                _port;
-   std::string             _response_body;
-   std::thread             _worker;
-};
-
-/**
- * JSON-RPC endpoint that either serves two calls on one connection or closes
- * the first keep-alive connection before accepting the second call.
- */
-class reusable_json_rpc_server {
-public:
-   /** Connection behavior exercised by one server instance. */
-   enum class behavior {
-      healthy_keep_alive,
-      stale_after_first_response,
-   };
-
-   /** Start the scripted endpoint on an ephemeral loopback port. */
-   explicit reusable_json_rpc_server(behavior selected_behavior)
-      : _acceptor(_io, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0))
-      , _port(_acceptor.local_endpoint().port())
-      , _behavior(selected_behavior)
-      , _worker([this] { serve(); }) {}
-
-   reusable_json_rpc_server(const reusable_json_rpc_server&) = delete;
-   reusable_json_rpc_server& operator=(const reusable_json_rpc_server&) = delete;
-
-   /** Stop a blocked accept and join the endpoint worker. */
-   ~reusable_json_rpc_server() {
-      _stop = true;
-      boost::system::error_code error;
-      _acceptor.close(error);
-      unblock_accept();
-      if (_worker.joinable())
-         _worker.join();
-   }
-
-   /** Return the TCP port assigned by the OS. */
-   uint16_t port() const { return _port; }
-
-   /** Return how many TCP connections the endpoint accepted. */
-   size_t connection_count() const { return _connection_count.load(); }
-
-   /** Return how many complete JSON-RPC requests the endpoint received. */
-   size_t request_count() const { return _request_count.load(); }
-
-private:
-   /** Connect once so a blocked accept can observe shutdown. */
-   void unblock_accept() {
-      boost::asio::io_context io;
-      tcp::socket socket(io);
-      boost::system::error_code error;
-      socket.connect(
-         tcp::endpoint(
-            boost::asio::ip::make_address("127.0.0.1"),
-            _port),
-         error);
-   }
-
-   /** Accept one connection unless shutdown has started. */
-   std::optional<tcp::socket> accept_connection() {
-      tcp::socket socket(_io);
-      boost::system::error_code error;
-      _acceptor.accept(socket, error);
-      if (error || _stop.load())
-         return std::nullopt;
-      _connection_count.fetch_add(1);
-      return socket;
-   }
-
-   /** Read one complete request and send the matching JSON-RPC response. */
-   bool serve_request(
-      tcp::socket& socket,
-      int64_t response_id,
-      std::string_view result,
-      bool keep_alive) {
-      boost::beast::flat_buffer request_buffer;
-      boost::beast::http::request<boost::beast::http::string_body> request;
-      boost::system::error_code error;
-      boost::beast::http::read(
-         socket,
-         request_buffer,
-         request,
-         error);
-      if (error)
-         return false;
-      _request_count.fetch_add(1);
-
-      boost::beast::http::response<boost::beast::http::string_body> response{
-         boost::beast::http::status::ok,
-         11};
-      response.set(
-         boost::beast::http::field::content_type,
-         "application/json");
-      response.keep_alive(keep_alive);
-      response.body() =
-         "{\"jsonrpc\":\"2.0\",\"id\":" +
-         std::to_string(response_id) +
-         ",\"result\":\"" +
-         std::string(result) +
-         "\"}";
-      response.prepare_payload();
-      boost::beast::http::write(socket, response, error);
-      return !error;
-   }
-
-   /** Execute the selected two-call connection script. */
-   void serve() {
-      auto first = accept_connection();
-      if (!first)
-         return;
-      if (!serve_request(*first, 1, "first", true))
-         return;
-
-      if (_behavior == behavior::healthy_keep_alive) {
-         (void)serve_request(*first, 2, "second", false);
-         return;
-      }
-
-      boost::system::error_code error;
-      first->shutdown(tcp::socket::shutdown_both, error);
-      first->close(error);
-      auto second = accept_connection();
-      if (!second)
-         return;
-      (void)serve_request(*second, 2, "second", false);
-   }
-
-   boost::asio::io_context _io;
-   tcp::acceptor _acceptor;
-   uint16_t _port;
-   behavior _behavior;
-   std::atomic_bool _stop{false};
-   std::atomic_size_t _connection_count{0};
-   std::atomic_size_t _request_count{0};
-   std::thread _worker;
-};
-
-/** One deterministic response consumed by continuation_json_rpc_server. */
-struct continuation_json_rpc_response {
-   /** Response behavior for one received request. */
-   enum class kind { result, error, raw_body, close_connection };
-
-   kind response_kind = kind::result;
-   fc::variant payload;
-   std::optional<int64_t> response_id;
-   std::chrono::microseconds delay{0};
-   bool keep_alive = true;
-   bool reset_after_response = false;
-
-   /** Return a successful JSON-RPC result. */
-   static continuation_json_rpc_response result(fc::variant value) {
-      return {.response_kind = kind::result, .payload = std::move(value)};
-   }
-
-   /** Return a successful result after a deterministic delay. */
-   static continuation_json_rpc_response delayed_result(fc::variant value, std::chrono::microseconds delay) {
-      return {.response_kind = kind::result, .payload = std::move(value), .delay = delay};
-   }
-
-   /** Return a JSON-RPC error object. */
-   static continuation_json_rpc_response error(fc::variant value) {
-      return {.response_kind = kind::error, .payload = std::move(value)};
-   }
-
-   /** Return a complete caller-supplied HTTP response body. */
-   static continuation_json_rpc_response raw(std::string body) {
-      return {.response_kind = kind::raw_body, .payload = fc::variant(std::move(body))};
-   }
-
-   /** Close the accepted connection without sending an HTTP response. */
-   static continuation_json_rpc_response close() { return {.response_kind = kind::close_connection}; }
-};
-
-/**
- * Scripted JSON-RPC endpoint that records connection affinity per request.
- *
- * Every parsed request consumes one response. Successful and error responses
- * echo the request ID unless the script supplies an override.
- */
-class continuation_json_rpc_server {
-public:
-   /** One request observed by the scripted endpoint. */
-   struct request_record {
-      std::string method;
-      size_t connection;
-   };
-
-   /** Start the endpoint with a fixed response script. */
-   explicit continuation_json_rpc_server(std::vector<continuation_json_rpc_response> responses)
-      : _responses(std::move(responses))
-      , _acceptor(_io, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0))
-      , _port(_acceptor.local_endpoint().port())
-      , _worker([this] { serve(); }) {}
-
-   continuation_json_rpc_server(const continuation_json_rpc_server&) = delete;
-   continuation_json_rpc_server& operator=(const continuation_json_rpc_server&) = delete;
-
-   /** Stop any blocked socket operation and join the worker. */
-   ~continuation_json_rpc_server() {
-      _stop = true;
-      boost::system::error_code error;
-      _acceptor.close(error);
-      {
-         std::scoped_lock lock(_socket_mutex);
-         if (_active_socket) {
-            _active_socket->cancel(error);
-            _active_socket->close(error);
-         }
-      }
-      unblock_accept();
-      if (_worker.joinable())
-         _worker.join();
-   }
-
-   /** Return the loopback URL selected for this endpoint. */
-   std::string url() const { return "http://127.0.0.1:" + std::to_string(_port); }
-
-   /** Return how many TCP connections accepted a scripted request. */
-   size_t connection_count() const { return _connection_count.load(); }
-
-   /** Return the requests observed so far. */
-   std::vector<request_record> requests() const {
-      std::scoped_lock lock(_records_mutex);
-      return _requests;
-   }
-
-private:
-   /** Connect once so a synchronous accept can observe teardown. */
-   void unblock_accept() {
-      boost::asio::io_context io;
-      tcp::socket socket(io);
-      boost::system::error_code error;
-      socket.connect(tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), _port), error);
-   }
-
-   /** Return a JSON-RPC envelope for one scripted response. */
-   static std::string response_body(const continuation_json_rpc_response& response, const fc::variant_object& request) {
-      if (response.response_kind == continuation_json_rpc_response::kind::raw_body)
-         return response.payload.as_string();
-
-      fc::mutable_variant_object envelope;
-      envelope("jsonrpc", "2.0")("id", response.response_id ? fc::variant(*response.response_id) : request["id"]);
-      if (response.response_kind == continuation_json_rpc_response::kind::result)
-         envelope("result", response.payload);
-      else
-         envelope("error", response.payload);
-      return fc::json::to_string(fc::variant(envelope), fc::json::yield_function_t{});
-   }
-
-   /** Close one socket with a reset so the client retains a stale cached lease. */
-   static void reset_socket(tcp::socket& socket) {
-      boost::system::error_code error;
-      socket.set_option(boost::asio::socket_base::linger(true, 0), error);
-      socket.close(error);
-   }
-
-   /** Consume the response script across as many connections as required. */
-   void serve() {
-      size_t response_index = 0;
-      while (!_stop.load() && response_index < _responses.size()) {
-         auto socket = std::make_shared<tcp::socket>(_io);
-         {
-            std::scoped_lock lock(_socket_mutex);
-            _active_socket = socket;
-         }
-
-         boost::system::error_code error;
-         _acceptor.accept(*socket, error);
-         if (error || _stop.load())
-            break;
-         const auto connection = _connection_count.fetch_add(1) + 1;
-         boost::beast::flat_buffer request_buffer;
-
-         while (!_stop.load() && response_index < _responses.size()) {
-            boost::beast::http::request<boost::beast::http::string_body> request;
-            boost::beast::http::read(*socket, request_buffer, request, error);
-            if (error)
-               break;
-
-            fc::variant parsed;
-            try {
-               parsed = fc::json::from_string(request.body());
-               const auto& object = parsed.get_object();
-               std::scoped_lock lock(_records_mutex);
-               _requests.push_back({.method = object["method"].as_string(), .connection = connection});
-            } catch (...) {
-               reset_socket(*socket);
-               break;
-            }
-
-            const auto response = _responses[response_index++];
-            if (response.response_kind == continuation_json_rpc_response::kind::close_connection) {
-               reset_socket(*socket);
-               break;
-            }
-            if (response.delay.count() > 0)
-               std::this_thread::sleep_for(response.delay);
-            if (_stop.load())
-               break;
-
-            boost::beast::http::response<boost::beast::http::string_body> http_response{boost::beast::http::status::ok,
-                                                                                        request.version()};
-            http_response.set(boost::beast::http::field::content_type, "application/json");
-            http_response.body() = response_body(response, parsed.get_object());
-            http_response.keep_alive(response.keep_alive);
-            http_response.prepare_payload();
-            boost::beast::http::write(*socket, http_response, error);
-            if (error)
-               break;
-            if (response.reset_after_response) {
-               reset_socket(*socket);
-               break;
-            }
-            if (!response.keep_alive) {
-               socket->close(error);
-               break;
-            }
-         }
-      }
-
-      boost::system::error_code error;
-      _acceptor.close(error);
-      std::scoped_lock lock(_socket_mutex);
-      _active_socket.reset();
-   }
-
-   std::vector<continuation_json_rpc_response> _responses;
-   boost::asio::io_context _io;
-   tcp::acceptor _acceptor;
-   uint16_t _port;
-   std::atomic_bool _stop{false};
-   std::atomic_size_t _connection_count{0};
-   mutable std::mutex _socket_mutex;
-   std::shared_ptr<tcp::socket> _active_socket;
-   mutable std::mutex _records_mutex;
-   std::vector<request_record> _requests;
-   std::thread _worker;
-};
+static_assert(std::is_move_constructible_v<fc::network::json_rpc::json_rpc_client>);
+static_assert(std::is_move_assignable_v<fc::network::json_rpc::json_rpc_client>);
 
 /** Return a JSON-RPC error object suitable for a scripted response. */
 fc::variant json_rpc_error_object(int64_t code, std::string message) {
@@ -540,14 +52,180 @@ BOOST_AUTO_TEST_CASE(default_endpoint_refresh_policy_is_preserved) {
       options.transport.refresh_dns_on_connection_failure);
 }
 
+/// One healthy persistent connection is validated exactly once before use.
+BOOST_AUTO_TEST_CASE(connection_validator_runs_once_per_persistent_connection) {
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("cluster-a"),
+      fc::test::scripted_json_rpc_response::result("first"),
+      fc::test::scripted_json_rpc_response::result("second"),
+   });
+   std::atomic_uint32_t attempts{0};
+   std::atomic_uint32_t successes{0};
+   fc::network::json_rpc::client_options options;
+   options.connection_validator = fc::network::json_rpc::connection_validation{
+      .method = "wire_chain_identity",
+      .validate_result =
+         [](const fc::variant& result) {
+            FC_ASSERT(result.as_string() == "cluster-a", "Unexpected JSON-RPC connection identity");
+         },
+      .on_attempt = [&] { attempts.fetch_add(1); },
+      .on_success = [&] { successes.fetch_add(1); },
+   };
+   fc::network::json_rpc::json_rpc_client client(
+      fc::url(server.url()),
+      std::nullopt,
+      fc::network::json_rpc::endpoint_refresh_policy::on_connection_failure,
+      std::move(options));
+
+   BOOST_CHECK_EQUAL(client.call_idempotent("wire_first").as_string(), "first");
+   BOOST_CHECK_EQUAL(client.call_idempotent("wire_second").as_string(), "second");
+   const std::vector<std::string> expected_methods{"wire_chain_identity", "wire_first", "wire_second"};
+   BOOST_CHECK(server.request_methods() == expected_methods);
+   BOOST_CHECK_EQUAL(server.connection_count(), 1u);
+   BOOST_CHECK_EQUAL(attempts.load(), 1u);
+   BOOST_CHECK_EQUAL(successes.load(), 1u);
+}
+
+/// Replacement connections cannot inherit a previous socket's validation.
+BOOST_AUTO_TEST_CASE(connection_validator_runs_again_after_reconnect) {
+   auto first = fc::test::scripted_json_rpc_response::result("first");
+   first.reset_after_response = true;
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("cluster-a"),
+      std::move(first),
+      fc::test::scripted_json_rpc_response::result("cluster-a"),
+      fc::test::scripted_json_rpc_response::result("second"),
+   });
+   std::atomic_uint32_t attempts{0};
+   fc::network::json_rpc::client_options options;
+   options.connection_validator = fc::network::json_rpc::connection_validation{
+      .method = "wire_chain_identity",
+      .validate_result = [](const fc::variant& result) {
+         FC_ASSERT(result.as_string() == "cluster-a", "Unexpected JSON-RPC connection identity");
+      },
+      .on_attempt = [&] { attempts.fetch_add(1); },
+   };
+   fc::network::json_rpc::json_rpc_client client(
+      fc::url(server.url()),
+      std::nullopt,
+      fc::network::json_rpc::endpoint_refresh_policy::on_connection_failure,
+      std::move(options));
+
+   BOOST_CHECK_EQUAL(client.call_idempotent("wire_first").as_string(), "first");
+   BOOST_CHECK_EQUAL(client.call_idempotent("wire_second").as_string(), "second");
+   BOOST_CHECK_EQUAL(server.connection_count(), 2u);
+   BOOST_CHECK_EQUAL(attempts.load(), 2u);
+}
+
+/// Validation cannot bless a socket that the peer closes before ordinary work.
+BOOST_AUTO_TEST_CASE(connection_validator_rejects_nonpersistent_response) {
+   auto validation = fc::test::scripted_json_rpc_response::result("cluster-a");
+   validation.keep_alive = false;
+   fc::test::scripted_json_rpc_server server({std::move(validation)});
+   fc::network::json_rpc::client_options options;
+   options.connection_validator = fc::network::json_rpc::connection_validation{
+      .method = "wire_chain_identity",
+      .validate_result = [](const fc::variant&) {},
+   };
+   fc::network::json_rpc::json_rpc_client client(
+      fc::url(server.url()),
+      std::nullopt,
+      fc::network::json_rpc::endpoint_refresh_policy::on_connection_failure,
+      std::move(options));
+
+   BOOST_CHECK_EXCEPTION(
+      client.call_idempotent("wire_protected"),
+      fc::exception,
+      [](const fc::exception& error) {
+         return error.to_detail_string().find("did not preserve a persistent connection") != std::string::npos;
+      });
+   BOOST_CHECK_EQUAL(server.request_count(), 1u);
+}
+
+/// Concurrent callers reserve distinct JSON-RPC IDs before transport admission.
+BOOST_AUTO_TEST_CASE(concurrent_calls_use_unique_request_ids) {
+   constexpr size_t caller_count = 16;
+   std::vector<fc::test::scripted_json_rpc_response> responses;
+   responses.reserve(caller_count);
+   for (size_t index = 0; index < caller_count; ++index)
+      responses.push_back(fc::test::scripted_json_rpc_response::result("ok"));
+   fc::test::scripted_json_rpc_server server(std::move(responses));
+   auto client = std::make_shared<fc::network::json_rpc::json_rpc_client>(fc::url(server.url()));
+
+   std::vector<std::future<fc::variant>> calls;
+   calls.reserve(caller_count);
+   for (size_t index = 0; index < caller_count; ++index) {
+      calls.push_back(std::async(std::launch::async, [client] { return client->call_idempotent("wire_read"); }));
+   }
+   for (auto& call : calls)
+      BOOST_CHECK_EQUAL(call.get().as_string(), "ok");
+
+   std::set<int64_t> ids;
+   for (const auto& request : server.requests()) {
+      BOOST_REQUIRE(request.id);
+      ids.insert(*request.id);
+   }
+   BOOST_CHECK_EQUAL(ids.size(), caller_count);
+}
+
+/// Moving a used client preserves the monotonic JSON-RPC request-ID sequence.
+BOOST_AUTO_TEST_CASE(move_preserves_next_request_id) {
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("first"),
+      fc::test::scripted_json_rpc_response::result("second"),
+   });
+   fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
+
+   BOOST_CHECK_EQUAL(client.call("wire_first").as_string(), "first");
+   auto moved = std::move(client);
+   BOOST_CHECK_EQUAL(moved.call("wire_second").as_string(), "second");
+
+   const auto requests = server.requests();
+   BOOST_REQUIRE_EQUAL(requests.size(), 2u);
+   BOOST_REQUIRE(requests[0].id);
+   BOOST_REQUIRE(requests[1].id);
+   BOOST_CHECK_EQUAL(*requests[0].id, 1);
+   BOOST_CHECK_EQUAL(*requests[1].id, 2);
+}
+
+/// Server destruction closes a pooled keep-alive connection held by a longer-lived client.
+BOOST_AUTO_TEST_CASE(server_destruction_does_not_wait_for_longer_lived_client) {
+   std::optional<fc::network::json_rpc::json_rpc_client> client;
+   const auto start = std::chrono::steady_clock::now();
+   {
+      fc::test::scripted_json_rpc_server server({
+         fc::test::scripted_json_rpc_response::result("ok"),
+      });
+      client.emplace(fc::url(server.url()));
+      BOOST_CHECK_EQUAL(client->call("wire_keep_alive").as_string(), "ok");
+   }
+   const auto elapsed = std::chrono::steady_clock::now() - start;
+
+   BOOST_CHECK_LT(elapsed, std::chrono::seconds(2));
+   client.reset();
+}
+
+/// The shared fixture consumes JSON-RPC notifications without manufacturing an invalid response.
+BOOST_AUTO_TEST_CASE(scripted_server_handles_notification_without_response_id) {
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("ignored"),
+   });
+   fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
+
+   BOOST_CHECK_NO_THROW(client.notify("wire_notification"));
+   const auto requests = server.requests();
+   BOOST_REQUIRE_EQUAL(requests.size(), 1u);
+   BOOST_CHECK_EQUAL(requests.front().method, "wire_notification");
+   BOOST_CHECK(!requests.front().id);
+}
+
 /// Explicitly idempotent calls reuse one healthy connection.
 BOOST_AUTO_TEST_CASE(idempotent_calls_reuse_a_healthy_connection) {
-   reusable_json_rpc_server server(
-      reusable_json_rpc_server::behavior::healthy_keep_alive);
-   fc::network::json_rpc::json_rpc_client client(
-      fc::url(
-         "http://127.0.0.1:" +
-         std::to_string(server.port())));
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("first"),
+      fc::test::scripted_json_rpc_response::result("second"),
+   });
+   fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
    BOOST_CHECK_EQUAL(
       client.call_idempotent("wire_first_probe").as_string(),
@@ -561,9 +239,9 @@ BOOST_AUTO_TEST_CASE(idempotent_calls_reuse_a_healthy_connection) {
 
 /// A result-aware JSON-RPC hook selects a follow-up on the exact connection.
 BOOST_AUTO_TEST_CASE(continuation_hook_selects_same_connection_followup) {
-   continuation_json_rpc_server server({
-      continuation_json_rpc_response::result("first"),
-      continuation_json_rpc_response::result("second"),
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("first"),
+      fc::test::scripted_json_rpc_response::result("second"),
    });
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
@@ -594,8 +272,8 @@ BOOST_AUTO_TEST_CASE(continuation_hook_selects_same_connection_followup) {
 
 /// An initial JSON-RPC error rejects the continuation before invoking its hook.
 BOOST_AUTO_TEST_CASE(continuation_initial_json_rpc_error_prevents_hook) {
-   continuation_json_rpc_server server({
-      continuation_json_rpc_response::error(json_rpc_error_object(-32000, "probe failed")),
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::error(json_rpc_error_object(-32000, "probe failed")),
    });
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
    bool hook_called = false;
@@ -613,8 +291,8 @@ BOOST_AUTO_TEST_CASE(continuation_initial_json_rpc_error_prevents_hook) {
 
 /// A malformed initial envelope rejects the continuation before invoking its hook.
 BOOST_AUTO_TEST_CASE(continuation_malformed_initial_envelope_prevents_hook) {
-   continuation_json_rpc_server server({
-      continuation_json_rpc_response::raw("{\"jsonrpc\":\"1.0\",\"id\":1,\"result\":\"first\"}"),
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::raw("{\"jsonrpc\":\"1.0\",\"id\":1,\"result\":\"first\"}"),
    });
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
    bool hook_called = false;
@@ -632,9 +310,9 @@ BOOST_AUTO_TEST_CASE(continuation_malformed_initial_envelope_prevents_hook) {
 
 /// A mismatched initial response ID rejects the continuation before invoking its hook.
 BOOST_AUTO_TEST_CASE(continuation_wrong_initial_id_prevents_hook) {
-   auto response = continuation_json_rpc_response::result("first");
+   auto response = fc::test::scripted_json_rpc_response::result("first");
    response.response_id = 99;
-   continuation_json_rpc_server server({std::move(response)});
+   fc::test::scripted_json_rpc_server server({std::move(response)});
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
    bool hook_called = false;
 
@@ -651,8 +329,8 @@ BOOST_AUTO_TEST_CASE(continuation_wrong_initial_id_prevents_hook) {
 
 /// A rejecting hook closes the retained connection without sending a follow-up.
 BOOST_AUTO_TEST_CASE(continuation_hook_rejection_prevents_followup) {
-   continuation_json_rpc_server server({
-      continuation_json_rpc_response::result("first"),
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("first"),
    });
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
@@ -666,9 +344,9 @@ BOOST_AUTO_TEST_CASE(continuation_hook_rejection_prevents_followup) {
 
 /// A JSON-RPC error from the follow-up is returned to the caller.
 BOOST_AUTO_TEST_CASE(continuation_followup_json_rpc_error_is_reported) {
-   continuation_json_rpc_server server({
-      continuation_json_rpc_response::result("first"),
-      continuation_json_rpc_response::error(json_rpc_error_object(-32001, "operation failed")),
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("first"),
+      fc::test::scripted_json_rpc_response::error(json_rpc_error_object(-32001, "operation failed")),
    });
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
@@ -683,10 +361,10 @@ BOOST_AUTO_TEST_CASE(continuation_followup_json_rpc_error_is_reported) {
 
 /// A mismatched follow-up response ID is rejected.
 BOOST_AUTO_TEST_CASE(continuation_wrong_followup_id_is_rejected) {
-   auto wrong_id = continuation_json_rpc_response::result("second");
+   auto wrong_id = fc::test::scripted_json_rpc_response::result("second");
    wrong_id.response_id = 99;
-   continuation_json_rpc_server server({
-      continuation_json_rpc_response::result("first"),
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("first"),
       std::move(wrong_id),
    });
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
@@ -702,12 +380,12 @@ BOOST_AUTO_TEST_CASE(continuation_wrong_followup_id_is_rejected) {
 
 /// A stale cached first connection replays only the probe and retains the replacement for the follow-up.
 BOOST_AUTO_TEST_CASE(continuation_replays_stale_initial_connection_once) {
-   auto stale = continuation_json_rpc_response::result("warm");
+   auto stale = fc::test::scripted_json_rpc_response::result("warm");
    stale.reset_after_response = true;
-   continuation_json_rpc_server server({
+   fc::test::scripted_json_rpc_server server({
       std::move(stale),
-      continuation_json_rpc_response::result("first"),
-      continuation_json_rpc_response::result("second"),
+      fc::test::scripted_json_rpc_response::result("first"),
+      fc::test::scripted_json_rpc_response::result("second"),
    });
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
@@ -731,9 +409,13 @@ BOOST_AUTO_TEST_CASE(continuation_replays_stale_initial_connection_once) {
 
 /// A non-replaying continuation probe fails instead of replacing a stale cached connection.
 BOOST_AUTO_TEST_CASE(continuation_never_policy_does_not_replay_stale_initial_connection) {
-   auto stale = continuation_json_rpc_response::result("warm");
+   auto stale = fc::test::scripted_json_rpc_response::result("warm");
    stale.reset_after_response = true;
-   continuation_json_rpc_server server({std::move(stale)});
+   fc::test::scripted_json_rpc_server server(
+      {std::move(stale)},
+      "127.0.0.1",
+      0,
+      true);
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
    bool hook_called = false;
 
@@ -752,8 +434,8 @@ BOOST_AUTO_TEST_CASE(continuation_never_policy_does_not_replay_stale_initial_con
 
 /// A total-timeout cap preserves stricter configured phase deadlines.
 BOOST_AUTO_TEST_CASE(continuation_timeout_cap_preserves_stricter_phase_timeout) {
-   continuation_json_rpc_server server({
-      continuation_json_rpc_response::delayed_result("first", 250ms),
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::delayed_result("first", 250ms),
    });
    fc::network::json_rpc::client_options options;
    options.request.timeouts.header = fc::milliseconds(40);
@@ -763,7 +445,6 @@ BOOST_AUTO_TEST_CASE(continuation_timeout_cap_preserves_stricter_phase_timeout) 
                                                  std::move(options));
    bool hook_called = false;
 
-   const auto start = fc::time_point::now();
    BOOST_CHECK_THROW(client.call_then("wire_identity_probe", fc::variants{},
                                       fc::network::json_rpc::call_options{.total_timeout_cap = fc::milliseconds(500)},
                                       [&](const fc::variant&) {
@@ -772,16 +453,14 @@ BOOST_AUTO_TEST_CASE(continuation_timeout_cap_preserves_stricter_phase_timeout) 
                                                                                             "wire_protected_operation"};
                                       }),
                      fc::timeout_exception);
-   const auto elapsed = fc::time_point::now() - start;
 
    BOOST_CHECK(!hook_called);
-   BOOST_CHECK_LT(elapsed.count(), fc::milliseconds(200).count());
 }
 
 /// A per-call cap cannot lengthen a stricter base total timeout.
 BOOST_AUTO_TEST_CASE(continuation_timeout_cap_cannot_expand_base_total_timeout) {
-   continuation_json_rpc_server server({
-      continuation_json_rpc_response::delayed_result("first", 250ms),
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::delayed_result("first", 250ms),
    });
    fc::network::json_rpc::client_options options;
    options.request.timeouts.header = fc::seconds(1);
@@ -791,7 +470,6 @@ BOOST_AUTO_TEST_CASE(continuation_timeout_cap_cannot_expand_base_total_timeout) 
                                                  std::move(options));
    bool hook_called = false;
 
-   const auto start = fc::time_point::now();
    BOOST_CHECK_THROW(client.call_then("wire_identity_probe", fc::variants{},
                                       fc::network::json_rpc::call_options{.total_timeout_cap = fc::milliseconds(500)},
                                       [&](const fc::variant&) {
@@ -800,17 +478,49 @@ BOOST_AUTO_TEST_CASE(continuation_timeout_cap_cannot_expand_base_total_timeout) 
                                                                                             "wire_protected_operation"};
                                       }),
                      fc::timeout_exception);
-   const auto elapsed = fc::time_point::now() - start;
 
    BOOST_CHECK(!hook_called);
-   BOOST_CHECK_LT(elapsed.count(), fc::milliseconds(200).count());
+}
+
+/// Connection validation cannot extend the initiating call's already-started total budget.
+BOOST_AUTO_TEST_CASE(connection_validation_inherits_initiating_call_total_deadline) {
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::delayed_result("cluster-a", 250ms),
+   });
+   fc::network::json_rpc::client_options options;
+   options.request.timeouts.total = fc::seconds(1);
+   options.connection_validator = fc::network::json_rpc::connection_validation{
+      .method = "wire_chain_identity",
+      .total_timeout_cap = fc::seconds(1),
+      .validate_result = [](const fc::variant&) {},
+   };
+   fc::network::json_rpc::json_rpc_client client(
+      fc::url(server.url()),
+      std::nullopt,
+      fc::network::json_rpc::endpoint_refresh_policy::on_connection_failure,
+      std::move(options));
+   bool hook_called = false;
+
+   BOOST_CHECK_THROW(
+      client.call_then(
+         "wire_protected_operation",
+         fc::variants{},
+         fc::network::json_rpc::call_options{.total_timeout_cap = fc::milliseconds(50)},
+         [&](const fc::variant&) {
+            hook_called = true;
+            return fc::network::json_rpc::continuation_call{.method = "wire_follow_up"};
+         }),
+      fc::timeout_exception);
+
+   BOOST_CHECK(!hook_called);
+   BOOST_CHECK(server.request_methods() == std::vector<std::string>{"wire_chain_identity"});
 }
 
 /// The follow-up receives a fresh total-timeout budget independent of the probe.
 BOOST_AUTO_TEST_CASE(continuation_followup_has_independent_total_timeout) {
-   continuation_json_rpc_server server({
-      continuation_json_rpc_response::result("first"),
-      continuation_json_rpc_response::delayed_result("second", 150ms),
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("first"),
+      fc::test::scripted_json_rpc_response::delayed_result("second", 150ms),
    });
    fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
@@ -831,12 +541,13 @@ BOOST_AUTO_TEST_CASE(continuation_followup_has_independent_total_timeout) {
 
 /// An idempotent call retries once when its cached connection has gone stale.
 BOOST_AUTO_TEST_CASE(idempotent_call_recovers_from_a_stale_cached_connection) {
-   reusable_json_rpc_server server(
-      reusable_json_rpc_server::behavior::stale_after_first_response);
-   fc::network::json_rpc::json_rpc_client client(
-      fc::url(
-         "http://127.0.0.1:" +
-         std::to_string(server.port())));
+   auto stale = fc::test::scripted_json_rpc_response::result("first");
+   stale.reset_after_response = true;
+   fc::test::scripted_json_rpc_server server({
+      std::move(stale),
+      fc::test::scripted_json_rpc_response::result("second"),
+   });
+   fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
    BOOST_CHECK_EQUAL(
       client.call_idempotent("wire_first_probe").as_string(),
@@ -851,11 +562,11 @@ BOOST_AUTO_TEST_CASE(idempotent_call_recovers_from_a_stale_cached_connection) {
 /// Caller-supplied retry options cannot make a default call replay.
 BOOST_AUTO_TEST_CASE(default_call_enforces_single_attempt) {
    auto warm =
-      continuation_json_rpc_response::result("warm");
-   continuation_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result("warm");
+   fc::test::scripted_json_rpc_server server({
       std::move(warm),
-      continuation_json_rpc_response::close(),
-      continuation_json_rpc_response::result("replayed"),
+      fc::test::scripted_json_rpc_response::close(),
+      fc::test::scripted_json_rpc_response::result("replayed"),
    });
    fc::network::json_rpc::client_options options;
    options.request.retry.max_attempts = 3;
@@ -930,9 +641,10 @@ BOOST_AUTO_TEST_CASE(endpoint_diagnostics_are_credential_free) {
 /// A peer that accepts the TCP request but withholds the HTTP response must
 /// release the caller within the active RPC deadline.
 BOOST_AUTO_TEST_CASE(call_times_out_when_http_response_hangs) {
-   hanging_http_server server;
-   fc::network::json_rpc::json_rpc_client client(
-      fc::url("http://127.0.0.1:" + std::to_string(server.port())));
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::hanging(),
+   });
+   fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
    const auto start = fc::time_point::now();
    BOOST_CHECK_THROW(
@@ -961,9 +673,10 @@ BOOST_AUTO_TEST_CASE(call_rejects_expired_ambient_deadline) {
 /// A peer that completes HTTP 200 with an oversized body must be rejected by
 /// the transport parser before JSON parsing or outpost envelope decoding.
 BOOST_AUTO_TEST_CASE(call_rejects_oversized_response_body) {
-   fixed_response_http_server server(std::string(OVERSIZED_RESPONSE_BODY_BYTES, 'x'));
-   fc::network::json_rpc::json_rpc_client client(
-      fc::url("http://127.0.0.1:" + std::to_string(server.port())));
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::raw(std::string(OVERSIZED_RESPONSE_BODY_BYTES, 'x')),
+   });
+   fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
    BOOST_CHECK_EXCEPTION(
       client.call("wire_body_limit_probe"),
@@ -973,9 +686,10 @@ BOOST_AUTO_TEST_CASE(call_rejects_oversized_response_body) {
 
 /// The raw HTTP helper shares the same bounded transport path as JSON-RPC calls.
 BOOST_AUTO_TEST_CASE(send_http_rejects_oversized_response_body) {
-   fixed_response_http_server server(std::string(OVERSIZED_RESPONSE_BODY_BYTES, 'x'));
-   fc::network::json_rpc::json_rpc_client client(
-      fc::url("http://127.0.0.1:" + std::to_string(server.port())));
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::raw(std::string(OVERSIZED_RESPONSE_BODY_BYTES, 'x')),
+   });
+   fc::network::json_rpc::json_rpc_client client(fc::url(server.url()));
 
    BOOST_CHECK_EXCEPTION(
       client.send_http(fc::network::json_rpc::http_verb::GET, "/"),

--- a/libraries/libfc/test/network/test_json_rpc_client.cpp
+++ b/libraries/libfc/test/network/test_json_rpc_client.cpp
@@ -831,8 +831,12 @@ BOOST_AUTO_TEST_CASE(continuation_followup_has_independent_total_timeout) {
 
 /// An idempotent call retries once when its cached connection has gone stale.
 BOOST_AUTO_TEST_CASE(idempotent_call_recovers_from_a_stale_cached_connection) {
-   reusable_json_rpc_server server(reusable_json_rpc_server::behavior::stale_after_first_response);
-   fc::network::json_rpc::json_rpc_client client(fc::url("http://127.0.0.1:" + std::to_string(server.port())));
+   reusable_json_rpc_server server(
+      reusable_json_rpc_server::behavior::stale_after_first_response);
+   fc::network::json_rpc::json_rpc_client client(
+      fc::url(
+         "http://127.0.0.1:" +
+         std::to_string(server.port())));
 
    BOOST_CHECK_EQUAL(
       client.call_idempotent("wire_first_probe").as_string(),

--- a/libraries/libfc/test/task/test_retry.cpp
+++ b/libraries/libfc/test/task/test_retry.cpp
@@ -85,6 +85,28 @@ BOOST_AUTO_TEST_CASE(deadline_scope_clamps_total_timeout) {
    BOOST_CHECK_LT(elapsed.count(), 1000 * 1000);
 }
 
+/// The retry envelope installs its calculated deadline around each attempt.
+BOOST_AUTO_TEST_CASE(installs_total_timeout_as_attempt_deadline) {
+   auto opts = fast_opts();
+   opts.total_timeout = fc::milliseconds(250);
+   std::optional<fc::time_point> observed_deadline;
+
+   const auto started = fc::time_point::now();
+   const auto result = retry_until<int>(
+      "installed-deadline",
+      opts,
+      [&]() -> std::optional<int> {
+         observed_deadline = fc::task::current_deadline();
+         return 7;
+      });
+
+   BOOST_CHECK_EQUAL(result, 7);
+   BOOST_REQUIRE(observed_deadline);
+   const auto observed_count = observed_deadline->time_since_epoch().count();
+   BOOST_CHECK_GE(observed_count, (started + fc::milliseconds(200)).time_since_epoch().count());
+   BOOST_CHECK_LE(observed_count, (started + fc::milliseconds(300)).time_since_epoch().count());
+}
+
 /// An already-expired caller scope must fail fast instead of invoking the
 /// predicate after the caller's budget has been exhausted.
 BOOST_AUTO_TEST_CASE(expired_deadline_scope_skips_first_attempt) {

--- a/plugins/outpost_solana_client_plugin/README.md
+++ b/plugins/outpost_solana_client_plugin/README.md
@@ -103,16 +103,19 @@ The expected hash must be canonical base58 encoding of exactly 32 bytes. Source
 it from a trusted deployment manifest or another control-plane source; do not
 derive the configured expectation from the same RPC URL being pinned.
 
-Two optional bounded-verification settings apply in pinned mode:
+One optional bounded-verification setting applies in pinned mode:
 
 | Option | Default | Description |
 |---|---:|---|
-| `--outpost-solana-cluster-identity-max-age-ms` | `30000` | Maximum successful-verification age used for freshness telemetry; protected RPCs still preflight every call |
 | `--outpost-solana-cluster-identity-probe-timeout-ms` | `5000` | Deadline for startup and runtime `getGenesisHash` probes |
 
 Signing and submission always force a fresh identity probe. A mismatch is
 sticky until process restart and blocks reads, transaction construction,
 simulation, fee estimation, signing, and submission.
+Operation-gate queueing is included in the configured RPC total timeout;
+startup and signing use the identity-probe timeout.
+Solana clients also always honor an earlier active task deadline; lower-level
+transport configuration cannot disable these fail-closed budgets.
 
 #### `--solana-idl-file` (optional, multi-token)
 
@@ -170,11 +173,11 @@ reads, transaction construction, simulation, fee estimation, and submission.
 Signing independently forces a fresh bounded observation immediately before
 the signer is invoked. Identity mismatch is sticky for the process lifetime.
 
-Prometheus exposes bounded-cardinality state, verification age,
-attempt/success/mismatch/failure/recovery counters, and blocked-operation
-counters. Labels contain only configured client IDs and fixed enums; URL
-credentials, signer IDs, expected/observed hashes, transactions, and account
-payloads are not metric labels.
+Prometheus exposes bounded-cardinality state, time since the latest successful
+verification, attempt/success/mismatch/failure/recovery counters, and
+blocked-operation counters. Labels contain only configured client IDs and fixed
+enums; URL credentials, signer IDs, expected/observed hashes, transactions, and
+account payloads are not metric labels.
 
 The absent-option legacy mode is a compatibility window for the initial
 release. Operators should add identities for all clients together. A later
@@ -213,7 +216,6 @@ package "sysio" {
    class solana_client_entry_t <<struct>> {
       + id : string
       + url : string
-      + signature_provider : signature_provider_ptr
       + client : solana_client_ptr
    }
 
@@ -264,7 +266,6 @@ package "fc::crypto" {
    }
 }
 
-solana_client_entry_t o-- signature_provider_ptr : signature_provider >
 solana_client --> signature_provider_ptr : signs with >
 
 @enduml

--- a/plugins/outpost_solana_client_plugin/README.md
+++ b/plugins/outpost_solana_client_plugin/README.md
@@ -107,7 +107,7 @@ Two optional bounded-verification settings apply in pinned mode:
 
 | Option | Default | Description |
 |---|---:|---|
-| `--outpost-solana-cluster-identity-max-age-ms` | `30000` | Maximum successful-verification age before reads reverify |
+| `--outpost-solana-cluster-identity-max-age-ms` | `30000` | Maximum successful-verification age used for freshness telemetry; protected RPCs still preflight every call |
 | `--outpost-solana-cluster-identity-probe-timeout-ms` | `5000` | Deadline for startup and runtime `getGenesisHash` probes |
 
 Signing and submission always force a fresh identity probe. A mismatch is
@@ -161,20 +161,20 @@ solana-idl-file = ./idl/counter_anchor.json
 
 Pinned clients verify `getGenesisHash` during construction before the plugin
 publishes any client. Runtime verification and each protected JSON-RPC call use
-the same authenticated HTTP transport session. If the verified session closes,
-the protected operation fails closed instead of falling back to another cached
-connection.
+one exact authenticated HTTP/TLS connection. If that connection closes before
+the follow-up, the protected operation fails closed instead of reconnecting or
+falling back to another cached connection.
 
-Read operations may reuse a successful observation only up to the configured
-maximum age. Every state-changing path forces a fresh observation before
-transaction construction, simulation, fee estimation, signing, or submission.
-Identity mismatch is sticky for the process lifetime.
+Every protected JSON-RPC operation performs a peer-bound preflight, including
+reads, transaction construction, simulation, fee estimation, and submission.
+Signing independently forces a fresh bounded observation immediately before
+the signer is invoked. Identity mismatch is sticky for the process lifetime.
 
-Prometheus exposes bounded-cardinality state, verification age, transport
-session id, attempt/success/mismatch/failure/recovery counters, and blocked
-operation counters. Labels contain only configured client IDs and fixed enums;
-URL credentials, signer IDs, expected/observed hashes, transactions, and
-account payloads are not metric labels.
+Prometheus exposes bounded-cardinality state, verification age,
+attempt/success/mismatch/failure/recovery counters, and blocked-operation
+counters. Labels contain only configured client IDs and fixed enums; URL
+credentials, signer IDs, expected/observed hashes, transactions, and account
+payloads are not metric labels.
 
 The absent-option legacy mode is a compatibility window for the initial
 release. Operators should add identities for all clients together. A later

--- a/plugins/outpost_solana_client_plugin/README.md
+++ b/plugins/outpost_solana_client_plugin/README.md
@@ -908,7 +908,11 @@ int main(int argc, char* argv[]) {
       auto client_entry = clients[0];
       auto& client = client_entry->client;
 
-      ilog("Connected to Solana RPC: {}", client_entry->url);
+      const auto identity = client->get_cluster_identity_snapshot();
+      ilog("Connected to Solana RPC (client_id={},endpoint={},cluster_identity_mode={})",
+           client_entry->id,
+           identity.sanitized_endpoint,
+           magic_enum::enum_name(identity.mode));
       ilog("Signer public key: {}", client->get_pubkey().to_base58());
 
       // ── Basic RPC Queries ──

--- a/plugins/outpost_solana_client_plugin/README.md
+++ b/plugins/outpost_solana_client_plugin/README.md
@@ -89,6 +89,11 @@ Pins each configured client to an independently obtained Solana genesis hash:
 <client-id>,<expected-genesis-hash>
 ```
 
+The check detects benign wrong-cluster routing or configuration. It does not
+authenticate a malicious RPC service—the genesis hash is public—and it cannot
+bind backends selected independently by a per-request routing proxy. Continue
+to use authenticated TLS endpoints and trusted network routing.
+
 The initial release has two configuration modes:
 
 - If the option is absent, every client preserves the legacy unpinned behavior.
@@ -109,13 +114,13 @@ One optional bounded-verification setting applies in pinned mode:
 |---|---:|---|
 | `--outpost-solana-cluster-identity-probe-timeout-ms` | `5000` | Deadline for startup and runtime `getGenesisHash` probes |
 
-Signing and submission always force a fresh identity probe. A mismatch is
-sticky until process restart and blocks reads, transaction construction,
-simulation, fee estimation, signing, and submission.
-Operation-gate queueing is included in the configured RPC total timeout;
-startup and signing use the identity-probe timeout.
-Solana clients also always honor an earlier active task deadline; lower-level
-transport configuration cannot disable these fail-closed budgets.
+Every new persistent connection is validated before its first ordinary request;
+healthy connections are validated once and replacements must validate again.
+Pinned signing stays local but requires a recent blockhash obtained over an
+admitted connection. A mismatch is sticky until process restart and blocks
+reads, transaction construction, simulation, fee estimation, signing, and
+submission. Solana clients always honor an earlier active task deadline;
+lower-level transport configuration cannot disable these fail-closed budgets.
 
 #### `--solana-idl-file` (optional, multi-token)
 
@@ -163,21 +168,25 @@ solana-idl-file = ./idl/counter_anchor.json
 ## Solana Cluster Identity Pinning
 
 Pinned clients verify `getGenesisHash` during construction before the plugin
-publishes any client. Runtime verification and each protected JSON-RPC call use
-one exact authenticated HTTP/TLS connection. If that connection closes before
-the follow-up, the protected operation fails closed instead of reconnecting or
-falling back to another cached connection.
+publishes any client. Every new HTTP/TLS connection is then validated before
+its first ordinary JSON-RPC request. A healthy persistent connection is
+validated once; every replacement or DNS fallback connection must pass its own
+validation. An endpoint that closes the validation response is rejected because
+no later request can be bound to that peer observation.
 
-Every protected JSON-RPC operation performs a peer-bound preflight, including
-reads, transaction construction, simulation, fee estimation, and submission.
-Signing independently forces a fresh bounded observation immediately before
-the signer is invoked. Identity mismatch is sticky for the process lifetime.
+Protected reads, transaction construction, simulation, fee estimation, and
+submission can use only an admitted live connection. Signing itself remains
+local: in pinned mode, the transaction's recent blockhash must have come from
+`getLatestBlockhash` over an admitted connection. Unpinned signing keeps the
+legacy local-only behavior. Identity mismatch is sticky for the process
+lifetime.
 
 Prometheus exposes bounded-cardinality state, time since the latest successful
-verification, attempt/success/mismatch/failure/recovery counters, and
-blocked-operation counters. Labels contain only configured client IDs and fixed
-enums; URL credentials, signer IDs, expected/observed hashes, transactions, and
-account payloads are not metric labels.
+verification, attempt/success/mismatch/failure/cancellation/recovery counters, and
+blocked-operation and protected-operation failure counters.
+Labels contain only configured client IDs and fixed enums; URL credentials,
+signer IDs, expected/observed hashes, transactions, and account payloads are
+not metric labels.
 
 The absent-option legacy mode is a compatibility window for the initial
 release. Operators should add identities for all clients together. A later

--- a/plugins/outpost_solana_client_plugin/README.md
+++ b/plugins/outpost_solana_client_plugin/README.md
@@ -5,6 +5,7 @@ The `outpost_solana_client_plugin` provides Solana JSON-RPC client integration f
 ## Table of Contents
 
 - [Plugin Configuration](#plugin-configuration)
+- [Solana Cluster Identity Pinning](#solana-cluster-identity-pinning)
 - [Class Diagrams](#class-diagrams)
 - [Client Architecture](#client-architecture)
 - [solana_client (RPC Client)](#solana_client-rpc-client)
@@ -80,6 +81,39 @@ HTTPS RPC endpoints use system CA roots and mandatory DNS/IP identity verificati
 `--outpost-solana-proxy http://host:port` for an explicit proxy. Verification cannot be disabled, and proxy
 environment variables are not applied implicitly.
 
+#### `--outpost-solana-cluster-identity` (optional for the initial release, multi-token)
+
+Pins each configured client to an independently obtained Solana genesis hash:
+
+```
+<client-id>,<expected-genesis-hash>
+```
+
+The initial release has two configuration modes:
+
+- If the option is absent, every client preserves the legacy unpinned behavior.
+  Startup emits a security warning and Prometheus reports
+  `mode="unpinned"` with `reason="missing_expected_identity"`.
+- If the option is present at least once, strict pinned mode applies to the
+  whole process. Every `--outpost-solana-client` must have exactly one matching
+  identity entry. Partial, duplicate, unknown-client, malformed, and
+  non-canonical hashes fail startup.
+
+The expected hash must be canonical base58 encoding of exactly 32 bytes. Source
+it from a trusted deployment manifest or another control-plane source; do not
+derive the configured expectation from the same RPC URL being pinned.
+
+Two optional bounded-verification settings apply in pinned mode:
+
+| Option | Default | Description |
+|---|---:|---|
+| `--outpost-solana-cluster-identity-max-age-ms` | `30000` | Maximum successful-verification age before reads reverify |
+| `--outpost-solana-cluster-identity-probe-timeout-ms` | `5000` | Deadline for startup and runtime `getGenesisHash` probes |
+
+Signing and submission always force a fresh identity probe. A mismatch is
+sticky until process restart and blocks reads, transaction construction,
+simulation, fee estimation, signing, and submission.
+
 #### `--solana-idl-file` (optional, multi-token)
 
 Loads one or more Anchor IDL JSON files for use with `solana_program_client`:
@@ -106,6 +140,7 @@ program; the clean-room outpost implementation is hosted inside the
 ./outpost_solana_client_tool \
    --signature-provider sol-signer,solana,solana,FDkbys9aWZSSCMYmstq948DfFmjxY69x4qUj7KSr7LCa,KEY:5pNoVifxrWsaAPDyaKGPoKiPjhhbHGaEFdTVmjx9qZJKS472eGsA5118YqEf2m7xUreC2kv6TDq9sssRceeQXHrJ \
    --outpost-solana-client my-client,sol-signer,https://api.devnet.solana.com \
+   --outpost-solana-cluster-identity my-client,<expected-genesis-hash> \
    --solana-idl-file ./idl/counter_anchor.json
 ```
 
@@ -116,8 +151,38 @@ The same options work in a config `.ini` file:
 ```ini
 signature-provider = sol-signer,solana,solana,FDkbys9aWZSSCMYmstq948DfFmjxY69x4qUj7KSr7LCa,KEY:5pNoVifxrWsaAPDyaKGPoKiPjhhbHGaEFdTVmjx9qZJKS472eGsA5118YqEf2m7xUreC2kv6TDq9sssRceeQXHrJ
 outpost-solana-client = my-client,sol-signer,https://api.devnet.solana.com
+outpost-solana-cluster-identity = my-client,<expected-genesis-hash>
 solana-idl-file = ./idl/counter_anchor.json
 ```
+
+---
+
+## Solana Cluster Identity Pinning
+
+Pinned clients verify `getGenesisHash` during construction before the plugin
+publishes any client. Runtime verification and each protected JSON-RPC call use
+the same authenticated HTTP transport session. If the verified session closes,
+the protected operation fails closed instead of falling back to another cached
+connection.
+
+Read operations may reuse a successful observation only up to the configured
+maximum age. Every state-changing path forces a fresh observation before
+transaction construction, simulation, fee estimation, signing, or submission.
+Identity mismatch is sticky for the process lifetime.
+
+Prometheus exposes bounded-cardinality state, verification age, transport
+session id, attempt/success/mismatch/failure/recovery counters, and blocked
+operation counters. Labels contain only configured client IDs and fixed enums;
+URL credentials, signer IDs, expected/observed hashes, transactions, and
+account payloads are not metric labels.
+
+The absent-option legacy mode is a compatibility window for the initial
+release. Operators should add identities for all clients together. A later
+release can make pinning mandatory after deployment tooling supplies the
+independent hashes.
+
+See [Solana cluster identity operations](../../docs/solana-cluster-identity.md)
+for rollout, alerting, and failure-response guidance.
 
 ---
 

--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin.hpp
@@ -56,11 +56,16 @@ enum class solana_outpost_role {
    underwriter
 };
 
+/**
+ * Immutable published binding for one configured Solana client.
+ *
+ * The raw signature provider is deliberately not exposed: every signing path
+ * must remain inside the bound solana_client so pinned mode cannot be bypassed.
+ */
 struct solana_client_entry_t {
-   std::string                        id;
-   std::string                        url;
-   fc::crypto::signature_provider_ptr signature_provider;
-   solana_client_ptr                  client;
+   const std::string       id;
+   const std::string       url;
+   const solana_client_ptr client;
 };
 
 using solana_client_entry_ptr = std::shared_ptr<solana_client_entry_t>;

--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin.hpp
@@ -8,6 +8,8 @@
 #include <fc/network/solana/solana_client.hpp>
 #include <fc/network/solana/solana_idl.hpp>
 
+#include <appbase/method.hpp>
+
 namespace sysio {
 using namespace fc::network::solana;
 
@@ -69,6 +71,22 @@ struct solana_client_entry_t {
 };
 
 using solana_client_entry_ptr = std::shared_ptr<solana_client_entry_t>;
+
+namespace solana_cluster_identity_metrics {
+
+/**
+ * Loosely coupled provider for current Solana cluster-identity snapshots.
+ *
+ * Consumers register an empty low-priority fallback when the Solana plugin is
+ * optional. The enabled Solana plugin registers the authoritative provider at
+ * the default priority.
+ */
+using snapshot_provider = appbase::method_decl<
+   struct snapshot_provider_tag,
+   std::vector<solana_cluster_identity_snapshot>(),
+   appbase::first_provider_policy>;
+
+} // namespace solana_cluster_identity_metrics
 
 /**
  * @brief Filter loaded IDL definitions down to the OPP outpost program.

--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin.hpp
@@ -385,6 +385,14 @@ public:
    virtual void plugin_shutdown();
 
    std::vector<solana_client_entry_ptr> get_clients();
+
+   /**
+    * Return credential-free cluster-identity snapshots for every configured
+    * client. The client ID is supplied by the plugin for legacy unpinned
+    * instances whose common-client constructor predates named connections.
+    */
+   std::vector<solana_cluster_identity_snapshot> get_cluster_identity_snapshots();
+
    solana_client_entry_ptr get_client(const std::string& id);
    const std::vector<std::pair<std::filesystem::path, std::vector<fc::network::solana::idl::program>>>& get_idl_files();
 

--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
@@ -127,9 +127,9 @@ std::vector<char> decode_latest_envelope_account(opp_solana_outpost_client&  pro
 /**
  * @brief Solana concrete `outpost_client`.
  *
- * Composes the plugin-owned `solana_client_entry_t` (shared chain connection +
- * signature provider) with the outpost program id + IDL to implement the
- * chain-agnostic SPI.
+ * Composes the plugin-owned immutable `solana_client_entry_t` binding (shared
+ * pinned-or-legacy chain client) with the outpost program id + IDL to implement
+ * the chain-agnostic SPI.
  *
  * `deliver_outbound_envelope` stages chunks through `epoch_in`, then sends a
  * zero-data terminal `epoch_in` call. When that call reaches consensus the

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
@@ -1,6 +1,8 @@
-#include <ranges>
-
 #include <fc/log/logger.hpp>
+#include <magic_enum/magic_enum.hpp>
+
+#include <ranges>
+#include <set>
 
 #include <sysio/http_client_plugin/http_client_options.hpp>
 #include <sysio/outpost_solana_client_plugin.hpp>
@@ -11,6 +13,9 @@ namespace sysio {
 
 namespace {
 constexpr auto option_name_client          = "outpost-solana-client";
+constexpr auto option_name_cluster_identity = "outpost-solana-cluster-identity";
+constexpr auto option_name_identity_max_age = "outpost-solana-cluster-identity-max-age-ms";
+constexpr auto option_name_identity_timeout = "outpost-solana-cluster-identity-probe-timeout-ms";
 constexpr auto option_idl_file             = "solana-idl-file";
 constexpr auto option_outpost_program_name = "solana-outpost-program-name";
 constexpr outbound_http::transport_option_names
@@ -21,6 +26,16 @@ constexpr outbound_http::transport_option_names
          "outpost-solana-additional-ca-path",
       .proxy = "outpost-solana-proxy",
    };
+constexpr uint32_t default_identity_max_age_ms = 30'000;
+constexpr uint32_t default_identity_probe_timeout_ms = 5'000;
+
+/** Credential-bearing client configuration parsed before any client is published. */
+struct parsed_client_spec {
+   std::string id;
+   std::string signature_provider_id;
+   std::string rpc_url;
+   fc::url     parsed_rpc_url;
+};
 
 [[maybe_unused]] inline fc::logger& logger() {
    static fc::logger log{"outpost_solana_client_plugin"};
@@ -66,6 +81,18 @@ public:
       return std::views::values(_clients) | std::ranges::to<std::vector>();
    }
 
+   std::vector<solana_cluster_identity_snapshot> get_cluster_identity_snapshots() {
+      std::vector<solana_cluster_identity_snapshot> snapshots;
+      snapshots.reserve(_clients.size());
+      for (const auto& [client_id, entry] : _clients) {
+         auto snapshot = entry->client->get_cluster_identity_snapshot();
+         if (snapshot.client_id.empty())
+            snapshot.client_id = client_id;
+         snapshots.push_back(std::move(snapshot));
+      }
+      return snapshots;
+   }
+
    solana_client_entry_ptr get_client(const std::string& id) {
       return _clients.at(id);
    }
@@ -108,15 +135,16 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
       outpost_rpc::rpc_options(
          options,
          transport_option_names);
+   std::vector<parsed_client_spec> parsed_clients;
+   parsed_clients.reserve(client_specs.size());
+   std::set<std::string> client_ids;
 
-   for (auto& client_spec : client_specs) {
-      dlog("Adding configured Solana client");
+   for (const auto& client_spec : client_specs) {
       auto parts = fc::split(client_spec, ',');
       SYS_ASSERT(parts.size() == 3,
                  chain::plugin_config_exception,
-                 "Invalid {} spec '{}' (expected: <client-id>,<sig-provider-id>,<rpc-url>)",
-                 option_name_client,
-                 client_spec);
+                 "Invalid {} spec (expected exactly: <client-id>,<sig-provider-id>,<rpc-url>)",
+                 option_name_client);
 
       auto& id     = parts[0];
       auto& sig_id = parts[1];
@@ -124,29 +152,124 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
       SYS_ASSERT(!id.empty(), chain::plugin_config_exception,
                  "Invalid {} spec: Solana client id must not be empty", option_name_client);
       SYS_ASSERT(!sig_id.empty(), chain::plugin_config_exception,
-                 "Invalid {} spec for client '{}': signer name must not be empty", option_name_client, id);
+                 "Invalid {} spec for client '{}': signature provider reference must not be empty",
+                 option_name_client, id);
       SYS_ASSERT(!url.empty(), chain::plugin_config_exception,
                  "Invalid {} spec for client '{}': RPC URL must not be empty", option_name_client, id);
+      SYS_ASSERT(client_ids.emplace(id).second, chain::plugin_config_exception,
+                 "Duplicate {} client id '{}'", option_name_client, id);
       SYS_ASSERT(sig_mgr.is_explicitly_configured_provider(sig_id),
                  chain::plugin_config_exception,
-                 "Outpost Solana client '{}' references signer '{}', but no explicitly named "
-                 "--signature-provider with that name was specified",
-                 id,
-                 sig_id);
+                 "Outpost Solana client '{}' does not reference an explicitly configured signature provider",
+                 id);
 
       auto sig_provider = sig_mgr.get_provider(sig_id);
       SYS_ASSERT(sig_provider->target_chain == fc::crypto::chain_kind_solana &&
                     sig_provider->key_type == fc::crypto::chain_key_type_solana,
                  chain::plugin_config_exception,
-                 "Outpost Solana client '{}' signer '{}' must use chain=solana and key-type=solana",
-                 id,
-                 sig_id);
+                 "Outpost Solana client '{}' signature provider must use chain=solana and key-type=solana",
+                 id);
 
-      my->add_client(id, std::make_shared<solana_client_entry_t>(
-                            id, url, sig_provider,
-                            std::make_shared<solana_client>(sig_provider, url, rpc_options)));
-      ilog("Added solana client (id={},sig_id={},endpoint={})",
-           id, sig_id, fc::http::sanitized_endpoint(fc::url(url)));
+      fc::url parsed_rpc_url;
+      try {
+         parsed_rpc_url = fc::url(url);
+      } catch (const std::exception&) {
+         SYS_ASSERT(false, chain::plugin_config_exception,
+                    "Invalid {} spec for client '{}': RPC URL is malformed",
+                    option_name_client, id);
+      }
+      SYS_ASSERT((parsed_rpc_url.proto() == "http" || parsed_rpc_url.proto() == "https") &&
+                    parsed_rpc_url.host() && !parsed_rpc_url.host()->empty(),
+                 chain::plugin_config_exception,
+                 "Invalid {} spec for client '{}': RPC URL must contain an HTTP(S) scheme and host",
+                 option_name_client, id);
+
+      parsed_clients.push_back(parsed_client_spec{id, sig_id, url, std::move(parsed_rpc_url)});
+   }
+
+   std::map<std::string, solana_genesis_hash> expected_identities;
+   const bool pinning_enabled = options.contains(option_name_cluster_identity);
+   if (pinning_enabled) {
+      const auto identity_specs = options.at(option_name_cluster_identity).as<std::vector<std::string>>();
+      for (const auto& identity_spec : identity_specs) {
+         auto parts = fc::split(identity_spec, ',');
+         SYS_ASSERT(parts.size() == 2, chain::plugin_config_exception,
+                    "Invalid {} spec (expected exactly: <client-id>,<expected-genesis-hash>)",
+                    option_name_cluster_identity);
+         const auto& client_id = parts[0];
+         const auto& expected_hash = parts[1];
+         SYS_ASSERT(!client_id.empty(), chain::plugin_config_exception,
+                    "Invalid {} spec: Solana client id must not be empty", option_name_cluster_identity);
+         SYS_ASSERT(!expected_hash.empty(), chain::plugin_config_exception,
+                    "Invalid {} spec for client '{}': reason={}", option_name_cluster_identity, client_id,
+                    magic_enum::enum_name(solana_cluster_identity_reason::missing_expected_identity));
+         SYS_ASSERT(client_ids.contains(client_id), chain::plugin_config_exception,
+                    "Invalid {} spec for unknown client '{}'", option_name_cluster_identity, client_id);
+         SYS_ASSERT(!expected_identities.contains(client_id), chain::plugin_config_exception,
+                    "Duplicate {} spec for client '{}'", option_name_cluster_identity, client_id);
+         try {
+            expected_identities.emplace(client_id, parse_solana_genesis_hash(expected_hash));
+         } catch (const std::exception&) {
+            SYS_ASSERT(false, chain::plugin_config_exception,
+                       "Invalid {} spec for client '{}': reason={}",
+                       option_name_cluster_identity, client_id,
+                       magic_enum::enum_name(solana_cluster_identity_reason::malformed_expected_identity));
+         }
+      }
+
+      for (const auto& client : parsed_clients) {
+         SYS_ASSERT(expected_identities.contains(client.id), chain::plugin_config_exception,
+                    "Pinned Solana configuration is missing {} for client '{}'",
+                    option_name_cluster_identity, client.id);
+      }
+   }
+
+   const auto maximum_age = fc::milliseconds(options.at(option_name_identity_max_age).as<uint32_t>());
+   const auto probe_timeout = fc::milliseconds(options.at(option_name_identity_timeout).as<uint32_t>());
+   SYS_ASSERT(maximum_age.count() > 0, chain::plugin_config_exception,
+              "--{} must be greater than zero", option_name_identity_max_age);
+   SYS_ASSERT(probe_timeout.count() > 0, chain::plugin_config_exception,
+              "--{} must be greater than zero", option_name_identity_timeout);
+
+   // Construct every client before publishing any of them. If a pinned startup
+   // probe fails, the plugin exits with an empty registry rather than exposing
+   // the clients that happened to validate first.
+   std::vector<solana_client_entry_ptr> pending_clients;
+   pending_clients.reserve(parsed_clients.size());
+   for (const auto& client : parsed_clients) {
+      auto sig_provider = sig_mgr.get_provider(client.signature_provider_id);
+      solana_client_ptr rpc_client;
+      if (pinning_enabled) {
+         rpc_client = std::make_shared<solana_client>(
+            sig_provider, client.parsed_rpc_url,
+            solana_cluster_identity_config{
+               .client_id = client.id,
+               .expected_genesis_hash = expected_identities.at(client.id),
+               .maximum_verification_age = maximum_age,
+               .probe_timeout = probe_timeout,
+            },
+            rpc_options);
+      } else {
+         rpc_client = std::make_shared<solana_client>(
+            sig_provider, client.parsed_rpc_url, rpc_options);
+         wlog("SEC-139 staged rollout: Solana client '{}' is running without cluster identity "
+              "pinning (reason={}). Supply --{} for every configured Solana client to enable "
+              "strict pinned mode.",
+              client.id, magic_enum::enum_name(solana_cluster_identity_reason::missing_expected_identity),
+              option_name_cluster_identity);
+      }
+      pending_clients.push_back(std::make_shared<solana_client_entry_t>(
+         client.id, client.rpc_url, sig_provider, std::move(rpc_client)));
+   }
+
+   for (std::size_t i = 0; i < pending_clients.size(); ++i) {
+      auto& entry = pending_clients[i];
+      const auto client_id = entry->id;
+      my->add_client(client_id, std::move(entry));
+      ilog("Added Solana client (id={},endpoint={},cluster_identity_mode={})",
+           client_id, fc::http::sanitized_endpoint(parsed_clients[i].parsed_rpc_url),
+           pinning_enabled ? magic_enum::enum_name(solana_cluster_identity_mode::pinned)
+                           : magic_enum::enum_name(solana_cluster_identity_mode::unpinned));
    }
 }
 
@@ -161,6 +284,20 @@ void outpost_solana_client_plugin::set_program_options(options_description& cli,
       "Outpost Solana Client spec, the plugin supports 1 to many clients in a given process. "
       "Format: `<sol-client-id>,<sig-provider-id>,<rpc-url>`. The signer id must "
       "match an explicitly named --signature-provider with the Solana target chain and key type")(
+      option_name_cluster_identity,
+      boost::program_options::value<std::vector<std::string>>()->multitoken(),
+      "Optional staged Solana cluster identity pin. Format: "
+      "`<sol-client-id>,<expected-genesis-hash>`. When this option is present, "
+      "every configured Solana client must have exactly one canonical 32-byte "
+      "base58 genesis hash; when absent, legacy unpinned behavior is preserved "
+      "with a prominent security warning")(
+      option_name_identity_max_age,
+      boost::program_options::value<uint32_t>()->default_value(default_identity_max_age_ms),
+      "Maximum age in milliseconds of a successful Solana cluster identity "
+      "observation before a protected read must reverify")(
+      option_name_identity_timeout,
+      boost::program_options::value<uint32_t>()->default_value(default_identity_probe_timeout_ms),
+      "Maximum duration in milliseconds of each Solana cluster identity probe")(
       option_idl_file,
       boost::program_options::value<std::vector<std::filesystem::path>>()->multitoken(),
       "Solana program IDL file(s). Expects each file to be a JSON IDL (Anchor format) program definition.")(
@@ -182,6 +319,11 @@ void outpost_solana_client_plugin::plugin_shutdown() {
 
 std::vector<solana_client_entry_ptr> outpost_solana_client_plugin::get_clients() {
    return my->get_clients();
+}
+
+std::vector<solana_cluster_identity_snapshot>
+outpost_solana_client_plugin::get_cluster_identity_snapshots() {
+   return my->get_cluster_identity_snapshots();
 }
 
 solana_client_entry_ptr outpost_solana_client_plugin::get_client(const std::string& id) {

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <fc/log/logger.hpp>
+#include <future>
 #include <magic_enum/magic_enum.hpp>
 #include <ranges>
 #include <set>
@@ -25,6 +27,7 @@ constexpr outbound_http::transport_option_names
       .proxy = "outpost-solana-proxy",
    };
 constexpr uint32_t default_identity_probe_timeout_ms = 5'000;
+constexpr size_t max_concurrent_startup_validations = 8;
 
 /** Credential-bearing client configuration parsed before any client is published. */
 struct parsed_client_spec {
@@ -46,6 +49,7 @@ class outpost_solana_client_plugin_impl {
    using file_idl_programs_t = std::pair<std::filesystem::path, std::vector<fc::network::solana::idl::program>>;
    std::vector<file_idl_programs_t> _idl_files{};
    std::string _outpost_program_name{OPP_SOLANA_OUTPOST_PROGRAM_NAME};
+   solana_cluster_identity_metrics::snapshot_provider::method_type::handle _snapshot_provider;
 
 public:
    void set_outpost_program_name(std::string name) {
@@ -88,12 +92,24 @@ public:
       return snapshots;
    }
 
-   solana_client_entry_ptr get_client(const std::string& id) { return _clients.at(id); }
+   solana_client_entry_ptr get_client(const std::string& id) {
+      const auto found = _clients.find(id);
+      FC_ASSERT(found != _clients.end(), "Unknown Solana client id '{}'", id);
+      return found->second;
+   }
 
    void add_client(const std::string& id, solana_client_entry_ptr client) {
       FC_ASSERT(client, "Client cannot be null");
       FC_ASSERT(!_clients.contains(id), "Client with id {} already exists", id);
       _clients.emplace(id, client);
+   }
+
+   /** Publish the configured clients through the app-level metrics interface. */
+   void register_snapshot_provider() {
+      _snapshot_provider =
+         app()
+            .get_method<solana_cluster_identity_metrics::snapshot_provider>()
+            .register_provider([this] { return get_cluster_identity_snapshots(); });
    }
 
    const std::vector<file_idl_programs_t>& get_idl_files() { return _idl_files; }
@@ -128,10 +144,12 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
    parsed_clients.reserve(client_specs.size());
    std::set<std::string> client_ids;
 
-   for (const auto& client_spec : client_specs) {
+   for (size_t spec_index = 0; spec_index < client_specs.size(); ++spec_index) {
+      const auto& client_spec = client_specs[spec_index];
       auto parts = fc::split(client_spec, ',');
       SYS_ASSERT(parts.size() == 3, chain::plugin_config_exception,
-                 "Invalid {} spec (expected exactly: <client-id>,<sig-provider-id>,<rpc-url>)", option_name_client);
+                 "Invalid {} entry #{} (expected exactly: <client-id>,<sig-provider-id>,<rpc-url>)",
+                 option_name_client, spec_index + 1);
 
       auto& id = parts[0];
       auto& sig_id = parts[1];
@@ -174,11 +192,12 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
    const bool pinning_enabled = options.contains(option_name_cluster_identity);
    if (pinning_enabled) {
       const auto identity_specs = options.at(option_name_cluster_identity).as<std::vector<std::string>>();
-      for (const auto& identity_spec : identity_specs) {
+      for (size_t spec_index = 0; spec_index < identity_specs.size(); ++spec_index) {
+         const auto& identity_spec = identity_specs[spec_index];
          auto parts = fc::split(identity_spec, ',');
          SYS_ASSERT(parts.size() == 2, chain::plugin_config_exception,
-                    "Invalid {} spec (expected exactly: <client-id>,<expected-genesis-hash>)",
-                    option_name_cluster_identity);
+                    "Invalid {} entry #{} (expected exactly: <client-id>,<expected-genesis-hash>)",
+                    option_name_cluster_identity, spec_index + 1);
          const auto& client_id = parts[0];
          const auto& expected_hash = parts[1];
          SYS_ASSERT(!client_id.empty(), chain::plugin_config_exception,
@@ -213,29 +232,52 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
    // Construct every client before publishing any of them. If a pinned startup
    // probe fails, the plugin exits with an empty registry rather than exposing
    // the clients that happened to validate first.
-   std::vector<solana_client_entry_ptr> pending_clients;
-   pending_clients.reserve(parsed_clients.size());
-   for (const auto& client : parsed_clients) {
-      auto sig_provider = sig_mgr.get_provider(client.signature_provider_id);
-      solana_client_ptr rpc_client;
-      if (pinning_enabled) {
-         rpc_client = std::make_shared<solana_client>(
-            sig_provider, client.parsed_rpc_url, rpc_options,
-            solana_cluster_identity_config{
-               .client_id = client.id,
-               .expected_genesis_hash = expected_identities.at(client.id),
-               .probe_timeout = probe_timeout,
-            });
-      } else {
-         rpc_client = std::make_shared<solana_client>(sig_provider, client.parsed_rpc_url, rpc_options);
+   std::vector<solana_client_entry_ptr> pending_clients(parsed_clients.size());
+   if (pinning_enabled) {
+      for (size_t batch_begin = 0; batch_begin < parsed_clients.size();
+           batch_begin += max_concurrent_startup_validations) {
+         const auto batch_end =
+            std::min(parsed_clients.size(), batch_begin + max_concurrent_startup_validations);
+         std::vector<std::future<solana_client_entry_ptr>> startup_validations;
+         startup_validations.reserve(batch_end - batch_begin);
+         for (size_t index = batch_begin; index < batch_end; ++index) {
+            const auto& client = parsed_clients[index];
+            auto sig_provider = sig_mgr.get_provider(client.signature_provider_id);
+            const auto expected_identity = expected_identities.at(client.id);
+            startup_validations.push_back(std::async(
+               std::launch::async,
+               [sig_provider, client, rpc_options, expected_identity, probe_timeout] {
+                  auto rpc_client = std::make_shared<solana_client>(
+                     sig_provider,
+                     client.parsed_rpc_url,
+                     rpc_options,
+                     solana_cluster_identity_config{
+                        .client_id = client.id,
+                        .expected_genesis_hash = expected_identity,
+                        .probe_timeout = probe_timeout,
+                     });
+                  return std::make_shared<solana_client_entry_t>(
+                     client.id,
+                     client.rpc_url,
+                     std::move(rpc_client));
+               }));
+         }
+         for (size_t batch_offset = 0; batch_offset < startup_validations.size(); ++batch_offset)
+            pending_clients[batch_begin + batch_offset] = startup_validations[batch_offset].get();
+      }
+   } else {
+      for (size_t index = 0; index < parsed_clients.size(); ++index) {
+         const auto& client = parsed_clients[index];
+         auto sig_provider = sig_mgr.get_provider(client.signature_provider_id);
+         auto rpc_client = std::make_shared<solana_client>(sig_provider, client.parsed_rpc_url, rpc_options);
          wlog("SEC-139 staged rollout: Solana client '{}' is running without cluster identity "
               "pinning (reason={}). Supply --{} for every configured Solana client to enable "
               "strict pinned mode.",
               client.id, magic_enum::enum_name(solana_cluster_identity_reason::missing_expected_identity),
               option_name_cluster_identity);
+         pending_clients[index] =
+            std::make_shared<solana_client_entry_t>(client.id, client.rpc_url, std::move(rpc_client));
       }
-      pending_clients.push_back(
-         std::make_shared<solana_client_entry_t>(client.id, client.rpc_url, std::move(rpc_client)));
    }
 
    for (std::size_t i = 0; i < pending_clients.size(); ++i) {
@@ -247,6 +289,7 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
            pinning_enabled ? magic_enum::enum_name(solana_cluster_identity_mode::pinned)
                            : magic_enum::enum_name(solana_cluster_identity_mode::unpinned));
    }
+   my->register_snapshot_provider();
 }
 
 void outpost_solana_client_plugin::plugin_startup() {

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
@@ -13,7 +13,6 @@ namespace sysio {
 namespace {
 constexpr auto option_name_client = "outpost-solana-client";
 constexpr auto option_name_cluster_identity = "outpost-solana-cluster-identity";
-constexpr auto option_name_identity_max_age = "outpost-solana-cluster-identity-max-age-ms";
 constexpr auto option_name_identity_timeout = "outpost-solana-cluster-identity-probe-timeout-ms";
 constexpr auto option_idl_file = "solana-idl-file";
 constexpr auto option_outpost_program_name = "solana-outpost-program-name";
@@ -25,7 +24,6 @@ constexpr outbound_http::transport_option_names
          "outpost-solana-additional-ca-path",
       .proxy = "outpost-solana-proxy",
    };
-constexpr uint32_t default_identity_max_age_ms = 30'000;
 constexpr uint32_t default_identity_probe_timeout_ms = 5'000;
 
 /** Credential-bearing client configuration parsed before any client is published. */
@@ -208,10 +206,7 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
       }
    }
 
-   const auto maximum_age = fc::milliseconds(options.at(option_name_identity_max_age).as<uint32_t>());
    const auto probe_timeout = fc::milliseconds(options.at(option_name_identity_timeout).as<uint32_t>());
-   SYS_ASSERT(maximum_age.count() > 0, chain::plugin_config_exception, "--{} must be greater than zero",
-              option_name_identity_max_age);
    SYS_ASSERT(probe_timeout.count() > 0, chain::plugin_config_exception, "--{} must be greater than zero",
               option_name_identity_timeout);
 
@@ -224,14 +219,13 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
       auto sig_provider = sig_mgr.get_provider(client.signature_provider_id);
       solana_client_ptr rpc_client;
       if (pinning_enabled) {
-         rpc_client = std::make_shared<solana_client>(sig_provider, client.parsed_rpc_url,
-                                                      solana_cluster_identity_config{
-                                                         .client_id = client.id,
-                                                         .expected_genesis_hash = expected_identities.at(client.id),
-                                                         .maximum_verification_age = maximum_age,
-                                                         .probe_timeout = probe_timeout,
-                                                      },
-                                                      rpc_options);
+         rpc_client = std::make_shared<solana_client>(
+            sig_provider, client.parsed_rpc_url, rpc_options,
+            solana_cluster_identity_config{
+               .client_id = client.id,
+               .expected_genesis_hash = expected_identities.at(client.id),
+               .probe_timeout = probe_timeout,
+            });
       } else {
          rpc_client = std::make_shared<solana_client>(sig_provider, client.parsed_rpc_url, rpc_options);
          wlog("SEC-139 staged rollout: Solana client '{}' is running without cluster identity "
@@ -241,7 +235,7 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
               option_name_cluster_identity);
       }
       pending_clients.push_back(
-         std::make_shared<solana_client_entry_t>(client.id, client.rpc_url, sig_provider, std::move(rpc_client)));
+         std::make_shared<solana_client_entry_t>(client.id, client.rpc_url, std::move(rpc_client)));
    }
 
    for (std::size_t i = 0; i < pending_clients.size(); ++i) {
@@ -270,10 +264,6 @@ void outpost_solana_client_plugin::set_program_options(options_description& cli,
       "every configured Solana client must have exactly one canonical 32-byte "
       "base58 genesis hash; when absent, legacy unpinned behavior is preserved "
       "with a prominent security warning")(
-      option_name_identity_max_age,
-      boost::program_options::value<uint32_t>()->default_value(default_identity_max_age_ms),
-      "Maximum successful Solana cluster identity age in milliseconds used for freshness telemetry; protected RPCs "
-      "still preflight every call")(
       option_name_identity_timeout,
       boost::program_options::value<uint32_t>()->default_value(default_identity_probe_timeout_ms),
       "Maximum duration in milliseconds of each Solana cluster identity probe")(

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client_plugin.cpp
@@ -1,6 +1,5 @@
 #include <fc/log/logger.hpp>
 #include <magic_enum/magic_enum.hpp>
-
 #include <ranges>
 #include <set>
 
@@ -12,11 +11,11 @@
 namespace sysio {
 
 namespace {
-constexpr auto option_name_client          = "outpost-solana-client";
+constexpr auto option_name_client = "outpost-solana-client";
 constexpr auto option_name_cluster_identity = "outpost-solana-cluster-identity";
 constexpr auto option_name_identity_max_age = "outpost-solana-cluster-identity-max-age-ms";
 constexpr auto option_name_identity_timeout = "outpost-solana-cluster-identity-probe-timeout-ms";
-constexpr auto option_idl_file             = "solana-idl-file";
+constexpr auto option_idl_file = "solana-idl-file";
 constexpr auto option_outpost_program_name = "solana-outpost-program-name";
 constexpr outbound_http::transport_option_names
    transport_option_names{
@@ -34,7 +33,7 @@ struct parsed_client_spec {
    std::string id;
    std::string signature_provider_id;
    std::string rpc_url;
-   fc::url     parsed_rpc_url;
+   fc::url parsed_rpc_url;
 };
 
 [[maybe_unused]] inline fc::logger& logger() {
@@ -56,9 +55,7 @@ public:
       _outpost_program_name = std::move(name);
    }
 
-   const std::string& outpost_program_name() const {
-      return _outpost_program_name;
-   }
+   const std::string& outpost_program_name() const { return _outpost_program_name; }
 
    // Called only from plugin_initialize -- sequential, main-thread -- so the IDL list needs no synchronization.
    std::vector<file_idl_programs_t> load_idl_files(const std::vector<std::filesystem::path>& file_names) {
@@ -93,9 +90,7 @@ public:
       return snapshots;
    }
 
-   solana_client_entry_ptr get_client(const std::string& id) {
-      return _clients.at(id);
-   }
+   solana_client_entry_ptr get_client(const std::string& id) { return _clients.at(id); }
 
    void add_client(const std::string& id, solana_client_entry_ptr client) {
       FC_ASSERT(client, "Client cannot be null");
@@ -103,10 +98,7 @@ public:
       _clients.emplace(id, client);
    }
 
-   const std::vector<file_idl_programs_t>& get_idl_files() {
-      return _idl_files;
-   }
-
+   const std::vector<file_idl_programs_t>& get_idl_files() { return _idl_files; }
 };
 
 outpost_solana_client_plugin::outpost_solana_client_plugin()
@@ -121,8 +113,7 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
    }
    my->set_outpost_program_name(options.at(option_outpost_program_name).as<std::string>());
    ilog("Solana OPP outpost program name: {}", my->outpost_program_name());
-   FC_ASSERT(options.count(option_name_client),
-             "At least one solana client argument is required {}",
+   FC_ASSERT(options.count(option_name_client), "At least one solana client argument is required {}",
              option_name_client);
 
    // This plugin APPBASE_PLUGIN_REQUIRES the signature_provider_manager_plugin, which creates every configured provider
@@ -141,48 +132,42 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
 
    for (const auto& client_spec : client_specs) {
       auto parts = fc::split(client_spec, ',');
-      SYS_ASSERT(parts.size() == 3,
-                 chain::plugin_config_exception,
-                 "Invalid {} spec (expected exactly: <client-id>,<sig-provider-id>,<rpc-url>)",
-                 option_name_client);
+      SYS_ASSERT(parts.size() == 3, chain::plugin_config_exception,
+                 "Invalid {} spec (expected exactly: <client-id>,<sig-provider-id>,<rpc-url>)", option_name_client);
 
-      auto& id     = parts[0];
+      auto& id = parts[0];
       auto& sig_id = parts[1];
-      auto& url    = parts[2];
-      SYS_ASSERT(!id.empty(), chain::plugin_config_exception,
-                 "Invalid {} spec: Solana client id must not be empty", option_name_client);
+      auto& url = parts[2];
+      SYS_ASSERT(!id.empty(), chain::plugin_config_exception, "Invalid {} spec: Solana client id must not be empty",
+                 option_name_client);
       SYS_ASSERT(!sig_id.empty(), chain::plugin_config_exception,
-                 "Invalid {} spec for client '{}': signature provider reference must not be empty",
-                 option_name_client, id);
+                 "Invalid {} spec for client '{}': signature provider reference must not be empty", option_name_client,
+                 id);
       SYS_ASSERT(!url.empty(), chain::plugin_config_exception,
                  "Invalid {} spec for client '{}': RPC URL must not be empty", option_name_client, id);
-      SYS_ASSERT(client_ids.emplace(id).second, chain::plugin_config_exception,
-                 "Duplicate {} client id '{}'", option_name_client, id);
-      SYS_ASSERT(sig_mgr.is_explicitly_configured_provider(sig_id),
-                 chain::plugin_config_exception,
-                 "Outpost Solana client '{}' does not reference an explicitly configured signature provider",
-                 id);
+      SYS_ASSERT(client_ids.emplace(id).second, chain::plugin_config_exception, "Duplicate {} client id '{}'",
+                 option_name_client, id);
+      SYS_ASSERT(sig_mgr.is_explicitly_configured_provider(sig_id), chain::plugin_config_exception,
+                 "Outpost Solana client '{}' does not reference an explicitly configured signature provider", id);
 
       auto sig_provider = sig_mgr.get_provider(sig_id);
       SYS_ASSERT(sig_provider->target_chain == fc::crypto::chain_kind_solana &&
                     sig_provider->key_type == fc::crypto::chain_key_type_solana,
                  chain::plugin_config_exception,
-                 "Outpost Solana client '{}' signature provider must use chain=solana and key-type=solana",
-                 id);
+                 "Outpost Solana client '{}' signature provider must use chain=solana and key-type=solana", id);
 
       fc::url parsed_rpc_url;
       try {
          parsed_rpc_url = fc::url(url);
       } catch (const std::exception&) {
-         SYS_ASSERT(false, chain::plugin_config_exception,
-                    "Invalid {} spec for client '{}': RPC URL is malformed",
+         SYS_ASSERT(false, chain::plugin_config_exception, "Invalid {} spec for client '{}': RPC URL is malformed",
                     option_name_client, id);
       }
-      SYS_ASSERT((parsed_rpc_url.proto() == "http" || parsed_rpc_url.proto() == "https") &&
-                    parsed_rpc_url.host() && !parsed_rpc_url.host()->empty(),
+      SYS_ASSERT((parsed_rpc_url.proto() == "http" || parsed_rpc_url.proto() == "https") && parsed_rpc_url.host() &&
+                    !parsed_rpc_url.host()->empty(),
                  chain::plugin_config_exception,
-                 "Invalid {} spec for client '{}': RPC URL must contain an HTTP(S) scheme and host",
-                 option_name_client, id);
+                 "Invalid {} spec for client '{}': RPC URL must contain an HTTP(S) scheme and host", option_name_client,
+                 id);
 
       parsed_clients.push_back(parsed_client_spec{id, sig_id, url, std::move(parsed_rpc_url)});
    }
@@ -210,8 +195,7 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
          try {
             expected_identities.emplace(client_id, parse_solana_genesis_hash(expected_hash));
          } catch (const std::exception&) {
-            SYS_ASSERT(false, chain::plugin_config_exception,
-                       "Invalid {} spec for client '{}': reason={}",
+            SYS_ASSERT(false, chain::plugin_config_exception, "Invalid {} spec for client '{}': reason={}",
                        option_name_cluster_identity, client_id,
                        magic_enum::enum_name(solana_cluster_identity_reason::malformed_expected_identity));
          }
@@ -219,17 +203,17 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
 
       for (const auto& client : parsed_clients) {
          SYS_ASSERT(expected_identities.contains(client.id), chain::plugin_config_exception,
-                    "Pinned Solana configuration is missing {} for client '{}'",
-                    option_name_cluster_identity, client.id);
+                    "Pinned Solana configuration is missing {} for client '{}'", option_name_cluster_identity,
+                    client.id);
       }
    }
 
    const auto maximum_age = fc::milliseconds(options.at(option_name_identity_max_age).as<uint32_t>());
    const auto probe_timeout = fc::milliseconds(options.at(option_name_identity_timeout).as<uint32_t>());
-   SYS_ASSERT(maximum_age.count() > 0, chain::plugin_config_exception,
-              "--{} must be greater than zero", option_name_identity_max_age);
-   SYS_ASSERT(probe_timeout.count() > 0, chain::plugin_config_exception,
-              "--{} must be greater than zero", option_name_identity_timeout);
+   SYS_ASSERT(maximum_age.count() > 0, chain::plugin_config_exception, "--{} must be greater than zero",
+              option_name_identity_max_age);
+   SYS_ASSERT(probe_timeout.count() > 0, chain::plugin_config_exception, "--{} must be greater than zero",
+              option_name_identity_timeout);
 
    // Construct every client before publishing any of them. If a pinned startup
    // probe fails, the plugin exits with an empty registry rather than exposing
@@ -240,34 +224,32 @@ void outpost_solana_client_plugin::plugin_initialize(const variables_map& option
       auto sig_provider = sig_mgr.get_provider(client.signature_provider_id);
       solana_client_ptr rpc_client;
       if (pinning_enabled) {
-         rpc_client = std::make_shared<solana_client>(
-            sig_provider, client.parsed_rpc_url,
-            solana_cluster_identity_config{
-               .client_id = client.id,
-               .expected_genesis_hash = expected_identities.at(client.id),
-               .maximum_verification_age = maximum_age,
-               .probe_timeout = probe_timeout,
-            },
-            rpc_options);
+         rpc_client = std::make_shared<solana_client>(sig_provider, client.parsed_rpc_url,
+                                                      solana_cluster_identity_config{
+                                                         .client_id = client.id,
+                                                         .expected_genesis_hash = expected_identities.at(client.id),
+                                                         .maximum_verification_age = maximum_age,
+                                                         .probe_timeout = probe_timeout,
+                                                      },
+                                                      rpc_options);
       } else {
-         rpc_client = std::make_shared<solana_client>(
-            sig_provider, client.parsed_rpc_url, rpc_options);
+         rpc_client = std::make_shared<solana_client>(sig_provider, client.parsed_rpc_url, rpc_options);
          wlog("SEC-139 staged rollout: Solana client '{}' is running without cluster identity "
               "pinning (reason={}). Supply --{} for every configured Solana client to enable "
               "strict pinned mode.",
               client.id, magic_enum::enum_name(solana_cluster_identity_reason::missing_expected_identity),
               option_name_cluster_identity);
       }
-      pending_clients.push_back(std::make_shared<solana_client_entry_t>(
-         client.id, client.rpc_url, sig_provider, std::move(rpc_client)));
+      pending_clients.push_back(
+         std::make_shared<solana_client_entry_t>(client.id, client.rpc_url, sig_provider, std::move(rpc_client)));
    }
 
    for (std::size_t i = 0; i < pending_clients.size(); ++i) {
       auto& entry = pending_clients[i];
       const auto client_id = entry->id;
       my->add_client(client_id, std::move(entry));
-      ilog("Added Solana client (id={},endpoint={},cluster_identity_mode={})",
-           client_id, fc::http::sanitized_endpoint(parsed_clients[i].parsed_rpc_url),
+      ilog("Added Solana client (id={},endpoint={},cluster_identity_mode={})", client_id,
+           fc::http::sanitized_endpoint(parsed_clients[i].parsed_rpc_url),
            pinning_enabled ? magic_enum::enum_name(solana_cluster_identity_mode::pinned)
                            : magic_enum::enum_name(solana_cluster_identity_mode::unpinned));
    }
@@ -278,14 +260,11 @@ void outpost_solana_client_plugin::plugin_startup() {
 }
 
 void outpost_solana_client_plugin::set_program_options(options_description& cli, options_description& cfg) {
-   cfg.add_options()(
-      option_name_client,
-      boost::program_options::value<std::vector<std::string>>()->multitoken(),
-      "Outpost Solana Client spec, the plugin supports 1 to many clients in a given process. "
-      "Format: `<sol-client-id>,<sig-provider-id>,<rpc-url>`. The signer id must "
-      "match an explicitly named --signature-provider with the Solana target chain and key type")(
-      option_name_cluster_identity,
-      boost::program_options::value<std::vector<std::string>>()->multitoken(),
+   cfg.add_options()(option_name_client, boost::program_options::value<std::vector<std::string>>()->multitoken(),
+                     "Outpost Solana Client spec, the plugin supports 1 to many clients in a given process. "
+                     "Format: `<sol-client-id>,<sig-provider-id>,<rpc-url>`. The signer id must "
+                     "match an explicitly named --signature-provider with the Solana target chain and key type")(
+      option_name_cluster_identity, boost::program_options::value<std::vector<std::string>>()->multitoken(),
       "Optional staged Solana cluster identity pin. Format: "
       "`<sol-client-id>,<expected-genesis-hash>`. When this option is present, "
       "every configured Solana client must have exactly one canonical 32-byte "
@@ -293,13 +272,12 @@ void outpost_solana_client_plugin::set_program_options(options_description& cli,
       "with a prominent security warning")(
       option_name_identity_max_age,
       boost::program_options::value<uint32_t>()->default_value(default_identity_max_age_ms),
-      "Maximum age in milliseconds of a successful Solana cluster identity "
-      "observation before a protected read must reverify")(
+      "Maximum successful Solana cluster identity age in milliseconds used for freshness telemetry; protected RPCs "
+      "still preflight every call")(
       option_name_identity_timeout,
       boost::program_options::value<uint32_t>()->default_value(default_identity_probe_timeout_ms),
       "Maximum duration in milliseconds of each Solana cluster identity probe")(
-      option_idl_file,
-      boost::program_options::value<std::vector<std::filesystem::path>>()->multitoken(),
+      option_idl_file, boost::program_options::value<std::vector<std::filesystem::path>>()->multitoken(),
       "Solana program IDL file(s). Expects each file to be a JSON IDL (Anchor format) program definition.")(
       option_outpost_program_name,
       boost::program_options::value<std::string>()->default_value(OPP_SOLANA_OUTPOST_PROGRAM_NAME),
@@ -321,8 +299,7 @@ std::vector<solana_client_entry_ptr> outpost_solana_client_plugin::get_clients()
    return my->get_clients();
 }
 
-std::vector<solana_cluster_identity_snapshot>
-outpost_solana_client_plugin::get_cluster_identity_snapshots() {
+std::vector<solana_cluster_identity_snapshot> outpost_solana_client_plugin::get_cluster_identity_snapshots() {
    return my->get_cluster_identity_snapshots();
 }
 
@@ -335,12 +312,11 @@ outpost_solana_client_plugin::get_idl_files() {
    return my->get_idl_files();
 }
 
-std::shared_ptr<outpost_client>
-outpost_solana_client_plugin::create_outpost_client(const std::string&  sol_client_id,
-                                                  uint64_t            chain_code,
-                                                  uint32_t            chain_id,
-                                                  const std::string&  program_id,
-                                                  solana_outpost_role role) {
+std::shared_ptr<outpost_client> outpost_solana_client_plugin::create_outpost_client(const std::string& sol_client_id,
+                                                                                    uint64_t chain_code,
+                                                                                    uint32_t chain_id,
+                                                                                    const std::string& program_id,
+                                                                                    solana_outpost_role role) {
    auto entry = my->get_client(sol_client_id);
    FC_ASSERT(entry, "Unknown solana client id: {}", sol_client_id);
    FC_ASSERT(!program_id.empty(), "Solana program id is required");
@@ -354,11 +330,10 @@ outpost_solana_client_plugin::create_outpost_client(const std::string&  sol_clie
    FC_ASSERT(!program_idls.empty(),
              "IDL for program '{}' not loaded — pass --solana-idl-file (and --{} when the outpost "
              "IDL uses a different program name)",
-             my->outpost_program_name(),
-             option_outpost_program_name);
+             my->outpost_program_name(), option_outpost_program_name);
 
-   return std::make_shared<outpost_solana_client>(
-      entry, program_key, std::move(program_idls), chain_code, chain_id, role);
+   return std::make_shared<outpost_solana_client>(entry, program_key, std::move(program_idls), chain_code, chain_id,
+                                                  role);
 }
 
 std::vector<fc::network::solana::idl::program> filter_outpost_program_idls(

--- a/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
@@ -3,7 +3,7 @@
 #include <fc-test/build_info.hpp>
 #include <fc-test/crypto_utils.hpp>
 #include <fc-test/scripted_json_rpc_server.hpp>
-#include <fc/crypto/base58.hpp>
+#include <fc-test/solana_utils.hpp>
 #include <fc/crypto/base64.hpp>
 #include <fc/crypto/keccak256.hpp>
 #include <fc/io/json.hpp>
@@ -22,11 +22,16 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <future>
 #include <map>
+#include <memory>
 #include <set>
 #include <span>
+#include <thread>
 
 using namespace std::literals;
 using namespace fc::network::solana;
@@ -37,12 +42,6 @@ constexpr std::string_view counter_anchor_idl_fixture = "solana-idl-counter-anch
 constexpr std::string_view opp_outpost_idl_fixture = "solana-idl-opp-outpost-stub.json";
 constexpr std::string_view sec94_terminal_budget_fixture = "sec-94-solana-terminal-budget.json";
 constexpr std::string_view startup_test_rpc_url = "http://127.0.0.1:1";
-
-/** Return a deterministic canonical 32-byte Solana genesis hash. */
-std::string startup_test_genesis_hash(uint8_t seed) {
-   std::vector<char> bytes(32, static_cast<char>(seed));
-   return fc::to_base58(bytes, fc::yield_function_t{});
-}
 
 /** Build a named Solana signature-provider spec from the canonical fixture. */
 std::string named_solana_signature_provider(
@@ -337,8 +336,9 @@ BOOST_AUTO_TEST_CASE(startup_accepts_matching_named_signer) {
 }
 
 BOOST_AUTO_TEST_CASE(startup_accepts_complete_matching_cluster_identity) {
-   const auto genesis_hash = startup_test_genesis_hash(1);
+   const auto genesis_hash = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(genesis_hash),
       fc::test::scripted_json_rpc_response::result(genesis_hash),
    });
 
@@ -350,11 +350,50 @@ BOOST_AUTO_TEST_CASE(startup_accepts_complete_matching_cluster_identity) {
       "--outpost-solana-cluster-identity",
       "client-a," + genesis_hash,
    }));
-   BOOST_CHECK_EQUAL(server.request_count(), 1u);
+   BOOST_CHECK_EQUAL(server.request_count(), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(startup_validates_pinned_clients_concurrently) {
+   const auto genesis_hash = fc::test::solana_hash(1);
+   auto release_validations = std::make_shared<std::atomic_bool>(false);
+   fc::test::scripted_json_rpc_server first_server({
+      fc::test::scripted_json_rpc_response::gated_result(genesis_hash, release_validations),
+      fc::test::scripted_json_rpc_response::result(genesis_hash),
+   });
+   fc::test::scripted_json_rpc_server second_server({
+      fc::test::scripted_json_rpc_response::gated_result(genesis_hash, release_validations),
+      fc::test::scripted_json_rpc_response::result(genesis_hash),
+   });
+
+   auto initialization = std::async(std::launch::async, [&] {
+      initialize_outpost_plugin({
+         "--signature-provider",
+         named_solana_signature_provider(),
+         "--outpost-solana-client",
+         "client-a,signer-a," + first_server.url(),
+         "client-b,signer-a," + second_server.url(),
+         "--outpost-solana-cluster-identity",
+         "client-a," + genesis_hash,
+         "client-b," + genesis_hash,
+      });
+   });
+   const auto overlap_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+   while ((first_server.request_count() < 1 || second_server.request_count() < 1) &&
+          std::chrono::steady_clock::now() < overlap_deadline) {
+      std::this_thread::yield();
+   }
+   const bool validations_overlapped =
+      first_server.request_count() == 1 && second_server.request_count() == 1;
+   release_validations->store(true, std::memory_order_release);
+
+   BOOST_REQUIRE(validations_overlapped);
+   BOOST_CHECK_NO_THROW(initialization.get());
+   BOOST_CHECK_EQUAL(first_server.request_count(), 2u);
+   BOOST_CHECK_EQUAL(second_server.request_count(), 2u);
 }
 
 BOOST_AUTO_TEST_CASE(startup_rejects_partial_cluster_identity_configuration) {
-   const auto genesis_hash = startup_test_genesis_hash(1);
+   const auto genesis_hash = fc::test::solana_hash(1);
    BOOST_CHECK_THROW(initialize_outpost_plugin({
       "--signature-provider",
       named_solana_signature_provider(),
@@ -367,7 +406,7 @@ BOOST_AUTO_TEST_CASE(startup_rejects_partial_cluster_identity_configuration) {
 }
 
 BOOST_AUTO_TEST_CASE(startup_rejects_unknown_cluster_identity_client) {
-   const auto genesis_hash = startup_test_genesis_hash(1);
+   const auto genesis_hash = fc::test::solana_hash(1);
    BOOST_CHECK_THROW(initialize_outpost_plugin({
       "--signature-provider",
       named_solana_signature_provider(),
@@ -379,7 +418,7 @@ BOOST_AUTO_TEST_CASE(startup_rejects_unknown_cluster_identity_client) {
 }
 
 BOOST_AUTO_TEST_CASE(startup_rejects_duplicate_cluster_identity) {
-   const auto genesis_hash = startup_test_genesis_hash(1);
+   const auto genesis_hash = fc::test::solana_hash(1);
    BOOST_CHECK_THROW(initialize_outpost_plugin({
       "--signature-provider",
       named_solana_signature_provider(),
@@ -403,8 +442,8 @@ BOOST_AUTO_TEST_CASE(startup_rejects_malformed_expected_cluster_identity) {
 }
 
 BOOST_AUTO_TEST_CASE(startup_rejects_mismatched_observed_cluster_identity) {
-   const auto expected_hash = startup_test_genesis_hash(1);
-   const auto observed_hash = startup_test_genesis_hash(2);
+   const auto expected_hash = fc::test::solana_hash(1);
+   const auto observed_hash = fc::test::solana_hash(2);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::result(observed_hash),
    });
@@ -420,7 +459,7 @@ BOOST_AUTO_TEST_CASE(startup_rejects_mismatched_observed_cluster_identity) {
 }
 
 BOOST_AUTO_TEST_CASE(startup_hanging_cluster_identity_probe_obeys_deadline) {
-   const auto expected_hash = startup_test_genesis_hash(1);
+   const auto expected_hash = fc::test::solana_hash(1);
    fc::test::scripted_json_rpc_server server({
       fc::test::scripted_json_rpc_response::hanging(),
    });

--- a/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
@@ -2,6 +2,8 @@
 
 #include <fc-test/build_info.hpp>
 #include <fc-test/crypto_utils.hpp>
+#include <fc-test/scripted_json_rpc_server.hpp>
+#include <fc/crypto/base58.hpp>
 #include <fc/crypto/base64.hpp>
 #include <fc/crypto/keccak256.hpp>
 #include <fc/io/json.hpp>
@@ -35,6 +37,12 @@ constexpr std::string_view counter_anchor_idl_fixture = "solana-idl-counter-anch
 constexpr std::string_view opp_outpost_idl_fixture = "solana-idl-opp-outpost-stub.json";
 constexpr std::string_view sec94_terminal_budget_fixture = "sec-94-solana-terminal-budget.json";
 constexpr std::string_view startup_test_rpc_url = "http://127.0.0.1:1";
+
+/** Return a deterministic canonical 32-byte Solana genesis hash. */
+std::string startup_test_genesis_hash(uint8_t seed) {
+   std::vector<char> bytes(32, static_cast<char>(seed));
+   return fc::to_base58(bytes, fc::yield_function_t{});
+}
 
 /** Build a named Solana signature-provider spec from the canonical fixture. */
 std::string named_solana_signature_provider(
@@ -328,6 +336,107 @@ BOOST_AUTO_TEST_CASE(startup_accepts_matching_named_signer) {
    }));
 }
 
+BOOST_AUTO_TEST_CASE(startup_accepts_complete_matching_cluster_identity) {
+   const auto genesis_hash = startup_test_genesis_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(genesis_hash),
+   });
+
+   BOOST_CHECK_NO_THROW(initialize_outpost_plugin({
+      "--signature-provider",
+      named_solana_signature_provider(),
+      "--outpost-solana-client",
+      "client-a,signer-a," + server.url(),
+      "--outpost-solana-cluster-identity",
+      "client-a," + genesis_hash,
+   }));
+   BOOST_CHECK_EQUAL(server.request_count(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(startup_rejects_partial_cluster_identity_configuration) {
+   const auto genesis_hash = startup_test_genesis_hash(1);
+   BOOST_CHECK_THROW(initialize_outpost_plugin({
+      "--signature-provider",
+      named_solana_signature_provider(),
+      "--outpost-solana-client",
+      "client-a,signer-a," + std::string(startup_test_rpc_url),
+      "client-b,signer-a," + std::string(startup_test_rpc_url),
+      "--outpost-solana-cluster-identity",
+      "client-a," + genesis_hash,
+   }), sysio::chain::plugin_config_exception);
+}
+
+BOOST_AUTO_TEST_CASE(startup_rejects_unknown_cluster_identity_client) {
+   const auto genesis_hash = startup_test_genesis_hash(1);
+   BOOST_CHECK_THROW(initialize_outpost_plugin({
+      "--signature-provider",
+      named_solana_signature_provider(),
+      "--outpost-solana-client",
+      "client-a,signer-a," + std::string(startup_test_rpc_url),
+      "--outpost-solana-cluster-identity",
+      "client-b," + genesis_hash,
+   }), sysio::chain::plugin_config_exception);
+}
+
+BOOST_AUTO_TEST_CASE(startup_rejects_duplicate_cluster_identity) {
+   const auto genesis_hash = startup_test_genesis_hash(1);
+   BOOST_CHECK_THROW(initialize_outpost_plugin({
+      "--signature-provider",
+      named_solana_signature_provider(),
+      "--outpost-solana-client",
+      "client-a,signer-a," + std::string(startup_test_rpc_url),
+      "--outpost-solana-cluster-identity",
+      "client-a," + genesis_hash,
+      "client-a," + genesis_hash,
+   }), sysio::chain::plugin_config_exception);
+}
+
+BOOST_AUTO_TEST_CASE(startup_rejects_malformed_expected_cluster_identity) {
+   BOOST_CHECK_THROW(initialize_outpost_plugin({
+      "--signature-provider",
+      named_solana_signature_provider(),
+      "--outpost-solana-client",
+      "client-a,signer-a," + std::string(startup_test_rpc_url),
+      "--outpost-solana-cluster-identity",
+      "client-a,not-a-solana-genesis-hash",
+   }), sysio::chain::plugin_config_exception);
+}
+
+BOOST_AUTO_TEST_CASE(startup_rejects_mismatched_observed_cluster_identity) {
+   const auto expected_hash = startup_test_genesis_hash(1);
+   const auto observed_hash = startup_test_genesis_hash(2);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::result(observed_hash),
+   });
+
+   BOOST_CHECK_THROW(initialize_outpost_plugin({
+      "--signature-provider",
+      named_solana_signature_provider(),
+      "--outpost-solana-client",
+      "client-a,signer-a," + server.url(),
+      "--outpost-solana-cluster-identity",
+      "client-a," + expected_hash,
+   }), fc::exception);
+}
+
+BOOST_AUTO_TEST_CASE(startup_hanging_cluster_identity_probe_obeys_deadline) {
+   const auto expected_hash = startup_test_genesis_hash(1);
+   fc::test::scripted_json_rpc_server server({
+      fc::test::scripted_json_rpc_response::hanging(),
+   });
+
+   BOOST_CHECK_THROW(initialize_outpost_plugin({
+      "--signature-provider",
+      named_solana_signature_provider(),
+      "--outpost-solana-client",
+      "client-a,signer-a," + server.url(),
+      "--outpost-solana-cluster-identity",
+      "client-a," + expected_hash,
+      "--outpost-solana-cluster-identity-probe-timeout-ms",
+      "50",
+   }), fc::timeout_exception);
+}
+
 BOOST_AUTO_TEST_CASE(startup_rejects_client_without_matching_named_signature_provider) {
    BOOST_CHECK_THROW(initialize_outpost_plugin({
       "--signature-provider",
@@ -412,6 +521,30 @@ BOOST_AUTO_TEST_CASE(authenticated_transport_options_are_registered) {
    BOOST_CHECK(option_names.contains("outpost-solana-additional-ca-file"));
    BOOST_CHECK(option_names.contains("outpost-solana-additional-ca-path"));
    BOOST_CHECK(option_names.contains("outpost-solana-proxy"));
+   BOOST_CHECK(option_names.contains("outpost-solana-cluster-identity"));
+   BOOST_CHECK(option_names.contains("outpost-solana-cluster-identity-max-age-ms"));
+   BOOST_CHECK(option_names.contains("outpost-solana-cluster-identity-probe-timeout-ms"));
+}
+
+BOOST_AUTO_TEST_CASE(startup_redacts_malformed_credential_bearing_rpc_url) {
+   const std::string credential = "sec139-secret-value";
+   const std::string malformed_url =
+      "http://rpc-user:" + credential + "@127.0.0.1:not-a-port/private?api-key=" + credential;
+
+   try {
+      initialize_outpost_plugin({
+         "--signature-provider",
+         named_solana_signature_provider(),
+         "--outpost-solana-client",
+         "client-a,signer-a," + malformed_url,
+      });
+      BOOST_FAIL("Expected malformed RPC URL configuration to fail");
+   } catch (const sysio::chain::plugin_config_exception& error) {
+      const auto detail = error.to_detail_string();
+      BOOST_CHECK(detail.find("client-a") != std::string::npos);
+      BOOST_CHECK(detail.find(credential) == std::string::npos);
+      BOOST_CHECK(detail.find(malformed_url) == std::string::npos);
+   }
 }
 
 /** Caller overrides do not replace JSON-RPC's retain-until-failure DNS policy. */

--- a/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
@@ -522,7 +522,6 @@ BOOST_AUTO_TEST_CASE(authenticated_transport_options_are_registered) {
    BOOST_CHECK(option_names.contains("outpost-solana-additional-ca-path"));
    BOOST_CHECK(option_names.contains("outpost-solana-proxy"));
    BOOST_CHECK(option_names.contains("outpost-solana-cluster-identity"));
-   BOOST_CHECK(option_names.contains("outpost-solana-cluster-identity-max-age-ms"));
    BOOST_CHECK(option_names.contains("outpost-solana-cluster-identity-probe-timeout-ms"));
 }
 

--- a/plugins/outpost_solana_client_plugin/tools/solana_client_rpc_tool/main.cpp
+++ b/plugins/outpost_solana_client_plugin/tools/solana_client_rpc_tool/main.cpp
@@ -8,6 +8,7 @@
 #include <fc/time.hpp>
 
 #include <fc/log/logger_config.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <sysio/outpost_client_plugin.hpp>
 #include <sysio/outpost_solana_client_plugin.hpp>
 #include <sysio/version/version.hpp>
@@ -312,7 +313,11 @@ int main(int argc, char* argv[]) {
       auto client_entry = clients[0];
       auto& client = client_entry->client;
 
-      ilog("Connected to Solana RPC: {}", client_entry->url);
+      const auto identity = client_entry->client->get_cluster_identity_snapshot();
+      ilog("Connected to Solana RPC (client_id={},endpoint={},cluster_identity_mode={})",
+           client_entry->id,
+           identity.sanitized_endpoint,
+           magic_enum::enum_name(identity.mode));
       ilog("Signer public key: {}", client->get_pubkey().to_string(fc::yield_function_t{}));
 
       // Query basic chain information

--- a/plugins/prometheus_plugin/CMakeLists.txt
+++ b/plugins/prometheus_plugin/CMakeLists.txt
@@ -7,5 +7,5 @@ plugin_target(
         http_plugin
         chain_plugin
         net_plugin
+        outpost_solana_client_plugin
 )
-

--- a/plugins/prometheus_plugin/src/metrics.hpp
+++ b/plugins/prometheus_plugin/src/metrics.hpp
@@ -5,6 +5,7 @@
 #include <fc/network/http/http_client.hpp>
 #include <fc/network/solana/solana_client.hpp>
 #include <magic_enum/magic_enum.hpp>
+#include <limits>
 #include <map>
 #include <prometheus/counter.h>
 #include <prometheus/info.h>
@@ -141,8 +142,10 @@ struct catalog_type {
       prometheus::Family<Counter>& verification_successes;
       prometheus::Family<Counter>& verification_mismatches;
       prometheus::Family<Counter>& verification_failures;
+      prometheus::Family<Counter>& verification_cancellations;
       prometheus::Family<Counter>& verification_recoveries;
       prometheus::Family<Counter>& blocked_operations;
+      prometheus::Family<Counter>& protected_operation_failures;
    };
    solana_cluster_identity_metrics solana_identity_metrics;
 
@@ -154,8 +157,10 @@ struct catalog_type {
       Counter* verification_successes = nullptr;
       Counter* verification_mismatches = nullptr;
       Counter* verification_failures = nullptr;
+      Counter* verification_cancellations = nullptr;
       Counter* verification_recoveries = nullptr;
       std::map<fc::network::solana::solana_cluster_identity_operation, Counter*> blocked_operations;
+      std::map<fc::network::solana::solana_cluster_identity_operation, Counter*> protected_operation_failures;
       fc::network::solana::solana_cluster_identity_snapshot previous;
    };
    std::unordered_map<std::string, tracked_solana_identity_series> tracked_solana_identity_series_by_client;
@@ -255,7 +260,7 @@ struct catalog_type {
                "Current Solana cluster identity mode, status, and reason (always 1)")}
           , .verification_age_seconds{family<Gauge>(
                "nodeop_solana_cluster_identity_verification_age_seconds",
-               "Age of the last successful Solana cluster identity verification; -1 when never verified")}
+               "Age of the last successful Solana cluster identity verification; NaN when never verified")}
           , .verification_attempts{family<Counter>(
                "nodeop_solana_cluster_identity_verification_attempts_total",
                "Total Solana cluster identity verification attempts")}
@@ -268,12 +273,18 @@ struct catalog_type {
           , .verification_failures{family<Counter>(
                "nodeop_solana_cluster_identity_verification_failures_total",
                "Total Solana cluster identity verification transport or format failures")}
+          , .verification_cancellations{family<Counter>(
+               "nodeop_solana_cluster_identity_verification_cancellations_total",
+               "Total Solana cluster identity verifications cancelled by the local caller")}
           , .verification_recoveries{family<Counter>(
                "nodeop_solana_cluster_identity_verification_recoveries_total",
                "Total Solana cluster identity verification recoveries")}
           , .blocked_operations{family<Counter>(
                "nodeop_solana_cluster_identity_blocked_operations_total",
                "Total protected Solana operations blocked by cluster identity verification")}
+          , .protected_operation_failures{family<Counter>(
+               "nodeop_solana_cluster_identity_protected_operation_failures_total",
+               "Total pinned Solana RPC operations that failed before returning a result")}
          } {
       for (const auto failure : magic_enum::enum_values<fc::http::failure_kind>()) {
          const auto index = magic_enum::enum_index(failure);
@@ -405,25 +416,37 @@ struct catalog_type {
             series.verification_successes = &solana_identity_metrics.verification_successes.Add(client_labels);
             series.verification_mismatches = &solana_identity_metrics.verification_mismatches.Add(client_labels);
             series.verification_failures = &solana_identity_metrics.verification_failures.Add(client_labels);
+            series.verification_cancellations =
+               &solana_identity_metrics.verification_cancellations.Add(client_labels);
             series.verification_recoveries = &solana_identity_metrics.verification_recoveries.Add(client_labels);
             for (const auto operation : magic_enum::enum_values<solana_cluster_identity_operation>()) {
                auto operation_labels = client_labels;
                operation_labels.emplace("operation", std::string(magic_enum::enum_name(operation)));
                series.blocked_operations.emplace(operation,
                                                  &solana_identity_metrics.blocked_operations.Add(operation_labels));
+               series.protected_operation_failures.emplace(
+                  operation,
+                  &solana_identity_metrics.protected_operation_failures.Add(operation_labels));
             }
-         } else {
-            solana_identity_metrics.state.Remove(series.state);
          }
 
-         auto state_labels = client_labels;
-         state_labels.emplace("mode", std::string(magic_enum::enum_name(snapshot.mode)));
-         state_labels.emplace("status", std::string(magic_enum::enum_name(snapshot.status)));
-         state_labels.emplace("reason", std::string(magic_enum::enum_name(snapshot.reason)));
-         series.state = &solana_identity_metrics.state.Add(state_labels);
-         series.state->Set(1);
+         const bool state_changed =
+            inserted || snapshot.mode != series.previous.mode || snapshot.status != series.previous.status ||
+            snapshot.reason != series.previous.reason;
+         if (state_changed && !inserted)
+            solana_identity_metrics.state.Remove(series.state);
+         if (state_changed) {
+            auto state_labels = client_labels;
+            state_labels.emplace("mode", std::string(magic_enum::enum_name(snapshot.mode)));
+            state_labels.emplace("status", std::string(magic_enum::enum_name(snapshot.status)));
+            state_labels.emplace("reason", std::string(magic_enum::enum_name(snapshot.reason)));
+            series.state = &solana_identity_metrics.state.Add(state_labels);
+            series.state->Set(1);
+         }
          series.verification_age_seconds->Set(
-            snapshot.verification_age ? static_cast<double>(snapshot.verification_age->count()) / 1'000'000.0 : -1.0);
+            snapshot.verification_age
+               ? static_cast<double>(snapshot.verification_age->count()) / 1'000'000.0
+               : std::numeric_limits<double>::quiet_NaN());
 
          increment_from_snapshot(*series.verification_attempts, snapshot.verification_attempts,
                                  series.previous.verification_attempts);
@@ -433,6 +456,8 @@ struct catalog_type {
                                  series.previous.verification_mismatches);
          increment_from_snapshot(*series.verification_failures, snapshot.verification_failures,
                                  series.previous.verification_failures);
+         increment_from_snapshot(*series.verification_cancellations, snapshot.verification_cancellations,
+                                 series.previous.verification_cancellations);
          increment_from_snapshot(*series.verification_recoveries, snapshot.verification_recoveries,
                                  series.previous.verification_recoveries);
          for (const auto operation : magic_enum::enum_values<solana_cluster_identity_operation>()) {
@@ -442,6 +467,15 @@ struct catalog_type {
                                      ? series.previous.blocked_operations.at(operation)
                                      : 0;
             increment_from_snapshot(*series.blocked_operations.at(operation), current, previous);
+
+            const auto protected_current = snapshot.protected_operation_failures.contains(operation)
+                                              ? snapshot.protected_operation_failures.at(operation)
+                                              : 0;
+            const auto protected_previous = series.previous.protected_operation_failures.contains(operation)
+                                               ? series.previous.protected_operation_failures.at(operation)
+                                               : 0;
+            increment_from_snapshot(*series.protected_operation_failures.at(operation), protected_current,
+                                    protected_previous);
          }
          series.previous = snapshot;
       }
@@ -460,10 +494,15 @@ struct catalog_type {
          solana_identity_metrics.verification_successes.Remove(series.verification_successes);
          solana_identity_metrics.verification_mismatches.Remove(series.verification_mismatches);
          solana_identity_metrics.verification_failures.Remove(series.verification_failures);
+         solana_identity_metrics.verification_cancellations.Remove(series.verification_cancellations);
          solana_identity_metrics.verification_recoveries.Remove(series.verification_recoveries);
          for (const auto& [operation, counter] : series.blocked_operations) {
             (void)operation;
             solana_identity_metrics.blocked_operations.Remove(counter);
+         }
+         for (const auto& [operation, counter] : series.protected_operation_failures) {
+            (void)operation;
+            solana_identity_metrics.protected_operation_failures.Remove(counter);
          }
          it = tracked_solana_identity_series_by_client.erase(it);
       }

--- a/plugins/prometheus_plugin/src/metrics.hpp
+++ b/plugins/prometheus_plugin/src/metrics.hpp
@@ -6,6 +6,8 @@
 #include <sysio/chain_plugin/tracked_votes.hpp>
 
 #include <fc/network/http/http_client.hpp>
+#include <fc/network/solana/solana_client.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <prometheus/counter.h>
 #include <prometheus/info.h>
 #include <prometheus/registry.h>
@@ -13,6 +15,7 @@
 #include <fc/log/logger.hpp>
 
 #include <array>
+#include <map>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -132,6 +135,35 @@ struct catalog_type {
    Counter& bytes_transferred;
    Counter& num_scrapes;
 
+   /** Families exposing bounded-cardinality Solana identity verification telemetry. */
+   struct solana_cluster_identity_metrics {
+      prometheus::Family<Gauge>& state;
+      prometheus::Family<Gauge>& verification_age_seconds;
+      prometheus::Family<Gauge>& transport_session_id;
+      prometheus::Family<Counter>& verification_attempts;
+      prometheus::Family<Counter>& verification_successes;
+      prometheus::Family<Counter>& verification_mismatches;
+      prometheus::Family<Counter>& verification_failures;
+      prometheus::Family<Counter>& verification_recoveries;
+      prometheus::Family<Counter>& blocked_operations;
+   };
+   solana_cluster_identity_metrics solana_identity_metrics;
+
+   /** Live Prometheus handles and previous cumulative values for one configured client. */
+   struct tracked_solana_identity_series {
+      Gauge* state = nullptr;
+      Gauge* verification_age_seconds = nullptr;
+      Gauge* transport_session_id = nullptr;
+      Counter* verification_attempts = nullptr;
+      Counter* verification_successes = nullptr;
+      Counter* verification_mismatches = nullptr;
+      Counter* verification_failures = nullptr;
+      Counter* verification_recoveries = nullptr;
+      std::map<fc::network::solana::solana_cluster_identity_operation, Counter*> blocked_operations;
+      fc::network::solana::solana_cluster_identity_snapshot previous;
+   };
+   std::unordered_map<std::string, tracked_solana_identity_series>
+      tracked_solana_identity_series_by_client;
 
    catalog_type()
        : info(family<prometheus::Info>("nodeop", "static information about the server"))
@@ -221,7 +253,36 @@ struct catalog_type {
        , blocks_incoming(build<Counter>("nodeop_blocks_incoming", "number of incoming blocks"))
        , bytes_transferred(build<Counter>("exposer_transferred_bytes_total",
                                           "total number of bytes for responses to prometheus scrape requests"))
-       , num_scrapes(build<Counter>("exposer_scrapes_total", "total number of prometheus scrape requests received")) {
+       , num_scrapes(build<Counter>("exposer_scrapes_total", "total number of prometheus scrape requests received"))
+       , solana_identity_metrics{
+            .state{family<Gauge>(
+               "nodeop_solana_cluster_identity",
+               "Current Solana cluster identity mode, status, and reason (always 1)")}
+          , .verification_age_seconds{family<Gauge>(
+               "nodeop_solana_cluster_identity_verification_age_seconds",
+               "Age of the last successful Solana cluster identity verification; -1 when never verified")}
+          , .transport_session_id{family<Gauge>(
+               "nodeop_solana_cluster_identity_transport_session_id",
+               "Process-local authenticated transport session used for the last Solana identity verification")}
+          , .verification_attempts{family<Counter>(
+               "nodeop_solana_cluster_identity_verification_attempts_total",
+               "Total Solana cluster identity verification attempts")}
+          , .verification_successes{family<Counter>(
+               "nodeop_solana_cluster_identity_verification_successes_total",
+               "Total successful Solana cluster identity verifications")}
+          , .verification_mismatches{family<Counter>(
+               "nodeop_solana_cluster_identity_verification_mismatches_total",
+               "Total Solana cluster identity mismatches")}
+          , .verification_failures{family<Counter>(
+               "nodeop_solana_cluster_identity_verification_failures_total",
+               "Total Solana cluster identity verification transport or format failures")}
+          , .verification_recoveries{family<Counter>(
+               "nodeop_solana_cluster_identity_verification_recoveries_total",
+               "Total Solana cluster identity verification recoveries")}
+          , .blocked_operations{family<Counter>(
+               "nodeop_solana_cluster_identity_blocked_operations_total",
+               "Total protected Solana operations blocked by cluster identity verification")}
+         } {
       for (const auto failure : magic_enum::enum_values<fc::http::failure_kind>()) {
          const auto index = magic_enum::enum_index(failure);
          FC_ASSERT(index, "Unknown outbound HTTP failure kind");
@@ -318,6 +379,109 @@ struct catalog_type {
          } else {
             ++it;
          }
+      }
+   }
+
+   /** Refresh credential-free Solana identity series from plugin snapshots. */
+   void update(const std::vector<fc::network::solana::solana_cluster_identity_snapshot>& snapshots) {
+      using namespace fc::network::solana;
+
+      std::unordered_set<std::string> live_clients;
+      live_clients.reserve(snapshots.size());
+
+      auto increment_from_snapshot = [](Counter& counter, std::uint64_t current, std::uint64_t previous) {
+         counter.Increment(current >= previous ? current - previous : current);
+      };
+
+      for (const auto& snapshot : snapshots) {
+         live_clients.insert(snapshot.client_id);
+         auto [it, inserted] =
+            tracked_solana_identity_series_by_client.try_emplace(snapshot.client_id);
+         auto& series = it->second;
+         const prometheus::Labels client_labels{{"client_id", snapshot.client_id}};
+
+         if (inserted) {
+            series.verification_age_seconds =
+               &solana_identity_metrics.verification_age_seconds.Add(client_labels);
+            series.transport_session_id =
+               &solana_identity_metrics.transport_session_id.Add(client_labels);
+            series.verification_attempts =
+               &solana_identity_metrics.verification_attempts.Add(client_labels);
+            series.verification_successes =
+               &solana_identity_metrics.verification_successes.Add(client_labels);
+            series.verification_mismatches =
+               &solana_identity_metrics.verification_mismatches.Add(client_labels);
+            series.verification_failures =
+               &solana_identity_metrics.verification_failures.Add(client_labels);
+            series.verification_recoveries =
+               &solana_identity_metrics.verification_recoveries.Add(client_labels);
+            for (const auto operation :
+                 magic_enum::enum_values<solana_cluster_identity_operation>()) {
+               auto operation_labels = client_labels;
+               operation_labels.emplace("operation", std::string(magic_enum::enum_name(operation)));
+               series.blocked_operations.emplace(
+                  operation, &solana_identity_metrics.blocked_operations.Add(operation_labels));
+            }
+         } else {
+            solana_identity_metrics.state.Remove(series.state);
+         }
+
+         auto state_labels = client_labels;
+         state_labels.emplace("mode", std::string(magic_enum::enum_name(snapshot.mode)));
+         state_labels.emplace("status", std::string(magic_enum::enum_name(snapshot.status)));
+         state_labels.emplace("reason", std::string(magic_enum::enum_name(snapshot.reason)));
+         series.state = &solana_identity_metrics.state.Add(state_labels);
+         series.state->Set(1);
+         series.verification_age_seconds->Set(
+            snapshot.verification_age
+               ? static_cast<double>(snapshot.verification_age->count()) / 1'000'000.0
+               : -1.0);
+         series.transport_session_id->Set(snapshot.transport_session_id);
+
+         increment_from_snapshot(*series.verification_attempts, snapshot.verification_attempts,
+                                 series.previous.verification_attempts);
+         increment_from_snapshot(*series.verification_successes, snapshot.verification_successes,
+                                 series.previous.verification_successes);
+         increment_from_snapshot(*series.verification_mismatches, snapshot.verification_mismatches,
+                                 series.previous.verification_mismatches);
+         increment_from_snapshot(*series.verification_failures, snapshot.verification_failures,
+                                 series.previous.verification_failures);
+         increment_from_snapshot(*series.verification_recoveries, snapshot.verification_recoveries,
+                                 series.previous.verification_recoveries);
+         for (const auto operation :
+              magic_enum::enum_values<solana_cluster_identity_operation>()) {
+            const auto current = snapshot.blocked_operations.contains(operation)
+                                    ? snapshot.blocked_operations.at(operation)
+                                    : 0;
+            const auto previous = series.previous.blocked_operations.contains(operation)
+                                     ? series.previous.blocked_operations.at(operation)
+                                     : 0;
+            increment_from_snapshot(*series.blocked_operations.at(operation), current, previous);
+         }
+         series.previous = snapshot;
+      }
+
+      for (auto it = tracked_solana_identity_series_by_client.begin();
+           it != tracked_solana_identity_series_by_client.end();) {
+         if (live_clients.contains(it->first)) {
+            ++it;
+            continue;
+         }
+
+         auto& series = it->second;
+         solana_identity_metrics.state.Remove(series.state);
+         solana_identity_metrics.verification_age_seconds.Remove(series.verification_age_seconds);
+         solana_identity_metrics.transport_session_id.Remove(series.transport_session_id);
+         solana_identity_metrics.verification_attempts.Remove(series.verification_attempts);
+         solana_identity_metrics.verification_successes.Remove(series.verification_successes);
+         solana_identity_metrics.verification_mismatches.Remove(series.verification_mismatches);
+         solana_identity_metrics.verification_failures.Remove(series.verification_failures);
+         solana_identity_metrics.verification_recoveries.Remove(series.verification_recoveries);
+         for (const auto& [operation, counter] : series.blocked_operations) {
+            (void)operation;
+            solana_identity_metrics.blocked_operations.Remove(counter);
+         }
+         it = tracked_solana_identity_series_by_client.erase(it);
       }
    }
 

--- a/plugins/prometheus_plugin/src/metrics.hpp
+++ b/plugins/prometheus_plugin/src/metrics.hpp
@@ -1,22 +1,20 @@
 #pragma once
 
-#include <sysio/http_plugin/http_plugin.hpp>
-#include <sysio/net_plugin/net_plugin.hpp>
-#include <sysio/producer_plugin/producer_plugin.hpp>
-#include <sysio/chain_plugin/tracked_votes.hpp>
-
+#include <array>
+#include <fc/log/logger.hpp>
 #include <fc/network/http/http_client.hpp>
 #include <fc/network/solana/solana_client.hpp>
 #include <magic_enum/magic_enum.hpp>
+#include <map>
 #include <prometheus/counter.h>
 #include <prometheus/info.h>
 #include <prometheus/registry.h>
 #include <prometheus/text_serializer.h>
-#include <fc/log/logger.hpp>
-
-#include <array>
-#include <map>
 #include <string>
+#include <sysio/chain_plugin/tracked_votes.hpp>
+#include <sysio/http_plugin/http_plugin.hpp>
+#include <sysio/net_plugin/net_plugin.hpp>
+#include <sysio/producer_plugin/producer_plugin.hpp>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -26,7 +24,7 @@ namespace sysio::metrics {
 
 struct catalog_type {
 
-   using Gauge   = prometheus::Gauge;
+   using Gauge = prometheus::Gauge;
    using Counter = prometheus::Counter;
 
    template <typename T>
@@ -96,7 +94,7 @@ struct catalog_type {
 
    struct block_metrics {
       Counter& num_blocks_created;
-      Gauge&   current_block_num;
+      Gauge& current_block_num;
       Counter& block_total_time_us_block;
       Counter& block_idle_time_us_block;
       Counter& block_num_success_trx_block;
@@ -139,7 +137,6 @@ struct catalog_type {
    struct solana_cluster_identity_metrics {
       prometheus::Family<Gauge>& state;
       prometheus::Family<Gauge>& verification_age_seconds;
-      prometheus::Family<Gauge>& transport_session_id;
       prometheus::Family<Counter>& verification_attempts;
       prometheus::Family<Counter>& verification_successes;
       prometheus::Family<Counter>& verification_mismatches;
@@ -153,7 +150,6 @@ struct catalog_type {
    struct tracked_solana_identity_series {
       Gauge* state = nullptr;
       Gauge* verification_age_seconds = nullptr;
-      Gauge* transport_session_id = nullptr;
       Counter* verification_attempts = nullptr;
       Counter* verification_successes = nullptr;
       Counter* verification_mismatches = nullptr;
@@ -162,8 +158,7 @@ struct catalog_type {
       std::map<fc::network::solana::solana_cluster_identity_operation, Counter*> blocked_operations;
       fc::network::solana::solana_cluster_identity_snapshot previous;
    };
-   std::unordered_map<std::string, tracked_solana_identity_series>
-      tracked_solana_identity_series_by_client;
+   std::unordered_map<std::string, tracked_solana_identity_series> tracked_solana_identity_series_by_client;
 
    catalog_type()
        : info(family<prometheus::Info>("nodeop", "static information about the server"))
@@ -261,9 +256,6 @@ struct catalog_type {
           , .verification_age_seconds{family<Gauge>(
                "nodeop_solana_cluster_identity_verification_age_seconds",
                "Age of the last successful Solana cluster identity verification; -1 when never verified")}
-          , .transport_session_id{family<Gauge>(
-               "nodeop_solana_cluster_identity_transport_session_id",
-               "Process-local authenticated transport session used for the last Solana identity verification")}
           , .verification_attempts{family<Counter>(
                "nodeop_solana_cluster_identity_verification_attempts_total",
                "Total Solana cluster identity verification attempts")}
@@ -286,15 +278,16 @@ struct catalog_type {
       for (const auto failure : magic_enum::enum_values<fc::http::failure_kind>()) {
          const auto index = magic_enum::enum_index(failure);
          FC_ASSERT(index, "Unknown outbound HTTP failure kind");
-         outbound_http_failure_counts[*index] =
-            &outbound_http_failures.Add({{"category", std::string(fc::http::failure_kind_name(failure))}});
+         outbound_http_failure_counts[*index] = &outbound_http_failures.Add({
+            {"category", std::string(fc::http::failure_kind_name(failure))}
+         });
       }
    }
 
    std::string report() {
       update_outbound_http_metrics();
       const prometheus::TextSerializer serializer;
-      auto                             result = serializer.Serialize(registry.Collect());
+      auto result = serializer.Serialize(registry.Collect());
       bytes_transferred.Increment(result.size());
       num_scrapes.Increment(1);
       return result;
@@ -305,21 +298,23 @@ struct catalog_type {
       const auto current = fc::http::get_metrics_snapshot();
       outbound_http_requests.Increment(current.requests - last_outbound_http_metrics.requests);
       outbound_http_successes.Increment(current.successes - last_outbound_http_metrics.successes);
-      outbound_http_request_bytes.Increment(
-         current.request_bytes - last_outbound_http_metrics.request_bytes);
-      outbound_http_response_bytes.Increment(
-         current.response_bytes - last_outbound_http_metrics.response_bytes);
+      outbound_http_request_bytes.Increment(current.request_bytes - last_outbound_http_metrics.request_bytes);
+      outbound_http_response_bytes.Increment(current.response_bytes - last_outbound_http_metrics.response_bytes);
       for (const auto failure : magic_enum::enum_values<fc::http::failure_kind>()) {
          const auto index = magic_enum::enum_index(failure);
          FC_ASSERT(index, "Unknown outbound HTTP failure kind");
-         outbound_http_failure_counts[*index]->Increment(
-            current.failures[*index] - last_outbound_http_metrics.failures[*index]);
+         outbound_http_failure_counts[*index]->Increment(current.failures[*index] -
+                                                         last_outbound_http_metrics.failures[*index]);
       }
       last_outbound_http_metrics = current;
    }
 
    void update(const http_plugin::metrics& metrics) {
-      http_request_counts.Add({{"handler", metrics.target}}).Increment(1);
+      http_request_counts
+         .Add({
+            {"handler", metrics.target}
+      })
+         .Increment(1);
    }
 
    void update(const net_plugin::p2p_connections_metrics& metrics) {
@@ -335,12 +330,15 @@ struct catalog_type {
 
       for (const auto& peer : metrics.stats.peers) {
          const std::string remote_ip = boost::asio::ip::make_address_v6(peer.address).to_string();
-         const std::string conn_num  = std::to_string(peer.connection_id);
-         const std::string key       = remote_ip + '|' + conn_num;
+         const std::string conn_num = std::to_string(peer.connection_id);
+         const std::string key = remote_ip + '|' + conn_num;
          live_keys.insert(key);
 
-         const prometheus::Labels labels{{"remote_ip", remote_ip}, {"connection_id", conn_num}};
-         auto&      handles    = tracked_p2p_series[key];
+         const prometheus::Labels labels{
+            {"remote_ip",     remote_ip},
+            {"connection_id", conn_num }
+         };
+         auto& handles = tracked_p2p_series[key];
          const bool first_seen = handles.empty();
 
          auto add_and_set_gauge = [&](prometheus::Family<Gauge>& fam, const auto& value) {
@@ -395,32 +393,24 @@ struct catalog_type {
 
       for (const auto& snapshot : snapshots) {
          live_clients.insert(snapshot.client_id);
-         auto [it, inserted] =
-            tracked_solana_identity_series_by_client.try_emplace(snapshot.client_id);
+         auto [it, inserted] = tracked_solana_identity_series_by_client.try_emplace(snapshot.client_id);
          auto& series = it->second;
-         const prometheus::Labels client_labels{{"client_id", snapshot.client_id}};
+         const prometheus::Labels client_labels{
+            {"client_id", snapshot.client_id}
+         };
 
          if (inserted) {
-            series.verification_age_seconds =
-               &solana_identity_metrics.verification_age_seconds.Add(client_labels);
-            series.transport_session_id =
-               &solana_identity_metrics.transport_session_id.Add(client_labels);
-            series.verification_attempts =
-               &solana_identity_metrics.verification_attempts.Add(client_labels);
-            series.verification_successes =
-               &solana_identity_metrics.verification_successes.Add(client_labels);
-            series.verification_mismatches =
-               &solana_identity_metrics.verification_mismatches.Add(client_labels);
-            series.verification_failures =
-               &solana_identity_metrics.verification_failures.Add(client_labels);
-            series.verification_recoveries =
-               &solana_identity_metrics.verification_recoveries.Add(client_labels);
-            for (const auto operation :
-                 magic_enum::enum_values<solana_cluster_identity_operation>()) {
+            series.verification_age_seconds = &solana_identity_metrics.verification_age_seconds.Add(client_labels);
+            series.verification_attempts = &solana_identity_metrics.verification_attempts.Add(client_labels);
+            series.verification_successes = &solana_identity_metrics.verification_successes.Add(client_labels);
+            series.verification_mismatches = &solana_identity_metrics.verification_mismatches.Add(client_labels);
+            series.verification_failures = &solana_identity_metrics.verification_failures.Add(client_labels);
+            series.verification_recoveries = &solana_identity_metrics.verification_recoveries.Add(client_labels);
+            for (const auto operation : magic_enum::enum_values<solana_cluster_identity_operation>()) {
                auto operation_labels = client_labels;
                operation_labels.emplace("operation", std::string(magic_enum::enum_name(operation)));
-               series.blocked_operations.emplace(
-                  operation, &solana_identity_metrics.blocked_operations.Add(operation_labels));
+               series.blocked_operations.emplace(operation,
+                                                 &solana_identity_metrics.blocked_operations.Add(operation_labels));
             }
          } else {
             solana_identity_metrics.state.Remove(series.state);
@@ -433,10 +423,7 @@ struct catalog_type {
          series.state = &solana_identity_metrics.state.Add(state_labels);
          series.state->Set(1);
          series.verification_age_seconds->Set(
-            snapshot.verification_age
-               ? static_cast<double>(snapshot.verification_age->count()) / 1'000'000.0
-               : -1.0);
-         series.transport_session_id->Set(snapshot.transport_session_id);
+            snapshot.verification_age ? static_cast<double>(snapshot.verification_age->count()) / 1'000'000.0 : -1.0);
 
          increment_from_snapshot(*series.verification_attempts, snapshot.verification_attempts,
                                  series.previous.verification_attempts);
@@ -448,11 +435,9 @@ struct catalog_type {
                                  series.previous.verification_failures);
          increment_from_snapshot(*series.verification_recoveries, snapshot.verification_recoveries,
                                  series.previous.verification_recoveries);
-         for (const auto operation :
-              magic_enum::enum_values<solana_cluster_identity_operation>()) {
-            const auto current = snapshot.blocked_operations.contains(operation)
-                                    ? snapshot.blocked_operations.at(operation)
-                                    : 0;
+         for (const auto operation : magic_enum::enum_values<solana_cluster_identity_operation>()) {
+            const auto current =
+               snapshot.blocked_operations.contains(operation) ? snapshot.blocked_operations.at(operation) : 0;
             const auto previous = series.previous.blocked_operations.contains(operation)
                                      ? series.previous.blocked_operations.at(operation)
                                      : 0;
@@ -471,7 +456,6 @@ struct catalog_type {
          auto& series = it->second;
          solana_identity_metrics.state.Remove(series.state);
          solana_identity_metrics.verification_age_seconds.Remove(series.verification_age_seconds);
-         solana_identity_metrics.transport_session_id.Remove(series.transport_session_id);
          solana_identity_metrics.verification_attempts.Remove(series.verification_attempts);
          solana_identity_metrics.verification_successes.Remove(series.verification_successes);
          solana_identity_metrics.verification_mismatches.Remove(series.verification_mismatches);
@@ -515,9 +499,7 @@ struct catalog_type {
       head_block_num.Set(metrics.head_block_num);
    }
 
-   void update(const speculative_block_metrics& metrics) {
-      update(speculative_metrics, metrics);
-   }
+   void update(const speculative_block_metrics& metrics) { update(speculative_metrics, metrics); }
 
    void update(const incoming_block_metrics& metrics) {
       trxs_incoming_total.Increment(metrics.trxs_incoming_total);
@@ -534,17 +516,19 @@ struct catalog_type {
 
    void update_prometheus_info() {
       info_details = info.Add({
-            {"server_version", fc::itoh(static_cast<uint32_t>(app().version()))},
-            {"chain_id", app().get_plugin<chain_plugin>().get_chain_id().str()},
-            {"server_version_string", app().version_string()},
-            {"server_full_version_string", app().full_version_string()},
-            {"earliest_available_block_num", to_string(app().get_plugin<chain_plugin>().chain().earliest_available_block_num())}
-         });
+         {"server_version",               fc::itoh(static_cast<uint32_t>(app().version()))     },
+         {"chain_id",                     app().get_plugin<chain_plugin>().get_chain_id().str()},
+         {"server_version_string",        app().version_string()                               },
+         {"server_full_version_string",   app().full_version_string()                          },
+         {"earliest_available_block_num",
+          to_string(app().get_plugin<chain_plugin>().chain().earliest_available_block_num())   }
+      });
    }
    void register_update_handlers(boost::asio::io_context::strand& strand) {
       auto& http = app().get_plugin<http_plugin>();
-      http.register_update_metrics(
-          [&strand, this](http_plugin::metrics metrics) { boost::asio::post(strand, [metrics = std::move(metrics), this]() { update(metrics); }); });
+      http.register_update_metrics([&strand, this](http_plugin::metrics metrics) {
+         boost::asio::post(strand, [metrics = std::move(metrics), this]() { update(metrics); });
+      });
 
       auto& net = app().get_plugin<net_plugin>();
 
@@ -556,26 +540,23 @@ struct catalog_type {
          // Increment is thread safe
          failed_p2p_connections.Increment(1);
       });
-      net.register_increment_dropped_trxs([this]() { 
+      net.register_increment_dropped_trxs([this]() {
          // Increment is thread safe
          dropped_trxs_total.Increment(1);
       });
 
       auto& producer = app().get_plugin<producer_plugin>();
-      producer.register_update_speculative_block_metrics(
-              [&strand, this](const speculative_block_metrics& metrics) {
-                 boost::asio::post(strand,[metrics, this]() { update(metrics); });
-              });
+      producer.register_update_speculative_block_metrics([&strand, this](const speculative_block_metrics& metrics) {
+         boost::asio::post(strand, [metrics, this]() { update(metrics); });
+      });
 
       auto& chain = app().get_plugin<chain_plugin>().chain();
-      chain.register_update_produced_block_metrics(
-          [&strand, this](const produced_block_metrics& metrics) {
-             boost::asio::post(strand, [metrics, this]() { update(metrics); });
-          });
-      chain.register_update_incoming_block_metrics(
-          [&strand, this](const incoming_block_metrics& metrics) {
-             boost::asio::post(strand, [metrics, this]() { update(metrics); });
-          });
+      chain.register_update_produced_block_metrics([&strand, this](const produced_block_metrics& metrics) {
+         boost::asio::post(strand, [metrics, this]() { update(metrics); });
+      });
+      chain.register_update_incoming_block_metrics([&strand, this](const incoming_block_metrics& metrics) {
+         boost::asio::post(strand, [metrics, this]() { update(metrics); });
+      });
    }
 };
 

--- a/plugins/prometheus_plugin/src/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/src/prometheus_plugin.cpp
@@ -4,6 +4,7 @@
 #include <sysio/chain/thread_utils.hpp>
 #include <sysio/http_plugin/macros.hpp>
 #include <sysio/http_plugin/http_plugin.hpp>
+#include <sysio/outpost_solana_client_plugin.hpp>
 
 #include <fc/log/logger.hpp>
 
@@ -39,6 +40,9 @@ namespace sysio {
 
       void metrics(const fc::variant_object&, chain::plugin_interface::next_function<std::string> results) {
          boost::asio::post(_impl->_prometheus_strand, [this, results=std::move(results)]() {
+            if (auto* solana_plugin = app().find_plugin<outpost_solana_client_plugin>()) {
+               _impl->_catalog.update(solana_plugin->get_cluster_identity_snapshots());
+            }
             results(_impl->_catalog.report());
          });
       }

--- a/plugins/prometheus_plugin/src/prometheus_plugin.cpp
+++ b/plugins/prometheus_plugin/src/prometheus_plugin.cpp
@@ -14,12 +14,16 @@ namespace sysio {
 
    using namespace prometheus;
 
+   constexpr int optional_metrics_fallback_priority = 1'000;
+
    struct prometheus_plugin_impl {
 
       sysio::chain::named_thread_pool<struct prom> _prometheus_thread_pool;
       boost::asio::io_context::strand              _prometheus_strand{_prometheus_thread_pool.get_executor()};
       metrics::catalog_type                        _catalog;
       fc::microseconds                             _max_response_time_us;
+      solana_cluster_identity_metrics::snapshot_provider::method_type* _solana_identity_snapshots = nullptr;
+      solana_cluster_identity_metrics::snapshot_provider::method_type::handle _empty_solana_identity_snapshots;
    };
 
    prometheus_plugin::prometheus_plugin()
@@ -40,9 +44,7 @@ namespace sysio {
 
       void metrics(const fc::variant_object&, chain::plugin_interface::next_function<std::string> results) {
          boost::asio::post(_impl->_prometheus_strand, [this, results=std::move(results)]() {
-            if (auto* solana_plugin = app().find_plugin<outpost_solana_client_plugin>()) {
-               _impl->_catalog.update(solana_plugin->get_cluster_identity_snapshots());
-            }
+            _impl->_catalog.update((*_impl->_solana_identity_snapshots)());
             results(_impl->_catalog.report());
          });
       }
@@ -52,6 +54,13 @@ namespace sysio {
 
    void prometheus_plugin::plugin_initialize(const variables_map& options) {
       my->_catalog.register_update_handlers(my->_prometheus_strand);
+      auto& solana_identity_snapshots =
+         app().get_method<solana_cluster_identity_metrics::snapshot_provider>();
+      my->_solana_identity_snapshots = &solana_identity_snapshots;
+      my->_empty_solana_identity_snapshots =
+         solana_identity_snapshots.register_provider(
+            [] { return std::vector<fc::network::solana::solana_cluster_identity_snapshot>{}; },
+            optional_metrics_fallback_priority);
 
       auto& _http_plugin = app().get_plugin<http_plugin>();
       my->_max_response_time_us = _http_plugin.get_max_response_time();

--- a/plugins/prometheus_plugin/test/test_solana_cluster_identity_metrics.cpp
+++ b/plugins/prometheus_plugin/test/test_solana_cluster_identity_metrics.cpp
@@ -3,13 +3,11 @@
  * @brief Tests bounded, credential-free Solana cluster identity telemetry.
  */
 
-#include <boost/test/unit_test.hpp>
-
-#include <fc/network/solana/solana_client.hpp>
-
-#include <string>
-
 #include "../src/metrics.hpp"
+
+#include <boost/test/unit_test.hpp>
+#include <fc/network/solana/solana_client.hpp>
+#include <string>
 
 using namespace fc::network::solana;
 using sysio::metrics::catalog_type;
@@ -25,30 +23,24 @@ BOOST_AUTO_TEST_CASE(exports_state_counters_and_bounded_operation_labels) {
       .status = solana_cluster_identity_status::mismatch,
       .reason = solana_cluster_identity_reason::identity_mismatch,
       .verification_age = fc::seconds(2),
-      .transport_session_id = 3,
       .verification_attempts = 4,
       .verification_successes = 3,
       .verification_mismatches = 1,
-      .blocked_operations = {
-         {solana_cluster_identity_operation::signing, 2},
-      },
+      .blocked_operations =
+         {
+                              {solana_cluster_identity_operation::signing, 2},
+                              },
    };
 
    catalog.update({snapshot});
    const auto output = catalog.report();
 
-   BOOST_CHECK(output.find(
-      "nodeop_solana_cluster_identity{client_id=\"client-a\",mode=\"pinned\","
-      "reason=\"identity_mismatch\",status=\"mismatch\"} 1") != std::string::npos);
-   BOOST_CHECK(output.find(
-      "nodeop_solana_cluster_identity_verification_age_seconds{client_id=\"client-a\"} 2") !=
-      std::string::npos);
-   BOOST_CHECK(output.find(
-      "nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 4") !=
-      std::string::npos);
-   BOOST_CHECK(output.find(
-      "nodeop_solana_cluster_identity_transport_session_id{client_id=\"client-a\"} 3") !=
-      std::string::npos);
+   BOOST_CHECK(output.find("nodeop_solana_cluster_identity{client_id=\"client-a\",mode=\"pinned\","
+                           "reason=\"identity_mismatch\",status=\"mismatch\"} 1") != std::string::npos);
+   BOOST_CHECK(output.find("nodeop_solana_cluster_identity_verification_age_seconds{client_id=\"client-a\"} 2") !=
+               std::string::npos);
+   BOOST_CHECK(output.find("nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 4") !=
+               std::string::npos);
    BOOST_CHECK(output.find("operation=\"signing\"} 2") != std::string::npos);
    BOOST_CHECK(output.find("rpc.example") == std::string::npos);
 }
@@ -66,9 +58,8 @@ BOOST_AUTO_TEST_CASE(replaces_state_series_and_does_not_double_count_snapshots) 
    catalog.update({snapshot});
    catalog.update({snapshot});
    auto output = catalog.report();
-   BOOST_CHECK(output.find(
-      "nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 2") !=
-      std::string::npos);
+   BOOST_CHECK(output.find("nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 2") !=
+               std::string::npos);
 
    snapshot.mode = solana_cluster_identity_mode::pinned;
    snapshot.status = solana_cluster_identity_status::verified;
@@ -79,9 +70,8 @@ BOOST_AUTO_TEST_CASE(replaces_state_series_and_does_not_double_count_snapshots) 
 
    BOOST_CHECK(output.find("mode=\"unpinned\"") == std::string::npos);
    BOOST_CHECK(output.find("status=\"verified\"") != std::string::npos);
-   BOOST_CHECK(output.find(
-      "nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 3") !=
-      std::string::npos);
+   BOOST_CHECK(output.find("nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 3") !=
+               std::string::npos);
 
    catalog.update(std::vector<solana_cluster_identity_snapshot>{});
    output = catalog.report();

--- a/plugins/prometheus_plugin/test/test_solana_cluster_identity_metrics.cpp
+++ b/plugins/prometheus_plugin/test/test_solana_cluster_identity_metrics.cpp
@@ -26,9 +26,14 @@ BOOST_AUTO_TEST_CASE(exports_state_counters_and_bounded_operation_labels) {
       .verification_attempts = 4,
       .verification_successes = 3,
       .verification_mismatches = 1,
+      .verification_cancellations = 1,
       .blocked_operations =
          {
                               {solana_cluster_identity_operation::signing, 2},
+                              },
+      .protected_operation_failures =
+         {
+                              {solana_cluster_identity_operation::rpc_read, 1},
                               },
    };
 
@@ -41,7 +46,12 @@ BOOST_AUTO_TEST_CASE(exports_state_counters_and_bounded_operation_labels) {
                std::string::npos);
    BOOST_CHECK(output.find("nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 4") !=
                std::string::npos);
+   BOOST_CHECK(
+      output.find("nodeop_solana_cluster_identity_verification_cancellations_total{client_id=\"client-a\"} 1") !=
+      std::string::npos);
    BOOST_CHECK(output.find("operation=\"signing\"} 2") != std::string::npos);
+   BOOST_CHECK(output.find("nodeop_solana_cluster_identity_protected_operation_failures_total{client_id=\"client-a\","
+                           "operation=\"rpc_read\"} 1") != std::string::npos);
    BOOST_CHECK(output.find("rpc.example") == std::string::npos);
 }
 

--- a/plugins/prometheus_plugin/test/test_solana_cluster_identity_metrics.cpp
+++ b/plugins/prometheus_plugin/test/test_solana_cluster_identity_metrics.cpp
@@ -1,0 +1,91 @@
+/**
+ * @file test_solana_cluster_identity_metrics.cpp
+ * @brief Tests bounded, credential-free Solana cluster identity telemetry.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <fc/network/solana/solana_client.hpp>
+
+#include <string>
+
+#include "../src/metrics.hpp"
+
+using namespace fc::network::solana;
+using sysio::metrics::catalog_type;
+
+BOOST_AUTO_TEST_SUITE(prometheus_solana_cluster_identity_metrics)
+
+BOOST_AUTO_TEST_CASE(exports_state_counters_and_bounded_operation_labels) {
+   catalog_type catalog;
+   solana_cluster_identity_snapshot snapshot{
+      .client_id = "client-a",
+      .sanitized_endpoint = "https://rpc.example:443",
+      .mode = solana_cluster_identity_mode::pinned,
+      .status = solana_cluster_identity_status::mismatch,
+      .reason = solana_cluster_identity_reason::identity_mismatch,
+      .verification_age = fc::seconds(2),
+      .transport_session_id = 3,
+      .verification_attempts = 4,
+      .verification_successes = 3,
+      .verification_mismatches = 1,
+      .blocked_operations = {
+         {solana_cluster_identity_operation::signing, 2},
+      },
+   };
+
+   catalog.update({snapshot});
+   const auto output = catalog.report();
+
+   BOOST_CHECK(output.find(
+      "nodeop_solana_cluster_identity{client_id=\"client-a\",mode=\"pinned\","
+      "reason=\"identity_mismatch\",status=\"mismatch\"} 1") != std::string::npos);
+   BOOST_CHECK(output.find(
+      "nodeop_solana_cluster_identity_verification_age_seconds{client_id=\"client-a\"} 2") !=
+      std::string::npos);
+   BOOST_CHECK(output.find(
+      "nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 4") !=
+      std::string::npos);
+   BOOST_CHECK(output.find(
+      "nodeop_solana_cluster_identity_transport_session_id{client_id=\"client-a\"} 3") !=
+      std::string::npos);
+   BOOST_CHECK(output.find("operation=\"signing\"} 2") != std::string::npos);
+   BOOST_CHECK(output.find("rpc.example") == std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(replaces_state_series_and_does_not_double_count_snapshots) {
+   catalog_type catalog;
+   solana_cluster_identity_snapshot snapshot{
+      .client_id = "client-a",
+      .mode = solana_cluster_identity_mode::unpinned,
+      .status = solana_cluster_identity_status::unpinned,
+      .reason = solana_cluster_identity_reason::missing_expected_identity,
+      .verification_attempts = 2,
+   };
+
+   catalog.update({snapshot});
+   catalog.update({snapshot});
+   auto output = catalog.report();
+   BOOST_CHECK(output.find(
+      "nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 2") !=
+      std::string::npos);
+
+   snapshot.mode = solana_cluster_identity_mode::pinned;
+   snapshot.status = solana_cluster_identity_status::verified;
+   snapshot.reason = solana_cluster_identity_reason::none;
+   snapshot.verification_attempts = 3;
+   catalog.update({snapshot});
+   output = catalog.report();
+
+   BOOST_CHECK(output.find("mode=\"unpinned\"") == std::string::npos);
+   BOOST_CHECK(output.find("status=\"verified\"") != std::string::npos);
+   BOOST_CHECK(output.find(
+      "nodeop_solana_cluster_identity_verification_attempts_total{client_id=\"client-a\"} 3") !=
+      std::string::npos);
+
+   catalog.update(std::vector<solana_cluster_identity_snapshot>{});
+   output = catalog.report();
+   BOOST_CHECK(output.find("client_id=\"client-a\"") == std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- add optional `--outpost-solana-cluster-identity <client-id>,<expected-genesis-hash>` configuration for a backward-compatible initial release
- preserve legacy unpinned behavior when no identities are configured; once any identity is present, require complete one-to-one coverage for every Solana client
- add a generic libfc HTTP once-per-new-connection validation hook and a generic JSON-RPC adapter; keep Solana genesis-hash policy in the Solana client
- validate every newly established persistent HTTP/TLS connection with `getGenesisHash` before ordinary RPC traffic; replacement and fallback connections validate independently
- make confirmed identity mismatches sticky, cross-check public `getGenesisHash` results before admitting queued calls, and honor both deadlines and cancellation while queued
- bind pinned signing to blockhashes obtained through this client's validated RPC connection, without adding network I/O to local signing
- submit transactions once and bound confirmation polling, including an in-flight status RPC, by the absolute retry deadline
- perform bounded all-or-nothing startup validation and expose bounded-cardinality Prometheus status, failure, cancellation, recovery, and blocked-operation telemetry

## Why

Before this change, a configured Solana RPC URL proved only that something answered JSON-RPC; nodeop had no trusted identity for the cluster behind that endpoint. A stale deployment setting, DNS or load-balancer misroute, or reconnect/fallback to a different backend could therefore move reads and transaction submission to the wrong Solana cluster without an explicit failure.

That failure can look healthy at every individual step: `getLatestBlockhash` returns a valid blockhash, local signing succeeds, submission returns a signature, and status polling returns structurally valid responses—but all of them describe the wrong ledger. A startup-only or process-wide check would still leave a gap because persistent HTTP connections are replaced over time and a replacement can reach a different backend.

This PR makes cluster identity part of connection admission. Every new persistent connection must report the independently configured genesis hash before it carries protected operations, blockhash provenance ties pinned signing to this validated client, and a confirmed mismatch fails closed. The companion tooling PR provisions and verifies the trusted hash instead of asking the runtime endpoint to attest to itself.

## Backward-compatible rollout

The initial release has two process-wide modes:

- with no identity entries, existing configurations remain usable in legacy unpinned mode; nodeop emits a security warning per client and Prometheus reports the missing identity
- once any identity entry is present, strict pinned mode requires exactly one valid canonical 32-byte genesis hash for every configured Solana client; partial, duplicate, unknown-client, and malformed configurations fail startup

There is no mixed pinned/unpinned mode. The companion tooling change in [wire-tools-ts PR #42](https://github.com/Wire-Network/wire-tools-ts/pull/42) / [SEC-142](https://wire-network.atlassian.net/browse/SEC-142) provisions trusted hashes for local validators, requires independently supplied hashes for external clusters, verifies external endpoints, persists the identity, and renders this node option.

## Architecture

[PR #535](https://github.com/Wire-Network/wire-sysio/pull/535) is merged. Its generic connection-affine continuation remains independent. This PR adds a generic connection-lifecycle validator in libfc HTTP; JSON-RPC only adapts method/parameters/result framing, while Solana owns the expected-genesis-hash predicate, sticky mismatch policy, blockhash provenance, and operation telemetry.

Validation state belongs to the live HTTP/TLS connection and is discarded when it closes. A replacement connection cannot inherit admission. The narrow Solana RPC gate makes a returned public `getGenesisHash` mismatch atomic with queued-call admission and observes the same deadline/cancellation contract as the blocking transport.

Jira: [SEC-139](https://wire-network.atlassian.net/browse/SEC-139)

## Validation

Current head: `1fe7776c6f4036379f43d5019a9c716f24a1f6ef`

- post-merge full Release build passed locally
- focused Release CTest suites passed: `test_fc`, `test_outpost_solana_client_plugin`, and `test_prometheus_plugin`
- combined JSON-RPC and Solana libfc suites passed five consecutive stress runs (124 cases per run)
- targeted regressions cover per-connection replacement validation, queued sticky mismatch, gate deadline/cancellation without network I/O, hanging confirmation RPC deadline enforcement, no transaction resubmission, startup rollback, and metrics
- `git diff --check` passed
- combined Release platform build and all 13 E2E flows passed: [run #30467121335](https://github.com/Wire-Network/wire-platform-build-system/actions/runs/30467121335)
  - `wire-sysio`: `1fe7776c6f4036379f43d5019a9c716f24a1f6ef`
  - companion `wire-tools-ts`: `39a832774f4a9310ec5207f3a3ef56bb839cc50f`
- no `contracts/sysio.*` paths are changed, so the system-contract E2E gate does not apply

## Residual risk

- legacy unpinned mode deliberately preserves compatibility but does not provide SEC-139 protection; warnings and metrics make that state observable during migration
- genesis-hash comparison detects accidental/wrong-cluster routing but does not cryptographically authenticate a malicious RPC endpoint; trusted provisioning plus TLS/trusted routing remain required
- a confirmed mismatch is intentionally sticky and requires endpoint/configuration correction plus process restart


[SEC-142]: https://wire-network.atlassian.net/browse/SEC-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
