### PR TITLE
Packaging: wire-cdt release-asset consumption, macOS + system-contracts artifacts, Strategy-C release workflows

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,9 +1,9 @@
 {
-    "wirecdt":{
-       "target":"master",
-       "prerelease":true
-    },
-    "wiresystemcontracts":{
-       "ref":"release/4.0"
-    }
- }
+  "wirecdt": {
+    "release": "v1.0.0-dev",
+    "channel": "prerelease"
+  },
+  "wiresystemcontracts": {
+    "ref": "release/4.0"
+  }
+}

--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -2,8 +2,5 @@
   "wirecdt": {
     "release": "v1.0.0-dev",
     "channel": "prerelease"
-  },
-  "wiresystemcontracts": {
-    "ref": "release/4.0"
   }
 }

--- a/.cicd/platforms/asan.Dockerfile
+++ b/.cicd/platforms/asan.Dockerfile
@@ -76,3 +76,15 @@ EOF
 
 ENV SYSIO_PLATFORM_HAS_EXTRAS_CMAKE=1
 ENV ASAN_OPTIONS=detect_leaks=0
+
+# GitHub CLI from the official apt repository. The release workflows use `gh`
+# inside these images (linux_amd64_build.yaml downloads the pinned wire-cdt
+# release asset with `gh release download`), and it is installed in EVERY
+# platform image rather than just the packaging one so the images stay uniform.
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y gh

--- a/.cicd/platforms/asserton.Dockerfile
+++ b/.cicd/platforms/asserton.Dockerfile
@@ -79,3 +79,15 @@ COPY <<-EOF /extras.cmake
 EOF
 
 ENV SYSIO_PLATFORM_HAS_EXTRAS_CMAKE=1
+
+# GitHub CLI from the official apt repository. The release workflows use `gh`
+# inside these images (linux_amd64_build.yaml downloads the pinned wire-cdt
+# release asset with `gh release download`), and it is installed in EVERY
+# platform image rather than just the packaging one so the images stay uniform.
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y gh

--- a/.cicd/platforms/gcc.Dockerfile
+++ b/.cicd/platforms/gcc.Dockerfile
@@ -63,3 +63,15 @@ COPY <<-EOF /extras.cmake
 EOF
 
 ENV SYSIO_PLATFORM_HAS_EXTRAS_CMAKE=1
+
+# GitHub CLI from the official apt repository. The release workflows use `gh`
+# inside these images (linux_amd64_build.yaml downloads the pinned wire-cdt
+# release asset with `gh release download`), and it is installed in EVERY
+# platform image rather than just the packaging one so the images stay uniform.
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y gh

--- a/.cicd/platforms/ubsan.Dockerfile
+++ b/.cicd/platforms/ubsan.Dockerfile
@@ -80,3 +80,15 @@ EOF
 
 ENV SYSIO_PLATFORM_HAS_EXTRAS_CMAKE=1
 ENV UBSAN_OPTIONS=print_stacktrace=1,suppressions=/ubsan.supp
+
+# GitHub CLI from the official apt repository. The release workflows use `gh`
+# inside these images (linux_amd64_build.yaml downloads the pinned wire-cdt
+# release asset with `gh release download`), and it is installed in EVERY
+# platform image rather than just the packaging one so the images stay uniform.
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y gh

--- a/.cicd/platforms/ubuntu24.Dockerfile
+++ b/.cicd/platforms/ubuntu24.Dockerfile
@@ -53,3 +53,15 @@ RUN apt-get update && apt-get upgrade -y && \
 ENV CC=/usr/bin/clang-18
 ENV CXX=/usr/bin/clang++-18
 ENV CMAKE_MAKE_PROGRAM=/usr/bin/ninja
+
+# GitHub CLI from the official apt repository. The release workflows use `gh`
+# inside these images (linux_amd64_build.yaml downloads the pinned wire-cdt
+# release asset with `gh release download`), and it is installed in EVERY
+# platform image rather than just the packaging one so the images stay uniform.
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y gh

--- a/.github/scripts/cmake-version.py
+++ b/.github/scripts/cmake-version.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Read or rewrite the ``VERSION_*`` block in wire-sysio's root ``CMakeLists.txt``.
+
+The release workflows are the only consumers: ``prepare-release.yaml`` writes the
+requested version into the tree, and ``tag-release.yaml`` reads it back to assert
+that master's HEAD really carries the version being tagged. Both go through this
+one parser so the two halves of that assertion can never drift apart.
+
+The version string is ``<major>.<minor>.<patch>[-<suffix>]``, matching the
+``VERSION_FULL`` composition in ``CMakeLists.txt``. The suffix carries the release
+channel: any suffix (``dev``, ``rc1``, ...) means prerelease, no suffix means
+stable.
+
+Usage::
+
+    cmake-version.py read [--cmakelists PATH]
+    cmake-version.py write <version> [--cmakelists PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+#: ``<major>.<minor>.<patch>`` with an optional ``-<suffix>`` of dot-separated
+#: alphanumerics -- deliberately conservative so a typo cannot reach the tree.
+VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*))?$")
+
+DEFAULT_CMAKELISTS = Path(__file__).resolve().parents[2] / "CMakeLists.txt"
+
+
+def _field_re(name: str) -> re.Pattern[str]:
+    """Build the anchored matcher for one ``set(<name> <value>)`` line.
+
+    The trailing run is ``[ \\t]*`` rather than ``\\s*`` on purpose: ``\\s``
+    matches newlines, so with :data:`re.MULTILINE` the pattern would extend past
+    the closing paren and swallow the blank line that follows it -- ``write``
+    would then quietly delete one blank line per field on every release
+    preparation.
+    """
+    return re.compile(rf"^set\({name}\s+(.*)\)[ \t]*$", re.MULTILINE)
+
+
+def read_version(text: str) -> str:
+    """Return the ``VERSION_FULL`` string composed from the ``set(VERSION_*)`` lines."""
+    parts = {}
+    for name in ("VERSION_MAJOR", "VERSION_MINOR", "VERSION_PATCH", "VERSION_SUFFIX"):
+        match = _field_re(name).search(text)
+        if match is None:
+            if name == "VERSION_SUFFIX":
+                parts[name] = ""
+                continue
+            raise SystemExit(f"cmake-version: {name} not found in CMakeLists.txt")
+        parts[name] = match.group(1).strip().strip('"')
+
+    version = f"{parts['VERSION_MAJOR']}.{parts['VERSION_MINOR']}.{parts['VERSION_PATCH']}"
+    if parts["VERSION_SUFFIX"]:
+        version = f"{version}-{parts['VERSION_SUFFIX']}"
+    return version
+
+
+def write_version(text: str, version: str) -> str:
+    """Return ``text`` with the ``set(VERSION_*)`` lines rewritten to ``version``."""
+    match = VERSION_RE.match(version)
+    if match is None:
+        raise SystemExit(
+            f"cmake-version: '{version}' is not <major>.<minor>.<patch>[-<suffix>]"
+        )
+    major, minor, patch, suffix = match.groups()
+
+    # An empty suffix is written as `""` rather than as a bare empty token so the
+    # line stays valid CMake and `if(VERSION_SUFFIX)` still evaluates false.
+    replacements = {
+        "VERSION_MAJOR": major,
+        "VERSION_MINOR": minor,
+        "VERSION_PATCH": patch,
+        "VERSION_SUFFIX": suffix if suffix else '""',
+    }
+    for name, value in replacements.items():
+        text, count = _field_re(name).subn(f"set({name} {value})", text, count=1)
+        if count != 1:
+            raise SystemExit(f"cmake-version: could not rewrite set({name} ...)")
+    return text
+
+
+def main() -> int:
+    """Parse arguments and dispatch to the read or write mode."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("read", "write"))
+    parser.add_argument("version", nargs="?", help="version to write (write mode only)")
+    parser.add_argument("--cmakelists", type=Path, default=DEFAULT_CMAKELISTS)
+    args = parser.parse_args()
+
+    text = args.cmakelists.read_text()
+
+    if args.mode == "read":
+        print(read_version(text))
+        return 0
+
+    if not args.version:
+        raise SystemExit("cmake-version: write mode requires a version argument")
+    args.cmakelists.write_text(write_version(text, args.version))
+    print(read_version(args.cmakelists.read_text()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/cmake-version.py
+++ b/.github/scripts/cmake-version.py
@@ -2,19 +2,27 @@
 """Read or rewrite the ``VERSION_*`` block in wire-sysio's root ``CMakeLists.txt``.
 
 The release workflows are the only consumers: ``prepare-release.yaml`` writes the
-requested version into the tree, and ``tag-release.yaml`` reads it back to assert
-that master's HEAD really carries the version being tagged. Both go through this
-one parser so the two halves of that assertion can never drift apart.
+requested version into the tree, ``tag-release.yaml`` reads it back to assert that
+master's HEAD really carries the version being tagged, and ``release.yaml``
+validates the tag it was handed. All three go through this one parser so those
+assertions can never drift apart.
 
 The version string is ``<major>.<minor>.<patch>[-<suffix>]``, matching the
 ``VERSION_FULL`` composition in ``CMakeLists.txt``. The suffix carries the release
 channel: any suffix (``dev``, ``rc1``, ...) means prerelease, no suffix means
 stable.
 
+``validate`` exposes that same grammar as a standalone check so the workflows
+never re-spell it as an inline bash regex: every version/tag shape assertion in
+prepare-release.yaml, tag-release.yaml and release.yaml routes through this one
+implementation of :data:`VERSION_RE`.
+
 Usage::
 
     cmake-version.py read [--cmakelists PATH]
     cmake-version.py write <version> [--cmakelists PATH]
+    cmake-version.py validate <version>
+    cmake-version.py validate --tag <vversion>
 """
 
 from __future__ import annotations
@@ -41,6 +49,31 @@ def _field_re(name: str) -> re.Pattern[str]:
     preparation.
     """
     return re.compile(rf"^set\({name}\s+(.*)\)[ \t]*$", re.MULTILINE)
+
+
+def validate_version(version: str, tag: bool = False) -> str:
+    """Return the BARE version after asserting ``version`` matches the grammar.
+
+    ``tag`` mode is the release-tag spelling: the leading ``v`` every tag carries
+    is required, then stripped before the check, so :data:`VERSION_RE` stays the
+    ONE definition of the grammar for both the bare and the tagged spelling. The
+    bare version is returned (and printed by ``main``) so a caller can validate
+    and destructure a tag in one call instead of re-deriving ``${TAG#v}``.
+    """
+    bare = version
+    if tag:
+        if not version.startswith("v"):
+            raise SystemExit(
+                f"cmake-version: tag '{version}' must start with 'v'"
+            )
+        bare = version[1:]
+    if VERSION_RE.match(bare) is None:
+        prefix = "v" if tag else ""
+        raise SystemExit(
+            f"cmake-version: '{version}' is not "
+            f"{prefix}<major>.<minor>.<patch>[-<suffix>]"
+        )
+    return bare
 
 
 def read_version(text: str) -> str:
