### PR TITLE
feat(release): channel-aware OPP bundle publishing + release version manifests (SHARED-14)

### DIFF
--- a/.cicd/defaults.json
+++ b/.cicd/defaults.json
@@ -1,6 +1,0 @@
-{
-  "wirecdt": {
-    "release": "v1.0.0-dev",
-    "channel": "prerelease"
-  }
-}

--- a/.github/scripts/resolve-opp-bundles-run.sh
+++ b/.github/scripts/resolve-opp-bundles-run.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Resolve the opp-bundles.yaml run that published a given TAG's OPP model
+# bundles, discriminated by the tag-suffixed published-versions artifact.
+#
+# Usage: resolve-opp-bundles-run.sh <tag>
+#
+# Emits `opp-bundles-run-id=<id>` on STDOUT, shaped to be redirected straight
+# into "$GITHUB_OUTPUT". EVERY progress, diagnostic and error line goes to
+# STDERR instead, so that redirect can never swallow the log or corrupt the
+# outputs file. (Same conventions as resolve-build-run.sh — which stays
+# byte-locked with wire-cdt's copy and therefore is NOT extended for this.)
+#
+# tag-release.yaml dispatches opp-bundles.yaml ON the tag ref, so the run's
+# head_branch is the tag name — the same discriminator resolve-build-run.sh
+# uses. The run must ALSO carry the `opp-published-versions-<tag>` artifact:
+# the artifact name encodes the run's own ref (opp-bundles.yaml uploads it as
+# opp-published-versions-${GITHUB_REF_NAME}), so its presence proves the run
+# published THIS tag's bundles and its versions file is the one to record.
+#
+# Environment:
+#   GH_TOKEN           (required) auth for `gh api`
+#   GITHUB_REPOSITORY  (required) owner/repo whose runs are queried
+#   RESOLVE_ATTEMPTS   poll attempts before giving up (default 60)
+#   RESOLVE_INTERVAL   seconds between attempts (default 30)
+#
+# The default 60 x 30s (30 min) is far smaller than resolve-build-run.sh's
+# budget: the opp-bundles run takes ~10 minutes and is dispatched at the same
+# moment as the platform builds, which release.yaml waits out FIRST — by the
+# time this resolver runs, the opp run has usually been finished for hours.
+set -euo pipefail
+
+readonly default_attempts=60
+readonly default_interval=30
+readonly workflow="opp-bundles.yaml"
+
+die() {
+   echo "::error::$*" >&2
+   exit 1
+}
+
+[[ $# -eq 1 ]] || die "usage: resolve-opp-bundles-run.sh <tag>"
+
+tag="$1"
+
+[[ -n "${GH_TOKEN:-}" ]] || die "GH_TOKEN is not set"
+[[ -n "${GITHUB_REPOSITORY:-}" ]] || die "GITHUB_REPOSITORY is not set"
+
+attempts="${RESOLVE_ATTEMPTS:-$default_attempts}"
+interval="${RESOLVE_INTERVAL:-$default_interval}"
+artifact_name="opp-published-versions-${tag}"
+
+# First attempt only: dump the candidate runs the API actually returned before
+# the filter is applied, so a head_branch-semantics mismatch is visible in
+# minute one instead of after the whole polling budget.
+log_candidates=1
+
+# Resolve the successful opp-bundles run AT THE TAG REF carrying the
+# tag-suffixed published-versions artifact.
+resolve_run() {
+   local runs_json candidate_ids candidate artifact_count
+   runs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs?event=workflow_dispatch&branch=${tag}&per_page=50")"
+   if [[ "$log_candidates" == "1" ]]; then
+      {
+         echo "--- ${workflow} candidate runs at head_branch ${tag} (want artifact ${artifact_name}) ---"
+         jq -r '.workflow_runs | length | "candidates: \(.)"' <<<"$runs_json"
+         jq -c '.workflow_runs[] | {id, head_branch, event, status, conclusion}' <<<"$runs_json"
+      } >&2
+   fi
+   candidate_ids="$(
+      jq -r '
+         [.workflow_runs[]
+           | select(.status == "completed" and .conclusion == "success")]
+         | .[].id' <<<"$runs_json"
+   )"
+   # Newest first (the API's default order): the newest successful run's
+   # artifact carries the versions actually published last.
+   for candidate in $candidate_ids; do
+      artifact_count="$(
+         gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate}/artifacts" \
+            --jq --arg name "$artifact_name" '[.artifacts[] | select(.name == $name)] | length'
+      )"
+      if [[ "$artifact_count" -gt 0 ]]; then
+         echo "$candidate"
+         return 0
+      fi
+      echo "Run ${candidate} succeeded but carries no ${artifact_name} artifact; skipping" >&2
+   done
+   echo ""
+}
+
+run_id=""
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+   run_id="$(resolve_run)"
+   log_candidates=0
+   if [[ -n "$run_id" ]]; then
+      break
+   fi
+   echo "Waiting for the ${workflow} run of ${tag} carrying ${artifact_name} (attempt ${attempt}/${attempts})" >&2
+   sleep "$interval"
+done
+
+[[ -n "$run_id" ]] \
+   || die "No successful ${workflow} run with artifact ${artifact_name} found for ${tag}. Dispatch it with: gh workflow run ${workflow} --ref ${tag} -f channel=<dev|stable>"
+
+echo "opp-bundles-run-id=${run_id}"

--- a/.github/workflows/linux_amd64_build.yaml
+++ b/.github/workflows/linux_amd64_build.yaml
@@ -13,8 +13,8 @@ on:
       - master
   workflow_dispatch:
     inputs:
-      override-cdt-release:
-        description: 'Override the pinned wire-cdt RELEASE tag for this one build (e.g. v1.0.0-rc2). Its channel is then derived from the release itself instead of being asserted against .cicd/defaults.json.'
+      wire-cdt-release:
+        description: 'Explicit wire-cdt RELEASE tag to build against (e.g. v1.0.0-rc2). Its channel is then derived from the release itself. When omitted, a tag build resolves the latest published wire-cdt release in the same channel as the version being built.'
         type: string
 
 permissions:
@@ -155,10 +155,13 @@ jobs:
           restore-keys: |
             ccache-${{ matrix.platform }}-
 
-      # Wire CDT is acquired from a pinned GitHub RELEASE asset, not from a CI
+      # Wire CDT is acquired from a GitHub RELEASE asset, not from a CI
       # artifact: CI artifacts expire after 30 days, so an old tag could no longer
-      # be rebuilt reproducibly. The release is pinned in .cicd/defaults.json
-      # (wirecdt.release + wirecdt.channel) and resolved by the `v` job.
+      # be rebuilt reproducibly. The release is resolved by the `v` job — an
+      # explicit `wire-cdt-release` dispatch input, or the latest published
+      # wire-cdt release in the same channel as the version being built. The
+      # resolved tag is recorded in build-metadata.json and, downstream, in the
+      # release's wire-sysio-versions-<version>.json.
       #
       # Wire-Network/wire-cdt is public, so no GH_TOKEN_DEV is required here; the
       # workflow's own GITHUB_TOKEN is passed as GH_TOKEN purely to lift the
@@ -176,20 +179,20 @@ jobs:
           set -euo pipefail
 
           if [[ -z "$CDT_RELEASE" || "$CDT_RELEASE" == "null" ]]; then
-            echo "::error::.cicd/defaults.json does not pin wirecdt.release" >&2
+            echo "::error::The v job did not resolve a wire-cdt release for this build" >&2
             exit 1
           fi
 
           not_published_hint() {
             echo "::error::Wire CDT release ${CDT_RELEASE} could not be read from Wire-Network/wire-cdt." >&2
-            echo "The pinned release may not be PUBLISHED YET: tag-release.yaml creates wire-cdt releases as DRAFTS, and a draft is invisible to this build (as is a deleted or renamed tag). Check https://github.com/Wire-Network/wire-cdt/releases against wirecdt.release in .cicd/defaults.json, and publish the wire-cdt release before re-running this build." >&2
+            echo "The resolved release may not be PUBLISHED YET: tag-release.yaml creates wire-cdt releases as DRAFTS, and a draft is invisible to this build (as is a deleted or renamed tag). Check https://github.com/Wire-Network/wire-cdt/releases, and publish the wire-cdt release (or dispatch with an explicit wire-cdt-release) before re-running this build." >&2
           }
 
