### PR TITLE
Test: compare the renamed pre-shutdown snapshot and pin the head

### DIFF
--- a/tests/nodeop_chainbase_allocation_test.py
+++ b/tests/nodeop_chainbase_allocation_test.py
@@ -2,7 +2,6 @@
 
 import signal
 import json
-import time
 import os
 import filecmp
 
@@ -79,14 +78,29 @@ try:
 
     producerNode.kill(signal.SIGTERM)
 
-    # wait for all blocks to arrive and be processed by irrNode
-    time.sleep(3)
+    # Wait for irrNode to catch up to the promoted producer schedule. The producer is already at or
+    # past setProdsBlockNum, and the blocks it emitted before dying carry irrNode to the same point,
+    # so the snapshot below covers the updated global_property_object.
+    def isSetProdsBlockNumIrrOnIrrNode():
+        """Report whether irrNode has advanced its LIB to the set-prods block."""
+        return irrNode.getIrreversibleBlockNum() >= setProdsBlockNum
+    assert Utils.waitForBool(isSetProdsBlockNumIrrOnIrrNode, timeout=30, sleepTime=0.1), \
+        f"irrNode did not reach irreversible block {setProdsBlockNum}"
 
-    # Create the snapshot and rename it to avoid name conflict later on
+    # Take down every remaining source of blocks. irrNode runs in irreversible read mode, so its head
+    # is its LIB, and any block delivered after the first snapshot advances that LIB -- leaving the two
+    # snapshots describing different chain states and making them legitimately unequal. With no peer
+    # left to serve blocks, the restart below replays the same persisted state and lands on the same head.
+    nonProdNode.kill(signal.SIGTERM)
+    cluster.biosNode.kill(signal.SIGTERM)
+
+    # Create the snapshot and rename it, because the post-restart snapshot is written under the same
+    # head-block-derived name and createSnapshot refuses to overwrite an existing file.
     res = irrNode.createSnapshot()
-    beforeShutdownSnapshotPath = res["payload"]["snapshot_name"]
-    snapshotPathWithoutExt, snapshotExt = os.path.splitext(beforeShutdownSnapshotPath)
-    os.rename(beforeShutdownSnapshotPath, snapshotPathWithoutExt + "_before_shutdown" + snapshotExt)
+    beforeShutdownBlockNum = res["payload"]["head_block_num"]
+    snapshotPathWithoutExt, snapshotExt = os.path.splitext(res["payload"]["snapshot_name"])
+    beforeShutdownSnapshotPath = snapshotPathWithoutExt + "_before_shutdown" + snapshotExt
+    os.rename(res["payload"]["snapshot_name"], beforeShutdownSnapshotPath)
 
     # Restart irr node and ensure the snapshot is still identical
     irrNode.kill(signal.SIGTERM)
@@ -94,7 +108,10 @@ try:
     assert isRelaunchSuccess, "Fail to relaunch"
     res = irrNode.createSnapshot()
     afterShutdownSnapshotPath = res["payload"]["snapshot_name"]
-    assert filecmp.cmp(beforeShutdownSnapshotPath, afterShutdownSnapshotPath), "snapshot is not identical"
+    afterShutdownBlockNum = res["payload"]["head_block_num"]
+    assert afterShutdownBlockNum == beforeShutdownBlockNum, \
+        f"snapshots cover different blocks: {beforeShutdownBlockNum} before shutdown, {afterShutdownBlockNum} after"
+    assert filecmp.cmp(beforeShutdownSnapshotPath, afterShutdownSnapshotPath, shallow=False), "snapshot is not identical"
 
     testSuccessful = True
 finally:


### PR DESCRIPTION
`nodeop_chainbase_allocation_test` failed in the ubsan job of run 31047433131 with `FileNotFoundError` rather than its own assertion message.

The comparison read the pre-rename path, which no longer exists once the snapshot is moved aside. When both snapshots land on the same head the two names are identical, so `filecmp` compared the post-restart snapshot with itself and the `snapshot is not identical` assertion could never fail. When the heads differ the path is gone and the test dies inside `filecmp`.

The heads differ whenever the irreversible-mode node is still short of the producer's final LIB. Killing the sole producer can leave its last block undelivered, and the fixed three second sleep was not a guarantee that the node had caught up. In the failing run the snapshot landed one block short of the schedule promotion, so `global_property_object` was not exercised either. The test now waits on the node's own LIB, then takes down the remaining peers so nothing can advance it between the two snapshots.

It also compares with `shallow=False` so matching stat signatures cannot stand in for a byte comparison, and reports a mismatched head directly instead of letting it surface as a confusing byte difference.

Exercised locally across runs that landed on different heads, which is the variability that broke the previous version.