@@ -88,10 +121,38 @@ def write_version(text: str, version: str) -> str:
 def main() -> int:
     """Parse arguments and dispatch to the read or write mode."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("mode", choices=("read", "write"))
-    parser.add_argument("version", nargs="?", help="version to write (write mode only)")
+    parser.add_argument("mode", choices=("read", "write", "validate"))
+    parser.add_argument(
+        "version", nargs="?", help="version to write or validate"
+    )
+    # `--tag` carries its VALUE rather than flagging the trailing positional:
+    # argparse cannot fill an `nargs="?"` positional that follows an optional on
+    # the command line, so `validate --tag v1.0.0` would fail as an unrecognized
+    # argument in the flag form.
+    parser.add_argument(
+        "--tag",
+        metavar="TAG",
+        help="validate mode: the vX.Y.Z[-suffix] tag to check; prints its bare version",
+    )
     parser.add_argument("--cmakelists", type=Path, default=DEFAULT_CMAKELISTS)
     args = parser.parse_args()
+
+    # `validate` is a pure grammar check on its ARGUMENT, so it deliberately runs
+    # before the file is touched: a caller validating a dispatch input must not
+    # also depend on a readable CMakeLists.txt.
+    if args.mode == "validate":
+        if args.tag:
+            # The tag form is consumed as `version=$(... validate --tag "$TAG")`,
+            # so it prints the bare version; the plain form is a pure exit-status
+            # check and stays silent on success.
+            print(validate_version(args.tag, tag=True))
+            return 0
+        if not args.version:
+            raise SystemExit(
+                "cmake-version: validate mode requires a version argument or --tag"
+            )
+        validate_version(args.version)
+        return 0
 
     text = args.cmakelists.read_text()
 

--- a/.github/scripts/install-wire-cdt-package.sh
+++ b/.github/scripts/install-wire-cdt-package.sh
@@ -5,6 +5,32 @@ set -euo pipefail
 # root to later sysio build steps. Release-tag builds need the package variant
 # that includes CDT protobuf tools for OPP contract model generation.
 
+# The wire-cdt deb uses the DISTRO-TOOLCHAIN layout (the shape distros use for a
+# bundled compiler, cf. /usr/lib/llvm-18):
+#
+#   /usr/lib/cdt/                  the entire self-contained toolchain -- bin/
+#                                  (incl. the bundled clang/lld/llvm-* set),
+#                                  lib/, include/, lib/cmake/cdt/, scripts/,
+#                                  share/, cdt.imports
+#   /usr/bin/<tool>                symlinks -> ../lib/cdt/bin/<tool>, PUBLIC
+#                                  ENTRY POINTS ONLY (no bare clang/llvm names)
+#   /usr/lib/cmake/cdt/            discoverable cdt-config.cmake => find_package
+#   /usr/share/licenses/wire-cdt/  license texts
+#
+# There is NO /usr/cdt subtree and no /opt payload (that is the portable
+# tarball's root, not the deb's).
+#
+# CDT_ROOT is the SELF-CONTAINED HOME, not /usr: build-sysio.sh checks
+# "$CDT_ROOT/lib/cmake/cdt/cdt-config.cmake" and cmake/contract-tools.cmake
+# builds "$CDT_ROOT/lib/cmake/cdt/CDTWasmToolchain.cmake", both of which only
+# resolve under /usr/lib/cdt. (find_package(cdt) alone would need nothing at all,
+# thanks to the /usr/lib/cmake/cdt copy -- but this repo passes CDT_ROOT
+# explicitly, so it must point at the home.)
+CDT_EXPECTED_ROOT="/usr/lib/cdt"
+
+# Public entry points that must be on PATH via /usr/bin after install.
+CDT_ENTRY_POINTS=(cdt-cc cdt-cpp cdt-protoc cdt-protoc-gen-zpp)
+
 CDT_DEB="${1:?usage: install-wire-cdt-package.sh <cdt-deb>}"
 
 if [[ "$CDT_DEB" != /* ]]; then
@@ -17,25 +43,82 @@ fi
 
 echo "Wire CDT Debian package SHA-256: $(sha256sum "$CDT_DEB" | awk '{print $1}')"
 
-cdt_config_path="$(
-  dpkg-deb --contents "$CDT_DEB" |
-    awk '$NF ~ /\/lib\/cmake\/cdt\/cdt-config\.cmake$/ { path=$NF; sub(/^\.\//, "/", path); print path; exit }'
+cdt_payload="$(dpkg-deb --contents "$CDT_DEB" | awk '{print $6}')"
+
+# Derive the toolchain HOME from cdt.imports, which exists exactly once and sits
+# at the root of the self-contained tree. Deriving from cdt-config.cmake would be
+# ambiguous now that the deb ships TWO copies of it (the home's own, plus the
+# discoverable one at /usr/lib/cmake/cdt).
+cdt_root="$(
+  printf '%s\n' "$cdt_payload" |
+    awk '$0 ~ /\/cdt\.imports$/ { path=$0; sub(/^\.\//, "/", path); sub(/\/cdt\.imports$/, "", path); print path; exit }'
 )"
-if [[ -z "$cdt_config_path" ]]; then
-  echo "Wire CDT Debian package does not contain lib/cmake/cdt/cdt-config.cmake" >&2
+if [[ -z "$cdt_root" ]]; then
+  echo "Wire CDT Debian package does not contain cdt.imports" >&2
   exit 1
 fi
 
-cdt_root="${cdt_config_path%/lib/cmake/cdt/cdt-config.cmake}"
+# The home is DERIVED from the package above, then asserted against the layout
+# this repo expects, so a layout change in wire-cdt fails here with a clear
+# message instead of surfacing later as a missing toolchain during the build.
+if [[ "$cdt_root" != "$CDT_EXPECTED_ROOT" ]]; then
+  echo "Wire CDT toolchain home is '$cdt_root', expected '$CDT_EXPECTED_ROOT'" >&2
+  echo "The deb must use the distro-toolchain layout (self-contained tree at /usr/lib/cdt)." >&2
+  exit 1
+fi
+
+# Payload-shape assertions, before anything is installed.
+for required in \
+  "./usr/lib/cdt/bin/cdt-cc" \
+  "./usr/lib/cdt/lib/cmake/cdt/cdt-config.cmake" \
+  "./usr/lib/cdt/cdt.imports" \
+  "./usr/lib/cmake/cdt/cdt-config.cmake"; do
+  if ! printf '%s\n' "$cdt_payload" | grep -qx "$required"; then
+    echo "Wire CDT package payload is missing $required" >&2
+    exit 1
+  fi
+done
+
+if printf '%s\n' "$cdt_payload" | grep -q '^\./usr/cdt/'; then
+  echo "Wire CDT package installs into a /usr/cdt subtree; expected the /usr/lib/cdt home" >&2
+  exit 1
+fi
+
+# The bundled clang / lld / llvm-* binaries must stay private to the home. In
+# /usr/bin they would collide with the distro's own toolchain packages and either
+# fail this apt-get install or hijack the compiler the sysio build itself uses.
+for banned in clang clang++ opt llc lld ld.lld wasm-ld; do
+  if printf '%s\n' "$cdt_payload" | grep -qx "./usr/bin/$banned"; then
+    echo "Wire CDT package ships ./usr/bin/$banned, which collides with the distro toolchain" >&2
+    exit 1
+  fi
+done
+if printf '%s\n' "$cdt_payload" | grep -qE '^\./usr/bin/llvm-'; then
+  echo "Wire CDT package ships bare llvm-* binaries in /usr/bin" >&2
+  exit 1
+fi
 
 apt-get update
 apt-get install -y "$CDT_DEB"
 
+# Public entry points must be reachable on PATH through the /usr/bin symlinks.
+for entry in "${CDT_ENTRY_POINTS[@]}"; do
+  if [[ ! -x "/usr/bin/$entry" ]]; then
+    echo "Wire CDT package did not expose /usr/bin/$entry (missing or dangling symlink)" >&2
+    exit 1
+  fi
+done
+
+# build-sysio.sh checks "$CDT_ROOT/lib/cmake/cdt/cdt-config.cmake" and
+# cmake/contract-tools.cmake builds "$CDT_ROOT/lib/cmake/cdt/CDTWasmToolchain.cmake";
+# both must resolve under the home for the contracts build to work at all.
 for required in \
   "$cdt_root/lib/cmake/cdt/cdt-config.cmake" \
+  "$cdt_root/lib/cmake/cdt/CDTWasmToolchain.cmake" \
   "$cdt_root/bin/cdt-cc" \
   "$cdt_root/bin/cdt-protoc" \
-  "$cdt_root/bin/cdt-protoc-gen-zpp"; do
+  "$cdt_root/bin/cdt-protoc-gen-zpp" \
+  "$cdt_root/cdt.imports"; do
   if [[ ! -e "$required" ]]; then
     echo "Wire CDT package did not install required file: $required" >&2
     exit 1
@@ -51,4 +134,7 @@ if [[ -n "${GITHUB_ENV:-}" ]]; then
   echo "CDT_ROOT=$cdt_root" >>"$GITHUB_ENV"
 fi
 
-echo "Prepared Wire CDT package from $CDT_DEB at $cdt_root"
+echo "Prepared Wire CDT package from $CDT_DEB"
+echo "Resolved CDT root: $cdt_root (self-contained toolchain home)"
+echo "  entry points on PATH: /usr/bin/{$(IFS=,; echo "${CDT_ENTRY_POINTS[*]}")} -> ../lib/cdt/bin/"
+echo "  discoverable cmake config: /usr/lib/cmake/cdt/cdt-config.cmake (find_package(cdt) needs no CMAKE_PREFIX_PATH)"

--- a/.github/scripts/resolve-build-run.sh
+++ b/.github/scripts/resolve-build-run.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Resolve the workflow run that built a given TAG REF, for each named workflow.
+#
+# Usage: resolve-build-run.sh <tag> <target-sha> <workflow.yaml>...
+#
+# Emits one `<workflow-basename-sans-.yaml>-run-id=<id>` line per workflow on
+# STDOUT, shaped to be redirected straight into "$GITHUB_OUTPUT". EVERY progress,
+# diagnostic and error line goes to STDERR instead, so that redirect can never
+# swallow the log or corrupt the outputs file.
+#
+# Environment:
+#   GH_TOKEN           (required) auth for `gh api`
+#   GITHUB_REPOSITORY  (required) owner/repo whose runs are queried
+#   RESOLVE_ATTEMPTS   poll attempts before giving up (default 330)
+#   RESOLVE_INTERVAL   seconds between attempts (default 60)
+#
+# The default 330 x 60s is deliberately longer than a full cold build: the asset
+# workflow is dispatched at the SAME moment as the platform builds, so it must
+# outlast the whole build, not merely the artifact upload that follows one. Kept
+# under the 6h GitHub-hosted job ceiling.
+#
+# This file is kept BYTE-IDENTICAL with wire-sysio/.github/scripts/resolve-build-run.sh
+# (`diff` across the two repos is the check): both repos run the same Strategy-C
+# release path, and the resolver's failure modes are subtle enough that a forked
+# copy would drift silently. Repo-specific bits -- which workflows to wait for,
+# and how TARGET_SHA is derived -- stay at the call sites, which is exactly why
+# they are arguments here.
+set -euo pipefail
+
+readonly default_attempts=330
+readonly default_interval=60
+
+die() {
+   echo "::error::$*" >&2
+   exit 1
+}
+
+[[ $# -ge 3 ]] || die "usage: resolve-build-run.sh <tag> <target-sha> <workflow.yaml>..."
+
+tag="$1"
+target_sha="$2"
+shift 2
+workflows=("$@")
+
+[[ -n "${GH_TOKEN:-}" ]] || die "GH_TOKEN is not set"
+[[ -n "${GITHUB_REPOSITORY:-}" ]] || die "GITHUB_REPOSITORY is not set"
+
+attempts="${RESOLVE_ATTEMPTS:-$default_attempts}"
+interval="${RESOLVE_INTERVAL:-$default_interval}"
+
+# First attempt only (see below): dump the candidate runs the API actually
+# returned before the filter is applied.
+log_candidates=1
+
+# Resolve ONE workflow's successful run AT THE TAG REF.
+#
+# The run must be a build OF THE TAG REF, not merely of the same commit: a
+# master-push build sits at the identical SHA but does not carry the tag-only
+# packaging behaviour, so matching it would attach the wrong artifact set.
+# head_branch is the tag name for both a tag push and a workflow_dispatch on the
+# tag ref -- tag-release.yaml uses the latter, because a GITHUB_TOKEN-created tag
+# fires no push event -- so both events are accepted and head_branch is the
+# discriminator.
+resolve_run() {
+   local workflow="$1" runs_json
+   runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs?head_sha=${target_sha}&per_page=50")"
+   if [[ "$log_candidates" == "1" ]]; then
+      # A head_branch-semantics mismatch is the classic resolver failure. Dumping
+      # the candidates on attempt ONE makes it visible in minute one instead of
+      # after 5.5 hours of silent polling.
+      {
+         echo "--- ${workflow} candidate runs at ${target_sha} (want head_branch == ${tag}) ---"
+         jq -r '.workflow_runs | length | "candidates: \(.)"' <<<"$runs_json"
+         jq -c '.workflow_runs[] | {id, head_branch, event, status, conclusion}' <<<"$runs_json"
+      } >&2
+   fi
+   jq -r --arg tag "$tag" '
+      [.workflow_runs[]
+        | select(.status == "completed" and .conclusion == "success")
+        | select(.event == "push" or .event == "workflow_dispatch")
+        | select(.head_branch == $tag)]
+      | .[0].id // empty' <<<"$runs_json"
+}
+
+declare -A run_ids=()
+for workflow in "${workflows[@]}"; do
+   run_ids["$workflow"]=""
+done
+
+# ALL requested workflows are polled every iteration, and a resolved one is never
+# re-queried: waiting for them in sequence would spend the whole budget on the
+# first workflow while the second sat finished and unclaimed.
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+   pending=0
+   for workflow in "${workflows[@]}"; do
+      [[ -n "${run_ids[$workflow]}" ]] || run_ids["$workflow"]="$(resolve_run "$workflow")"
+      [[ -n "${run_ids[$workflow]}" ]] || pending=1
+   done
+   log_candidates=0
+   if [[ "$pending" -eq 0 ]]; then
+      break
+   fi
+   status=""
+   for workflow in "${workflows[@]}"; do
+      status+=" ${workflow%.yaml}=${run_ids[$workflow]:-pending}"
+   done
+   echo "Waiting for tag-ref builds of ${tag} (${target_sha}):${status} (attempt ${attempt}/${attempts})" >&2
+   sleep "$interval"
+done
+
+# Emitted only after EVERY workflow resolved: a partial output set would let the
+# caller download one platform's artifacts and publish an incomplete release.
+for workflow in "${workflows[@]}"; do
+   [[ -n "${run_ids[$workflow]}" ]] \
+      || die "No successful ${workflow} run found for ${tag} (${target_sha})"
+done
+for workflow in "${workflows[@]}"; do
+   echo "${workflow%.yaml}-run-id=${run_ids[$workflow]}"
+done

--- a/.github/workflows/linux_amd64_build.yaml
+++ b/.github/workflows/linux_amd64_build.yaml
@@ -16,9 +16,6 @@ on:
       override-cdt-release:
         description: 'Override the pinned wire-cdt RELEASE tag for this one build (e.g. v1.0.0-rc2). Its channel is then derived from the release itself instead of being asserted against .cicd/defaults.json.'
         type: string
-      override-sys-system-contracts:
-        description: 'Override sys-system-contracts ref'
-        type: string
 
 permissions:
   actions: read
@@ -513,9 +510,8 @@ jobs:
       # once CDT moved to release assets.)
       cdt-release: ${{steps.versions.outputs.cdt-release}}
       cdt-channel: ${{steps.versions.outputs.cdt-channel}}
-      wire-system-contracts-ref: ${{steps.versions.outputs.wire-system-contracts-ref}}
     steps:
-      - name: Setup wire-cdt and wire-system-contracts versions
+      - name: Setup wire-cdt version
         id: versions
         env:
           GH_TOKEN: ${{secrets.GH_TOKEN_DEV}}
@@ -526,7 +522,6 @@ jobs:
           # values are inert data: bash does not re-evaluate command substitution found inside a
           # variable's value. github.repository / github.sha are likewise read via env and quoted.
           OVERRIDE_CDT_RELEASE: ${{ inputs.override-cdt-release }}
-          OVERRIDE_SYS_SYSTEM_CONTRACTS: ${{ inputs.override-sys-system-contracts }}
           REPO: ${{ github.repository }}
           REF_SHA: ${{ github.sha }}
         run: |
@@ -536,17 +531,14 @@ jobs:
           # such as "4.1.0" and "release/4.0". The pattern is held in a variable so [[ =~ ]] treats it
           # as a regex, and the candidate matched is only ever the variable's literal value.
           ref_re='^[A-Za-z0-9._/+-]+$'
-          for ov in "$OVERRIDE_CDT_RELEASE" "$OVERRIDE_SYS_SYSTEM_CONTRACTS"; do
-            if [[ -n "$ov" && ! "$ov" =~ $ref_re ]]; then
-              echo "::error::Invalid override ref '$ov'; only [A-Za-z0-9._/+-] are allowed." >&2
-              exit 1
-            fi
-          done
+          if [[ -n "$OVERRIDE_CDT_RELEASE" && ! "$OVERRIDE_CDT_RELEASE" =~ $ref_re ]]; then
+            echo "::error::Invalid override ref '$OVERRIDE_CDT_RELEASE'; only [A-Za-z0-9._/+-] are allowed." >&2
+            exit 1
+          fi
 
           DEFAULTS_JSON=$(curl -sSfL "$(gh api "https://api.github.com/repos/${REPO}/contents/.cicd/defaults.json?ref=${REF_SHA}" --jq .download_url)")
           echo "cdt-release=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.release')" >> "$GITHUB_OUTPUT"
           echo "cdt-channel=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.channel')" >> "$GITHUB_OUTPUT"
-          echo "wire-system-contracts-ref=$(echo "$DEFAULTS_JSON" | jq -r '.wiresystemcontracts.ref')" >> "$GITHUB_OUTPUT"
 
           # A one-off build against a different wire-cdt release. The pinned
           # channel no longer describes it, so the channel is set to the `derive`
@@ -558,9 +550,6 @@ jobs:
               echo "cdt-release=$OVERRIDE_CDT_RELEASE"
               echo "cdt-channel=derive"
             } >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -n "$OVERRIDE_SYS_SYSTEM_CONTRACTS" ]]; then
-            echo "wire-system-contracts-ref=$OVERRIDE_SYS_SYSTEM_CONTRACTS" >> "$GITHUB_OUTPUT"
           fi
 
   verify-packages:

--- a/.github/workflows/linux_amd64_build.yaml
+++ b/.github/workflows/linux_amd64_build.yaml
@@ -566,14 +566,11 @@ jobs:
 
       - name: Run packaging verification suite
         run: |
-          ls -la artifacts/
-          tools/packaging/tests/verify-scripts.sh
-          # Arch-suffixed on purpose: a bare wire-sysio-*.tar.gz would also match the
-          # system-contracts bundle that tag builds add to this artifact.
-          tools/packaging/tests/verify-tgz.sh artifacts/wire-sysio-*-x86_64.tar.gz
-          tools/packaging/tests/verify-deb.sh artifacts/wire-sysio_*.deb artifacts/wire-sysio-dev_*.deb
-          # wire-sysio-[0-9]* matches the base rpm only (the dev rpm is wire-sysio-dev-*).
-          tools/packaging/tests/verify-rpm.sh artifacts/wire-sysio-[0-9]*.rpm artifacts/wire-sysio-dev-*.rpm
+          # No version argument: on this path the artifact names carry a version
+          # this job does not know, so the suite uses its documented safe globs.
+          # The suite owns the artifact list and the no-bare-tgz-glob rule, shared
+          # with release.yaml's verification of the same package set.
+          tools/packaging/tests/verify-all.sh artifacts
 
   all-passing:
     name: All Required Tests Passed

--- a/.github/workflows/linux_amd64_build.yaml
+++ b/.github/workflows/linux_amd64_build.yaml
@@ -13,16 +13,9 @@ on:
       - master
   workflow_dispatch:
     inputs:
-      override-cdt:
-        description: 'Override cdt target'
+      override-cdt-release:
+        description: 'Override the pinned wire-cdt RELEASE tag for this one build (e.g. v1.0.0-rc2). Its channel is then derived from the release itself instead of being asserted against .cicd/defaults.json.'
         type: string
-      override-cdt-prerelease:
-        type: choice
-        description: Override cdt prelease
-        options:
-        - default
-        - true
-        - false
       override-sys-system-contracts:
         description: 'Override sys-system-contracts ref'
         type: string
@@ -142,8 +135,14 @@ jobs:
         with:
           submodules: recursive
 
+      # Split restore/save (not the monolithic actions/cache): the post-job save of
+      # the monolithic action runs BEFORE the vcpkg-binary-cache directory has been
+      # fully populated on a partial-restore run, so the freshly built binaries were
+      # never persisted. The paired save step below runs immediately after the build
+      # script, and only when the restore missed the exact key (caches are immutable).
       - name: Restore vcpkg binary cache
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # actions/cache@v5
+        id: restore-vcpkg
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/vcpkg-binary-cache
           key: vcpkg-binaries-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/vcpkg-triplets/**') }}
@@ -159,33 +158,105 @@ jobs:
           restore-keys: |
             ccache-${{ matrix.platform }}-
 
-      - name: Download Wire CDT package for release tag
+      # Wire CDT is acquired from a pinned GitHub RELEASE asset, not from a CI
+      # artifact: CI artifacts expire after 30 days, so an old tag could no longer
+      # be rebuilt reproducibly. The release is pinned in .cicd/defaults.json
+      # (wirecdt.release + wirecdt.channel) and resolved by the `v` job.
+      #
+      # Wire-Network/wire-cdt is public, so no GH_TOKEN_DEV is required here; the
+      # workflow's own GITHUB_TOKEN is passed as GH_TOKEN purely to lift the
+      # unauthenticated rate limit. The .cicd/platforms images bake the GitHub
+      # CLI (see the gh block in each Dockerfile), so `gh release download` does
+      # the asset resolution instead of a hand-rolled curl + jq walk of the
+      # assets array.
+      - name: Download Wire CDT release package for release tag
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
-        with:
-          name: cdt_ubuntu_package_amd64
-          path: cdt-package
-          github-token: ${{ secrets.GH_TOKEN_DEV }}
-          repository: Wire-Network/wire-cdt
-          run-id: ${{ needs.v.outputs.cdt-artifact-run-id }}
+        env:
+          CDT_RELEASE: ${{ needs.v.outputs.cdt-release }}
+          CDT_CHANNEL: ${{ needs.v.outputs.cdt-channel }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$CDT_RELEASE" || "$CDT_RELEASE" == "null" ]]; then
+            echo "::error::.cicd/defaults.json does not pin wirecdt.release" >&2
+            exit 1
+          fi
+
+          not_published_hint() {
+            echo "::error::Wire CDT release ${CDT_RELEASE} could not be read from Wire-Network/wire-cdt." >&2
+            echo "The pinned release may not be PUBLISHED YET: tag-release.yaml creates wire-cdt releases as DRAFTS, and a draft is invisible to this build (as is a deleted or renamed tag). Check https://github.com/Wire-Network/wire-cdt/releases against wirecdt.release in .cicd/defaults.json, and publish the wire-cdt release before re-running this build." >&2
+          }
+
+          # The pinned release's channel must agree with the pin, otherwise the
+          # prepare-release resolution and the build disagree about what shipped.
+          # `derive` is the one-off override path (workflow_dispatch
+          # override-cdt-release): there is no pin to agree with, so the release's
+          # own flag is reported rather than asserted.
+          if ! release_view="$(gh release view "$CDT_RELEASE" -R Wire-Network/wire-cdt --json tagName,isDraft,isPrerelease 2>&1)"; then
+            not_published_hint
+            echo "$release_view" >&2
+            exit 1
+          fi
+          # A draft is normally invisible to this token and would already have
+          # failed above; the explicit check covers the case where it IS visible,
+          # so the failure names the reason instead of surfacing as a missing asset.
+          if [[ "$(jq -r '.isDraft' <<<"$release_view")" == "true" ]]; then
+            echo "::error::Wire CDT release ${CDT_RELEASE} is still a DRAFT. Publish it (tag-release.yaml creates wire-cdt releases as drafts; release.yaml flips them) before running this build." >&2
+            exit 1
+          fi
+
+          release_prerelease="$(jq -r 'if .isPrerelease then "true" else "false" end' <<<"$release_view")"
+          case "$CDT_CHANNEL" in
+            prerelease) expected_prerelease="true" ;;
+            stable)     expected_prerelease="false" ;;
+            derive)
+              echo "Wire CDT release ${CDT_RELEASE} supplied by override-cdt-release; derived channel: $([[ "$release_prerelease" == "true" ]] && echo prerelease || echo stable)"
+              expected_prerelease="$release_prerelease"
+              ;;
+            *)
+              echo "::error::Unknown wirecdt.channel '${CDT_CHANNEL}' (expected 'prerelease' or 'stable')" >&2
+              exit 1
+              ;;
+          esac
+          if [[ "$release_prerelease" != "$expected_prerelease" ]]; then
+            echo "::error::Wire CDT release ${CDT_RELEASE} has prerelease=${release_prerelease}, but .cicd/defaults.json pins channel '${CDT_CHANNEL}'" >&2
+            exit 1
+          fi
+
+          # `wire-cdt_<version>_amd64.deb` is the BASE package; the dev package is
+          # `wire-cdt-dev_<version>_amd64.deb`, which this pattern does not match
+          # (the base name ends at the underscore).
+          mkdir -p cdt-package
+          if ! download_log="$(gh release download "$CDT_RELEASE" \
+                -R Wire-Network/wire-cdt \
+                -p 'wire-cdt_*_amd64.deb' \
+                -D cdt-package 2>&1)"; then
+            not_published_hint
+            echo "::error::...or the release exists but carries no wire-cdt_*_amd64.deb asset." >&2
+            echo "$download_log" >&2
+            gh release view "$CDT_RELEASE" -R Wire-Network/wire-cdt --json assets \
+              --jq '.assets[].name' >&2 || true
+            exit 1
+          fi
+
+          asset_name="$(basename "$(find cdt-package -type f -name 'wire-cdt_*_amd64.deb' -print -quit)")"
+          echo "Resolved Wire CDT release ${CDT_RELEASE} (channel ${CDT_CHANNEL})"
+          echo "Downloaded Wire CDT asset ${asset_name}"
+          echo "CDT_ASSET_NAME=${asset_name}" >> "$GITHUB_ENV"
 
       - name: Install Wire CDT package for release tag
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         env:
-          CDT_ARTIFACT_ID: ${{ needs.v.outputs.cdt-artifact-id }}
-          CDT_ARTIFACT_NAME: ${{ needs.v.outputs.cdt-artifact-name }}
-          CDT_ARTIFACT_RUN_URL: ${{ needs.v.outputs.cdt-artifact-run-url }}
-          CDT_ARTIFACT_SHA: ${{ needs.v.outputs.cdt-artifact-sha }}
+          CDT_RELEASE: ${{ needs.v.outputs.cdt-release }}
         run: |
-          cdt_deb="$(find cdt-package -type f -name 'cdt_*_amd64.deb' -print -quit)"
+          cdt_deb="$(find cdt-package -type f -name 'wire-cdt_*_amd64.deb' -print -quit)"
           if [[ -z "$cdt_deb" ]]; then
             echo "::error::No Wire CDT Debian package was downloaded."
             find cdt-package -maxdepth 3 -type f -print || true
             exit 1
           fi
-          echo "Installing Wire CDT artifact ${CDT_ARTIFACT_NAME} (${CDT_ARTIFACT_ID})"
-          echo "Wire CDT artifact run: ${CDT_ARTIFACT_RUN_URL}"
-          echo "Wire CDT source commit: ${CDT_ARTIFACT_SHA}"
+          echo "Installing Wire CDT asset ${CDT_ASSET_NAME} from release ${CDT_RELEASE}"
           sha256sum "$cdt_deb"
           bash .github/scripts/install-wire-cdt-package.sh "$cdt_deb"
 
@@ -200,6 +271,16 @@ jobs:
         run: |
           chown -R "$(id -u):$(id -g)" "$PWD"
           bash .github/scripts/build-sysio.sh "${{ matrix.build_jobs }}"
+
+      # Saved immediately after the build script populated vcpkg-binary-cache, and
+      # only on an exact-key miss -- GitHub Actions caches are immutable, so saving
+      # onto an existing key is a wasted upload that logs a warning.
+      - name: Save vcpkg binary cache
+        if: ${{ success() && steps.restore-vcpkg.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # actions/cache/save@v5
+        with:
+          path: ${{ github.workspace }}/vcpkg-binary-cache
+          key: vcpkg-binaries-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/vcpkg-triplets/**') }}
 
       - name: Show vcpkg logs if failure
         if: failure()
@@ -364,29 +445,74 @@ jobs:
           cpack -G RPM
           cmake --build . --target package-tgz
 
+      # Release-tag builds compile the system contracts from source (checked by
+      # assert-system-contract-build.sh above), so the tag build is the only place
+      # the .wasm/.abi pair exists. It ships as its own release asset, named
+      # `wire-sysio-system-contracts-<version>.tar.gz` so that it can never be
+      # mistaken for a platform tarball (`wire-sysio-<version>-<arch>.tar.gz`).
+      - name: Bundle system contracts artifact
+        if: ${{ steps.build.outcome == 'success' && matrix.platform == 'ubuntu24' && startsWith(github.ref, 'refs/tags/v') && !cancelled() }}
+        run: |
+          set -euo pipefail
+          cd build
+
+          # The version is taken from the produced base deb so the tarball, the deb,
+          # the rpm and the platform tgz can never disagree about it.
+          base_deb="$(find . -maxdepth 1 -type f -name 'wire-sysio_*_amd64.deb' -print -quit)"
+          [[ -n "$base_deb" ]] || { echo "::error::base deb not found; cannot derive the contracts bundle version" >&2; exit 1; }
+          version="$(basename "$base_deb")"
+          version="${version#wire-sysio_}"
+          version="${version%_amd64.deb}"
+
+          bundle="wire-sysio-system-contracts-${version}"
+          stage="$PWD/system-contracts-stage/${bundle}"
+          rm -rf "$PWD/system-contracts-stage"
+          mkdir -p "$stage"
+
+          # contracts_target() builds into <build>/contracts/sysio.<name>/, so the
+          # artifacts sit at exactly depth 2 -- deeper matches would be build scratch.
+          mapfile -t artifacts < <(
+            find contracts -mindepth 2 -maxdepth 2 -type f \
+              \( -name 'sysio.*.wasm' -o -name 'sysio.*.abi' \) | sort
+          )
+          if [[ ${#artifacts[@]} -eq 0 ]]; then
+            echo "::error::No sysio.*.wasm / sysio.*.abi found under build/contracts" >&2
+            exit 1
+          fi
+          for artifact in "${artifacts[@]}"; do
+            install -D "$artifact" "$stage/$(basename "$(dirname "$artifact")")/$(basename "$artifact")"
+          done
+
+          tar -czf "${bundle}.tar.gz" -C "$PWD/system-contracts-stage" "$bundle"
+          rm -rf "$PWD/system-contracts-stage"
+          echo "Bundled ${#artifacts[@]} system-contract artifacts into ${bundle}.tar.gz"
+
       - name: Upload release package set
         if: ${{ steps.build.outcome == 'success' && matrix.platform == 'ubuntu24' && !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # actions/upload-artifact@v6
         with:
           name: wire-sysio-packages-amd64
           if-no-files-found: error
+          # Explicit per-artifact globs: the platform tarball is arch-suffixed and the
+          # system-contracts bundle is matched by its own name, so neither can be
+          # picked up as the other by glob order.
           path: |
             build/wire-sysio_*.deb
             build/wire-sysio-dev_*.deb
             build/wire-sysio-*.rpm
-            build/wire-sysio-*.tar.gz
+            build/wire-sysio-*-x86_64.tar.gz
+            build/wire-sysio-system-contracts-*.tar.gz
 
   v:
     name: Discover Versions
     runs-on: ubuntu-latest
     outputs:
-      cdt-target: ${{steps.versions.outputs.cdt-target}}
-      cdt-prerelease: ${{steps.versions.outputs.cdt-prerelease}}
-      cdt-artifact-run-id: ${{steps.cdt-artifact.outputs.run-id}}
-      cdt-artifact-id: ${{steps.cdt-artifact.outputs.artifact-id}}
-      cdt-artifact-name: ${{steps.cdt-artifact.outputs.artifact-name}}
-      cdt-artifact-run-url: ${{steps.cdt-artifact.outputs.run-url}}
-      cdt-artifact-sha: ${{steps.cdt-artifact.outputs.commit-sha}}
+      # `cdt-release` / `cdt-channel` pin the RELEASE whose asset a tag build
+      # installs. (The former `cdt-target` / `cdt-prerelease` outputs went with
+      # the CI-artifact acquisition path they served -- nothing consumed them
+      # once CDT moved to release assets.)
+      cdt-release: ${{steps.versions.outputs.cdt-release}}
+      cdt-channel: ${{steps.versions.outputs.cdt-channel}}
       wire-system-contracts-ref: ${{steps.versions.outputs.wire-system-contracts-ref}}
     steps:
       - name: Setup wire-cdt and wire-system-contracts versions
@@ -399,8 +525,7 @@ jobs:
           # shell code in trusted CI that holds GH_TOKEN_DEV (WSA-094 / SEC-094). As env vars the
           # values are inert data: bash does not re-evaluate command substitution found inside a
           # variable's value. github.repository / github.sha are likewise read via env and quoted.
-          OVERRIDE_CDT: ${{ inputs.override-cdt }}
-          OVERRIDE_CDT_PRERELEASE: ${{ inputs.override-cdt-prerelease }}
+          OVERRIDE_CDT_RELEASE: ${{ inputs.override-cdt-release }}
           OVERRIDE_SYS_SYSTEM_CONTRACTS: ${{ inputs.override-sys-system-contracts }}
           REPO: ${{ github.repository }}
           REF_SHA: ${{ github.sha }}
@@ -411,7 +536,7 @@ jobs:
           # such as "4.1.0" and "release/4.0". The pattern is held in a variable so [[ =~ ]] treats it
           # as a regex, and the candidate matched is only ever the variable's literal value.
           ref_re='^[A-Za-z0-9._/+-]+$'
-          for ov in "$OVERRIDE_CDT" "$OVERRIDE_SYS_SYSTEM_CONTRACTS"; do
+          for ov in "$OVERRIDE_CDT_RELEASE" "$OVERRIDE_SYS_SYSTEM_CONTRACTS"; do
             if [[ -n "$ov" && ! "$ov" =~ $ref_re ]]; then
               echo "::error::Invalid override ref '$ov'; only [A-Za-z0-9._/+-] are allowed." >&2
               exit 1
@@ -419,101 +544,24 @@ jobs:
           done
 
           DEFAULTS_JSON=$(curl -sSfL "$(gh api "https://api.github.com/repos/${REPO}/contents/.cicd/defaults.json?ref=${REF_SHA}" --jq .download_url)")
-          echo "cdt-target=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.target')" >> "$GITHUB_OUTPUT"
-          echo "cdt-prerelease=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.prerelease')" >> "$GITHUB_OUTPUT"
+          echo "cdt-release=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.release')" >> "$GITHUB_OUTPUT"
+          echo "cdt-channel=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.channel')" >> "$GITHUB_OUTPUT"
           echo "wire-system-contracts-ref=$(echo "$DEFAULTS_JSON" | jq -r '.wiresystemcontracts.ref')" >> "$GITHUB_OUTPUT"
 
-          if [[ -n "$OVERRIDE_CDT" ]]; then
-            echo "cdt-target=$OVERRIDE_CDT" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "$OVERRIDE_CDT_PRERELEASE" == "true" || "$OVERRIDE_CDT_PRERELEASE" == "false" ]]; then
-            echo "cdt-prerelease=$OVERRIDE_CDT_PRERELEASE" >> "$GITHUB_OUTPUT"
+          # A one-off build against a different wire-cdt release. The pinned
+          # channel no longer describes it, so the channel is set to the `derive`
+          # sentinel: the download step then reports the release's OWN prerelease
+          # flag instead of asserting it against .cicd/defaults.json. Later lines
+          # win in $GITHUB_OUTPUT, so these override the pinned values above.
+          if [[ -n "$OVERRIDE_CDT_RELEASE" ]]; then
+            {
+              echo "cdt-release=$OVERRIDE_CDT_RELEASE"
+              echo "cdt-channel=derive"
+            } >> "$GITHUB_OUTPUT"
           fi
           if [[ -n "$OVERRIDE_SYS_SYSTEM_CONTRACTS" ]]; then
             echo "wire-system-contracts-ref=$OVERRIDE_SYS_SYSTEM_CONTRACTS" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Resolve Wire CDT package artifact run
-        id: cdt-artifact
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        env:
-          GH_TOKEN: ${{secrets.GH_TOKEN_DEV}}
-          CDT_TARGET: ${{steps.versions.outputs.cdt-target}}
-        run: |
-          set -euo pipefail
-
-          cdt_ref="$CDT_TARGET"
-          if [[ "$cdt_ref" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+._A-Za-z0-9]*)?$ ]]; then
-            cdt_ref="v$cdt_ref"
-          fi
-
-          cdt_sha="$(gh api "repos/Wire-Network/wire-cdt/commits/${cdt_ref}" --jq .sha)"
-          echo "Resolved Wire CDT target ${CDT_TARGET} to ${cdt_sha}"
-
-          for attempt in {1..30}; do
-            runs_json="$(gh api "repos/Wire-Network/wire-cdt/actions/workflows/build.yaml/runs?head_sha=${cdt_sha}&event=push&per_page=10")"
-            run_json="$(
-              jq -c '[.workflow_runs[]
-                | select(.status == "completed" and .conclusion == "success")]
-                | .[0] // empty' <<<"$runs_json"
-            )"
-            run_id=""
-            if [[ -n "$run_json" ]]; then
-              run_id="$(jq -r '.id // empty' <<<"$run_json")"
-            fi
-
-            if [[ -n "$run_id" ]]; then
-              run_url="$(jq -r '.html_url' <<<"$run_json")"
-              run_head_sha="$(jq -r '.head_sha' <<<"$run_json")"
-              if [[ "$run_head_sha" != "$cdt_sha" ]]; then
-                echo "::error::Wire CDT build run ${run_id} resolved to ${run_head_sha}, expected ${cdt_sha}" >&2
-                exit 1
-              fi
-
-              artifact_json="$(
-                gh api "repos/Wire-Network/wire-cdt/actions/runs/${run_id}/artifacts" |
-                  jq -c '[.artifacts[]
-                    | select(.name == "cdt_ubuntu_package_amd64" and .expired == false)]
-                    | .[0] // empty'
-              )"
-              artifact_id=""
-              if [[ -n "$artifact_json" ]]; then
-                artifact_id="$(jq -r '.id // empty' <<<"$artifact_json")"
-              fi
-              if [[ -n "$artifact_id" ]]; then
-                artifact_name="$(jq -r '.name' <<<"$artifact_json")"
-                artifact_size="$(jq -r '.size_in_bytes' <<<"$artifact_json")"
-                echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
-                echo "artifact-id=$artifact_id" >> "$GITHUB_OUTPUT"
-                echo "artifact-name=$artifact_name" >> "$GITHUB_OUTPUT"
-                echo "run-url=$run_url" >> "$GITHUB_OUTPUT"
-                echo "commit-sha=$cdt_sha" >> "$GITHUB_OUTPUT"
-                echo "Resolved Wire CDT target ${CDT_TARGET} to commit ${cdt_sha}"
-                echo "Resolved Wire CDT artifact run ${run_id}: ${run_url}"
-                echo "Resolved Wire CDT artifact ${artifact_name} (${artifact_id}, ${artifact_size} bytes)"
-                exit 0
-              fi
-
-              echo "::error::Wire CDT build run ${run_id} did not publish a non-expired cdt_ubuntu_package_amd64 artifact" >&2
-              exit 1
-            fi
-
-            failed_run_url="$(
-              jq -r '[.workflow_runs[]
-                | select(.status == "completed" and .conclusion != "success")]
-                | .[0].html_url // empty' <<<"$runs_json"
-            )"
-            if [[ -n "$failed_run_url" ]]; then
-              echo "::error::Wire CDT build run for ${cdt_sha} did not succeed: ${failed_run_url}" >&2
-              exit 1
-            fi
-
-            echo "Waiting for Wire CDT package artifact for ${cdt_sha} (attempt ${attempt}/30)"
-            sleep 60
-          done
-
-          echo "::error::Timed out waiting for Wire CDT package artifact for ${cdt_sha}" >&2
-          exit 1
 
   verify-packages:
     name: Verify packages (S1-S6)
@@ -531,7 +579,9 @@ jobs:
         run: |
           ls -la artifacts/
           tools/packaging/tests/verify-scripts.sh
-          tools/packaging/tests/verify-tgz.sh artifacts/wire-sysio-*.tar.gz
+          # Arch-suffixed on purpose: a bare wire-sysio-*.tar.gz would also match the
+          # system-contracts bundle that tag builds add to this artifact.
+          tools/packaging/tests/verify-tgz.sh artifacts/wire-sysio-*-x86_64.tar.gz
           tools/packaging/tests/verify-deb.sh artifacts/wire-sysio_*.deb artifacts/wire-sysio-dev_*.deb
           # wire-sysio-[0-9]* matches the base rpm only (the dev rpm is wire-sysio-dev-*).
           tools/packaging/tests/verify-rpm.sh artifacts/wire-sysio-[0-9]*.rpm artifacts/wire-sysio-dev-*.rpm

--- a/.github/workflows/macos_arm64_build.yaml
+++ b/.github/workflows/macos_arm64_build.yaml
@@ -10,21 +10,16 @@ on:
   schedule:
     # GitHub schedules run from the default branch, providing nightly coverage for origin/master.
     - cron: "0 8 * * *"
+  # NOTE: a `paths:` filter cannot be scoped to one ref pattern within a single
+  # `push:` block, and a tag push carries no new commits for the filter to match --
+  # so a `paths:`-filtered push trigger would silently suppress every `v*` tag run,
+  # which is exactly the run that produces the macOS release tarball. The filter is
+  # therefore kept on `pull_request:` only; master pushes now always build macOS.
   push:
     branches:
       - master
-    paths:
-      - ".github/workflows/macos_arm64_build.yaml"
-      - ".github/vcpkg-triplets/**"
-      - "cmake/**"
-      - "libraries/**"
-      - "plugins/**"
-      - "programs/**"
-      - "unittests/**"
-      - "tests/**"
-      - "CMakeLists.txt"
-      - "vcpkg.json"
-      - "vcpkg-configuration.json"
+    tags:
+      - "v*"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -69,8 +64,12 @@ jobs:
           "$RUNNER_TEMP/python-venv/bin/python" -m pip install numpy
           echo "$RUNNER_TEMP/python-venv/bin" >> "$GITHUB_PATH"
 
+      # Split restore/save (not the monolithic actions/cache) -- see the matching
+      # comment in linux_amd64_build.yaml: the paired save runs immediately after
+      # the build, and only on an exact-key miss (caches are immutable).
       - name: Restore vcpkg binary cache
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # actions/cache@v5
+        id: restore-vcpkg
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/vcpkg-binary-cache
           key: vcpkg-binaries-macos-arm64-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/vcpkg-triplets/arm64-osx-release.cmake') }}
@@ -93,6 +92,13 @@ jobs:
           VCPKG_HOST_TRIPLET: arm64-osx-release
         run: |
           bash .github/scripts/build-sysio.sh "$(sysctl -n hw.logicalcpu)"
+
+      - name: Save vcpkg binary cache
+        if: ${{ success() && steps.restore-vcpkg.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # actions/cache/save@v5
+        with:
+          path: ${{ github.workspace }}/vcpkg-binary-cache
+          key: vcpkg-binaries-macos-arm64-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/vcpkg-triplets/arm64-osx-release.cmake') }}
 
       - name: Enable macOS core dumps
         run: |
@@ -142,6 +148,29 @@ jobs:
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-macos-arm64-${{ github.sha }}
+
+      # macOS ships the portable tarball only -- there is no deb/rpm generator and no
+      # service payload (cmake/package.cmake gates those install() rules on NOT APPLE).
+      # WIRE_ARCH_TAG makes the artifact wire-sysio-<version>-macos-arm64.tar.gz, so it
+      # never collides with the Linux wire-sysio-<version>-x86_64.tar.gz on a release.
+      - name: Build portable tarball
+        run: |
+          cmake --build "$BUILD_DIR" --target package-tgz
+
+      - name: Verify portable tarball (S1, no-service)
+        run: |
+          set -euo pipefail
+          tarball="$(find "$BUILD_DIR" -maxdepth 1 -type f -name 'wire-sysio-*-macos-arm64.tar.gz' -print -quit)"
+          [[ -n "$tarball" ]] || { echo "::error::macOS portable tarball not found in $BUILD_DIR" >&2; exit 1; }
+          tools/packaging/tests/verify-tgz.sh --no-service "$tarball"
+
+      - name: Upload release package set
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # actions/upload-artifact@v6
+        with:
+          name: wire-sysio-packages-macos-arm64
+          if-no-files-found: error
+          path: |
+            ${{ env.BUILD_DIR }}/wire-sysio-*-macos-arm64.tar.gz
 
       - name: Upload core files from failed tests
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # actions/upload-artifact@v6

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,174 @@
+name: "Prepare Release"
+
+# Gate 1 of the Strategy-C release path (docs/release-workflow.md): produce the
+# version-bump PR a human reviews and merges. Nothing is tagged or published here.
+#
+# `version` is the SOLE input -- its suffix IS the channel everywhere downstream:
+# a suffix (-dev, -rcN, ...) means prerelease, no suffix means stable.
+#
+# Post-bump mode is the same dispatch: after a stable release lands, dispatch this
+# workflow again with the next `-dev` version to restore the development suffix on
+# master. The workflow labels the PR accordingly.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to prepare, without a leading v (e.g. 1.0.0-dev, 1.1.0-rc1, 1.1.0)"
+        type: string
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare:
+    name: Open the version-bump PR
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      # Untrusted dispatch input: passed as an environment variable and NEVER
+      # interpolated into a script body, so a value such as $(...) stays inert data.
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+        with:
+          ref: master
+          # Unshallowed so the remote-tracking refs exist: `git push
+          # --force-with-lease` below needs origin/<prep-branch> to compare
+          # against, and on a shallow clone with no such ref it fails with
+          # "stale info" whenever a previous prep attempt already pushed it.
+          fetch-depth: 0
+
+      - name: Validate version and derive the channel
+        id: version
+        run: |
+          set -euo pipefail
+
+          # Conservative allowlist -- the same grammar cmake-version.py enforces.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$ ]]; then
+            echo "::error::'${VERSION}' is not <major>.<minor>.<patch>[-<suffix>] (no leading v)" >&2
+            exit 1
+          fi
+
+          previous="$(python3 .github/scripts/cmake-version.py read)"
+
+          # Nothing to do: master already carries this version, so the bump would
+          # be an empty commit and the PR would have no diff to review. Fail here
+          # with the reason rather than at `git commit` with "nothing to commit".
+          if [[ "$previous" == "$VERSION" ]]; then
+            echo "::error::master is already at ${VERSION}; nothing to prepare. Dispatch with the NEXT version instead." >&2
+            exit 1
+          fi
+
+          if [[ "$VERSION" == *-* ]]; then
+            channel="prerelease"
+            prerelease="true"
+          else
+            channel="stable"
+            prerelease="false"
+          fi
+
+          # A suffixed version replacing an unsuffixed one is the post-stable
+          # restoration of the development suffix, not a release preparation.
+          if [[ "$previous" != *-* && "$VERSION" == *-* ]]; then
+            mode="post-bump"
+          else
+            mode="release-prep"
+          fi
+
+          {
+            echo "previous=$previous"
+            echo "channel=$channel"
+            echo "prerelease=$prerelease"
+            echo "mode=$mode"
+            echo "branch=release/prep-v${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Preparing ${previous} -> ${VERSION} (channel ${channel}, mode ${mode})"
+
+      - name: Write the version into CMakeLists.txt
+        run: |
+          python3 .github/scripts/cmake-version.py write "$VERSION"
+
+      - name: Pin the latest published wire-cdt release for the channel
+        id: cdt
+        env:
+          CDT_PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          CDT_CHANNEL: ${{ steps.version.outputs.channel }}
+        run: |
+          set -euo pipefail
+
+          # Resolve-at-prepare, pin-at-build: the tag build downloads exactly this
+          # release's asset, so re-runs are reproducible, the CDT version is
+          # reviewable at gate 1, and there is no publish-order race at release time.
+          #
+          # There is no first-class "latest prerelease" endpoint, so the release list
+          # is filtered by draft/prerelease and the newest by creation date wins.
+          releases_json="$(
+            gh api "repos/Wire-Network/wire-cdt/releases?per_page=100" \
+              -H "X-GitHub-Api-Version: 2022-11-28"
+          )"
+          cdt_release="$(
+            jq -r --argjson pre "$CDT_PRERELEASE" '
+              [.[] | select(.draft == false and .prerelease == $pre)]
+              | sort_by(.created_at)
+              | last
+              | .tag_name // empty' <<<"$releases_json"
+          )"
+          if [[ -z "$cdt_release" ]]; then
+            echo "::error::No published wire-cdt release found for channel ${CDT_CHANNEL}" >&2
+            exit 1
+          fi
+
+          jq --indent 2 --arg release "$cdt_release" --arg channel "$CDT_CHANNEL" \
+            '.wirecdt.release = $release | .wirecdt.channel = $channel' \
+            .cicd/defaults.json > .cicd/defaults.json.next
+          mv .cicd/defaults.json.next .cicd/defaults.json
+
+          echo "release=$cdt_release" >> "$GITHUB_OUTPUT"
+          echo "Pinned wire-cdt ${cdt_release} (channel ${CDT_CHANNEL})"
+
+      - name: Open the bump PR
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
+          PREVIOUS: ${{ steps.version.outputs.previous }}
+          CHANNEL: ${{ steps.version.outputs.channel }}
+          MODE: ${{ steps.version.outputs.mode }}
+          CDT_RELEASE: ${{ steps.cdt.outputs.release }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add CMakeLists.txt .cicd/defaults.json
+          git commit -m "chore(release): ${MODE} ${PREVIOUS} -> ${VERSION}"
+          # --force-with-lease, not a bare push: re-dispatching the prep for the
+          # same version (a fixed pin, a re-resolved CDT release) must be able to
+          # replace the previous attempt's branch tip instead of failing
+          # non-fast-forward, while still refusing to clobber a tip that someone
+          # else moved since this run's fetch.
+          git push --force-with-lease origin "$BRANCH"
+
+          # NOTE: a PR opened with GITHUB_TOKEN starts its `pull_request` checks in
+          # an approval-required state -- gate 1 includes an "Approve and run" click.
+          # printf, not an indented heredoc: every body line must start at column 0
+          # or GitHub renders the whole description as a code block.
+          body="$(printf '%s\n' \
+            "${MODE}: \`${PREVIOUS}\` -> \`${VERSION}\` (channel: **${CHANNEL}**)." \
+            "" \
+            "- \`CMakeLists.txt\`: \`VERSION_*\` set to \`${VERSION}\`." \
+            "- \`.cicd/defaults.json\`: \`wirecdt.release\` pinned to \`${CDT_RELEASE}\`, \`wirecdt.channel\` set to \`${CHANNEL}\`." \
+            "" \
+            "Review the pinned Wire CDT release, then merge. Tagging is a separate," \
+            "approval-gated dispatch of \`tag-release.yaml\` with the same version.")"
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "chore(release): ${MODE} v${VERSION}" \
+            --body "$body"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -25,6 +25,13 @@ defaults:
   run:
     shell: bash
 
+# One prep run per version, and never cancel one mid-flight: a cancelled run can
+# leave a pushed prep branch with no PR opened for it. Matches wire-cdt's
+# prepare-release.yaml.
+concurrency:
+  group: prepare-release-${{ inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   prepare:
     name: Open the version-bump PR
@@ -49,11 +56,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Conservative allowlist -- the same grammar cmake-version.py enforces.
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$ ]]; then
-            echo "::error::'${VERSION}' is not <major>.<minor>.<patch>[-<suffix>] (no leading v)" >&2
-            exit 1
-          fi
+          # The grammar is cmake-version.py's VERSION_RE, asserted by the parser
+          # itself rather than re-spelled here: an inline copy is one edit away
+          # from accepting a version the `write` below would then reject.
+          python3 .github/scripts/cmake-version.py validate "$VERSION" \
+            || { echo "::error::'${VERSION}' is not <major>.<minor>.<patch>[-<suffix>] (no leading v)" >&2; exit 1; }
 
           previous="$(python3 .github/scripts/cmake-version.py read)"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,13 @@
 name: "Release Actions"
 
 on:
+  # Manual fallback: publishing a release by hand still populates its assets.
+  # Release-published events always run the DEFAULT branch's workflow file.
   release:
     types: [published]
-  # Validation path: release-published events always run the DEFAULT branch's
-  # workflow file, so pre-merge testing (and re-runs against an existing
-  # release) go through manual dispatch with the tag as input.
+  # The Strategy-C path: tag-release.yaml dispatches this workflow with the tag it
+  # just created, after dispatching the linux + macOS builds on the same tag ref.
+  # Dispatch is also how a failed asset run is retried against an existing release.
   workflow_dispatch:
     inputs:
       tag:
@@ -18,6 +20,12 @@ permissions:
   packages: write
   actions: read
 
+# One asset run per tag, and NEVER cancel one in flight: a cancelled run can leave
+# a release half-populated, and the workflow is cheap enough to let it finish.
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 defaults:
   run:
     shell: bash
@@ -26,58 +34,167 @@ jobs:
   publish-assets:
     name: Verify & attach release artifacts
     runs-on: ubuntu-latest
+    # tag-release.yaml dispatches this workflow at the same moment it dispatches the
+    # platform builds, so this job waits out a full build (linux_amd64_build allows
+    # itself 360 minutes). Kept under the 6h GitHub-hosted job ceiling.
+    timeout-minutes: 350
     outputs:
-      run-id: ${{ steps.run.outputs.run-id }}
+      linux-run-id: ${{ steps.run.outputs.linux-run-id }}
+      macos-run-id: ${{ steps.run.outputs.macos-run-id }}
     env:
       GH_TOKEN: ${{ github.token }}
       TAG: ${{ inputs.tag || github.ref_name }}
     steps:
+      - name: Validate the tag
+        run: |
+          set -euo pipefail
+
+          # TAG comes from a workflow_dispatch input on the Strategy-C path, so it
+          # is untrusted text that is about to be spliced into API paths, file
+          # names and a `gh release` target. Pin its shape before anything uses it.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::'${TAG}' is not a release tag (expected vX.Y.Z or vX.Y.Z-suffix)" >&2
+            exit 1
+          fi
+          echo "Publishing assets for ${TAG}"
+
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
 
-      - name: Resolve build run for the released commit
+      - name: Resolve build runs for the released commit
         id: run
         run: |
-          # The release points at a tag; the tag build (linux_amd64_build.yaml,
-          # push: tags v*) produced wire-sysio-packages-amd64 for exactly this
-          # commit. Same resolution pattern as the wire-cdt artifact lookup.
+          set -euo pipefail
+
+          # Both platform builds must have run AT THE TAG REF. Filtering on
+          # head_branch == "$TAG" is load-bearing: the master-push build sits at the
+          # same commit SHA but builds WITHOUT the system contracts, so matching it
+          # would attach a package set with no contracts bundle. Tag builds reach
+          # this workflow either as `push` (a human-pushed tag) or as
+          # `workflow_dispatch` (tag-release.yaml dispatching on refs/tags/<tag>) --
+          # both are accepted.
           sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq .sha)
-          run_id=""
-          for attempt in {1..30}; do
-            run_id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/linux_amd64_build.yaml/runs?head_sha=${sha}&event=push&per_page=10" \
-              --jq '[.workflow_runs[] | select(.status=="completed" and .conclusion=="success")][0].id // empty')
-            [[ -n "$run_id" ]] && break
-            echo "Waiting for successful tag build of ${sha} (attempt ${attempt}/30)"
+          echo "Released commit: ${sha}"
+
+          log_candidates=1
+          resolve_run() {
+            local workflow="$1" runs_json
+            runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs?head_sha=${sha}&per_page=50")"
+            if [[ "$log_candidates" == "1" ]]; then
+              # First attempt only: dump what the API actually returned. A
+              # head_branch-semantics mismatch (the classic resolver failure) is
+              # then visible in minute one instead of after 5.5 hours of polling.
+              {
+                echo "--- ${workflow} candidate runs at ${sha} (want head_branch == ${TAG}) ---"
+                jq -r '.workflow_runs | length | "candidates: \(.)"' <<<"$runs_json"
+                jq -c '.workflow_runs[] | {id, head_branch, event, status, conclusion}' <<<"$runs_json"
+              } >&2
+            fi
+            jq -r --arg tag "$TAG" '
+              [.workflow_runs[]
+                | select(.status == "completed" and .conclusion == "success")
+                | select(.event == "push" or .event == "workflow_dispatch")
+                | select(.head_branch == $tag)]
+              | .[0].id // empty' <<<"$runs_json"
+          }
+
+          # 330 minute-spaced attempts: this workflow is dispatched alongside the
+          # builds, so it must outlast a cold full build, not just the artifact
+          # upload that follows one.
+          linux_run_id=""
+          macos_run_id=""
+          for attempt in {1..330}; do
+            [[ -n "$linux_run_id" ]] || linux_run_id="$(resolve_run linux_amd64_build.yaml)"
+            [[ -n "$macos_run_id" ]] || macos_run_id="$(resolve_run macos_arm64_build.yaml)"
+            log_candidates=0
+            [[ -n "$linux_run_id" && -n "$macos_run_id" ]] && break
+            echo "Waiting for tag-ref builds of ${sha} (linux=${linux_run_id:-pending} macos=${macos_run_id:-pending}, attempt ${attempt}/330)"
             sleep 60
           done
-          [[ -n "$run_id" ]] || { echo "::error::No successful build run found for ${sha}"; exit 1; }
-          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+
+          [[ -n "$linux_run_id" ]] || { echo "::error::No successful linux_amd64_build run at ${TAG} (${sha})"; exit 1; }
+          [[ -n "$macos_run_id" ]] || { echo "::error::No successful macos_arm64_build run at ${TAG} (${sha})"; exit 1; }
+          echo "linux-run-id=$linux_run_id" >> "$GITHUB_OUTPUT"
+          echo "macos-run-id=$macos_run_id" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
         with:
           name: wire-sysio-packages-amd64
           path: dist
-          run-id: ${{ steps.run.outputs.run-id }}
+          run-id: ${{ steps.run.outputs.linux-run-id }}
+          github-token: ${{ github.token }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
+        with:
+          name: wire-sysio-packages-macos-arm64
+          path: dist
+          run-id: ${{ steps.run.outputs.macos-run-id }}
           github-token: ${{ github.token }}
 
       - name: Guard release tag matches artifact version
         run: |
-          tag="${GITHUB_REF_NAME#v}"
+          set -euo pipefail
+          version="${TAG#v}"
           ls -la dist/
-          [[ -f "dist/wire-sysio_${tag}_amd64.deb" ]] \
-            || { echo "::error::Release tag v${tag} does not match the artifact version (bump VERSION_* in CMakeLists.txt to match the tag before tagging)"; exit 1; }
+          [[ -f "dist/wire-sysio_${version}_amd64.deb" ]] \
+            || { echo "::error::Release tag ${TAG} does not match the artifact version (bump VERSION_* in CMakeLists.txt to match the tag before tagging)"; exit 1; }
 
+      # Every verification names its artifact EXPLICITLY. A `wire-sysio-*.tar.gz`
+      # glob would hand verify-tgz whichever of the three tarballs (linux, macOS,
+      # system contracts) sorted first -- a silent wrong-artifact verification.
       - name: Verify packages (S1-S6)
         run: |
-          tools/packaging/tests/verify-tgz.sh dist/wire-sysio-*.tar.gz
-          tools/packaging/tests/verify-deb.sh dist/wire-sysio_*.deb dist/wire-sysio-dev_*.deb
-          # wire-sysio-[0-9]* matches the base rpm only (the dev rpm is wire-sysio-dev-*).
-          tools/packaging/tests/verify-rpm.sh dist/wire-sysio-[0-9]*.rpm dist/wire-sysio-dev-*.rpm
+          set -euo pipefail
+          version="${TAG#v}"
+          tools/packaging/tests/verify-tgz.sh "dist/wire-sysio-${version}-x86_64.tar.gz"
+          tools/packaging/tests/verify-tgz.sh --no-service "dist/wire-sysio-${version}-macos-arm64.tar.gz"
+          tools/packaging/tests/verify-deb.sh "dist/wire-sysio_${version}_amd64.deb" "dist/wire-sysio-dev_${version}_amd64.deb"
+          tools/packaging/tests/verify-rpm.sh "dist/wire-sysio-${version}-x86_64.rpm" "dist/wire-sysio-dev-${version}-x86_64.rpm"
+
+      - name: Verify system contracts bundle
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          bundle="dist/wire-sysio-system-contracts-${version}.tar.gz"
+          [[ -f "$bundle" ]] || { echo "::error::system contracts bundle not found: $bundle"; exit 1; }
+          entries="$(tar tzf "$bundle")"
+          # A tag build compiles the contracts from source, so both halves of every
+          # contract (executable wasm + its abi) must be present.
+          echo "$entries" | grep -q '/sysio\..*\.wasm$' \
+            || { echo "::error::${bundle} contains no sysio.*.wasm"; exit 1; }
+          echo "$entries" | grep -q '/sysio\..*\.abi$' \
+            || { echo "::error::${bundle} contains no sysio.*.abi"; exit 1; }
+          echo "system contracts bundle OK: $(echo "$entries" | grep -c '\.wasm$') wasm, $(echo "$entries" | grep -c '\.abi$') abi"
 
       - name: Attach artifacts to the release
         run: |
-          sha256sum dist/* > "wire-sysio-${GITHUB_REF_NAME#v}-checksums.txt"
-          mv "wire-sysio-${GITHUB_REF_NAME#v}-checksums.txt" dist/
-          gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+          set -euo pipefail
+          version="${TAG#v}"
+          # Generated from INSIDE dist/ over an explicit, ordered file list:
+          # `sha256sum dist/*` would write `dist/`-prefixed paths into the file
+          # (useless to a downloader running `sha256sum -c` next to the assets)
+          # and would depend on glob order to avoid hashing the checksums file
+          # itself. Seven package assets + this file = the eight release assets.
+          (
+            cd dist
+            sha256sum \
+              "wire-sysio_${version}_amd64.deb" \
+              "wire-sysio-dev_${version}_amd64.deb" \
+              "wire-sysio-${version}-x86_64.rpm" \
+              "wire-sysio-dev-${version}-x86_64.rpm" \
+              "wire-sysio-${version}-x86_64.tar.gz" \
+              "wire-sysio-${version}-macos-arm64.tar.gz" \
+              "wire-sysio-system-contracts-${version}.tar.gz" \
+              > "wire-sysio-${version}-checksums.txt"
+          )
+          cat "dist/wire-sysio-${version}-checksums.txt"
+          gh release upload "$TAG" dist/* --clobber
+
+      - name: Publish the release
+        run: |
+          # tag-release.yaml creates the release as a DRAFT so no half-populated
+          # release is ever visible. Flipping the draft with GITHUB_TOKEN does NOT
+          # re-fire `release: published`, so this cannot recurse into this workflow.
+          gh release edit "$TAG" --draft=false
 
   experimental-binaries:
     name: experimental-binaries (ghcr mirror)
@@ -92,7 +209,7 @@ jobs:
         with:
           name: wire-sysio-packages-amd64
           path: .
-          run-id: ${{ needs.publish-assets.outputs.run-id }}
+          run-id: ${{ needs.publish-assets.outputs.linux-run-id }}
           github-token: ${{ github.token }}
 
       - name: Create Dockerfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,12 +39,25 @@ jobs:
     # itself 360 minutes). Kept under the 6h GitHub-hosted job ceiling.
     timeout-minutes: 350
     outputs:
-      linux-run-id: ${{ steps.run.outputs.linux-run-id }}
-      macos-run-id: ${{ steps.run.outputs.macos-run-id }}
+      # The step output names are derived from the workflow file names by
+      # resolve-build-run.sh; the JOB output names stay platform-flavoured for
+      # the experimental-binaries consumer below.
+      linux-run-id: ${{ steps.run.outputs.linux_amd64_build-run-id }}
+      macos-run-id: ${{ steps.run.outputs.macos_arm64_build-run-id }}
     env:
       GH_TOKEN: ${{ github.token }}
       TAG: ${{ inputs.tag || github.ref_name }}
     steps:
+      # Check out the TAG's tree, not the workflow ref's. On the Strategy-C path
+      # this workflow is dispatched with --ref master, so a bare checkout would
+      # verify a tag's artifacts with MASTER's verifier scripts -- and a retry
+      # against an older tag would verify it with whatever the scripts have since
+      # become. The tag's own verifiers are the ones that describe its packages.
+      # (`github.ref` is refs/tags/<tag> on the `release: published` path.)
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
       - name: Validate the tag
         run: |
           set -euo pipefail
@@ -52,82 +65,46 @@ jobs:
           # TAG comes from a workflow_dispatch input on the Strategy-C path, so it
           # is untrusted text that is about to be spliced into API paths, file
           # names and a `gh release` target. Pin its shape before anything uses it.
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
-            echo "::error::'${TAG}' is not a release tag (expected vX.Y.Z or vX.Y.Z-suffix)" >&2
-            exit 1
-          fi
+          # The grammar is cmake-version.py's VERSION_RE -- the ONE definition the
+          # prepare/tag workflows validate against too. NOTE this TIGHTENS the
+          # previous inline pattern, which also accepted an empty-ish or dotted
+          # suffix (v1.0.0-. / v1.0.0-a..b); the canonical grammar is
+          # dot-separated alphanumerics only.
+          python3 .github/scripts/cmake-version.py validate --tag "$TAG" >/dev/null \
+            || { echo "::error::'${TAG}' is not a release tag (expected vX.Y.Z or vX.Y.Z-suffix)" >&2; exit 1; }
           echo "Publishing assets for ${TAG}"
-
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
 
       - name: Resolve build runs for the released commit
         id: run
         run: |
           set -euo pipefail
 
-          # Both platform builds must have run AT THE TAG REF. Filtering on
-          # head_branch == "$TAG" is load-bearing: the master-push build sits at the
-          # same commit SHA but builds WITHOUT the system contracts, so matching it
-          # would attach a package set with no contracts bundle. Tag builds reach
-          # this workflow either as `push` (a human-pushed tag) or as
-          # `workflow_dispatch` (tag-release.yaml dispatching on refs/tags/<tag>) --
-          # both are accepted.
           sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq .sha)
           echo "Released commit: ${sha}"
 
-          log_candidates=1
-          resolve_run() {
-            local workflow="$1" runs_json
-            runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs?head_sha=${sha}&per_page=50")"
-            if [[ "$log_candidates" == "1" ]]; then
-              # First attempt only: dump what the API actually returned. A
-              # head_branch-semantics mismatch (the classic resolver failure) is
-              # then visible in minute one instead of after 5.5 hours of polling.
-              {
-                echo "--- ${workflow} candidate runs at ${sha} (want head_branch == ${TAG}) ---"
-                jq -r '.workflow_runs | length | "candidates: \(.)"' <<<"$runs_json"
-                jq -c '.workflow_runs[] | {id, head_branch, event, status, conclusion}' <<<"$runs_json"
-              } >&2
-            fi
-            jq -r --arg tag "$TAG" '
-              [.workflow_runs[]
-                | select(.status == "completed" and .conclusion == "success")
-                | select(.event == "push" or .event == "workflow_dispatch")
-                | select(.head_branch == $tag)]
-              | .[0].id // empty' <<<"$runs_json"
-          }
-
-          # 330 minute-spaced attempts: this workflow is dispatched alongside the
-          # builds, so it must outlast a cold full build, not just the artifact
-          # upload that follows one.
-          linux_run_id=""
-          macos_run_id=""
-          for attempt in {1..330}; do
-            [[ -n "$linux_run_id" ]] || linux_run_id="$(resolve_run linux_amd64_build.yaml)"
-            [[ -n "$macos_run_id" ]] || macos_run_id="$(resolve_run macos_arm64_build.yaml)"
-            log_candidates=0
-            [[ -n "$linux_run_id" && -n "$macos_run_id" ]] && break
-            echo "Waiting for tag-ref builds of ${sha} (linux=${linux_run_id:-pending} macos=${macos_run_id:-pending}, attempt ${attempt}/330)"
-            sleep 60
-          done
-
-          [[ -n "$linux_run_id" ]] || { echo "::error::No successful linux_amd64_build run at ${TAG} (${sha})"; exit 1; }
-          [[ -n "$macos_run_id" ]] || { echo "::error::No successful macos_arm64_build run at ${TAG} (${sha})"; exit 1; }
-          echo "linux-run-id=$linux_run_id" >> "$GITHUB_OUTPUT"
-          echo "macos-run-id=$macos_run_id" >> "$GITHUB_OUTPUT"
+          # The resolver (poll loop, tag-ref filtering, candidate dump, budgets)
+          # is byte-identical with wire-cdt's copy of this script; only the
+          # workflows to wait for differ, so they are the arguments. Filtering on
+          # the tag ref is what the script does and it is load-bearing here: the
+          # master-push build sits at the same commit SHA but builds WITHOUT the
+          # system contracts, so matching it would attach a package set with no
+          # contracts bundle. Progress goes to stderr, so this redirect cannot
+          # corrupt $GITHUB_OUTPUT.
+          .github/scripts/resolve-build-run.sh "$TAG" "$sha" \
+            linux_amd64_build.yaml macos_arm64_build.yaml >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
         with:
           name: wire-sysio-packages-amd64
           path: dist
-          run-id: ${{ steps.run.outputs.linux-run-id }}
+          run-id: ${{ steps.run.outputs.linux_amd64_build-run-id }}
           github-token: ${{ github.token }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
         with:
           name: wire-sysio-packages-macos-arm64
           path: dist
-          run-id: ${{ steps.run.outputs.macos-run-id }}
+          run-id: ${{ steps.run.outputs.macos_arm64_build-run-id }}
           github-token: ${{ github.token }}
 
       - name: Guard release tag matches artifact version
@@ -138,17 +115,14 @@ jobs:
           [[ -f "dist/wire-sysio_${version}_amd64.deb" ]] \
             || { echo "::error::Release tag ${TAG} does not match the artifact version (bump VERSION_* in CMakeLists.txt to match the tag before tagging)"; exit 1; }
 
-      # Every verification names its artifact EXPLICITLY. A `wire-sysio-*.tar.gz`
-      # glob would hand verify-tgz whichever of the three tarballs (linux, macOS,
-      # system contracts) sorted first -- a silent wrong-artifact verification.
       - name: Verify packages (S1-S6)
         run: |
           set -euo pipefail
           version="${TAG#v}"
-          tools/packaging/tests/verify-tgz.sh "dist/wire-sysio-${version}-x86_64.tar.gz"
-          tools/packaging/tests/verify-tgz.sh --no-service "dist/wire-sysio-${version}-macos-arm64.tar.gz"
-          tools/packaging/tests/verify-deb.sh "dist/wire-sysio_${version}_amd64.deb" "dist/wire-sysio-dev_${version}_amd64.deb"
-          tools/packaging/tests/verify-rpm.sh "dist/wire-sysio-${version}-x86_64.rpm" "dist/wire-sysio-dev-${version}-x86_64.rpm"
+          # Passing the version selects the explicit-names mode: the suite owns
+          # the artifact list and the no-bare-tgz-glob rule in one place, shared
+          # with linux_amd64_build.yaml's verification of the same package set.
+          tools/packaging/tests/verify-all.sh dist "$version"
 
       - name: Verify system contracts bundle
         run: |

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -55,10 +55,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$ ]]; then
-            echo "::error::'${VERSION}' is not <major>.<minor>.<patch>[-<suffix>] (no leading v)" >&2
-            exit 1
-          fi
+          # The grammar is cmake-version.py's VERSION_RE, asserted by the parser
+          # itself rather than re-spelled here -- the same check prepare-release
+          # ran on this version before it reached master.
+          python3 .github/scripts/cmake-version.py validate "$VERSION" \
+            || { echo "::error::'${VERSION}' is not <major>.<minor>.<patch>[-<suffix>] (no leading v)" >&2; exit 1; }
 
           # The same parser prepare-release.yaml writes with and release.yaml
           # cross-checks the tag against.

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,156 @@
+name: "Tag Release"
+
+# Gate 2 of the Strategy-C release path (docs/release-workflow.md). The job runs
+# under the `release` Environment, so it PAUSES for a required reviewer before it
+# creates anything. After approval it tags master, opens a DRAFT release, and
+# dispatches the platform builds plus the asset workflow.
+#
+# `version` is the SOLE input; its suffix IS the channel (suffix => prerelease).
+#
+# Structurally identical to wire-cdt/.github/workflows/tag-release.yaml -- the two
+# repos run the same release path, so the two files are kept in lock-step.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag, without a leading v (e.g. 1.0.0-dev, 1.1.0-rc1, 1.1.0). Must already be master's version."
+        type: string
+        required: true
+
+permissions:
+  contents: write
+  # `gh workflow run` dispatches the build + release workflows.
+  actions: write
+
+concurrency:
+  # One tagging run per version, and never cancel one mid-flight: a cancelled run
+  # can leave a tag without its draft release, which the next attempt would then
+  # refuse (never re-tag).
+  group: tag-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tag:
+    name: Tag master and start the release builds
+    runs-on: ubuntu-latest
+    # Required reviewers on this Environment are gate 2 -- nothing below runs until
+    # a human approves the deployment.
+    environment: release
+    env:
+      GH_TOKEN: ${{ github.token }}
+      # Untrusted dispatch input: environment variable only, never interpolated
+      # into a script body.
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+        with:
+          ref: master
+
+      - name: Assert master HEAD carries the requested version
+        id: assert
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$ ]]; then
+            echo "::error::'${VERSION}' is not <major>.<minor>.<patch>[-<suffix>] (no leading v)" >&2
+            exit 1
+          fi
+
+          # The same parser prepare-release.yaml writes with and release.yaml
+          # cross-checks the tag against.
+          head_version="$(python3 .github/scripts/cmake-version.py read)"
+          if [[ "$head_version" != "$VERSION" ]]; then
+            echo "::error::master HEAD is version ${head_version}, not ${VERSION}. Merge the prepare-release PR first." >&2
+            exit 1
+          fi
+
+          # The suffix decides the channel for the whole downstream path.
+          if [[ "$VERSION" == *-* ]]; then
+            prerelease="true"
+          else
+            prerelease="false"
+          fi
+
+          tag="v${VERSION}"
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+            echo "::error::Tag ${tag} already exists. Never re-tag -- cut the next -rcN instead." >&2
+            exit 1
+          fi
+
+          {
+            echo "tag=$tag"
+            echo "sha=$(git rev-parse HEAD)"
+            echo "prerelease=$prerelease"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create the annotated tag
+        env:
+          TAG: ${{ steps.assert.outputs.tag }}
+          SHA: ${{ steps.assert.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          # An annotated tag is TWO API calls, in this order: the tag object first,
+          # then the ref that points at it. `gh release create --verify-tag` needs
+          # the ref to exist, so the ref call must come second.
+          tag_sha="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/tags" -X POST \
+              -f tag="$TAG" \
+              -f message="$TAG" \
+              -f object="$SHA" \
+              -f type=commit \
+              --jq .sha
+          )"
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" -X POST \
+            -f ref="refs/tags/${TAG}" \
+            -f sha="$tag_sha" > /dev/null
+          echo "Created annotated tag ${TAG} -> ${SHA} (tag object ${tag_sha})"
+
+      - name: Create the draft release
+        env:
+          TAG: ${{ steps.assert.outputs.tag }}
+          PRERELEASE: ${{ steps.assert.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+
+          # Draft, so no half-populated release is ever public: release.yaml flips
+          # the draft only after every artifact has been verified and attached.
+          # The notes and the prerelease flag are set HERE -- release.yaml never
+          # creates the release on this path.
+          args=(--draft --verify-tag --title "$TAG" --generate-notes)
+          if [[ "$PRERELEASE" == "true" ]]; then
+            args+=(--prerelease)
+          fi
+          gh release create "$TAG" "${args[@]}"
+
+      - name: Dispatch the platform builds on the tag ref
+        env:
+          TAG: ${{ steps.assert.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # A tag created with GITHUB_TOKEN fires NO push event, so the tag builds
+          # must be dispatched explicitly. `--ref "$TAG"` (the bare tag name, which
+          # gh resolves to the tag ref) makes `github.ref` inside those runs the tag
+          # ref, so the existing startsWith(github.ref, 'refs/tags/v') gates --
+          # system-contract build, Wire CDT install, contracts bundle -- behave
+          # exactly as on a tag push.
+          gh workflow run linux_amd64_build.yaml --ref "$TAG"
+          gh workflow run macos_arm64_build.yaml --ref "$TAG"
+          echo "Dispatched linux_amd64_build.yaml and macos_arm64_build.yaml on ${TAG}"
+
+      - name: Dispatch the release asset workflow
+        env:
+          TAG: ${{ steps.assert.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # Dispatched on master (the workflow file's home); the tag travels as the
+          # input. release.yaml waits for both tag-ref builds to finish, verifies
+          # every artifact, attaches them, then flips the draft.
+          gh workflow run release.yaml --ref master -f tag="$TAG"
+          echo "Dispatched release.yaml for ${TAG}"

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -48,19 +48,37 @@ else()
 endif()
 string(REGEX REPLACE "^${CMAKE_PROJECT_NAME}-(.*)$" "${CMAKE_PROJECT_NAME}_\\1_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}" CPACK_DEBIAN_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}")
 
-string(APPEND CPACK_PACKAGE_FILE_NAME "-${CMAKE_SYSTEM_PROCESSOR}")
+# Architecture tag embedded in artifact file names. Linux keeps the bare
+# processor name so existing artifact names stay BYTE-IDENTICAL
+# (wire-sysio-<version>-x86_64.*); Apple builds are additionally qualified as
+# `macos-<processor>` so a macOS tarball can never be confused with -- or
+# glob-matched as -- the Linux one when both hang off the same release.
+# Deliberately NOT CPACK_SYSTEM_NAME: that would rename the Linux artifacts too.
+if(APPLE)
+   set(WIRE_ARCH_TAG "macos-${CMAKE_SYSTEM_PROCESSOR}")
+else()
+   set(WIRE_ARCH_TAG "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+string(APPEND CPACK_PACKAGE_FILE_NAME "-${WIRE_ARCH_TAG}")
 
 # ── Packaged service assets (systemd unit, tmpfiles.d, logrotate policy) ──
-# Literal `lib/...` on purpose (NOT ${CMAKE_INSTALL_LIBDIR}): systemd units and
-# tmpfiles.d fragments live in /usr/lib/systemd/system and /usr/lib/tmpfiles.d
-# on every supported distro -- never lib64/ or lib/<multiarch>/.
-install(FILES "${CMAKE_SOURCE_DIR}/tools/packaging/systemd/wire-sysio-nodeop.service"
-        DESTINATION lib/systemd/system COMPONENT base)
-install(FILES "${CMAKE_SOURCE_DIR}/tools/packaging/systemd/wire-sysio.conf"
-        DESTINATION lib/tmpfiles.d COMPONENT base)
-# logrotate policies are only read from /etc/logrotate.d -- absolute on purpose.
-install(FILES "${CMAKE_SOURCE_DIR}/tools/packaging/logrotate/wire-sysio-nodeop"
-        DESTINATION /etc/logrotate.d COMPONENT base)
+# Linux-only payload: systemd, tmpfiles.d and logrotate do not exist on macOS,
+# and the macOS portable tarball must ship the binaries alone (asserted by
+# `verify-tgz.sh --no-service`). Gating the install rules -- rather than moving
+# them to a new component -- keeps the TGZ pinned to the `base` component; a new
+# component would leak a third deb/rpm package on Linux.
+if(NOT APPLE)
+   # Literal `lib/...` on purpose (NOT ${CMAKE_INSTALL_LIBDIR}): systemd units and
+   # tmpfiles.d fragments live in /usr/lib/systemd/system and /usr/lib/tmpfiles.d
+   # on every supported distro -- never lib64/ or lib/<multiarch>/.
+   install(FILES "${CMAKE_SOURCE_DIR}/tools/packaging/systemd/wire-sysio-nodeop.service"
+           DESTINATION lib/systemd/system COMPONENT base)
+   install(FILES "${CMAKE_SOURCE_DIR}/tools/packaging/systemd/wire-sysio.conf"
+           DESTINATION lib/tmpfiles.d COMPONENT base)
+   # logrotate policies are only read from /etc/logrotate.d -- absolute on purpose.
+   install(FILES "${CMAKE_SOURCE_DIR}/tools/packaging/logrotate/wire-sysio-nodeop"
+           DESTINATION /etc/logrotate.d COMPONENT base)
+endif()
 
 # Per-generator staging/prefix/top-dir configuration, evaluated at cpack time.
 set(CPACK_PROJECT_CONFIG_FILE "${CMAKE_SOURCE_DIR}/cmake/cpack-project-config.cmake")

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,85 +1,169 @@
 # Release Workflow
 
-How a wire-sysio release goes from a version bump to a published GitHub
-Release with verified artifacts attached. Artifact contents are documented in
+How a wire-sysio release goes from a version bump to a published GitHub Release
+with verified artifacts attached. Artifact contents are documented in
 [release-layout.md](release-layout.md); build commands in
 [../BUILD.md](../BUILD.md).
 
-## Overview
+## Strategy C — independent per-repo releases
 
-1. **Version bump** — a PR to `master` updates `VERSION_MAJOR/MINOR/PATCH/SUFFIX`
-   in `CMakeLists.txt`. The version embedded in every artifact comes from here;
-   the release workflow fails fast if it doesn't match the tag.
-2. **Tag** — a maintainer pushes `v<version>`. The tag build
-   (`linux_amd64_build.yaml`) installs the Wire CDT package, builds the system
-   contracts from source (and asserts it), assembles the full package set
-   (base + dev deb/rpm, portable tgz) on the `ubuntu24` platform, and the
-   `verify-packages` job runs the packaging suite (S1-S6, including the
-   systemd-in-container service-start gate) against the produced artifacts.
-3. **Publish** — a maintainer publishes the GitHub Release for the tag. The
-   `Release Actions` workflow (`release.yaml`) locates the successful tag
-   build, downloads its `wire-sysio-packages-amd64` artifact, guards
-   tag↔version consistency, re-verifies the packages, attaches them plus a
-   sha256 checksums file to the release, and refreshes the
-   `wire-sysio-experimental-binaries` ghcr image.
+wire-sysio and wire-cdt release **independently**. There is no cross-repo release
+train and no shared pipeline: wire-cdt cuts its own release, and a wire-sysio
+release **consumes a pinned wire-cdt release asset**.
 
-For pre-merge validation, `release.yaml` also exposes `workflow_dispatch`
-with a `tag` input, which runs the same verify-and-attach path against an
-existing tag + release without waiting for a `release: published` event
-(those events always execute the workflow file from the default branch).
+The properties that follow from that choice:
 
-## Activity
+- **Resolve at prepare, pin at build.** `prepare-release.yaml` resolves the latest
+  published wire-cdt release for the channel and writes it into
+  `.cicd/defaults.json` (`wirecdt.release`, `wirecdt.channel`). The tag build then
+  downloads *exactly* that release's `wire-cdt_<version>_amd64.deb` asset. Re-runs
+  are reproducible, the CDT version is reviewable at gate 1, and there is no
+  publish-order race at release time. For a one-off experiment against a
+  different CDT, `linux_amd64_build.yaml` takes an `override-cdt-release`
+  dispatch input; its channel is then derived from the release's own prerelease
+  flag instead of being asserted against the pin.
+  (`.cicd/defaults.json`'s `wirecdt` block carries exactly the two keys the
+  release-asset path reads — `release` and `channel`. The former `target`
+  git-ref key had no reader and was removed.)
+- **Release assets, not CI artifacts.** CI artifacts expire after 30 days, so an
+  old tag could not be rebuilt from them. Release assets are durable.
+  Wire-Network/wire-cdt is public, so the download needs no special token — the
+  build's own `GITHUB_TOKEN` is passed to `gh` only to lift the unauthenticated
+  rate limit. (The `.cicd/platforms` images all bake the GitHub CLI, so the
+  download is a plain `gh release download`.)
+- **The version's suffix IS the channel.** `-dev` / `-rcN` means prerelease; no
+  suffix means stable. One input (`version`) decides everything downstream —
+  the release's prerelease flag, and which wire-cdt channel gets pinned.
+- **Two human gates.** Gate 1 is reviewing and merging the bump PR. Gate 2 is
+  approving the `release` Environment before anything is tagged or created.
+- **The system contracts ship as a release asset.** Only tag builds compile them
+  (`BUILD_SYSTEM_CONTRACTS=ON` plus `assert-system-contract-build.sh`), and they
+  are bundled as `wire-sysio-system-contracts-<version>.tar.gz`.
+
+## Packaged layouts — this repo vs the consumed wire-cdt deb
+
+The two repos package **differently on purpose**. Do not copy wire-cdt's private
+home into wire-sysio.
+
+| Artifact | Programs / payload | Notes |
+|---|---|---|
+| **wire-sysio deb / rpm** | `/usr/bin/nodeop`, `/usr/bin/clio`, `/usr/bin/kiod` — installed **directly**, own names, no private home and no symlink indirection | prefix `/usr`, `COMPONENT base`; plus `/usr/lib/systemd/system/`, `/usr/lib/tmpfiles.d/`, `/etc/logrotate.d/`. Asserted by `tools/packaging/tests/verify-{deb,rpm}.sh`. |
+| **wire-sysio tarball** | self-contained tree | see [release-layout.md](release-layout.md) |
+| **wire-cdt deb / rpm** (consumed) | self-contained toolchain home at `/usr/lib/cdt`, with only public `cdt-*` / `sysio-*` entry points symlinked into `/usr/bin` | distro-toolchain layout (cf. `/usr/lib/llvm-18`) |
+
+wire-cdt needs the private home for one specific reason: it **bundles its own
+LLVM**, so `clang`, `lld`, `llvm-ar` … would collide with the distro's `clang` /
+`lld` / `llvm` packages if installed into `/usr/bin`. wire-sysio bundles no such
+thing — `nodeop` / `clio` / `kiod` are unique names — so they install straight
+into `/usr/bin` and must stay there.
+
+`install-wire-cdt-package.sh` therefore exports `CDT_ROOT=/usr/lib/cdt` (the
+toolchain home, not `/usr`): `build-sysio.sh` checks
+`$CDT_ROOT/lib/cmake/cdt/cdt-config.cmake` and `cmake/contract-tools.cmake`
+builds `$CDT_ROOT/lib/cmake/cdt/CDTWasmToolchain.cmake`, both of which only
+resolve under the home.
+
+## The workflows
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `prepare-release.yaml` | `workflow_dispatch(version)` | Validates the version, writes `VERSION_*` into `CMakeLists.txt`, resolves + pins the latest published wire-cdt release for the channel, opens the `release/prep-v<version>` PR. |
+| `tag-release.yaml` | `workflow_dispatch(version)`, `environment: release` | Asserts master HEAD carries the version, creates the annotated tag (`POST /git/tags` then `POST /git/refs`), creates the DRAFT release with generated notes, dispatches both platform builds on the tag ref, dispatches `release.yaml`. |
+| `linux_amd64_build.yaml` | tag ref (dispatched or pushed) | Installs the pinned wire-cdt release deb, builds with system contracts ON, assembles deb + rpm + portable tgz, bundles the contracts, uploads `wire-sysio-packages-amd64`. |
+| `macos_arm64_build.yaml` | tag ref (dispatched or pushed) | Builds, tests, produces the portable tarball, verifies it in `--no-service` mode, uploads `wire-sysio-packages-macos-arm64`. |
+| `release.yaml` | `workflow_dispatch(tag)`; `release: published` as a manual fallback | Awaits both tag-ref builds, downloads both artifacts, verifies each one explicitly, attaches assets + checksums to the draft, then flips the draft public. |
+
+### Post-bump
+
+After a **stable** release lands, dispatch `prepare-release.yaml` again with the
+next `-dev` version to restore the development suffix on master. It is the same
+workflow and the same single input; the PR is labelled `post-bump`.
+
+### Why the builds are dispatched explicitly
+
+A tag created with `GITHUB_TOKEN` fires **no** `push` event, so the tag builds
+would never start on their own. `tag-release.yaml` dispatches them on
+`refs/tags/<tag>`, which makes `github.ref` inside those runs the tag ref — so the
+existing `startsWith(github.ref, 'refs/tags/v')` gates behave exactly as they
+would on a human-pushed tag.
+
+`release.yaml`'s build resolver requires `head_branch == <tag>` for the same
+reason it accepts both `push` and `workflow_dispatch`: the master-push build sits
+at the same commit SHA but builds **without** the system contracts, and matching it
+would attach a package set with no contracts bundle.
+
+### Known friction (documented, not fixed)
+
+- A PR opened with `GITHUB_TOKEN` starts its `pull_request` checks in an
+  approval-required state — gate 1 includes an "Approve and run" click.
+- Branch protection on master must require the packaging checks, or gate 1 is
+  decorative.
+
+## Human vs system
 
 ```mermaid
 flowchart TD
-    A[PR: bump VERSION_* in CMakeLists.txt] --> B[Merge to master]
-    B --> C[Push tag v&lt;version&gt;]
-    C --> D[Tag build: linux_amd64_build.yaml]
-    D --> D1[Install Wire CDT package]
-    D1 --> D2[Build + test, system contracts ON]
-    D2 --> D3[assert-system-contract-build]
-    D3 --> D4[Assemble packages: deb + rpm + tgz]
-    D4 --> D5[Upload wire-sysio-packages-amd64]
-    D5 --> E{verify-packages: S1-S6}
-    E -- fail --> X1[Fix and re-tag]
-    E -- pass --> F[Maintainer publishes GitHub Release]
-    F --> G[Release Actions: release.yaml]
-    G --> G1[Resolve successful tag build run]
-    G1 --> G2{Tag matches artifact version?}
-    G2 -- no --> X2[Fail: bump CMakeLists VERSION_* first]
-    G2 -- yes --> G3[Re-verify packages S1-S6]
-    G3 --> G4[Attach artifacts + sha256 checksums]
-    G4 --> G5[Push ghcr experimental-binaries image]
-    G5 --> H([Release live with verified artifacts])
+    classDef human fill:#FFE9B8,stroke:#8a6d1a,color:#1a1a1a
+    classDef system fill:#DCEBFF,stroke:#1e5aa8,color:#1a1a1a
+    classDef gate fill:#FFD9D9,stroke:#a83232,color:#1a1a1a
+
+    H1[/"Human: pick version — its suffix IS the channel<br>(-dev/-rcN = prerelease, none = stable)"/]:::human
+    H2[/"Human: dispatch prepare-release (input: version)"/]:::human
+    S1["System: edit VERSION_*, resolve+pin latest<br>wire-cdt release (sysio only), open bump PR"]:::system
+    G1{{"GATE 1 — Human: 'Approve and run' the PR checks,<br>review (incl. pinned CDT), merge"}}:::gate
+    H3[/"Human: dispatch tag-release (input: version)"/]:::human
+    G2{{"GATE 2 — Human: approve 'release' Environment"}}:::gate
+    S3["System: assert version == master HEAD,<br>create annotated tag + DRAFT release,<br>DISPATCH linux + macos builds on the tag ref"]:::system
+    S4["System: tag builds produce packages<br>(sysio: installs pinned wire-cdt release deb,<br>builds + asserts system contracts, bundles them)"]:::system
+    S6["System: release.yaml — await tag-ref builds,<br>download, verify each artifact explicitly"]:::system
+    S7["System: attach assets + checksums,<br>flip draft to public"]:::system
+    H4[/"Human: sanity-check the release page"/]:::human
+
+    H1 --> H2 --> S1 --> G1 --> H3 --> G2 --> S3 --> S4 --> S6 --> S7 --> H4
 ```
 
-## Sequence
+## Release assets
 
-```mermaid
-sequenceDiagram
-    actor M as Maintainer
-    participant GH as GitHub
-    participant B as Build workflow<br/>(linux_amd64_build)
-    participant V as verify-packages job
-    participant R as Release Actions<br/>(release.yaml)
-    participant REG as ghcr.io
+Eight assets, excluding GitHub's auto-added source archives:
 
-    M->>GH: merge version-bump PR (CMakeLists VERSION_*)
-    M->>GH: push tag v<version>
-    GH->>B: trigger (push: tags v*)
-    B->>B: install Wire CDT, build + test,<br/>system contracts ON + assert
-    B->>B: cpack DEB/RPM + package-tgz (ubuntu24)
-    B->>GH: upload artifact wire-sysio-packages-amd64
-    GH->>V: run after build
-    V->>GH: download artifact
-    V->>V: S1 tgz - S2 deb - S3 rpm - S5 lint<br/>(S6 systemd service-start inside S2/S3)
-    V-->>GH: all-passing gate
-    M->>GH: publish Release for tag
-    GH->>R: trigger (release: published)
-    R->>GH: resolve successful tag-build run (gh api)
-    R->>GH: download wire-sysio-packages-amd64
-    R->>R: guard: tag == artifact version
-    R->>R: re-verify packages (S1-S6)
-    R->>GH: gh release upload artifacts + checksums
-    R->>REG: push wire-sysio-experimental-binaries:v<version>
-```
+| Asset | Produced by |
+|---|---|
+| `wire-sysio_<version>_amd64.deb` | linux tag build (`cpack -G DEB`, base component) |
+| `wire-sysio-dev_<version>_amd64.deb` | linux tag build (dev component) |
+| `wire-sysio-<version>-x86_64.rpm` | linux tag build (`cpack -G RPM`, base component) |
+| `wire-sysio-dev-<version>-x86_64.rpm` | linux tag build (dev component) |
+| `wire-sysio-<version>-x86_64.tar.gz` | linux tag build (`package-tgz`) |
+| `wire-sysio-<version>-macos-arm64.tar.gz` | macOS tag build (`package-tgz`) |
+| `wire-sysio-system-contracts-<version>.tar.gz` | linux tag build (`sysio.*/{*.wasm,*.abi}`) |
+| `wire-sysio-<version>-checksums.txt` | `release.yaml` |
+
+The `-macos-arm64` suffix comes from `WIRE_ARCH_TAG` in `cmake/package.cmake`;
+Linux artifact names are unchanged. The contracts bundle is deliberately named so
+it can never be glob-matched as a platform tarball — every verification in
+`release.yaml` names its artifact explicitly for the same reason.
+
+## Verification
+
+`release.yaml` runs the packaging suite against each artifact by name:
+
+- `verify-tgz.sh` on the Linux tarball (asserts the systemd unit, tmpfiles.d
+  fragment and logrotate policy are present).
+- `verify-tgz.sh --no-service` on the macOS tarball (asserts the binaries and
+  licenses are present AND that the service files are **absent** — those
+  `install()` rules are gated on `NOT APPLE`).
+- `verify-deb.sh` / `verify-rpm.sh` on the base + dev packages.
+- A contracts-bundle check: the tarball must contain both `sysio.*.wasm` and
+  `sysio.*.abi` entries.
+
+The same suite runs as the `verify-packages` job on every build, so a packaging
+regression fails CI long before a release is cut.
+
+## Failure and rollback
+
+- `release.yaml` is idempotent for a tag (`gh release upload --clobber`).
+  Recovery from a failed asset run is: fix, then re-dispatch `release.yaml` with
+  the same tag. **Never re-tag.**
+- Wrong tag or wrong content: delete the draft release and the tag, then cut the
+  next `-rcN`.
+- Abandoned drafts are surfaced at the next release's prepare step; deleting them
+  is a deliberate human action.

--- a/tools/packaging/tests/verify-all.sh
+++ b/tools/packaging/tests/verify-all.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Run the whole packaging verification suite (S1-S6) over one directory of artifacts.
+#
+# Usage: verify-all.sh <dir> [version]
+#
+#   WITH <version>    -- the RELEASE path. Every artifact is named EXPLICITLY, so
+#                        a missing or misnamed file fails here rather than being
+#                        waved through by a glob that happened to match nothing.
+#                        The release directory also holds the macOS tarball.
+#   WITHOUT <version> -- the BUILD path. The caller does not know the version the
+#                        artifact names carry, so the safe globs documented below
+#                        are used instead. The linux build artifact contains no
+#                        macOS tarball, hence no macOS check in this mode.
+#
+# THE GLOB RULE -- the reason this lives in ONE file: never hand verify-tgz.sh a
+# bare `wire-sysio-*.tar.gz`. That pattern globs the linux tarball, the macOS
+# tarball and the system-contracts bundle that tag builds add, and the verifier
+# silently checks whichever one sorted first -- so a broken tarball can ship
+# having "passed". Every tarball pattern here is ARCH-SUFFIXED, and the base rpm
+# is matched as `wire-sysio-[0-9]*` so the `-dev` rpm can never be picked up in
+# its place.
+#
+# The system-contracts bundle is deliberately NOT verified here: it exists only
+# on the tag/release path and its check (wasm + abi presence) is a different
+# assertion, so it stays its own step in release.yaml.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+
+[[ $# -ge 1 && $# -le 2 ]] || { echo "usage: verify-all.sh <dir> [version]" >&2; exit 1; }
+dir="$1"
+version="${2:-}"
+[[ -d "$dir" ]] || { echo "verify-all: not a directory: $dir" >&2; exit 1; }
+
+ls -la "$dir"
+
+# S5 first: a static lint of the packaged unit, the maintainer scripts and the
+# verifier suite itself, so a broken verifier is reported as such instead of as
+# a package failure.
+"$here/verify-scripts.sh"
+
+if [[ -n "$version" ]]; then
+   "$here/verify-tgz.sh" "$dir/wire-sysio-${version}-x86_64.tar.gz"
+   # --no-service: the macOS tarball must carry no Linux service payload.
+   "$here/verify-tgz.sh" --no-service "$dir/wire-sysio-${version}-macos-arm64.tar.gz"
+   "$here/verify-deb.sh" "$dir/wire-sysio_${version}_amd64.deb" "$dir/wire-sysio-dev_${version}_amd64.deb"
+   "$here/verify-rpm.sh" "$dir/wire-sysio-${version}-x86_64.rpm" "$dir/wire-sysio-dev-${version}-x86_64.rpm"
+else
+   "$here/verify-tgz.sh" "$dir"/wire-sysio-*-x86_64.tar.gz
+   "$here/verify-deb.sh" "$dir"/wire-sysio_*.deb "$dir"/wire-sysio-dev_*.deb
+   "$here/verify-rpm.sh" "$dir"/wire-sysio-[0-9]*.rpm "$dir"/wire-sysio-dev-*.rpm
+fi

--- a/tools/packaging/tests/verify-deb.sh
+++ b/tools/packaging/tests/verify-deb.sh
@@ -6,7 +6,11 @@ d="$1"; dev="$2"
 [ -f "$d" ] || { echo "S2 FAIL: deb not found: $d"; exit 1; }
 fail() { echo "S2 FAIL: $1"; exit 1; }
 c=$(dpkg-deb -c "$d" | awk '{print $6}')
-for f in ./usr/bin/nodeop ./usr/lib/systemd/system/wire-sysio-nodeop.service ./usr/lib/tmpfiles.d/wire-sysio.conf ./etc/logrotate.d/wire-sysio-nodeop; do
+# The wire-sysio programs install DIRECTLY at /usr/bin under their own names --
+# no private home, no symlink indirection. (wire-cdt's /usr/lib/cdt home exists
+# solely because it bundles clang/lld/llvm-* binaries whose names collide with
+# the distro's toolchain packages; wire-sysio bundles no such thing.)
+for f in ./usr/bin/nodeop ./usr/bin/clio ./usr/bin/kiod ./usr/lib/systemd/system/wire-sysio-nodeop.service ./usr/lib/tmpfiles.d/wire-sysio.conf ./etc/logrotate.d/wire-sysio-nodeop; do
     echo "$c" | grep -qx "$f" || fail "payload missing $f"
 done
 echo "$c" | grep -q "^./usr/include/" && fail "base deb leaks headers"

--- a/tools/packaging/tests/verify-rpm.sh
+++ b/tools/packaging/tests/verify-rpm.sh
@@ -6,7 +6,11 @@ r="$1"; dev="$2"
 [ -f "$r" ] || { echo "S3 FAIL: rpm not found: $r"; exit 1; }
 fail() { echo "S3 FAIL: $1"; exit 1; }
 l=$(rpm -qlp "$r" 2>/dev/null)
-for f in /usr/bin/nodeop /usr/lib/systemd/system/wire-sysio-nodeop.service /usr/lib/tmpfiles.d/wire-sysio.conf /etc/logrotate.d/wire-sysio-nodeop; do
+# The wire-sysio programs install DIRECTLY at /usr/bin under their own names --
+# no private home, no symlink indirection. (wire-cdt's /usr/lib/cdt home exists
+# solely because it bundles clang/lld/llvm-* binaries whose names collide with
+# the distro's toolchain packages; wire-sysio bundles no such thing.)
+for f in /usr/bin/nodeop /usr/bin/clio /usr/bin/kiod /usr/lib/systemd/system/wire-sysio-nodeop.service /usr/lib/tmpfiles.d/wire-sysio.conf /etc/logrotate.d/wire-sysio-nodeop; do
     echo "$l" | grep -qx "$f" || fail "payload missing $f"
 done
 echo "$l" | grep -q "^/usr/include/" && fail "base rpm leaks headers"

--- a/tools/packaging/tests/verify-scripts.sh
+++ b/tools/packaging/tests/verify-scripts.sh
@@ -7,6 +7,10 @@ fail() { echo "S5 FAIL: $1"; exit 1; }
 for s in debian/config debian/postinst debian/prerm debian/postrm rpm/post.sh rpm/preun.sh rpm/postun.sh tests/verify-tgz.sh tests/verify-deb.sh tests/verify-rpm.sh tests/verify-install-manifest.sh tests/verify-scripts.sh; do
     sh -n "$root/$s" || fail "sh -n $s"
 done
+# tests/verify-all.sh is the one bash member of the suite ([[ ]] / arrays), so it
+# is parsed by bash: `sh -n` would accept it while checking a grammar it is not
+# written in.
+bash -n "$root/tests/verify-all.sh" || fail "bash -n tests/verify-all.sh"
 unit="$root/systemd/wire-sysio-nodeop.service"
 if command -v systemd-analyze >/dev/null 2>&1; then
     # /usr/bin/nodeop is absent on build hosts; that one finding is expected.

--- a/tools/packaging/tests/verify-tgz.sh
+++ b/tools/packaging/tests/verify-tgz.sh
@@ -1,6 +1,20 @@
 #!/bin/sh
-# S1 gate: portable tarball layout. Usage: verify-tgz.sh <tarball>
+# S1 gate: portable tarball layout. Usage: verify-tgz.sh [--no-service] <tarball>
+#
+# Default mode verifies a LINUX portable tarball: the binaries plus the packaged
+# service assets (systemd unit, tmpfiles.d fragment, logrotate policy).
+#
+# --no-service verifies a tarball built on a platform that ships no service
+# payload (macOS -- cmake/package.cmake gates those install() rules on NOT APPLE).
+# It asserts the root directory, the binaries and the bundled licenses ARE
+# present, and that every service file is ABSENT: a macOS tarball that somehow
+# carried a systemd unit would mean the payload gating regressed.
 set -e
+no_service=0
+if [ "$1" = "--no-service" ]; then
+    no_service=1
+    shift
+fi
 t="$1"
 [ -f "$t" ] || { echo "S1 FAIL: tarball not found: $t"; exit 1; }
 fail() { echo "S1 FAIL: $1"; exit 1; }
@@ -8,7 +22,30 @@ list=$(tar tzf "$t")
 bad=$(echo "$list" | grep -v '^wire-sysio/' || true)
 [ -z "$bad" ] || fail "entries outside wire-sysio/: $bad"
 echo "$list" | grep -q '^wire-sysio/usr/' && fail "unexpected usr/ layer inside tarball"
-for f in bin/nodeop lib/systemd/system/wire-sysio-nodeop.service lib/tmpfiles.d/wire-sysio.conf etc/logrotate.d/wire-sysio-nodeop; do
+
+service_files="lib/systemd/system/wire-sysio-nodeop.service lib/tmpfiles.d/wire-sysio.conf etc/logrotate.d/wire-sysio-nodeop"
+
+# All three programs install into the `base` component (programs/*/CMakeLists.txt),
+# so all three belong in the portable tarball on every platform -- a tarball with
+# nodeop but no clio/kiod means the component staging regressed. (A single-element
+# `for` loop here was also a shellcheck SC2043.)
+for f in bin/nodeop bin/clio bin/kiod; do
     echo "$list" | grep -qx "wire-sysio/$f" || fail "missing wire-sysio/$f"
 done
-echo "S1 PASS: $t"
+
+if [ "$no_service" -eq 1 ]; then
+    # Licenses are part of the base component on every platform, so their absence
+    # would mean the tarball was staged from the wrong component set.
+    echo "$list" | grep -q '^wire-sysio/share/licenses/sysio/' \
+        || fail "missing wire-sysio/share/licenses/sysio/"
+    for f in $service_files; do
+        echo "$list" | grep -qx "wire-sysio/$f" \
+            && fail "service file present in a no-service tarball: wire-sysio/$f"
+    done
+    echo "S1 PASS (no-service): $t"
+else
+    for f in $service_files; do
+        echo "$list" | grep -qx "wire-sysio/$f" || fail "missing wire-sysio/$f"
+    done
+    echo "S1 PASS: $t"
+fi


### PR DESCRIPTION
## Summary

Part 2 of the packaging effort (pairs with wire-cdt PR #100 — same merge window required: this PR consumes the renamed `wire-cdt_*` deb).

**CDT acquisition**: tag builds install the wire-cdt deb from a **pinned GitHub release asset** (`.cicd/defaults.json` → `wirecdt.release`/`wirecdt.channel`, written by `prepare-release.yaml` at version-bump time — resolve-at-prepare, pin-at-build, reproducible re-runs). The ~60-line CI artifact-resolution machinery and `wirecdt.target`/`prerelease` keys are gone; `gh` CLI baked into all five platform images. Install script asserts the `/usr/lib/cdt` home, `/usr/bin` entry-point symlinks, and rejects bare llvm/clang names. `nodeop`/`clio`/`kiod` stay directly in `/usr/bin` (unchanged, now explicitly asserted in verify-deb/rpm).

**Artifacts (8 per release)**: existing 2 deb + 2 rpm + linux tgz, plus `wire-sysio-<v>-macos-arm64.tar.gz` (service payload gated `if(NOT APPLE)`; `WIRE_ARCH_TAG` keeps Linux filenames byte-identical; verify-tgz `--no-service` mode) and `wire-sysio-system-contracts-<v>.tar.gz` (tag builds, after the contract-build assertion) + checksums.

**CI**: vcpkg binary cache monolithic→split restore/save (save-immediately-after-build) in both build workflows; explicit per-artifact tgz verification (no glob-order hazards).

**Release (Strategy C)**: `prepare-release.yaml` (sole `version` input; channel from suffix; pins the latest published wire-cdt release for the channel) → `tag-release.yaml` (`environment: release` approval, tag-exists guard, draft-first, dispatches both tag builds) → `release.yaml` (dispatch-path TAG fix, head_branch run resolver, awaits linux+macOS, 8-asset publish, draft flip). Flow diagram in `docs/release-workflow.md`.

**Evidence**: linux run 30308008876 (5-leg matrix + platform-image rebuilds with gh) and macOS run 30308010424 green, artifacts `wire-sysio-packages-{amd64,macos-arm64}` correctly named.