-          # The pinned release's channel must agree with the pin, otherwise the
-          # prepare-release resolution and the build disagree about what shipped.
-          # `derive` is the one-off override path (workflow_dispatch
-          # override-cdt-release): there is no pin to agree with, so the release's
-          # own flag is reported rather than asserted.
+          # The resolved release's channel must agree with the v job's
+          # resolution, otherwise the resolution and the build disagree about
+          # what shipped. `derive` is the explicit-input path (workflow_dispatch
+          # wire-cdt-release): there is no resolved channel to agree with, so
+          # the release's own flag is reported rather than asserted.
           if ! release_view="$(gh release view "$CDT_RELEASE" -R Wire-Network/wire-cdt --json tagName,isDraft,isPrerelease 2>&1)"; then
             not_published_hint
             echo "$release_view" >&2
@@ -208,16 +211,16 @@ jobs:
             prerelease) expected_prerelease="true" ;;
             stable)     expected_prerelease="false" ;;
             derive)
-              echo "Wire CDT release ${CDT_RELEASE} supplied by override-cdt-release; derived channel: $([[ "$release_prerelease" == "true" ]] && echo prerelease || echo stable)"
+              echo "Wire CDT release ${CDT_RELEASE} supplied by wire-cdt-release; derived channel: $([[ "$release_prerelease" == "true" ]] && echo prerelease || echo stable)"
               expected_prerelease="$release_prerelease"
               ;;
             *)
-              echo "::error::Unknown wirecdt.channel '${CDT_CHANNEL}' (expected 'prerelease' or 'stable')" >&2
+              echo "::error::Unknown cdt-channel '${CDT_CHANNEL}' (expected 'prerelease' or 'stable')" >&2
               exit 1
               ;;
           esac
           if [[ "$release_prerelease" != "$expected_prerelease" ]]; then
-            echo "::error::Wire CDT release ${CDT_RELEASE} has prerelease=${release_prerelease}, but .cicd/defaults.json pins channel '${CDT_CHANNEL}'" >&2
+            echo "::error::Wire CDT release ${CDT_RELEASE} has prerelease=${release_prerelease}, but the v job resolved channel '${CDT_CHANNEL}'" >&2
             exit 1
           fi
 
@@ -484,6 +487,25 @@ jobs:
           rm -rf "$PWD/system-contracts-stage"
           echo "Bundled ${#artifacts[@]} system-contract artifacts into ${bundle}.tar.gz"
 
