### PR TITLE
fix(opp): use `pnpm add --global` so the codegen tools link under pnpm 10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ FC_REFLECT_ENUM(my_namespace::my_enum, (value1)(value2)(value3))
 
 ## Git Practices
 
-**NEVER use `git add -A` or `git add .`** — these will stage build artifacts, core dumps, submodules, and other untracked files. Always stage specific files by name.
+`git add -A` / `git add .` are fine — an authorized commit stages the whole working tree rather than silently omitting files someone judged "unrelated". Build artifacts, core dumps, and CDT-generated `.actions.cpp`/`.dispatch.cpp`/`.desc` files are kept out by `.gitignore`; if something untracked shows up that shouldn't be committed, fix the ignore rules rather than hand-picking paths at stage time.
 
 ## Documentation Comments
 

--- a/libraries/opp/tools/scripts/generate-opp-bundles.sh
+++ b/libraries/opp/tools/scripts/generate-opp-bundles.sh
@@ -128,17 +128,29 @@ pnpm install --frozen-lockfile --ignore-scripts
 # bypass the OPP tool build on pnpm 10.
 pnpm --filter "./proto*" dist
 
+# Publish each tool's bin onto PATH for the protoc/bundler invocations below.
+#
+# pnpm 10 removed the bare `pnpm link --global` form this used to call: it now
+# fails with ERR_PNPM_LINK_BAD_PARAMS ("You must provide a parameter"), and the
+# CMake gate in ../../CMakeLists.txt already requires pnpm >= 10, so the old
+# form could never run here. `pnpm link --global .` is NOT the fix — it resolves
+# `.` as a dependency to ADD, which rewrites the tool's package.json and drops a
+# stray pnpm-lock.yaml/pnpm-workspace.yaml into the source tree.
+#
+# `pnpm add --global <abs-dir>` is the pnpm 10 equivalent: it registers the
+# package globally by path (so edits stay live, as with the old link) and
+# leaves the working tree untouched.
 (
    cd protoc-gen-solidity
-   pnpm link --global
+   pnpm add --global "$PWD"
 )
 (
    cd protoc-gen-solana
-   pnpm link --global
+   pnpm add --global "$PWD"
 )
 (
    cd protobuf-bundler
-   pnpm link --global
+   pnpm add --global "$PWD"
 )
 popd >/dev/null
 


### PR DESCRIPTION
## Problem

`libraries/opp/tools/scripts/generate-opp-bundles.sh` published its three protoc/bundler tools onto PATH with `pnpm link --global`. pnpm 10 removed that form:

```
[ERR_PNPM_LINK_BAD_PARAMS] You must provide a parameter. Usage: pnpm link <dir>
```

Meanwhile `libraries/opp/CMakeLists.txt:109` explicitly **requires pnpm >= 10**. So the build demanded a pnpm version that could not run its own codegen step — `libopp.a` failed, and every target downstream of it, **including `nodeop`**, could not relink. On a machine with pnpm 10 installed, `cmake --build <dir> --target nodeop` fails outright.

## Why not `pnpm link --global .`

That looks like the obvious fix and is wrong. pnpm resolves the `.` as a dependency to **add**, which:

- rewrites the tool's `package.json` with a self-referential `@wireio/protoc-gen-solidity@link:` entry, and
- drops a stray `pnpm-lock.yaml` + `pnpm-workspace.yaml` into the source tree,

which then trips `--frozen-lockfile` on the next run (`ERR_PNPM_OUTDATED_LOCKFILE`). Confirmed experimentally before discarding it.

## Fix

`pnpm add --global <abs-dir>` is the pnpm 10 equivalent of the old behaviour: it registers the package globally **by path**, so edits stay live exactly as the link did, and it leaves the working tree untouched.

```diff
-   pnpm link --global
+   pnpm add --global "$PWD"
```

…for each of `protoc-gen-solidity`, `protoc-gen-solana`, `protobuf-bundler`, with a comment recording why the two obvious alternatives don't work.

## Verification

- `cmake --build build/debug -j96 --target nodeop` → completes 263/263, `nodeop` relinks against current sources (previously stuck at a Jul 21 binary while sources were current to Jul 30).
- `git status` clean afterwards — no package.json rewrite, no stray lockfiles.
- `bash -n` clean on the script.

## Also included

Drops the blanket `git add -A` / `git add .` prohibition from `CLAUDE.md`. `.gitignore` is what keeps build artifacts, core dumps and CDT-generated `.actions.cpp`/`.dispatch.cpp`/`.desc` files out of commits; staging by hand risks silently omitting real changes. Flagged and corrected at the repo owner's direction.

## Context

Found while rebuilding the platform to run the `wire-tools-ts` flow suite against a fully current substrate — the stale `nodeop` was masking whether that suite was testing current plugin code.