+      # The resolved wire-cdt release travels with the package set so
+      # release.yaml can record it in wire-sysio-versions-<version>.json without
+      # re-resolving (the "latest in channel" answer is time-dependent; the
+      # build's answer is the authoritative one). Transport metadata only —
+      # release.yaml reads it and drops it before attaching assets.
+      - name: Record build metadata
+        if: ${{ steps.build.outcome == 'success' && matrix.platform == 'ubuntu24' && startsWith(github.ref, 'refs/tags/v') && !cancelled() }}
+        env:
+          CDT_RELEASE: ${{ needs.v.outputs.cdt-release }}
+          CDT_CHANNEL: ${{ needs.v.outputs.cdt-channel }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg cdt_release "$CDT_RELEASE" \
+            --arg cdt_channel "$CDT_CHANNEL" \
+            '{ "wire-cdt": { "release": $cdt_release, "channel": $cdt_channel } }' \
+            > build/build-metadata.json
+          cat build/build-metadata.json
+
       - name: Upload release package set
         if: ${{ steps.build.outcome == 'success' && matrix.platform == 'ubuntu24' && !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # actions/upload-artifact@v6
@@ -492,25 +514,34 @@ jobs:
           if-no-files-found: error
           # Explicit per-artifact globs: the platform tarball is arch-suffixed and the
           # system-contracts bundle is matched by its own name, so neither can be
-          # picked up as the other by glob order.
+          # picked up as the other by glob order. build-metadata.json only exists
+          # on tag builds (upload-artifact skips a missing entry when others match).
           path: |
             build/wire-sysio_*.deb
             build/wire-sysio-dev_*.deb
             build/wire-sysio-*.rpm
             build/wire-sysio-*-x86_64.tar.gz
             build/wire-sysio-system-contracts-*.tar.gz
+            build/build-metadata.json
 
   v:
     name: Discover Versions
     runs-on: ubuntu-latest
     outputs:
-      # `cdt-release` / `cdt-channel` pin the RELEASE whose asset a tag build
-      # installs. (The former `cdt-target` / `cdt-prerelease` outputs went with
-      # the CI-artifact acquisition path they served -- nothing consumed them
-      # once CDT moved to release assets.)
+      # `cdt-release` / `cdt-channel` name the RELEASE whose asset a tag build
+      # installs. The former `.cicd/defaults.json` pin is gone: an explicit
+      # `wire-cdt-release` input wins (channel `derive`); otherwise a tag build
+      # resolves the LATEST PUBLISHED wire-cdt release in the SAME channel as
+      # the version being built. The resolved value is recorded in the build's
+      # `build-metadata.json` artifact and lands in the release's
+      # `wire-sysio-versions-<version>.json` — the durable record.
       cdt-release: ${{steps.versions.outputs.cdt-release}}
       cdt-channel: ${{steps.versions.outputs.cdt-channel}}
     steps:
+      # The version being built (and therefore the channel to resolve wire-cdt
+      # in) comes from this ref's CMakeLists.txt via cmake-version.py.
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # actions/checkout@v5
+
       - name: Setup wire-cdt version
         id: versions
         env:
@@ -520,37 +551,81 @@ jobs:
           # script, so interpolating an override directly would let a value such as $(...) run as
           # shell code in trusted CI that holds GH_TOKEN_DEV (WSA-094 / SEC-094). As env vars the
           # values are inert data: bash does not re-evaluate command substitution found inside a
-          # variable's value. github.repository / github.sha are likewise read via env and quoted.
-          OVERRIDE_CDT_RELEASE: ${{ inputs.override-cdt-release }}
-          REPO: ${{ github.repository }}
-          REF_SHA: ${{ github.sha }}
+          # variable's value. github.ref is likewise read via env and quoted.
+          WIRE_CDT_RELEASE: ${{ inputs.wire-cdt-release }}
+          REF: ${{ github.ref }}
         run: |
+          set -euo pipefail
           # Defense in depth: reject ref/target overrides containing anything outside a conservative
           # allowlist. This blocks every shell metacharacter and newline (so an override can never
           # break out of $GITHUB_OUTPUT's "name=value" line either) while still accepting real values
           # such as "4.1.0" and "release/4.0". The pattern is held in a variable so [[ =~ ]] treats it
           # as a regex, and the candidate matched is only ever the variable's literal value.
           ref_re='^[A-Za-z0-9._/+-]+$'
-          if [[ -n "$OVERRIDE_CDT_RELEASE" && ! "$OVERRIDE_CDT_RELEASE" =~ $ref_re ]]; then
-            echo "::error::Invalid override ref '$OVERRIDE_CDT_RELEASE'; only [A-Za-z0-9._/+-] are allowed." >&2
+          if [[ -n "$WIRE_CDT_RELEASE" && ! "$WIRE_CDT_RELEASE" =~ $ref_re ]]; then
+            echo "::error::Invalid wire-cdt-release '$WIRE_CDT_RELEASE'; only [A-Za-z0-9._/+-] are allowed." >&2
             exit 1
           fi
 
-          DEFAULTS_JSON=$(curl -sSfL "$(gh api "https://api.github.com/repos/${REPO}/contents/.cicd/defaults.json?ref=${REF_SHA}" --jq .download_url)")
-          echo "cdt-release=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.release')" >> "$GITHUB_OUTPUT"
-          echo "cdt-channel=$(echo "$DEFAULTS_JSON" | jq -r '.wirecdt.channel')" >> "$GITHUB_OUTPUT"
-
-          # A one-off build against a different wire-cdt release. The pinned
-          # channel no longer describes it, so the channel is set to the `derive`
-          # sentinel: the download step then reports the release's OWN prerelease
-          # flag instead of asserting it against .cicd/defaults.json. Later lines
-          # win in $GITHUB_OUTPUT, so these override the pinned values above.
-          if [[ -n "$OVERRIDE_CDT_RELEASE" ]]; then
+          # An explicit release wins. Its channel is set to the `derive`
+          # sentinel: the download step then reports the release's OWN
+          # prerelease flag instead of asserting a resolved channel.
+          if [[ -n "$WIRE_CDT_RELEASE" ]]; then
             {
-              echo "cdt-release=$OVERRIDE_CDT_RELEASE"
+              echo "cdt-release=$WIRE_CDT_RELEASE"
               echo "cdt-channel=derive"
             } >> "$GITHUB_OUTPUT"
+            echo "Using explicit wire-cdt release ${WIRE_CDT_RELEASE} (channel derived from the release)"
+            exit 0
           fi
+
+          # Only tag builds install CDT (the download/install steps are gated on
+          # refs/tags/v*); non-tag builds emit empty outputs that nothing reads.
+          if [[ "$REF" != refs/tags/v* ]]; then
+            {
+              echo "cdt-release="
+              echo "cdt-channel="
+            } >> "$GITHUB_OUTPUT"
+            echo "Non-tag build: no wire-cdt release to resolve."
+            exit 0
+          fi
+
+          # The version's suffix IS the channel (same rule as everywhere on the
+          # Strategy-C path); resolve the latest PUBLISHED wire-cdt release in
+          # that channel. There is no first-class "latest prerelease" endpoint,
+          # so the release list is filtered by draft/prerelease and the newest
+          # by creation date wins — the same resolution prepare-release
+          # performed when it wrote the retired .cicd/defaults.json pin.
+          version="$(python3 .github/scripts/cmake-version.py read)"
+          if [[ "$version" == *-* ]]; then
+            channel="prerelease"
+            prerelease="true"
+          else
+            channel="stable"
+            prerelease="false"
+          fi
+
+          releases_json="$(
+            gh api "repos/Wire-Network/wire-cdt/releases?per_page=100" \
+              -H "X-GitHub-Api-Version: 2022-11-28"
+          )"
+          cdt_release="$(
+            jq -r --argjson pre "$prerelease" '
+              [.[] | select(.draft == false and .prerelease == $pre)]
+              | sort_by(.created_at)
+              | last
+              | .tag_name // empty' <<<"$releases_json"
+          )"
+          if [[ -z "$cdt_release" ]]; then
+            echo "::error::No published wire-cdt release found for channel ${channel} (version ${version}). Publish one, or dispatch with an explicit wire-cdt-release." >&2
+            exit 1
+          fi
+
+          {
+            echo "cdt-release=$cdt_release"
+            echo "cdt-channel=$channel"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved wire-cdt ${cdt_release} (latest published in channel ${channel} for version ${version})"
 
   verify-packages:
     name: Verify packages (S1-S6)

--- a/.github/workflows/opp-bundles.yaml
+++ b/.github/workflows/opp-bundles.yaml
@@ -2,9 +2,30 @@ name: "OPP Bundles"
 
 on:
   # Manual trigger so a publish can be run on demand (e.g. to ship a bundle whose
-  # proto already merged to master but whose publish run failed). Publishes the
-  # current master state — same code path as the push trigger.
+  # proto already merged to master but whose publish run failed), and the
+  # Strategy-C release path: tag-release.yaml dispatches this workflow ON THE TAG
+  # REF (`--ref v<version>`) with the tag's channel, so the tag's own protos and
+  # tooling produce the published bundles. A bare dispatch (all defaults) is the
+  # legacy behavior — publishes the current ref's state exactly like the push
+  # trigger.
+  #
+  # NOTE: this workflow must NEVER gain an `environment:` — the cargo publisher
+  # role's OIDC trust (wire-infra ArtifactManagementStack.PublisherRepositorySub,
+  # `repo:Wire-Network/wire-sysio:*`) matches the plain ref-form `sub` claim,
+  # which covers master, feature branches, AND tag refs; an environment rewrites
+  # the claim shape (`environment:`-form) and breaks the role assumption.
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Release channel matching wire-sysio. 'dev' appends the -dev prerelease suffix to the resolved bundle version; 'stable' publishes the bare version; 'none' = legacy behavior (identical to a pre-channel dispatch)."
+        type: choice
+        options: [none, dev, stable]
+        default: none
+      package-version:
+        description: "Explicit semver override for the bundle version (skips npm-based resolution). Must carry the -dev suffix when channel is dev."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - master
@@ -50,17 +71,42 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # aws-actions/configure-aws-credentials@v6.2.2
         with:
-          # wire-infra ArtifactManagementStack — the role trusts ONLY
-          # repo:Wire-Network/wire-sysio:ref:refs/heads/master via GitHub OIDC.
+          # wire-infra ArtifactManagementStack — the role trusts any wire-sysio
+          # ref via GitHub OIDC (PublisherRepositorySub =
+          # repo:Wire-Network/wire-sysio:*), so both master dispatches and the
+          # tag-ref dispatches from tag-release.yaml can assume it.
           # generate-opp-bundles.sh --publish mints the CodeArtifact token from
           # these credentials and exports CARGO_REGISTRIES_WIRE_INDEX/_TOKEN.
           role-to-assume: arn:aws:iam::619322354039:role/wire-pkg-cargo-publisher
           aws-region: us-east-1
 
+      - name: Validate release inputs
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          # Untrusted dispatch inputs: environment variables only, never
+          # interpolated into the script body (repo convention).
+          CHANNEL: ${{ inputs.channel }}
+          PACKAGE_VERSION: ${{ inputs.package-version }}
+        run: |
+          set -euo pipefail
+          # `channel` is a choice input, but assert anyway so a REST-dispatched
+          # payload cannot smuggle an arbitrary value into the publish command.
+          case "$CHANNEL" in
+            none|dev|stable) ;;
+            *) echo "::error::Invalid channel '${CHANNEL}' (expected none|dev|stable)" >&2; exit 1 ;;
+          esac
+          if [[ -n "$PACKAGE_VERSION" ]]; then
+            semver_re='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'
+            [[ "$PACKAGE_VERSION" =~ $semver_re ]] \
+              || { echo "::error::Invalid package-version '${PACKAGE_VERSION}' (expected X.Y.Z[-suffix])" >&2; exit 1; }
+          fi
+
       - name: Generate & Publish OPP Bundles
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CHANNEL: ${{ inputs.channel }}
+          PACKAGE_VERSION: ${{ inputs.package-version }}
         run: |
           # `npm publish` (invoked by wire-protobuf-bundler --publish) does NOT read a
           # bare $NPM_TOKEN env var — it needs an _authToken line in .npmrc. Without
@@ -69,7 +115,54 @@ jobs:
           # the token confined to the push/dispatch publish step — it is never present
           # during pull_request validation or the dependency install step.
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
-          ./libraries/opp/tools/scripts/generate-opp-bundles.sh --publish
+          args=(--publish)
+          # `channel` only exists on the dispatch path (empty on push); 'none'
+          # keeps the legacy no-channel behavior byte-identical.
+          if [[ -n "${CHANNEL:-}" && "$CHANNEL" != "none" ]]; then
+            args+=(--channel "$CHANNEL")
+          fi
+          if [[ -n "${PACKAGE_VERSION:-}" ]]; then
+            args+=(--package-version "$PACKAGE_VERSION")
+          fi
+          ./libraries/opp/tools/scripts/generate-opp-bundles.sh "${args[@]}"
+
+      - name: Record published versions
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          # The RENDERED manifests are the authority on what was just published —
+          # the bundler stamps the resolved version into each generated package.
+          typescript_version="$(jq -r .version build/opp/typescript/package.json)"
+          solidity_version="$(jq -r .version build/opp/solidity/package.json)"
+          solana_version="$(grep -m1 '^version' build/opp/solana/Cargo.toml | sed -E 's/^version *= *"([^"]+)"/\1/')"
+          jq -n \
+            --arg channel "${CHANNEL:-none}" \
+            --arg ref "${GITHUB_REF_NAME}" \
+            --arg sha "${GITHUB_SHA}" \
+            --arg ts "$typescript_version" \
+            --arg sol "$solidity_version" \
+            --arg solana "$solana_version" \
+            '{
+              "channel": $channel,
+              "wire-sysio-ref": $ref,
+              "wire-sysio-sha": $sha,
+              "@wireio/opp-typescript-models": $ts,
+              "@wireio/opp-solidity-models": $sol,
+              "wire-opp-solana-models": $solana
+            }' > opp-published-versions.json
+          cat opp-published-versions.json
+
+      # The artifact name carries the run's ref so release.yaml can pick the run
+      # that published THIS tag's bundles (see resolve-opp-bundles-run.sh).
+      - name: Upload published-versions artifact
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # actions/upload-artifact@v6
+        with:
+          name: opp-published-versions-${{ github.ref_name }}
+          path: opp-published-versions.json
+          if-no-files-found: error
 
       - name: Validate OPP Bundles
         if: github.event_name == 'pull_request'

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -102,43 +102,13 @@ jobs:
         run: |
           python3 .github/scripts/cmake-version.py write "$VERSION"
 
-      - name: Pin the latest published wire-cdt release for the channel
-        id: cdt
-        env:
-          CDT_PRERELEASE: ${{ steps.version.outputs.prerelease }}
-          CDT_CHANNEL: ${{ steps.version.outputs.channel }}
-        run: |
-          set -euo pipefail
-
-          # Resolve-at-prepare, pin-at-build: the tag build downloads exactly this
-          # release's asset, so re-runs are reproducible, the CDT version is
-          # reviewable at gate 1, and there is no publish-order race at release time.
-          #
-          # There is no first-class "latest prerelease" endpoint, so the release list
-          # is filtered by draft/prerelease and the newest by creation date wins.
-          releases_json="$(
-            gh api "repos/Wire-Network/wire-cdt/releases?per_page=100" \
-              -H "X-GitHub-Api-Version: 2022-11-28"
-          )"
-          cdt_release="$(
-            jq -r --argjson pre "$CDT_PRERELEASE" '
-              [.[] | select(.draft == false and .prerelease == $pre)]
-              | sort_by(.created_at)
-              | last
-              | .tag_name // empty' <<<"$releases_json"
-          )"
-          if [[ -z "$cdt_release" ]]; then
-            echo "::error::No published wire-cdt release found for channel ${CDT_CHANNEL}" >&2
-            exit 1
-          fi
-
-          jq --indent 2 --arg release "$cdt_release" --arg channel "$CDT_CHANNEL" \
-            '.wirecdt.release = $release | .wirecdt.channel = $channel' \
-            .cicd/defaults.json > .cicd/defaults.json.next
-          mv .cicd/defaults.json.next .cicd/defaults.json
-
-          echo "release=$cdt_release" >> "$GITHUB_OUTPUT"
-          echo "Pinned wire-cdt ${cdt_release} (channel ${CDT_CHANNEL})"
+      # NOTE: the former "Pin the latest published wire-cdt release" step (and
+      # its .cicd/defaults.json pin file) is retired. The tag build's `v` job
+      # now resolves the CDT release itself — an explicit `wire-cdt-release`
+      # dispatch input on tag-release.yaml/linux_amd64_build.yaml, or the latest
+      # published wire-cdt release in the version's channel — and the resolved
+      # value is recorded durably in the release's
+      # wire-sysio-versions-<version>.json asset.
 
       - name: Open the bump PR
         env:
@@ -146,14 +116,13 @@ jobs:
           PREVIOUS: ${{ steps.version.outputs.previous }}
           CHANNEL: ${{ steps.version.outputs.channel }}
           MODE: ${{ steps.version.outputs.mode }}
-          CDT_RELEASE: ${{ steps.cdt.outputs.release }}
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add CMakeLists.txt .cicd/defaults.json
+          git add CMakeLists.txt
           git commit -m "chore(release): ${MODE} ${PREVIOUS} -> ${VERSION}"
           # --force-with-lease, not a bare push: re-dispatching the prep for the
           # same version (a fixed pin, a re-resolved CDT release) must be able to
@@ -170,9 +139,11 @@ jobs:
             "${MODE}: \`${PREVIOUS}\` -> \`${VERSION}\` (channel: **${CHANNEL}**)." \
             "" \
             "- \`CMakeLists.txt\`: \`VERSION_*\` set to \`${VERSION}\`." \
-            "- \`.cicd/defaults.json\`: \`wirecdt.release\` pinned to \`${CDT_RELEASE}\`, \`wirecdt.channel\` set to \`${CHANNEL}\`." \
             "" \
-            "Review the pinned Wire CDT release, then merge. Tagging is a separate," \
+            "The tag build resolves the Wire CDT release itself (latest published" \
+            "in this channel, or an explicit \`wire-cdt-release\` dispatch input);" \
+            "the resolved version is recorded in the release's" \
+            "\`wire-sysio-versions-<version>.json\`. Tagging is a separate," \
             "approval-gated dispatch of \`tag-release.yaml\` with the same version.")"
           gh pr create \
             --base master \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,6 +93,9 @@ jobs:
           .github/scripts/resolve-build-run.sh "$TAG" "$sha" \
             linux_amd64_build.yaml macos_arm64_build.yaml >> "$GITHUB_OUTPUT"
 
+          # The released commit SHA also feeds the source-refs manifest below.
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
         with:
           name: wire-sysio-packages-amd64
@@ -106,6 +109,24 @@ jobs:
           path: dist
           run-id: ${{ steps.run.outputs.macos_arm64_build-run-id }}
           github-token: ${{ github.token }}
+
+      # build-metadata.json is TRANSPORT metadata from the linux tag build (the
+      # wire-cdt release the build actually installed) — read it, then remove it
+      # so the verify suite, the checksums list and `gh release upload dist/*`
+      # all see exactly the seven-package set they always have.
+      - name: Extract build metadata
+        id: metadata
+        run: |
+          set -euo pipefail
+          metadata_file="dist/build-metadata.json"
+          [[ -f "$metadata_file" ]] \
+            || { echo "::error::${metadata_file} missing from the linux build artifact (the tag build records the resolved wire-cdt release there)" >&2; exit 1; }
+          cdt_release="$(jq -r '."wire-cdt".release' "$metadata_file")"
+          [[ -n "$cdt_release" && "$cdt_release" != "null" ]] \
+            || { echo "::error::${metadata_file} carries no wire-cdt release" >&2; exit 1; }
+          echo "cdt-release=${cdt_release}" >> "$GITHUB_OUTPUT"
+          rm "$metadata_file"
+          echo "Build used wire-cdt ${cdt_release}"
 
       - name: Guard release tag matches artifact version
         run: |
@@ -139,6 +160,77 @@ jobs:
             || { echo "::error::${bundle} contains no sysio.*.abi"; exit 1; }
           echo "system contracts bundle OK: $(echo "$entries" | grep -c '\.wasm$') wasm, $(echo "$entries" | grep -c '\.abi$') abi"
 
+      # tag-release.yaml dispatched opp-bundles.yaml on the tag ref alongside
+      # the platform builds; by now (after waiting out the builds) its ~10 min
+      # run has long finished. The run is discriminated by head_branch == tag
+      # AND its tag-suffixed published-versions artifact.
+      - name: Resolve the OPP bundles run for the tag
+        id: opp
+        run: |
+          set -euo pipefail
+          .github/scripts/resolve-opp-bundles-run.sh "$TAG" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # actions/download-artifact@v8.0.1
+        with:
+          name: opp-published-versions-${{ env.TAG }}
+          path: opp
+          run-id: ${{ steps.opp.outputs.opp-bundles-run-id }}
+          github-token: ${{ github.token }}
+
+      # The versions manifest is the durable record of what this release is
+      # made of (it replaced the .cicd/defaults.json CDT pin); the source-refs
+      # manifest maps the same components to git refs + commit SHAs. The three
+      # generated model packages repeat wire-sysio's ref/sha — they are
+      # generated from the protos in THIS repo at THIS tag.
+      - name: Generate versions and source-refs manifests
+        env:
+          SHA: ${{ steps.run.outputs.sha }}
+          CDT_RELEASE: ${{ steps.metadata.outputs.cdt-release }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+
+          opp_versions="opp/opp-published-versions.json"
+          [[ -f "$opp_versions" ]] \
+            || { echo "::error::${opp_versions} missing from the opp-bundles artifact" >&2; exit 1; }
+          typescript_version="$(jq -r '."@wireio/opp-typescript-models"' "$opp_versions")"
+          solidity_version="$(jq -r '."@wireio/opp-solidity-models"' "$opp_versions")"
+          solana_version="$(jq -r '."wire-opp-solana-models"' "$opp_versions")"
+
+          # wire-cdt is public, so the workflow token resolves its tag SHA.
+          cdt_sha="$(gh api "repos/Wire-Network/wire-cdt/commits/${CDT_RELEASE}" --jq .sha)"
+
+          # Repo entries carry their release TAG (v-prefixed); registry entries
+          # carry the published package version exactly as npm/cargo know it.
+          jq -n \
+            --arg sysio "$TAG" \
+            --arg cdt "$CDT_RELEASE" \
+            --arg ts "$typescript_version" \
+            --arg sol "$solidity_version" \
+            --arg solana "$solana_version" \
+            '{
+              "wire-sysio": $sysio,
+              "wire-cdt": $cdt,
+              "@wireio/opp-typescript-models": $ts,
+              "@wireio/opp-solidity-models": $sol,
+              "wire-opp-solana-models": $solana
+            }' > "dist/wire-sysio-versions-${version}.json"
+
+          jq -n \
+            --arg tag "$TAG" \
+            --arg sha "$SHA" \
+            --arg cdt_tag "$CDT_RELEASE" \
+            --arg cdt_sha "$cdt_sha" \
+            '{
+              "wire-sysio":                    { "repo": "Wire-Network/wire-sysio", "ref": $tag,     "sha": $sha },
+              "wire-cdt":                      { "repo": "Wire-Network/wire-cdt",   "ref": $cdt_tag, "sha": $cdt_sha },
+              "@wireio/opp-typescript-models": { "repo": "Wire-Network/wire-sysio", "ref": $tag,     "sha": $sha },
+              "@wireio/opp-solidity-models":   { "repo": "Wire-Network/wire-sysio", "ref": $tag,     "sha": $sha },
+              "wire-opp-solana-models":        { "repo": "Wire-Network/wire-sysio", "ref": $tag,     "sha": $sha }
+            }' > "dist/wire-sysio-source-refs-${version}.json"
+
+          cat "dist/wire-sysio-versions-${version}.json" "dist/wire-sysio-source-refs-${version}.json"
+
       - name: Attach artifacts to the release
         run: |
           set -euo pipefail
@@ -147,7 +239,8 @@ jobs:
           # `sha256sum dist/*` would write `dist/`-prefixed paths into the file
           # (useless to a downloader running `sha256sum -c` next to the assets)
           # and would depend on glob order to avoid hashing the checksums file
-          # itself. Seven package assets + this file = the eight release assets.
+          # itself. Seven package assets + two version manifests + this file =
+          # the ten release assets.
           (
             cd dist
             sha256sum \
@@ -158,10 +251,65 @@ jobs:
               "wire-sysio-${version}-x86_64.tar.gz" \
               "wire-sysio-${version}-macos-arm64.tar.gz" \
               "wire-sysio-system-contracts-${version}.tar.gz" \
+              "wire-sysio-versions-${version}.json" \
+              "wire-sysio-source-refs-${version}.json" \
               > "wire-sysio-${version}-checksums.txt"
           )
           cat "dist/wire-sysio-${version}-checksums.txt"
           gh release upload "$TAG" dist/* --clobber
+
+      # The component-version and source-ref tables ride the release notes so
+      # the release is self-describing without downloading the JSON assets.
+      # A marker-delimited section keeps retries idempotent: any previous
+      # generated section is stripped before the fresh one is appended.
+      - name: Append component tables to the release notes
+        env:
+          SHA: ${{ steps.run.outputs.sha }}
+          CDT_RELEASE: ${{ steps.metadata.outputs.cdt-release }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          versions_json="dist/wire-sysio-versions-${version}.json"
+          refs_json="dist/wire-sysio-source-refs-${version}.json"
+
+          typescript_version="$(jq -r '."@wireio/opp-typescript-models"' "$versions_json")"
+          solidity_version="$(jq -r '."@wireio/opp-solidity-models"' "$versions_json")"
+          solana_version="$(jq -r '."wire-opp-solana-models"' "$versions_json")"
+          cdt_sha="$(jq -r '."wire-cdt".sha' "$refs_json")"
+
+          gh release view "$TAG" --json body --jq .body > body.md
+          # Strip any previous generated section (idempotent retries).
+          sed -i '/<!-- wire-versions:begin -->/,/<!-- wire-versions:end -->/d' body.md
+
+          # printf, not an indented heredoc: every body line must start at
+          # column 0 or GitHub renders the whole section as a code block.
+          {
+            cat body.md
+            printf '%s\n' \
+              "" \
+              "<!-- wire-versions:begin -->" \
+              "## Component versions" \
+              "" \
+              "| Component | Version |" \
+              "|---|---|" \
+              "| wire-sysio | [\`${TAG}\`](https://github.com/Wire-Network/wire-sysio/releases/tag/${TAG}) |" \
+              "| wire-cdt | [\`${CDT_RELEASE}\`](https://github.com/Wire-Network/wire-cdt/releases/tag/${CDT_RELEASE}) |" \
+              "| @wireio/opp-typescript-models | [\`${typescript_version}\`](https://www.npmjs.com/package/@wireio/opp-typescript-models/v/${typescript_version}) |" \
+              "| @wireio/opp-solidity-models | [\`${solidity_version}\`](https://www.npmjs.com/package/@wireio/opp-solidity-models/v/${solidity_version}) |" \
+              "| wire-opp-solana-models | \`${solana_version}\` (cargo registry \`sparse+https://public.crates.pkgs.wire-dev.com/\`) |" \
+              "" \
+              "## Source refs" \
+              "" \
+              "| Component | Ref | Commit |" \
+              "|---|---|---|" \
+              "| wire-sysio | \`${TAG}\` | [\`${SHA:0:7}\`](https://github.com/Wire-Network/wire-sysio/commit/${SHA}) |" \
+              "| wire-cdt | \`${CDT_RELEASE}\` | [\`${cdt_sha:0:7}\`](https://github.com/Wire-Network/wire-cdt/commit/${cdt_sha}) |" \
+              "| @wireio/opp-typescript-models | \`${TAG}\` | [\`${SHA:0:7}\`](https://github.com/Wire-Network/wire-sysio/commit/${SHA}) |" \
+              "| @wireio/opp-solidity-models | \`${TAG}\` | [\`${SHA:0:7}\`](https://github.com/Wire-Network/wire-sysio/commit/${SHA}) |" \
+              "| wire-opp-solana-models | \`${TAG}\` | [\`${SHA:0:7}\`](https://github.com/Wire-Network/wire-sysio/commit/${SHA}) |" \
+              "<!-- wire-versions:end -->"
+          } > body-next.md
+          gh release edit "$TAG" --notes-file body-next.md
 
       - name: Publish the release
         run: |

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -16,6 +16,11 @@ on:
         description: "Version to tag, without a leading v (e.g. 1.0.0-dev, 1.1.0-rc1, 1.1.0). Must already be master's version."
         type: string
         required: true
+      wire-cdt-release:
+        description: "Optional wire-cdt RELEASE tag to build against (e.g. v1.0.1). When omitted, the build resolves the latest published wire-cdt release in the same channel as this version."
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -131,6 +136,9 @@ jobs:
       - name: Dispatch the platform builds on the tag ref
         env:
           TAG: ${{ steps.assert.outputs.tag }}
+          # Untrusted dispatch input: environment variable only, never
+          # interpolated into the script body.
+          WIRE_CDT_RELEASE: ${{ inputs.wire-cdt-release }}
         run: |
           set -euo pipefail
 
@@ -140,9 +148,35 @@ jobs:
           # ref, so the existing startsWith(github.ref, 'refs/tags/v') gates --
           # system-contract build, Wire CDT install, contracts bundle -- behave
           # exactly as on a tag push.
-          gh workflow run linux_amd64_build.yaml --ref "$TAG"
+          #
+          # An explicit wire-cdt-release travels to the linux build (the only CDT
+          # consumer); when omitted, the build's `v` job resolves the latest
+          # published wire-cdt release in this version's channel.
+          linux_args=()
+          if [[ -n "$WIRE_CDT_RELEASE" ]]; then
+            linux_args+=(-f wire-cdt-release="$WIRE_CDT_RELEASE")
+          fi
+          gh workflow run linux_amd64_build.yaml --ref "$TAG" "${linux_args[@]}"
           gh workflow run macos_arm64_build.yaml --ref "$TAG"
           echo "Dispatched linux_amd64_build.yaml and macos_arm64_build.yaml on ${TAG}"
+
+      - name: Dispatch the OPP bundles publish on the tag ref
+        env:
+          TAG: ${{ steps.assert.outputs.tag }}
+          PRERELEASE: ${{ steps.assert.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+
+          # The models are generated from the tag's protos, so the workflow runs
+          # ON the tag ref (the cargo publisher OIDC trust accepts refs/tags/v*
+          # alongside master — wire-infra ArtifactManagementStack). The version
+          # suffix decides the channel, same rule as everywhere downstream.
+          channel=stable
+          if [[ "$PRERELEASE" == "true" ]]; then
+            channel=dev
+          fi
+          gh workflow run opp-bundles.yaml --ref "$TAG" -f channel="$channel"
+          echo "Dispatched opp-bundles.yaml on ${TAG} (channel ${channel})"
 
       - name: Dispatch the release asset workflow
         env:

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -9,22 +9,23 @@ with verified artifacts attached. Artifact contents are documented in
 
 wire-sysio and wire-cdt release **independently**. There is no cross-repo release
 train and no shared pipeline: wire-cdt cuts its own release, and a wire-sysio
-release **consumes a pinned wire-cdt release asset**.
+release **consumes a wire-cdt release asset resolved at build time**.
 
 The properties that follow from that choice:
 
-- **Resolve at prepare, pin at build.** `prepare-release.yaml` resolves the latest
-  published wire-cdt release for the channel and writes it into
-  `.cicd/defaults.json` (`wirecdt.release`, `wirecdt.channel`). The tag build then
-  downloads *exactly* that release's `wire-cdt_<version>_amd64.deb` asset. Re-runs
-  are reproducible, the CDT version is reviewable at gate 1, and there is no
-  publish-order race at release time. For a one-off experiment against a
-  different CDT, `linux_amd64_build.yaml` takes an `override-cdt-release`
-  dispatch input; its channel is then derived from the release's own prerelease
-  flag instead of being asserted against the pin.
-  (`.cicd/defaults.json`'s `wirecdt` block carries exactly the two keys the
-  release-asset path reads — `release` and `channel`. The former `target`
-  git-ref key had no reader and was removed.)
+- **Resolve at build, record at release.** The tag build's `v` job resolves the
+  wire-cdt release itself: an explicit `wire-cdt-release` dispatch input (on
+  `tag-release.yaml`, forwarded to `linux_amd64_build.yaml`) wins; otherwise the
+  latest **published** wire-cdt release in the same channel as the version being
+  built is used. The build downloads that release's
+  `wire-cdt_<version>_amd64.deb` asset, records the resolved tag in its
+  `build-metadata.json` artifact, and `release.yaml` writes it durably into the
+  release's `wire-sysio-versions-<version>.json` asset — the record of what the
+  release was built against. (The former `.cicd/defaults.json` pin, written by
+  `prepare-release.yaml`, is retired; the versions manifest replaced it.)
+  For a one-off experiment against a different CDT, the same `wire-cdt-release`
+  input works on a direct `linux_amd64_build.yaml` dispatch; its channel is then
+  derived from the release's own prerelease flag instead of being asserted.
 - **Release assets, not CI artifacts.** CI artifacts expire after 30 days, so an
   old tag could not be rebuilt from them. Release assets are durable.
   Wire-Network/wire-cdt is public, so the download needs no special token — the
@@ -33,7 +34,9 @@ The properties that follow from that choice:
   download is a plain `gh release download`.)
 - **The version's suffix IS the channel.** `-dev` / `-rcN` means prerelease; no
   suffix means stable. One input (`version`) decides everything downstream —
-  the release's prerelease flag, and which wire-cdt channel gets pinned.
+  the release's prerelease flag, which wire-cdt channel the build resolves in,
+  and which channel the OPP model bundles publish under (`-dev` bundle versions
+  on prerelease, bare versions on stable).
 - **Two human gates.** Gate 1 is reviewing and merging the bump PR. Gate 2 is
   approving the `release` Environment before anything is tagged or created.
 - **The system contracts ship as a release asset.** Only tag builds compile them
@@ -67,11 +70,12 @@ resolve under the home.
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `prepare-release.yaml` | `workflow_dispatch(version)` | Validates the version, writes `VERSION_*` into `CMakeLists.txt`, resolves + pins the latest published wire-cdt release for the channel, opens the `release/prep-v<version>` PR. |
-| `tag-release.yaml` | `workflow_dispatch(version)`, `environment: release` | Asserts master HEAD carries the version, creates the annotated tag (`POST /git/tags` then `POST /git/refs`), creates the DRAFT release with generated notes, dispatches both platform builds on the tag ref, dispatches `release.yaml`. |
-| `linux_amd64_build.yaml` | tag ref (dispatched or pushed) | Installs the pinned wire-cdt release deb, builds with system contracts ON, assembles deb + rpm + portable tgz, bundles the contracts, uploads `wire-sysio-packages-amd64`. |
+| `prepare-release.yaml` | `workflow_dispatch(version)` | Validates the version, writes `VERSION_*` into `CMakeLists.txt`, opens the `release/prep-v<version>` PR. |
+| `tag-release.yaml` | `workflow_dispatch(version, wire-cdt-release?)`, `environment: release` | Asserts master HEAD carries the version, creates the annotated tag (`POST /git/tags` then `POST /git/refs`), creates the DRAFT release with generated notes, dispatches both platform builds AND `opp-bundles.yaml` (with the version's channel) on the tag ref, dispatches `release.yaml`. |
+| `linux_amd64_build.yaml` | tag ref (dispatched or pushed) | Resolves the wire-cdt release (explicit input or latest published in the channel), installs its deb, builds with system contracts ON, assembles deb + rpm + portable tgz, bundles the contracts, records `build-metadata.json`, uploads `wire-sysio-packages-amd64`. |
 | `macos_arm64_build.yaml` | tag ref (dispatched or pushed) | Builds, tests, produces the portable tarball, verifies it in `--no-service` mode, uploads `wire-sysio-packages-macos-arm64`. |
-| `release.yaml` | `workflow_dispatch(tag)`; `release: published` as a manual fallback | Awaits both tag-ref builds, downloads both artifacts, verifies each one explicitly, attaches assets + checksums to the draft, then flips the draft public. |
+| `opp-bundles.yaml` | tag ref (dispatched, `channel` input) | Generates the OPP model bundles from the tag's protos, publishes `@wireio/opp-{typescript,solidity}-models` to npm and `wire-opp-solana-models` to the WIRE cargo registry (channel `dev` → `-dev` versions), uploads `opp-published-versions-<tag>`. |
+| `release.yaml` | `workflow_dispatch(tag)`; `release: published` as a manual fallback | Awaits both tag-ref builds, downloads both artifacts, verifies each one explicitly, resolves the tag's opp-bundles run, generates `wire-sysio-versions-<version>.json` + `wire-sysio-source-refs-<version>.json`, attaches assets + checksums, appends the component-version/source-ref tables to the notes, then flips the draft public. |
 
 ### Post-bump
 
@@ -109,14 +113,14 @@ flowchart TD
 
     H1[/"Human: pick version — its suffix IS the channel<br>(-dev/-rcN = prerelease, none = stable)"/]:::human
     H2[/"Human: dispatch prepare-release (input: version)"/]:::human
-    S1["System: edit VERSION_*, resolve+pin latest<br>wire-cdt release (sysio only), open bump PR"]:::system
-    G1{{"GATE 1 — Human: 'Approve and run' the PR checks,<br>review (incl. pinned CDT), merge"}}:::gate
-    H3[/"Human: dispatch tag-release (input: version)"/]:::human
+    S1["System: edit VERSION_*, open bump PR"]:::system
+    G1{{"GATE 1 — Human: 'Approve and run' the PR checks,<br>review, merge"}}:::gate
+    H3[/"Human: dispatch tag-release (input: version,<br>optional wire-cdt-release)"/]:::human
     G2{{"GATE 2 — Human: approve 'release' Environment"}}:::gate
-    S3["System: assert version == master HEAD,<br>create annotated tag + DRAFT release,<br>DISPATCH linux + macos builds on the tag ref"]:::system
-    S4["System: tag builds produce packages<br>(sysio: installs pinned wire-cdt release deb,<br>builds + asserts system contracts, bundles them)"]:::system
-    S6["System: release.yaml — await tag-ref builds,<br>download, verify each artifact explicitly"]:::system
-    S7["System: attach assets + checksums,<br>flip draft to public"]:::system
+    S3["System: assert version == master HEAD,<br>create annotated tag + DRAFT release,<br>DISPATCH linux + macos builds + opp-bundles<br>(channel from the suffix) on the tag ref"]:::system
+    S4["System: tag builds produce packages<br>(sysio: resolves + installs wire-cdt release deb,<br>builds + asserts system contracts, bundles them,<br>records build-metadata.json);<br>opp-bundles publishes the model packages"]:::system
+    S6["System: release.yaml — await tag-ref builds,<br>download, verify each artifact explicitly,<br>generate versions + source-refs manifests"]:::system
+    S7["System: attach assets + checksums,<br>append component tables to the notes,<br>flip draft to public"]:::system
     H4[/"Human: sanity-check the release page"/]:::human
 
     H1 --> H2 --> S1 --> G1 --> H3 --> G2 --> S3 --> S4 --> S6 --> S7 --> H4
@@ -124,7 +128,7 @@ flowchart TD
 
 ## Release assets
 
-Eight assets, excluding GitHub's auto-added source archives:
+Ten assets, excluding GitHub's auto-added source archives:
 
 | Asset | Produced by |
 |---|---|
@@ -135,6 +139,8 @@ Eight assets, excluding GitHub's auto-added source archives:
 | `wire-sysio-<version>-x86_64.tar.gz` | linux tag build (`package-tgz`) |
 | `wire-sysio-<version>-macos-arm64.tar.gz` | macOS tag build (`package-tgz`) |
 | `wire-sysio-system-contracts-<version>.tar.gz` | linux tag build (`sysio.*/{*.wasm,*.abi}`) |
+| `wire-sysio-versions-<version>.json` | `release.yaml` (wire-sysio + wire-cdt + OPP model versions) |
+| `wire-sysio-source-refs-<version>.json` | `release.yaml` (same components → repo/ref/sha) |
 | `wire-sysio-<version>-checksums.txt` | `release.yaml` |
 
 The `-macos-arm64` suffix comes from `WIRE_ARCH_TAG` in `cmake/package.cmake`;

--- a/libraries/opp/tools/protobuf-bundler/src/constants.ts
+++ b/libraries/opp/tools/protobuf-bundler/src/constants.ts
@@ -17,6 +17,24 @@ export const PUBLISHABLE_TARGETS: Target[] = [
 export const CARGO_PUBLISHABLE_TARGETS: Target[] = [Target.Solana]
 
 /**
+ * Release channel for published bundle versions, matching the wire-sysio
+ * release channels: `dev` appends the prerelease suffix to the resolved
+ * version (e.g. `1.0.41-dev`); `stable` publishes the bare version
+ * (identical to the historical no-channel behavior). The version RESOLUTION
+ * (latest published → patch bump) is the same for every channel.
+ */
+export enum Channel {
+  dev = "dev",
+  stable = "stable"
+}
+
+/**
+ * Prerelease suffix appended to the resolved version on the dev channel.
+ * The suffix spelling is the channel name itself.
+ */
+export const DEV_PRERELEASE_SUFFIX = Channel.dev
+
+/**
  * Cargo registry name for the WIRE CodeArtifact repository. The publish
  * environment supplies `CARGO_REGISTRIES_WIRE_INDEX` / `_TOKEN`
  * (see libraries/opp/tools/scripts/generate-opp-bundles.sh).

--- a/libraries/opp/tools/protobuf-bundler/src/index.ts
+++ b/libraries/opp/tools/protobuf-bundler/src/index.ts
@@ -6,6 +6,8 @@ import { log, setLogLevel } from "./util/logger.js"
 import { bundleCommand } from "./commands/bundle.js"
 import { resolveSynchronizedVersion } from "./util/resolveVersion.js"
 import {
+  Channel,
+  DEV_PRERELEASE_SUFFIX,
   Target,
   ALL_TARGETS,
   PUBLISHABLE_TARGETS,
@@ -67,6 +69,12 @@ async function main(): Promise<void> {
       describe:
         "Semver version. If omitted, resolved from npm (ts/solidity synced, solana defaults to 0.1.0)."
     })
+    .option("channel", {
+      type: "string",
+      choices: Object.values(Channel),
+      describe:
+        "Release channel matching wire-sysio. 'dev' appends the -dev prerelease suffix to the resolved version; 'stable' (or omitted) publishes the bare version. Version resolution itself is unchanged."
+    })
     .option("publish", {
       type: "boolean",
       default: false,
@@ -106,11 +114,28 @@ async function main(): Promise<void> {
     requestedTargets.includes(t)
   )
 
+  // An explicit --package-version wins over resolution, but must agree with
+  // the requested channel's suffix — error on mismatch, never silently rewrite.
+  const channel = argv.channel as Channel | undefined,
+    devSuffix = `-${DEV_PRERELEASE_SUFFIX}`
+  if (argv.packageVersion && channel === Channel.dev) {
+    Assert.ok(
+      argv.packageVersion.endsWith(devSuffix),
+      `--channel ${Channel.dev} requires a --package-version ending in "${devSuffix}" (got "${argv.packageVersion}")`
+    )
+  }
+  if (argv.packageVersion && channel === Channel.stable) {
+    Assert.ok(
+      !argv.packageVersion.includes("-"),
+      `--channel ${Channel.stable} requires a bare --package-version with no prerelease suffix (got "${argv.packageVersion}")`
+    )
+  }
+
   // Resolve version — synchronized for ts/solidity if any are in the set
   const hasNpmTargets = targets.some(t => PUBLISHABLE_TARGETS.includes(t)),
     packageVersion =
       argv.packageVersion ??
-      (hasNpmTargets ? resolveSynchronizedVersion() : "0.1.0")
+      (hasNpmTargets ? resolveSynchronizedVersion(channel) : "0.1.0")
 
   await bundleCommand({
     repo: argv.repo,

--- a/libraries/opp/tools/protobuf-bundler/src/util/resolveVersion.ts
+++ b/libraries/opp/tools/protobuf-bundler/src/util/resolveVersion.ts
@@ -2,6 +2,8 @@ import { execSync } from "node:child_process"
 import { asOption } from "@3fv/prelude-ts"
 import { log } from "./logger.js"
 import {
+  Channel,
+  DEV_PRERELEASE_SUFFIX,
   Target,
   TargetPackageName,
   PUBLISHABLE_TARGETS
@@ -73,8 +75,16 @@ export function resolveNextVersion(packageName: string): string {
  * For the typescript/solidity pair: query all publishable package versions
  * from npm, take the greatest semver, increment patch, and return that
  * version. This ensures both packages always publish at the same version.
+ *
+ * @param channel optional release channel — `Channel.dev` appends the
+ *   prerelease suffix to the resolved version (`X.Y.Z-dev`);
+ *   `Channel.stable` or omitted returns the bare version. The resolution
+ *   itself (latest published → patch bump) is identical for every channel;
+ *   the parse below already reads the `X.Y.Z` core out of a suffixed latest
+ *   (`1.0.40-dev` → next `1.0.41[-dev]`), so consecutive dev publishes bump
+ *   normally.
  */
-export function resolveSynchronizedVersion(): string {
+export function resolveSynchronizedVersion(channel?: Channel): string {
   log.info("Resolving synchronized version for publishable targets…")
 
   const versions = PUBLISHABLE_TARGETS.map(target => {
@@ -109,7 +119,9 @@ export function resolveSynchronizedVersion(): string {
     )
     .map(maxVersion => {
       const m = maxVersion.match(/^(\d+)\.(\d+)\.(\d+)/)!
-      const next = `${m[1]}.${m[2]}.${parseInt(m[3], 10) + 1}`
+      const core = `${m[1]}.${m[2]}.${parseInt(m[3], 10) + 1}`,
+        next =
+          channel === Channel.dev ? `${core}-${DEV_PRERELEASE_SUFFIX}` : core
       log.info("Synchronized next version: %s", next)
       return next
     })

--- a/libraries/opp/tools/protobuf-bundler/tests/resolveVersion.test.ts
+++ b/libraries/opp/tools/protobuf-bundler/tests/resolveVersion.test.ts
@@ -1,0 +1,160 @@
+jest.mock("node:child_process", () => ({ execSync: jest.fn() }))
+
+import { execSync } from "node:child_process"
+import {
+  queryNpmVersion,
+  resolveNextVersion,
+  resolveSynchronizedVersion
+} from "@wireio/wire-protobuf-bundler/util/resolveVersion"
+import {
+  Channel,
+  Target,
+  TargetPackageName
+} from "@wireio/wire-protobuf-bundler/constants"
+
+const mockExecSync = execSync as jest.Mock
+
+const TYPESCRIPT_PACKAGE = TargetPackageName[Target.Typescript]
+const SOLIDITY_PACKAGE = TargetPackageName[Target.Solidity]
+
+interface NpmCommandError extends Error {
+  stderr?: Buffer
+}
+
+/** Build the error shape npm produces for an unpublished package. */
+function npmNotFoundError(): NpmCommandError {
+  const error: NpmCommandError = new Error("npm show failed")
+  error.stderr = Buffer.from("npm ERR! code E404 - not found")
+  return error
+}
+
+/**
+ * Mock `npm show <pkg> version` per package: a string resolves as the
+ * published version, `undefined` simulates an unpublished package (E404).
+ */
+function mockNpmVersions(
+  byPackage: Record<string, string | undefined>
+): void {
+  mockExecSync.mockImplementation((command: string) => {
+    const packageName = Object.keys(byPackage).find(name =>
+      String(command).includes(name)
+    )
+    if (!packageName) {
+      throw new Error(`Unexpected npm command: ${command}`)
+    }
+    const version = byPackage[packageName]
+    if (version === undefined) {
+      throw npmNotFoundError()
+    }
+    return `${version}\n`
+  })
+}
+
+beforeEach(() => {
+  mockExecSync.mockReset()
+})
+
+describe("queryNpmVersion", () => {
+  it("returns the trimmed published version", () => {
+    mockNpmVersions({ [TYPESCRIPT_PACKAGE]: "1.0.40" })
+    expect(queryNpmVersion(TYPESCRIPT_PACKAGE)).toBe("1.0.40")
+  })
+
+  it("returns undefined for an unpublished package (E404)", () => {
+    mockNpmVersions({ [TYPESCRIPT_PACKAGE]: undefined })
+    expect(queryNpmVersion(TYPESCRIPT_PACKAGE)).toBeUndefined()
+  })
+
+  it("throws on a non-404 npm failure", () => {
+    mockExecSync.mockImplementation(() => {
+      const error: NpmCommandError = new Error("network down")
+      error.stderr = Buffer.from("npm ERR! code ECONNRESET")
+      throw error
+    })
+    expect(() => queryNpmVersion(TYPESCRIPT_PACKAGE)).toThrow(
+      /Failed to query npm/
+    )
+  })
+})
+
+describe("resolveNextVersion", () => {
+  it("bumps the patch of the latest published version", () => {
+    mockNpmVersions({ [TYPESCRIPT_PACKAGE]: "2.3.7" })
+    expect(resolveNextVersion(TYPESCRIPT_PACKAGE)).toBe("2.3.8")
+  })
+
+  it("throws when the package is not published", () => {
+    mockNpmVersions({ [TYPESCRIPT_PACKAGE]: undefined })
+    expect(() => resolveNextVersion(TYPESCRIPT_PACKAGE)).toThrow(
+      /please supply --package-version/
+    )
+  })
+
+  it("throws on an unparseable version", () => {
+    mockNpmVersions({ [TYPESCRIPT_PACKAGE]: "garbage" })
+    expect(() => resolveNextVersion(TYPESCRIPT_PACKAGE)).toThrow(
+      /unparseable version/
+    )
+  })
+})
+
+describe("resolveSynchronizedVersion", () => {
+  it("legacy no-channel path: greatest version + patch bump, bare", () => {
+    mockNpmVersions({
+      [TYPESCRIPT_PACKAGE]: "1.0.40",
+      [SOLIDITY_PACKAGE]: "1.0.40"
+    })
+    expect(resolveSynchronizedVersion()).toBe("1.0.41")
+  })
+
+  it("stable channel is byte-identical to the legacy path", () => {
+    mockNpmVersions({
+      [TYPESCRIPT_PACKAGE]: "1.0.40",
+      [SOLIDITY_PACKAGE]: "1.0.40"
+    })
+    expect(resolveSynchronizedVersion(Channel.stable)).toBe("1.0.41")
+  })
+
+  it("dev channel appends the -dev suffix after the normal bump", () => {
+    mockNpmVersions({
+      [TYPESCRIPT_PACKAGE]: "1.0.40",
+      [SOLIDITY_PACKAGE]: "1.0.40"
+    })
+    expect(resolveSynchronizedVersion(Channel.dev)).toBe("1.0.41-dev")
+  })
+
+  it("parses the core out of an already-suffixed latest (consecutive dev bumps)", () => {
+    mockNpmVersions({
+      [TYPESCRIPT_PACKAGE]: "1.0.41-dev",
+      [SOLIDITY_PACKAGE]: "1.0.41-dev"
+    })
+    expect(resolveSynchronizedVersion(Channel.dev)).toBe("1.0.42-dev")
+    expect(resolveSynchronizedVersion(Channel.stable)).toBe("1.0.42")
+  })
+
+  it("takes the greatest version across the publishable pair", () => {
+    mockNpmVersions({
+      [TYPESCRIPT_PACKAGE]: "1.1.0",
+      [SOLIDITY_PACKAGE]: "1.0.9"
+    })
+    expect(resolveSynchronizedVersion()).toBe("1.1.1")
+  })
+
+  it("ignores an unpublished package in the pair", () => {
+    mockNpmVersions({
+      [TYPESCRIPT_PACKAGE]: "2.1.3",
+      [SOLIDITY_PACKAGE]: undefined
+    })
+    expect(resolveSynchronizedVersion(Channel.dev)).toBe("2.1.4-dev")
+  })
+
+  it("throws when neither package is published", () => {
+    mockNpmVersions({
+      [TYPESCRIPT_PACKAGE]: undefined,
+      [SOLIDITY_PACKAGE]: undefined
+    })
+    expect(() => resolveSynchronizedVersion(Channel.dev)).toThrow(
+      /please supply --package-version/
+    )
+  })
+})

--- a/libraries/opp/tools/scripts/generate-opp-bundles.sh
+++ b/libraries/opp/tools/scripts/generate-opp-bundles.sh
@@ -6,26 +6,54 @@ set -euo pipefail
 # package repository just to install fish before publishing OPP artifacts.
 
 usage() {
-   echo "Usage: generate-opp-bundles.sh [--publish]" >&2
+   echo "Usage: generate-opp-bundles.sh [--publish] [--channel <dev|stable>] [--package-version <semver>]" >&2
 }
 
 publish=false
-for arg in "$@"; do
-   case "$arg" in
+channel=""
+package_version=""
+# Value-taking args require the while/shift form — a `for arg in "$@"` loop
+# cannot consume a following value.
+while [[ $# -gt 0 ]]; do
+   case "$1" in
       --publish)
          publish=true
+         shift
+         ;;
+      --channel)
+         if [[ $# -lt 2 ]]; then
+            echo "Error: --channel requires a value (dev|stable)." >&2
+            usage
+            exit 1
+         fi
+         channel="$2"
+         shift 2
+         ;;
+      --package-version)
+         if [[ $# -lt 2 ]]; then
+            echo "Error: --package-version requires a semver value." >&2
+            usage
+            exit 1
+         fi
+         package_version="$2"
+         shift 2
          ;;
       -h|--help)
          usage
          exit 0
          ;;
       *)
-         echo "Unknown argument: $arg" >&2
+         echo "Unknown argument: $1" >&2
          usage
          exit 1
          ;;
    esac
 done
+
+if [[ -n "$channel" && "$channel" != "dev" && "$channel" != "stable" ]]; then
+   echo "Error: --channel must be 'dev' or 'stable' (got '$channel')." >&2
+   exit 1
+fi
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 tools_root="$(cd -- "$script_dir/.." && pwd -P)"
@@ -130,6 +158,14 @@ done
 
 if [[ "$publish" == true ]]; then
    cmd+=(--publish)
+fi
+
+if [[ -n "$channel" ]]; then
+   cmd+=(--channel "$channel")
+fi
+
+if [[ -n "$package_version" ]]; then
+   cmd+=(--package-version "$package_version")
 fi
 
 echo "Running wire-protobuf-bundler for all targets..."


### PR DESCRIPTION
[SHARED-14](https://wire-network.atlassian.net/browse/SHARED-14) — run `opp-bundles` as part of the wire-sysio release, with a release `channel`, and make every release self-describing via version/source-ref manifests.

## What changed

### opp-bundles is now part of the release
- `tag-release.yaml` dispatches `opp-bundles.yaml --ref "$TAG" -f channel=<dev|stable>` alongside the platform builds (channel = the version suffix, same rule as everywhere on the Strategy-C path). The cargo publisher OIDC trust (`repo:Wire-Network/wire-sysio:*`) already covers tag refs — stale workflow comments claiming master-only were corrected.
- `opp-bundles.yaml` gains `channel` (`none|dev|stable`, default `none` = legacy behavior) and `package-version` inputs, and uploads an `opp-published-versions-<ref>` artifact recording the rendered manifest versions. Push/PR/bare-dispatch behavior is byte-identical to before.

### Channel support in the bundler (versioning UNCHANGED)
- Version resolution stays exactly as today (greatest published npm version + patch bump); the ONLY change is the `-dev` suffix appended when `--channel dev`. `stable`/omitted emit the bare version. No dist-tag changes, no publish-command changes.
- Identity `Channel` enum, `resolveSynchronizedVersion(channel?)`, `--channel` CLI option with suffix-consistency asserts on explicit `--package-version`; `generate-opp-bundles.sh` parser restructured (`while/shift`) for the value-taking flags.
- New `tests/resolveVersion.test.ts` — full suite 34/34 green, `tsc -b` clean.

### `.cicd/defaults.json` retired — CDT resolved at build, recorded at release
- `linux_amd64_build.yaml`'s `v` job resolves the wire-cdt release itself: explicit `wire-cdt-release` input (absorbs `override-cdt-release`) wins with channel `derive`; otherwise a tag build takes the latest **published** wire-cdt release in the version's channel. The resolved tag rides a `build-metadata.json` artifact.
- `prepare-release.yaml` no longer pins; `tag-release.yaml` forwards an optional `wire-cdt-release` input.

### Release manifests + notes tables
- `release.yaml` waits for the tag's opp-bundles run (new `.github/scripts/resolve-opp-bundles-run.sh` — `resolve-build-run.sh` stays byte-locked with wire-cdt), then generates and attaches `wire-sysio-versions-<v>.json` and `wire-sysio-source-refs-<v>.json` (models entries share wire-sysio's ref/sha — they are generated from this repo's protos), extends the checksums list to 10 assets, and appends marker-delimited **Component versions** / **Source refs** tables (npm/GitHub links) to the release notes before the draft flip. Retries are idempotent.
- `docs/release-workflow.md` updated (flow table, mermaid, asset table).

## Verification
- `pnpm test` in `libraries/opp/tools/protobuf-bundler`: 3 suites, 34/34 green; `pnpm run compile` clean.
- `bash -n` + shellcheck clean on both scripts; actionlint on all five workflows (only pre-existing info-level notes).
- End-to-end (dev-channel release cut) exercised via the SHARED-13 validation runs in wire-platform-build-system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SHARED-14]: https://wire-network.atlassian.net/browse/SHARED-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