### PR TITLE
Chain: keep a snapshot request alive until it answers its caller

### DIFF
--- a/libraries/chain/include/sysio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/sysio/chain/snapshot_scheduler.hpp
@@ -3,6 +3,7 @@
 #include <sysio/chain/pending_snapshot.hpp>
 
 #include <fc/crypto/blake3.hpp>
+#include <fc/log/log_message.hpp>
 #include <sysio/chain/config.hpp>
 #include <sysio/chain/exceptions.hpp>
 #include <sysio/chain/resource_limits.hpp>
@@ -208,6 +209,26 @@ private:
     */
    void clear_delivered_request_callback(uint32_t srid);
 
+   /**
+    * Erase request @p sri, resolving a completion callback it still carries.
+    *
+    * The single removal path for scheduled requests: every way a request can leave the container
+    * -- expiry from unschedule_snapshot_requests(), explicit cancellation through
+    * unschedule_snapshot() -- goes through here, so a caller waiting on a request can never have
+    * its callback destroyed instead of answered. A request that still carries a callback has not
+    * delivered a result, and that callback is invoked with a snapshot_execution_exception built
+    * from @p undelivered_reason. Callback exceptions are logged and swallowed: this is reached
+    * from the irreversible-block path, where a throwing completion callback must not escape into
+    * block processing.
+    *
+    * @param sri                 id of the request to remove
+    * @param undelivered_reason  message reported to a caller that is still waiting; built at the
+    *                            call site so it carries that site's log context
+    * @return the removed request
+    * @throws snapshot_request_not_found if no request has that id
+    */
+   snapshot_schedule_result remove_request(uint32_t sri, fc::log_message undelivered_reason);
+
    void x_serialize() {
       auto& vec = _snapshot_requests.get<as_vector>();
       std::vector<snapshot_schedule_information> sr(vec.begin(), vec.end());
@@ -241,6 +262,19 @@ public:
    // snapshot_information (or execution error) of the first snapshot this request delivers, or
    // with a snapshot_execution_exception if the request is removed without ever delivering one
    snapshot_schedule_result schedule_snapshot(const snapshot_request_information& sri, next_function<snapshot_information> next);
+
+   /**
+    * Cancel request @p sri.
+    *
+    * A request that has not yet delivered a snapshot may still have a caller waiting on it -- an
+    * outstanding /v1/producer/create_snapshot is a scheduled request, and is visible through
+    * get_snapshot_requests() like any other. Cancelling it resolves that caller with a
+    * snapshot_execution_exception rather than destroying its callback.
+    *
+    * @param sri id of the request to cancel
+    * @return the cancelled request
+    * @throws snapshot_request_not_found if no request has that id
+    */
    snapshot_schedule_result unschedule_snapshot(uint32_t sri);
 
    /**
@@ -251,10 +285,8 @@ public:
     * head; its end_block_num, which scheduling allows to equal start_block_num, does not shorten
     * that. A recurring request expires once lib_height reaches its end_block_num.
     *
-    * A removed request that still carries a completion callback never delivered a snapshot to its
-    * caller; its callback is invoked with a snapshot_execution_exception so the caller sees an error
-    * rather than having the callback silently destroyed. Callback exceptions are logged and
-    * swallowed -- this runs on the irreversible-block path.
+    * Removal goes through remove_request(), so a request removed while a caller is still waiting on
+    * it reports that as an error rather than having its callback destroyed.
     *
     * @param lib_height block number of the last irreversible block
     */

--- a/libraries/chain/include/sysio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/sysio/chain/snapshot_scheduler.hpp
@@ -65,9 +65,22 @@ public:
    struct snapshot_schedule_result : public snapshot_request_id_information, public snapshot_request_information {
    };
 
+   /**
+    * A request's completion callback, held so that everything able to answer the caller shares one
+    * consumable copy.
+    *
+    * A next_function may be invoked exactly once across all of its copies, yet more than one place
+    * can reach a caller: the handler stored on a pending snapshot, another handler if the request
+    * runs again after a fork, and the removal path when the request is cancelled or expires. Each
+    * holds this shared_ptr rather than its own copy of the callback and moves the callback out of it
+    * before use, so whichever gets there first is the one and only answer and the others find the
+    * slot empty. Null means the request was scheduled without a caller to answer.
+    */
+   using request_callback = std::shared_ptr<next_function<snapshot_information>>;
+
    struct snapshot_schedule_information : public snapshot_request_id_information, public snapshot_request_information {
       std::vector<snapshot_information> pending_snapshots;
-      next_function<snapshot_information> next; // not serialized
+      request_callback caller; // not serialized
    };
 
    struct get_snapshot_requests_result {
@@ -192,22 +205,17 @@ private:
    void notify_snapshot_finalized(const snapshot_information& si);
 
    /**
-    * Drop the completion callback request @p srid still holds, now that the callback has resolved.
+    * Take the completion callback out of @p caller if one is still waiting there.
     *
-    * A stored callback is a next_function, which may be invoked exactly once across all of its
-    * copies, so it has to be cleared the moment execute_snapshot()'s completion handler answers
-    * the caller. A request outlives its own snapshot in two ways, and both would otherwise reach
-    * that callback again: a request whose snapshot is forked out stays scheduled and runs again on
-    * the adopted branch, and a spent request is not collected until irreversibility passes its
-    * firing height. Clearing here is also what makes the converse true -- a request that still
-    * carries a callback is one whose caller is still waiting, which is what
-    * unschedule_snapshot_requests() relies on to report removal as a failure.
+    * Consuming the slot is what marks a caller answered, and it is visible to every other holder of
+    * the same request_callback -- see that alias for why answering has to be exclusive. Callers of
+    * this function own the answer and must deliver it.
     *
-    * No-op if the request is already gone or carries no callback.
-    *
-    * @param srid id of the request whose completion callback has just been resolved
+    * @param caller the request's shared callback slot; emptied when it still held a callback
+    * @return the callback to invoke, or an empty next_function if the caller has already been
+    *         answered or never existed
     */
-   void clear_delivered_request_callback(uint32_t srid);
+   static next_function<snapshot_information> take_pending_answer(const request_callback& caller);
 
    /**
     * Erase request @p sri, resolving a completion callback it still carries.
@@ -215,11 +223,12 @@ private:
     * The single removal path for scheduled requests: every way a request can leave the container
     * -- expiry from unschedule_snapshot_requests(), explicit cancellation through
     * unschedule_snapshot() -- goes through here, so a caller waiting on a request can never have
-    * its callback destroyed instead of answered. A request that still carries a callback has not
-    * delivered a result, and that callback is invoked with a snapshot_execution_exception built
-    * from @p undelivered_reason. Callback exceptions are logged and swallowed: this is reached
-    * from the irreversible-block path, where a throwing completion callback must not escape into
-    * block processing.
+    * its callback destroyed instead of answered. If the request's caller is still waiting, it is
+    * answered with a snapshot_execution_exception built from @p undelivered_reason; if a snapshot
+    * from this request already answered it, or one still in flight gets there first, nothing is
+    * reported twice. Callback exceptions are logged and swallowed: this is reached from the
+    * irreversible-block path, where a throwing completion callback must not escape into block
+    * processing.
     *
     * @param sri                 id of the request to remove
     * @param undelivered_reason  message reported to a caller that is still waiting; built at the
@@ -258,9 +267,9 @@ public:
 
    // snapshot scheduler handlers
    // schedule a snapshot request; scheduling validation errors are thrown to the caller.
-   // next (may be empty) is stored on the request and resolved exactly once: with the
-   // snapshot_information (or execution error) of the first snapshot this request delivers, or
-   // with a snapshot_execution_exception if the request is removed without ever delivering one
+   // next (may be empty) becomes the request's shared callback slot and is resolved at most once:
+   // with the snapshot_information (or execution error) of the first snapshot this request delivers,
+   // or with a snapshot_execution_exception if the request is removed before delivering one
    snapshot_schedule_result schedule_snapshot(const snapshot_request_information& sri, next_function<snapshot_information> next);
 
    /**
@@ -312,9 +321,10 @@ public:
    // add pending snapshot info to inflight snapshot request
    void add_pending_snapshot_info(const snapshot_information& si);
 
-   // execute snapshot request srid; next (may be empty) receives the result of the snapshot in
-   // addition to the scheduler's own bookkeeping handler
-   void execute_snapshot(uint32_t srid, chain::controller& chain, next_function<snapshot_information> next);
+   // execute snapshot request srid; caller (may be null) is the request's shared callback slot, and
+   // the snapshot answers whoever is still waiting there in addition to the scheduler's own
+   // bookkeeping handler
+   void execute_snapshot(uint32_t srid, chain::controller& chain, request_callback caller);
 
    // former producer_plugin snapshot fn
    void create_snapshot(next_function<snapshot_information> next, chain::controller& chain);

--- a/libraries/chain/include/sysio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/sysio/chain/snapshot_scheduler.hpp
@@ -190,6 +190,24 @@ private:
     */
    void notify_snapshot_finalized(const snapshot_information& si);
 
+   /**
+    * Drop the completion callback request @p srid still holds, now that the callback has resolved.
+    *
+    * A stored callback is a next_function, which may be invoked exactly once across all of its
+    * copies, so it has to be cleared the moment execute_snapshot()'s completion handler answers
+    * the caller. A request outlives its own snapshot in two ways, and both would otherwise reach
+    * that callback again: a request whose snapshot is forked out stays scheduled and runs again on
+    * the adopted branch, and a spent request is not collected until irreversibility passes its
+    * firing height. Clearing here is also what makes the converse true -- a request that still
+    * carries a callback is one whose caller is still waiting, which is what
+    * unschedule_snapshot_requests() relies on to report removal as a failure.
+    *
+    * No-op if the request is already gone or carries no callback.
+    *
+    * @param srid id of the request whose completion callback has just been resolved
+    */
+   void clear_delivered_request_callback(uint32_t srid);
+
    void x_serialize() {
       auto& vec = _snapshot_requests.get<as_vector>();
       std::vector<snapshot_schedule_information> sr(vec.begin(), vec.end());
@@ -219,9 +237,9 @@ public:
 
    // snapshot scheduler handlers
    // schedule a snapshot request; scheduling validation errors are thrown to the caller.
-   // next (may be empty) is stored on the request and called with the snapshot_information
-   // (or execution error) when a snapshot produced by this request completes; a request that
-   // expires without ever running reports that through the same callback
+   // next (may be empty) is stored on the request and resolved exactly once: with the
+   // snapshot_information (or execution error) of the first snapshot this request delivers, or
+   // with a snapshot_execution_exception if the request is removed without ever delivering one
    snapshot_schedule_result schedule_snapshot(const snapshot_request_information& sri, next_function<snapshot_information> next);
    snapshot_schedule_result unschedule_snapshot(uint32_t sri);
 
@@ -230,12 +248,13 @@ public:
     *
     * A one-time request is kept until lib_height passes its start_block_num, because it runs from
     * on_start_block() at start_block_num + 1 and irreversibility never runs ahead of the applied
-    * head. Any request expires once lib_height reaches its end_block_num.
+    * head; its end_block_num, which scheduling allows to equal start_block_num, does not shorten
+    * that. A recurring request expires once lib_height reaches its end_block_num.
     *
-    * A removed request that still carries a completion callback never ran; its callback is invoked
-    * with a snapshot_execution_exception so the caller sees an error rather than having the callback
-    * silently destroyed. Callback exceptions are logged and swallowed -- this runs on the
-    * irreversible-block path.
+    * A removed request that still carries a completion callback never delivered a snapshot to its
+    * caller; its callback is invoked with a snapshot_execution_exception so the caller sees an error
+    * rather than having the callback silently destroyed. Callback exceptions are logged and
+    * swallowed -- this runs on the irreversible-block path.
     *
     * @param lib_height block number of the last irreversible block
     */

--- a/libraries/chain/include/sysio/chain/snapshot_scheduler.hpp
+++ b/libraries/chain/include/sysio/chain/snapshot_scheduler.hpp
@@ -220,10 +220,25 @@ public:
    // snapshot scheduler handlers
    // schedule a snapshot request; scheduling validation errors are thrown to the caller.
    // next (may be empty) is stored on the request and called with the snapshot_information
-   // (or execution error) when a snapshot produced by this request completes
+   // (or execution error) when a snapshot produced by this request completes; a request that
+   // expires without ever running reports that through the same callback
    snapshot_schedule_result schedule_snapshot(const snapshot_request_information& sri, next_function<snapshot_information> next);
    snapshot_schedule_result unschedule_snapshot(uint32_t sri);
-   // remove requests that are expired at the given irreversible block height
+
+   /**
+    * Remove requests that can no longer produce a snapshot at the given irreversible block height.
+    *
+    * A one-time request is kept until lib_height passes its start_block_num, because it runs from
+    * on_start_block() at start_block_num + 1 and irreversibility never runs ahead of the applied
+    * head. Any request expires once lib_height reaches its end_block_num.
+    *
+    * A removed request that still carries a completion callback never ran; its callback is invoked
+    * with a snapshot_execution_exception so the caller sees an error rather than having the callback
+    * silently destroyed. Callback exceptions are logged and swallowed -- this runs on the
+    * irreversible-block path.
+    *
+    * @param lib_height block number of the last irreversible block
+    */
    void unschedule_snapshot_requests(block_num_type lib_height);
    get_snapshot_requests_result get_snapshot_requests();
 

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -12,9 +12,9 @@ void snapshot_scheduler::on_start_block(uint32_t height, chain::controller& chai
    // iterating. In irreversible read mode execute_snapshot() creates the snapshot synchronously and
    // runs the height-based request cleanup, erasing expired requests from _snapshot_requests; doing
    // that while the range-for below iterates the same container would invalidate the loop iterator.
-   bool                                found = false;
-   uint32_t                            srid  = 0;
-   next_function<snapshot_information> next;
+   bool             found = false;
+   uint32_t         srid  = 0;
+   request_callback caller;
 
    for(const auto& req: _snapshot_requests.get<0>()) {
       // -1 since its called from start block
@@ -24,20 +24,20 @@ void snapshot_scheduler::on_start_block(uint32_t height, chain::controller& chai
       if(recurring_snapshot || onetime_snapshot) {
          dlog("snapshot scheduler creating a snapshot from the request [start_block_num:{}, end_block_num={}, block_spacing={}], height={}",
               req.start_block_num, req.end_block_num, req.block_spacing, height);
-         srid  = req.snapshot_request_id;
-         next  = req.next;
-         found = true;
+         srid   = req.snapshot_request_id;
+         caller = req.caller;
+         found  = true;
          break;
       }
    }
 
-   // The request keeps its completion callback across execution: starting a snapshot is not
-   // delivering one. A snapshot taken here is only pending, and is discarded unfinalized if its
-   // block is forked out -- in which case the request, still scheduled, runs again when the adopted
-   // branch reapplies this height and it is that regenerated snapshot that answers the caller. The
-   // callback is dropped when it is actually resolved; see clear_delivered_request_callback().
+   // The snapshot shares the request's callback slot rather than taking a copy of the callback:
+   // starting a snapshot is not delivering one. A snapshot taken here is only pending, and is
+   // discarded unfinalized if its block is forked out -- in which case the request, still scheduled,
+   // runs again when the adopted branch reapplies this height, and whichever attempt reaches the
+   // caller first is the one that empties the slot.
    if(found)
-      execute_snapshot(srid, chain, next);
+      execute_snapshot(srid, chain, caller);
 }
 
 void snapshot_scheduler::on_irreversible_block(const signed_block_ptr& lib, const block_id_type& block_id, const chain::controller& chain) {
@@ -110,7 +110,13 @@ snapshot_scheduler::snapshot_schedule_result snapshot_scheduler::schedule_snapsh
    SYS_ASSERT(sri.start_block_num <= sri.end_block_num, chain::invalid_snapshot_request, "End block number should be greater or equal to start block number");
    SYS_ASSERT(sri.start_block_num + sri.block_spacing <= sri.end_block_num, chain::invalid_snapshot_request, "Block spacing exceeds defined by start and end range");
 
-   _snapshot_requests.emplace(snapshot_schedule_information{{_snapshot_id++}, {sri.block_spacing, sri.start_block_num, sri.end_block_num, sri.snapshot_description}, {}, next});
+   // a request with no caller to answer gets no slot at all, so a null slot and an emptied one are
+   // never confused with each other
+   request_callback caller;
+   if(next)
+      caller = std::make_shared<next_function<snapshot_information>>(std::move(next));
+
+   _snapshot_requests.emplace(snapshot_schedule_information{{_snapshot_id++}, {sri.block_spacing, sri.start_block_num, sri.end_block_num, sri.snapshot_description}, {}, std::move(caller)});
    x_serialize();
 
    // returning snapshot_schedule_result
@@ -124,15 +130,17 @@ snapshot_scheduler::snapshot_schedule_result snapshot_scheduler::remove_request(
 
    snapshot_schedule_result result{{existing->snapshot_request_id}, {existing->block_spacing, existing->start_block_num, existing->end_block_num, existing->snapshot_description}};
 
-   // Take the callback out before erasing. A request still holding one has not delivered a result
-   // to its caller -- execute_snapshot()'s completion handler drops the request's copy as soon as
-   // the caller is answered -- so it covers a request that never ran, one that ran but whose
-   // snapshot was forked out or deduplicated against a snapshot already pending for the same block,
-   // and one cancelled while a snapshot was still in flight. Report the removal through the
-   // callback rather than destroying it: dropping it releases the last reference to the caller's
-   // HTTP session, which closes the connection with no response at all and hangs the client until
-   // it times out.
-   next_function<snapshot_information> undelivered = existing->next;
+   // Take the callback out of the request's slot before erasing. A caller still waiting there has
+   // had no result: the request never ran, or it ran and its snapshot was forked out or deduplicated
+   // against one already pending for the same block. Report the removal through the callback rather
+   // than destroying it -- dropping it releases the last reference to the caller's HTTP session,
+   // which closes the connection with no response at all and hangs the client until it times out.
+   //
+   // Taking from the slot mutates what the request points at rather than the request itself, so no
+   // modify() is needed and no index key is affected; it is also what a snapshot still in flight
+   // from this request checks before answering, so a cancellation racing a finalizing snapshot
+   // produces exactly one answer.
+   next_function<snapshot_information> undelivered = take_pending_answer(existing->caller);
 
    _snapshot_requests.erase(existing);
    x_serialize();
@@ -195,22 +203,22 @@ void snapshot_scheduler::add_pending_snapshot_info(const snapshot_information& s
    }
 }
 
-void snapshot_scheduler::clear_delivered_request_callback(uint32_t srid) {
-   auto& snapshot_by_id = _snapshot_requests.get<by_snapshot_id>();
-   if(auto it = snapshot_by_id.find(srid); it != snapshot_by_id.end() && it->next)
-      snapshot_by_id.modify(it, [](snapshot_schedule_information& req) { req.next = {}; });
+next_function<snapshot_scheduler::snapshot_information> snapshot_scheduler::take_pending_answer(const request_callback& caller) {
+   if(!caller || !*caller)
+      return {};
+   return std::move(*caller);
 }
 
-void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chain, next_function<snapshot_information> http_next) {
+void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chain, request_callback caller) {
    _inflight_sid = srid;
-   // A next_function may be invoked exactly once across all of its copies, and copies of the handler
-   // below outlive a single call: it is stored on the pending snapshot, and create_snapshot() hands
-   // it to CATCH_AND_CALL(), which re-invokes it with the exception if delivery itself throws. Hold
-   // the caller's callback in a slot the handler empties before use, so the first delivery is the
-   // only one whichever copy runs it and whether or not the callback throws.
-   auto caller_slot = std::make_shared<next_function<snapshot_information>>(std::move(http_next));
-   const bool has_caller = static_cast<bool>(*caller_slot);
-   auto next = [srid, this, caller_slot, has_caller](const chain::next_function_variant<snapshot_information>& result) {
+   // The handler below outlives a single call -- it is stored on the pending snapshot, and
+   // create_snapshot() hands it to CATCH_AND_CALL(), which re-invokes it with the exception if
+   // delivery itself throws -- and it is not the only thing that can answer this caller. It shares
+   // the request's callback slot with the removal path and with any other snapshot this request has
+   // in flight, and empties that slot before use, so the first answer is the only one however many
+   // handlers exist and whether or not the callback throws.
+   const bool has_caller = static_cast<bool>(caller);
+   auto next = [srid, this, caller, has_caller](const chain::next_function_variant<snapshot_information>& result) {
       if(std::holds_alternative<fc::exception_ptr>(result)) {
          if (!has_caller)
             wlog("Snapshot creation error: {}", std::get<fc::exception_ptr>(result)->to_detail_string());
@@ -235,14 +243,11 @@ void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chai
          // every subscriber twice for scheduled snapshots.
       }
 
-      // Answer the caller last, with the scheduler's own bookkeeping already settled, and empty the
-      // slot before the call so a callback that throws cannot be reached again through this handler.
-      if(*caller_slot) {
-         auto answer = std::move(*caller_slot);
-         // Clear the request's copy before the call for the same reason: unschedule_snapshot_requests()
-         // would otherwise still find req.next set and resolve the very same next_function a second
-         // time, which a next_function does not permit.
-         clear_delivered_request_callback(srid);
+      // Answer the caller last, with the scheduler's own bookkeeping already settled. Taking the
+      // callback out of the slot before the call, rather than after, is what keeps a callback that
+      // throws from being reached a second time -- by this handler, by another snapshot from the
+      // same request, or by the request's removal.
+      if(auto answer = take_pending_answer(caller)) {
          try {
             answer(chain::next_function_variant<snapshot_information>{result}); // copy; next_function::operator() is rvalue-only
             // The callback belongs to the API caller and may fail for reasons of its own -- writing

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -12,8 +12,9 @@ void snapshot_scheduler::on_start_block(uint32_t height, chain::controller& chai
    // iterating. In irreversible read mode execute_snapshot() creates the snapshot synchronously and
    // unschedules the now-completed request, erasing from _snapshot_requests; doing that while the
    // range-for below iterates the same container would invalidate the loop iterator.
-   bool                                found = false;
-   uint32_t                            srid  = 0;
+   bool                                found   = false;
+   bool                                onetime = false;
+   uint32_t                            srid    = 0;
    next_function<snapshot_information> next;
 
    for(const auto& req: _snapshot_requests.get<0>()) {
@@ -24,15 +25,30 @@ void snapshot_scheduler::on_start_block(uint32_t height, chain::controller& chai
       if(recurring_snapshot || onetime_snapshot) {
          dlog("snapshot scheduler creating a snapshot from the request [start_block_num:{}, end_block_num={}, block_spacing={}], height={}",
               req.start_block_num, req.end_block_num, req.block_spacing, height);
-         srid  = req.snapshot_request_id;
-         next  = req.next;
-         found = true;
+         srid    = req.snapshot_request_id;
+         next    = req.next;
+         onetime = onetime_snapshot;
+         found   = true;
          break;
       }
    }
 
-   if(found)
-      execute_snapshot(srid, chain, next);
+   if(!found)
+      return;
+
+   if(onetime) {
+      // The request has handed its completion callback to the execution path and owes the caller
+      // nothing further: the result is delivered synchronously by create_snapshot() in irreversible
+      // read mode, otherwise by the pending snapshot once its block becomes irreversible. Drop the
+      // copy held by the request so unschedule_snapshot_requests() cannot later mistake this for a
+      // request that expired without ever running and report a spurious failure to a caller that has
+      // already been answered. Recurring requests keep their callback -- they can fire again.
+      auto& snapshot_by_id = _snapshot_requests.get<by_snapshot_id>();
+      if(auto it = snapshot_by_id.find(srid); it != snapshot_by_id.end())
+         snapshot_by_id.modify(it, [](snapshot_schedule_information& req) { req.next = {}; });
+   }
+
+   execute_snapshot(srid, chain, next);
 }
 
 void snapshot_scheduler::on_irreversible_block(const signed_block_ptr& lib, const block_id_type& block_id, const chain::controller& chain) {
@@ -61,7 +77,15 @@ void snapshot_scheduler::on_irreversible_block(const signed_block_ptr& lib, cons
 void snapshot_scheduler::unschedule_snapshot_requests(block_num_type lib_height) {
    std::vector<uint32_t> unschedule_snapshot_request_ids;
    for(const auto& req: _snapshot_requests.get<0>()) {
-      bool marked_for_deletion = (!req.block_spacing && lib_height >= req.start_block_num) || // if one time snapshot executed or scheduled for the past, it should be gone
+      // A one-time request runs from on_start_block() at height start_block_num + 1, so it has to
+      // survive until that height is reached. Irreversibility never runs ahead of the applied head,
+      // so lib_height > start_block_num is first observed while block start_block_num + 1 is being
+      // applied -- strictly after that block's block_start signal fired. Collecting at
+      // lib_height >= start_block_num instead loses the request whenever a node applies a run of
+      // blocks back to back (catching up after a stall, syncing, or switching forks): committing
+      // block start_block_num lands LIB exactly on the threshold, one block before the request's
+      // firing height is applied.
+      bool marked_for_deletion = (!req.block_spacing && lib_height > req.start_block_num) ||
                                  lib_height >= req.end_block_num;               // any snapshot can expire by end block num (end_block_num can be max value)
 
       // cleanup - remove expired (or invalid) request
@@ -70,8 +94,27 @@ void snapshot_scheduler::unschedule_snapshot_requests(block_num_type lib_height)
       }
    }
 
+   auto& snapshot_by_id = _snapshot_requests.get<by_snapshot_id>();
    for(const auto& i: unschedule_snapshot_request_ids) {
+      // A request still holding a completion callback never executed -- on_start_block() clears the
+      // callback the moment it hands the request off. Report the expiry through the callback rather
+      // than destroying it: dropping it releases the last reference to the caller's HTTP session,
+      // which closes the connection with no response at all and hangs the client until it times out.
+      next_function<snapshot_information> undelivered;
+      if(auto it = snapshot_by_id.find(i); it != snapshot_by_id.end())
+         undelivered = it->next;
+
       unschedule_snapshot(i);
+
+      if(undelivered) {
+         try {
+            auto ex = snapshot_execution_exception(FC_LOG_MESSAGE(
+                  error, "snapshot request {} expired at irreversible block {} without executing", i, lib_height));
+            undelivered(ex.dynamic_copy_exception());
+            // FC_LOG_AND_DROP rather than a rethrow: this runs on the irreversible-block path, where
+            // a throwing completion callback must not escape into block processing.
+         } FC_LOG_AND_DROP();
+      }
    }
 }
 
@@ -220,8 +263,11 @@ void snapshot_scheduler::create_snapshot(next_function<snapshot_information> nex
          snapshot_information si{head_id, head_block_num, head_block_time, chain_snapshot_header::current_version, snapshot_path.generic_string(), captured_root_hash};
          next(snapshot_information{si});
          notify_snapshot_finalized(si);
-         // irreversible-mode snapshots are produced directly from a scheduled one-shot request and
-         // never reach on_irreversible_block, so clean up the now-completed request here.
+         // Irreversible-mode snapshots queue no pending snapshot, so on_irreversible_block() has no
+         // promotion work to do for them; run the height-based request cleanup here as well. Note
+         // this call does not collect the request that just ran: head_block_num is one short of that
+         // request's firing height, and the threshold has to stay above it so a request is never
+         // dropped before it runs. It is collected on the next irreversible block.
          unschedule_snapshot_requests(head_block_num);
       }
       CATCH_AND_CALL(next);

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -10,11 +10,10 @@ namespace sysio::chain {
 void snapshot_scheduler::on_start_block(uint32_t height, chain::controller& chain) {
    // Identify the single request due at this height (one snapshot per height), then execute it AFTER
    // iterating. In irreversible read mode execute_snapshot() creates the snapshot synchronously and
-   // unschedules the now-completed request, erasing from _snapshot_requests; doing that while the
-   // range-for below iterates the same container would invalidate the loop iterator.
-   bool                                found   = false;
-   bool                                onetime = false;
-   uint32_t                            srid    = 0;
+   // runs the height-based request cleanup, erasing expired requests from _snapshot_requests; doing
+   // that while the range-for below iterates the same container would invalidate the loop iterator.
+   bool                                found = false;
+   uint32_t                            srid  = 0;
    next_function<snapshot_information> next;
 
    for(const auto& req: _snapshot_requests.get<0>()) {
@@ -25,30 +24,20 @@ void snapshot_scheduler::on_start_block(uint32_t height, chain::controller& chai
       if(recurring_snapshot || onetime_snapshot) {
          dlog("snapshot scheduler creating a snapshot from the request [start_block_num:{}, end_block_num={}, block_spacing={}], height={}",
               req.start_block_num, req.end_block_num, req.block_spacing, height);
-         srid    = req.snapshot_request_id;
-         next    = req.next;
-         onetime = onetime_snapshot;
-         found   = true;
+         srid  = req.snapshot_request_id;
+         next  = req.next;
+         found = true;
          break;
       }
    }
 
-   if(!found)
-      return;
-
-   if(onetime) {
-      // The request has handed its completion callback to the execution path and owes the caller
-      // nothing further: the result is delivered synchronously by create_snapshot() in irreversible
-      // read mode, otherwise by the pending snapshot once its block becomes irreversible. Drop the
-      // copy held by the request so unschedule_snapshot_requests() cannot later mistake this for a
-      // request that expired without ever running and report a spurious failure to a caller that has
-      // already been answered. Recurring requests keep their callback -- they can fire again.
-      auto& snapshot_by_id = _snapshot_requests.get<by_snapshot_id>();
-      if(auto it = snapshot_by_id.find(srid); it != snapshot_by_id.end())
-         snapshot_by_id.modify(it, [](snapshot_schedule_information& req) { req.next = {}; });
-   }
-
-   execute_snapshot(srid, chain, next);
+   // The request keeps its completion callback across execution: starting a snapshot is not
+   // delivering one. A snapshot taken here is only pending, and is discarded unfinalized if its
+   // block is forked out -- in which case the request, still scheduled, runs again when the adopted
+   // branch reapplies this height and it is that regenerated snapshot that answers the caller. The
+   // callback is dropped when it is actually resolved; see clear_delivered_request_callback().
+   if(found)
+      execute_snapshot(srid, chain, next);
 }
 
 void snapshot_scheduler::on_irreversible_block(const signed_block_ptr& lib, const block_id_type& block_id, const chain::controller& chain) {
@@ -85,8 +74,14 @@ void snapshot_scheduler::unschedule_snapshot_requests(block_num_type lib_height)
       // blocks back to back (catching up after a stall, syncing, or switching forks): committing
       // block start_block_num lands LIB exactly on the threshold, one block before the request's
       // firing height is applied.
-      bool marked_for_deletion = (!req.block_spacing && lib_height > req.start_block_num) ||
-                                 lib_height >= req.end_block_num;               // any snapshot can expire by end block num (end_block_num can be max value)
+      //
+      // end_block_num does not bound a one-time request. Scheduling accepts end_block_num equal to
+      // start_block_num -- what a caller asks for when pinning a snapshot to one specific block --
+      // and expiring on it would collect the request one block before it can ever fire, losing it
+      // in exactly the same back-to-back ordering. A recurring request has no single firing height
+      // to protect and expires on its end block as before.
+      bool marked_for_deletion = req.block_spacing ? lib_height >= req.end_block_num  // end_block_num can be max value
+                                                   : lib_height > req.start_block_num;
 
       // cleanup - remove expired (or invalid) request
       if(marked_for_deletion) {
@@ -96,10 +91,13 @@ void snapshot_scheduler::unschedule_snapshot_requests(block_num_type lib_height)
 
    auto& snapshot_by_id = _snapshot_requests.get<by_snapshot_id>();
    for(const auto& i: unschedule_snapshot_request_ids) {
-      // A request still holding a completion callback never executed -- on_start_block() clears the
-      // callback the moment it hands the request off. Report the expiry through the callback rather
-      // than destroying it: dropping it releases the last reference to the caller's HTTP session,
-      // which closes the connection with no response at all and hangs the client until it times out.
+      // A request still holding a completion callback never delivered a result to its caller: the
+      // callback is dropped from the request the moment execute_snapshot()'s completion handler
+      // resolves it. That covers a request that never ran and one that ran but whose snapshot was
+      // forked out or deduplicated against a snapshot already pending for the same block. Report
+      // the removal through the callback rather than destroying it: dropping it releases the last
+      // reference to the caller's HTTP session, which closes the connection with no response at all
+      // and hangs the client until it times out.
       next_function<snapshot_information> undelivered;
       if(auto it = snapshot_by_id.find(i); it != snapshot_by_id.end())
          undelivered = it->next;
@@ -109,7 +107,7 @@ void snapshot_scheduler::unschedule_snapshot_requests(block_num_type lib_height)
       if(undelivered) {
          try {
             auto ex = snapshot_execution_exception(FC_LOG_MESSAGE(
-                  error, "snapshot request {} expired at irreversible block {} without executing", i, lib_height));
+                  error, "snapshot request {} removed at irreversible block {} without producing a snapshot", i, lib_height));
             undelivered(ex.dynamic_copy_exception());
             // FC_LOG_AND_DROP rather than a rethrow: this runs on the irreversible-block path, where
             // a throwing completion callback must not escape into block processing.
@@ -193,11 +191,22 @@ void snapshot_scheduler::add_pending_snapshot_info(const snapshot_information& s
    }
 }
 
+void snapshot_scheduler::clear_delivered_request_callback(uint32_t srid) {
+   auto& snapshot_by_id = _snapshot_requests.get<by_snapshot_id>();
+   if(auto it = snapshot_by_id.find(srid); it != snapshot_by_id.end() && it->next)
+      snapshot_by_id.modify(it, [](snapshot_schedule_information& req) { req.next = {}; });
+}
+
 void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chain, next_function<snapshot_information> http_next) {
    _inflight_sid = srid;
    auto next = [srid, this, http_next](const chain::next_function_variant<snapshot_information>& result) {
-      if (http_next)
+      if (http_next) {
          http_next(chain::next_function_variant<snapshot_information>{result}); // copy; next_function::operator() is rvalue-only
+         // The caller now has its answer, so the request must stop carrying the callback: another
+         // snapshot from the same request would otherwise resolve it a second time, and collecting
+         // the request would report an undelivered failure over an answer already sent.
+         clear_delivered_request_callback(srid);
+      }
       if(std::holds_alternative<fc::exception_ptr>(result)) {
          if (!http_next)
             wlog("Snapshot creation error: {}", std::get<fc::exception_ptr>(result)->to_detail_string());

--- a/libraries/chain/snapshot_scheduler.cpp
+++ b/libraries/chain/snapshot_scheduler.cpp
@@ -89,31 +89,9 @@ void snapshot_scheduler::unschedule_snapshot_requests(block_num_type lib_height)
       }
    }
 
-   auto& snapshot_by_id = _snapshot_requests.get<by_snapshot_id>();
-   for(const auto& i: unschedule_snapshot_request_ids) {
-      // A request still holding a completion callback never delivered a result to its caller: the
-      // callback is dropped from the request the moment execute_snapshot()'s completion handler
-      // resolves it. That covers a request that never ran and one that ran but whose snapshot was
-      // forked out or deduplicated against a snapshot already pending for the same block. Report
-      // the removal through the callback rather than destroying it: dropping it releases the last
-      // reference to the caller's HTTP session, which closes the connection with no response at all
-      // and hangs the client until it times out.
-      next_function<snapshot_information> undelivered;
-      if(auto it = snapshot_by_id.find(i); it != snapshot_by_id.end())
-         undelivered = it->next;
-
-      unschedule_snapshot(i);
-
-      if(undelivered) {
-         try {
-            auto ex = snapshot_execution_exception(FC_LOG_MESSAGE(
-                  error, "snapshot request {} removed at irreversible block {} without producing a snapshot", i, lib_height));
-            undelivered(ex.dynamic_copy_exception());
-            // FC_LOG_AND_DROP rather than a rethrow: this runs on the irreversible-block path, where
-            // a throwing completion callback must not escape into block processing.
-         } FC_LOG_AND_DROP();
-      }
-   }
+   for(const auto& i: unschedule_snapshot_request_ids)
+      remove_request(i, FC_LOG_MESSAGE(
+            error, "snapshot request {} removed at irreversible block {} without producing a snapshot", i, lib_height));
 }
 
 std::optional<uint32_t> snapshot_scheduler::find_snapshot_request(uint32_t block_spacing, uint32_t start_block_num, uint32_t end_block_num) const {
@@ -139,17 +117,43 @@ snapshot_scheduler::snapshot_schedule_result snapshot_scheduler::schedule_snapsh
    return snapshot_schedule_result{{_snapshot_id - 1}, {sri.block_spacing, sri.start_block_num, sri.end_block_num, sri.snapshot_description}};
 }
 
-snapshot_scheduler::snapshot_schedule_result snapshot_scheduler::unschedule_snapshot(uint32_t sri) {
+snapshot_scheduler::snapshot_schedule_result snapshot_scheduler::remove_request(uint32_t sri, fc::log_message undelivered_reason) {
    auto& snapshot_by_id = _snapshot_requests.get<by_snapshot_id>();
    auto existing = snapshot_by_id.find(sri);
    SYS_ASSERT(existing != snapshot_by_id.end(), chain::snapshot_request_not_found, "Snapshot request not found");
 
    snapshot_schedule_result result{{existing->snapshot_request_id}, {existing->block_spacing, existing->start_block_num, existing->end_block_num, existing->snapshot_description}};
+
+   // Take the callback out before erasing. A request still holding one has not delivered a result
+   // to its caller -- execute_snapshot()'s completion handler drops the request's copy as soon as
+   // the caller is answered -- so it covers a request that never ran, one that ran but whose
+   // snapshot was forked out or deduplicated against a snapshot already pending for the same block,
+   // and one cancelled while a snapshot was still in flight. Report the removal through the
+   // callback rather than destroying it: dropping it releases the last reference to the caller's
+   // HTTP session, which closes the connection with no response at all and hangs the client until
+   // it times out.
+   next_function<snapshot_information> undelivered = existing->next;
+
    _snapshot_requests.erase(existing);
    x_serialize();
 
+   if(undelivered) {
+      try {
+         auto ex = snapshot_execution_exception(std::move(undelivered_reason));
+         undelivered(ex.dynamic_copy_exception());
+         // FC_LOG_AND_DROP rather than a rethrow: unschedule_snapshot_requests() reaches here on the
+         // irreversible-block path, where a throwing completion callback must not escape into block
+         // processing, and the request is already gone so there is nothing left to unwind.
+      } FC_LOG_AND_DROP();
+   }
+
    // returning snapshot_schedule_result
    return result;
+}
+
+snapshot_scheduler::snapshot_schedule_result snapshot_scheduler::unschedule_snapshot(uint32_t sri) {
+   return remove_request(sri, FC_LOG_MESSAGE(
+         error, "snapshot request {} was unscheduled before producing a snapshot", sri));
 }
 
 snapshot_scheduler::get_snapshot_requests_result snapshot_scheduler::get_snapshot_requests() {
@@ -199,16 +203,16 @@ void snapshot_scheduler::clear_delivered_request_callback(uint32_t srid) {
 
 void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chain, next_function<snapshot_information> http_next) {
    _inflight_sid = srid;
-   auto next = [srid, this, http_next](const chain::next_function_variant<snapshot_information>& result) {
-      if (http_next) {
-         http_next(chain::next_function_variant<snapshot_information>{result}); // copy; next_function::operator() is rvalue-only
-         // The caller now has its answer, so the request must stop carrying the callback: another
-         // snapshot from the same request would otherwise resolve it a second time, and collecting
-         // the request would report an undelivered failure over an answer already sent.
-         clear_delivered_request_callback(srid);
-      }
+   // A next_function may be invoked exactly once across all of its copies, and copies of the handler
+   // below outlive a single call: it is stored on the pending snapshot, and create_snapshot() hands
+   // it to CATCH_AND_CALL(), which re-invokes it with the exception if delivery itself throws. Hold
+   // the caller's callback in a slot the handler empties before use, so the first delivery is the
+   // only one whichever copy runs it and whether or not the callback throws.
+   auto caller_slot = std::make_shared<next_function<snapshot_information>>(std::move(http_next));
+   const bool has_caller = static_cast<bool>(*caller_slot);
+   auto next = [srid, this, caller_slot, has_caller](const chain::next_function_variant<snapshot_information>& result) {
       if(std::holds_alternative<fc::exception_ptr>(result)) {
-         if (!http_next)
+         if (!has_caller)
             wlog("Snapshot creation error: {}", std::get<fc::exception_ptr>(result)->to_detail_string());
       } else {
          // success, snapshot finalized
@@ -229,6 +233,24 @@ void snapshot_scheduler::execute_snapshot(uint32_t srid, chain::controller& chai
          // callbacks fire once per snapshot from create_snapshot() (irreversible mode) or
          // on_irreversible_block() (pending promotion). Notifying here as well would invoke
          // every subscriber twice for scheduled snapshots.
+      }
+
+      // Answer the caller last, with the scheduler's own bookkeeping already settled, and empty the
+      // slot before the call so a callback that throws cannot be reached again through this handler.
+      if(*caller_slot) {
+         auto answer = std::move(*caller_slot);
+         // Clear the request's copy before the call for the same reason: unschedule_snapshot_requests()
+         // would otherwise still find req.next set and resolve the very same next_function a second
+         // time, which a next_function does not permit.
+         clear_delivered_request_callback(srid);
+         try {
+            answer(chain::next_function_variant<snapshot_information>{result}); // copy; next_function::operator() is rvalue-only
+            // The callback belongs to the API caller and may fail for reasons of its own -- writing
+            // to a client that has gone away, say. Letting that escape would abort the pipeline that
+            // invoked this handler: on_irreversible_block() would skip notify_snapshot_finalized()
+            // for a snapshot that did finalize, and create_snapshot() would re-enter this handler
+            // through CATCH_AND_CALL() to report the caller's own failure back to it.
+         } FC_LOG_AND_DROP();
       }
    };
    create_snapshot(next, chain);

--- a/tests/nodeop_snapshot_forked_test.py
+++ b/tests/nodeop_snapshot_forked_test.py
@@ -60,10 +60,20 @@ def getSnapshotsCount(nodeId):
     if snapshotScheduleDB in snapshotDirContents: snapshotDirContents.remove(snapshotScheduleDB)
     return len(snapshotDirContents)
 
-def createNodeSnapshot(nodeId, node):
-    """Issue a blocking v1/producer/create_snapshot request against the given node."""
+def createNodeSnapshot(nodeId, node, outcome):
+    """Issue a blocking v1/producer/create_snapshot request and record how it completed.
+
+    The request outlives a fork of the block it snapshots: that pending snapshot is discarded
+    unfinalized and the still-scheduled request re-creates it once the adopted branch reapplies
+    the firing height. Only that regenerated snapshot can answer this call, so the outcome is
+    recorded rather than discarded -- a request that loses its completion callback along the way
+    closes the connection with no response, which arrives here as an exception.
+    """
     Print("Creating snapshot for node %d" % nodeId)
-    node.createSnapshot()
+    try:
+        outcome["response"] = node.createSnapshot()
+    except Exception as ex:
+        outcome["exception"] = ex
 
 try:
     TestHelper.printSystemInfo("BEGIN")
@@ -166,7 +176,9 @@ try:
     # create snapshot in a separate thread since it blocks until finalized; the snapshotted
     # block is forked out when the network re-merges, so the snapshot is re-created on the
     # adopted branch before the request completes
-    rpcThread = threading.Thread(target = createNodeSnapshot, args = (1, prodB))
+    # daemon so an unanswered request is reported by the join below rather than blocking exit
+    snapshotOutcome = {}
+    rpcThread = threading.Thread(target = createNodeSnapshot, args = (1, prodB, snapshotOutcome), daemon = True)
     rpcThread.start()
 
     assert not nonProdNode.verifyAlive(), "Bridge node should have been killed if test was functioning correctly."
@@ -188,7 +200,19 @@ try:
         "ERROR: Network did not reach consensus after bridge node was restarted."
 
     Print("Wait for rpc thread to complete")
-    rpcThread.join()
+    rpcThread.join(timeout=120)
+
+    # The snapshot the request first created was forked out; the request must still answer this
+    # caller from the snapshot it re-created on the adopted branch. A request that is dropped, or
+    # that gives up its completion callback when it starts executing, leaves nothing to answer
+    # with: the connection closes unanswered and the call never returns a snapshot.
+    assert not rpcThread.is_alive(), \
+        "ERROR: create_snapshot never completed after the snapshotted block was forked out"
+    assert "exception" not in snapshotOutcome, \
+        f"ERROR: create_snapshot failed after the snapshotted block was forked out: {snapshotOutcome['exception']}"
+    snapshotResponse = snapshotOutcome.get("response")
+    assert snapshotResponse is not None and "snapshot_name" in snapshotResponse.get("payload", {}), \
+        f"ERROR: create_snapshot returned no snapshot: {json.dumps(snapshotResponse, indent=1)}"
 
     for prodNode in prodNodes:
         info=prodNode.getInfo()

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -485,4 +485,98 @@ BOOST_AUTO_TEST_CASE(expired_onetime_request_reports_failure_to_caller) {
    BOOST_TEST(f.cb1_count == 0u);    // nothing was ever snapshotted
 }
 
+// A one-time request may pin itself to a single block: schedule_snapshot() accepts end_block_num
+// equal to start_block_num, and that is the request /v1/producer/schedule_snapshot builds when a
+// caller names one block. Expiring on end_block_num must not undercut the firing height, or the
+// same catch-up ordering silently loses exactly the requests that are most specific about which
+// block they want.
+BOOST_AUTO_TEST_CASE(exact_range_onetime_request_survives_lib_reaching_its_start_block) {
+   testing::tester            chain;
+   scheduler_callback_fixture f;
+   next_outcome               outcome;
+
+   chain.produce_block();
+   chain.control->abort_block(); // snapshot creation requires no pending block
+
+   const uint32_t start_block_num = chain.control->head().block_num() + 1;
+
+   snapshot_request_information sri;
+   sri.block_spacing        = 0;
+   sri.start_block_num      = start_block_num;
+   sri.end_block_num        = start_block_num; // the one block this request is pinned to
+   sri.snapshot_description = "one-time snapshot pinned to a single block";
+   f.scheduler.schedule_snapshot(sri, outcome.recorder());
+
+   // irreversibility lands on the pinned block, still one block short of the firing height
+   auto lib_block = chain.produce_block();
+   BOOST_REQUIRE_EQUAL(lib_block->block_num(), start_block_num);
+   f.scheduler.on_irreversible_block(lib_block, lib_block->calculate_id(), *chain.control);
+
+   BOOST_REQUIRE_EQUAL(f.scheduler.get_snapshot_requests().snapshot_requests.size(), 1u);
+   BOOST_TEST(outcome.errors == 0u);
+
+   // block start_block_num + 1 begins applying; head is still start_block_num
+   chain.control->abort_block();
+   f.scheduler.on_start_block(start_block_num + 1, *chain.control);
+
+   auto next_lib = chain.produce_block();
+   f.scheduler.on_irreversible_block(next_lib, next_lib->calculate_id(), *chain.control);
+
+   BOOST_TEST(outcome.successes == 1u);
+   BOOST_TEST(outcome.errors == 0u);
+   BOOST_TEST(f.cb1_count == 1u);
+   BOOST_TEST(f.scheduler.get_snapshot_requests().snapshot_requests.empty());
+}
+
+// Executing a request is not delivering its snapshot. Outside irreversible read mode the snapshot
+// is only pending, and it is discarded unfinalized if its block is forked out -- the caller has
+// been told nothing at that point. The request is still scheduled, so it runs again when the
+// adopted branch reapplies the firing height, and it is that regenerated snapshot that answers the
+// caller. A request that surrendered its callback at execution has nothing left to answer with.
+BOOST_AUTO_TEST_CASE(forked_out_snapshot_regenerates_and_still_answers_caller) {
+   testing::tester            chain;
+   scheduler_callback_fixture f;
+   next_outcome               outcome;
+
+   auto snapshotted_block = chain.produce_block();
+   chain.control->abort_block(); // snapshot creation requires no pending block
+
+   const uint32_t start_block_num = chain.control->head().block_num();
+   BOOST_REQUIRE_EQUAL(snapshotted_block->block_num(), start_block_num);
+
+   snapshot_request_information sri;
+   sri.block_spacing        = 0;
+   sri.start_block_num      = start_block_num;
+   sri.end_block_num        = std::numeric_limits<uint32_t>::max();
+   sri.snapshot_description = "on-demand snapshot whose block is forked out";
+   f.scheduler.schedule_snapshot(sri, outcome.recorder());
+
+   f.scheduler.on_start_block(start_block_num + 1, *chain.control); // snapshot of start_block_num pending
+
+   // Irreversibility settles on a competing block at the snapshotted height, so the pending
+   // snapshot is invalidated and discarded without its completion handler ever running.
+   block_id_type competing_id = snapshotted_block->calculate_id();
+   competing_id._hash[3] ^= 1; // a different id at the same height -- the block number is in _hash[0]
+   BOOST_REQUIRE_EQUAL(block_header::num_from_id(competing_id), start_block_num);
+   BOOST_REQUIRE(competing_id != snapshotted_block->calculate_id());
+   f.scheduler.on_irreversible_block(snapshotted_block, competing_id, *chain.control);
+
+   BOOST_TEST(outcome.successes == 0u);
+   BOOST_TEST(outcome.errors == 0u);
+   BOOST_TEST(f.cb1_count == 0u);
+   // still scheduled, so the firing height can run it again on the adopted branch
+   BOOST_REQUIRE_EQUAL(f.scheduler.get_snapshot_requests().snapshot_requests.size(), 1u);
+
+   f.scheduler.on_start_block(start_block_num + 1, *chain.control);
+
+   auto next_lib = chain.produce_block();
+   f.scheduler.on_irreversible_block(next_lib, next_lib->calculate_id(), *chain.control);
+
+   BOOST_TEST(outcome.successes == 1u); // the regenerated snapshot answers the original caller
+   BOOST_TEST(outcome.errors == 0u);    // and collecting the spent request does not re-resolve it
+   BOOST_TEST(f.cb1_count == 1u);
+   BOOST_TEST(f.cb2_count == 1u);
+   BOOST_TEST(f.scheduler.get_snapshot_requests().snapshot_requests.empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -579,4 +579,104 @@ BOOST_AUTO_TEST_CASE(forked_out_snapshot_regenerates_and_still_answers_caller) {
    BOOST_TEST(f.scheduler.get_snapshot_requests().snapshot_requests.empty());
 }
 
+// A completion callback belongs to the API caller and can fail on its own account -- writing to a
+// client that has gone away, say. It is still resolved: a next_function permits exactly one
+// invocation across all of its copies, so a request left holding one for unschedule_snapshot_requests
+// to resolve again would be undefined behavior. The snapshot itself is unaffected by the failure.
+BOOST_AUTO_TEST_CASE(throwing_completion_callback_is_resolved_once) {
+   testing::tester            chain;
+   scheduler_callback_fixture f;
+   uint32_t                   invocations = 0;
+
+   chain.produce_block();
+   chain.control->abort_block(); // snapshot creation requires no pending block
+
+   const uint32_t start_block_num = chain.control->head().block_num();
+
+   snapshot_request_information sri;
+   sri.block_spacing        = 0;
+   sri.start_block_num      = start_block_num;
+   sri.end_block_num        = std::numeric_limits<uint32_t>::max();
+   sri.snapshot_description = "on-demand snapshot whose caller fails to take the answer";
+   f.scheduler.schedule_snapshot(sri, [&invocations](const next_function_variant<snapshot_scheduler::snapshot_information>&) {
+      ++invocations;
+      throw std::runtime_error("completion callback failed");
+   });
+
+   f.scheduler.on_start_block(start_block_num + 1, *chain.control);
+
+   // This one irreversible block both delivers the snapshot and, because it carries LIB past the
+   // firing height, collects the request -- the ordering that would resolve the callback twice.
+   auto lib_block = chain.produce_block();
+   f.scheduler.on_irreversible_block(lib_block, lib_block->calculate_id(), *chain.control);
+
+   BOOST_TEST(invocations == 1u);
+   BOOST_TEST(f.scheduler.get_snapshot_requests().snapshot_requests.empty());
+   BOOST_TEST(f.cb1_count == 1u); // a failing caller does not cost the snapshot its finalized notification
+   BOOST_TEST(f.cb2_count == 1u);
+}
+
+// An outstanding /v1/producer/create_snapshot is a scheduled request like any other and is listed by
+// get_snapshot_requests(), so its id can be handed straight to /v1/producer/unschedule_snapshot.
+// Cancelling it must answer the caller rather than destroy the callback holding its HTTP session.
+BOOST_AUTO_TEST_CASE(unscheduling_an_outstanding_request_reports_failure_to_caller) {
+   testing::tester            chain;
+   scheduler_callback_fixture f;
+   next_outcome               outcome;
+
+   chain.produce_block();
+
+   snapshot_request_information sri;
+   sri.block_spacing        = 0;
+   sri.start_block_num      = chain.control->head().block_num() + 1;
+   sri.end_block_num        = std::numeric_limits<uint32_t>::max();
+   sri.snapshot_description = "on-demand snapshot cancelled before it runs";
+   const auto scheduled = f.scheduler.schedule_snapshot(sri, outcome.recorder());
+
+   f.scheduler.unschedule_snapshot(scheduled.snapshot_request_id);
+
+   BOOST_TEST(f.scheduler.get_snapshot_requests().snapshot_requests.empty());
+   BOOST_TEST(outcome.successes == 0u);
+   BOOST_TEST(outcome.errors == 1u); // caller gets an error, not a dropped connection
+   BOOST_TEST(f.cb1_count == 0u);    // nothing was ever snapshotted
+}
+
+// A request that has delivered its snapshot stays scheduled until irreversibility passes its firing
+// height, and an operator can cancel it in that window. Its caller has already been answered, so
+// cancellation must not reach the same callback a second time.
+BOOST_AUTO_TEST_CASE(unscheduling_a_delivered_request_does_not_re_resolve_caller) {
+   testing::tester            chain;
+   scheduler_callback_fixture f;
+   next_outcome               outcome;
+
+   chain.produce_block();
+   chain.control->abort_block(); // snapshot creation requires no pending block
+
+   const uint32_t start_block_num = chain.control->head().block_num() + 1;
+
+   snapshot_request_information sri;
+   sri.block_spacing        = 0;
+   sri.start_block_num      = start_block_num;
+   sri.end_block_num        = std::numeric_limits<uint32_t>::max();
+   sri.snapshot_description = "on-demand snapshot cancelled after it is answered";
+   const auto scheduled = f.scheduler.schedule_snapshot(sri, outcome.recorder());
+
+   auto lib_block = chain.produce_block();
+   BOOST_REQUIRE_EQUAL(lib_block->block_num(), start_block_num);
+   chain.control->abort_block();
+   f.scheduler.on_start_block(start_block_num + 1, *chain.control);
+
+   // irreversibility reaching the snapshotted block answers the caller but leaves the request
+   // scheduled -- collection waits until it passes the firing height
+   f.scheduler.on_irreversible_block(lib_block, lib_block->calculate_id(), *chain.control);
+   BOOST_REQUIRE(outcome.successes == 1u);
+   BOOST_REQUIRE_EQUAL(f.scheduler.get_snapshot_requests().snapshot_requests.size(), 1u);
+
+   f.scheduler.unschedule_snapshot(scheduled.snapshot_request_id);
+
+   BOOST_TEST(outcome.successes == 1u);
+   BOOST_TEST(outcome.errors == 0u);
+   BOOST_TEST(f.scheduler.get_snapshot_requests().snapshot_requests.empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -641,6 +641,43 @@ BOOST_AUTO_TEST_CASE(unscheduling_an_outstanding_request_reports_failure_to_call
    BOOST_TEST(f.cb1_count == 0u);    // nothing was ever snapshotted
 }
 
+// Cancellation can also land while a snapshot from the request is in flight: the pending snapshot
+// carries a handler that answers the caller when it finalizes, and the request is cancellable the
+// whole time. Both can reach the caller, so exactly one of them must, whichever gets there first.
+BOOST_AUTO_TEST_CASE(unscheduling_an_in_flight_request_answers_caller_once) {
+   testing::tester            chain;
+   scheduler_callback_fixture f;
+   next_outcome               outcome;
+
+   chain.produce_block();
+   chain.control->abort_block(); // snapshot creation requires no pending block
+
+   const uint32_t start_block_num = chain.control->head().block_num();
+
+   snapshot_request_information sri;
+   sri.block_spacing        = 0;
+   sri.start_block_num      = start_block_num;
+   sri.end_block_num        = std::numeric_limits<uint32_t>::max();
+   sri.snapshot_description = "on-demand snapshot cancelled while its snapshot is pending";
+   const auto scheduled = f.scheduler.schedule_snapshot(sri, outcome.recorder());
+
+   // the snapshot is taken and pending; it answers the caller only once its block is irreversible
+   f.scheduler.on_start_block(start_block_num + 1, *chain.control);
+   BOOST_REQUIRE(outcome.successes == 0u);
+
+   f.scheduler.unschedule_snapshot(scheduled.snapshot_request_id);
+   BOOST_REQUIRE(outcome.errors == 1u); // cancellation is what reaches the caller here
+
+   // the pending snapshot still finalizes, and must not answer the same caller a second time
+   auto lib_block = chain.produce_block();
+   f.scheduler.on_irreversible_block(lib_block, lib_block->calculate_id(), *chain.control);
+
+   BOOST_TEST(outcome.successes == 0u);
+   BOOST_TEST(outcome.errors == 1u);
+   BOOST_TEST(f.cb1_count == 1u); // the snapshot itself finalized and notified as usual
+   BOOST_TEST(f.cb2_count == 1u);
+}
+
 // A request that has delivered its snapshot stays scheduled until irreversibility passes its firing
 // height, and an operator can cancel it in that window. Its caller has already been answered, so
 // cancellation must not reach the same callback a second time.

--- a/tests/test_snapshot_scheduler.cpp
+++ b/tests/test_snapshot_scheduler.cpp
@@ -276,6 +276,23 @@ struct scheduler_callback_fixture {
    }
 };
 
+/// Tally of how a stored request-completion callback was resolved. A callback that is never
+/// resolved at all leaves both counters at zero -- that is the state that hangs a real HTTP caller.
+struct next_outcome {
+   uint32_t successes = 0;
+   uint32_t errors    = 0;
+
+   /// Callback to hand to schedule_snapshot(); records each resolution by kind.
+   auto recorder() {
+      return [this](const next_function_variant<snapshot_scheduler::snapshot_information>& res) {
+         if (std::holds_alternative<fc::exception_ptr>(res))
+            ++errors;
+         else
+            ++successes;
+      };
+   }
+};
+
 } // anonymous namespace
 
 // Scheduled snapshot with the chain NOT in irreversible read mode: the snapshot is pending
@@ -375,6 +392,97 @@ BOOST_AUTO_TEST_CASE(api_snapshot_duplicate_block_request_ignored_notifies_callb
    BOOST_TEST(next2_success == 0u); // duplicate request was ignored, not chained
    BOOST_TEST(f.cb1_count == 1u);
    BOOST_TEST(f.cb2_count == 1u);
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Request lifetime versus irreversibility.
+//
+// producer_plugin::create_snapshot() schedules a one-time request anchored one block ahead of the
+// head the caller observed, and on_start_block() runs it at start_block_num + 1. A node that applies
+// a run of blocks back to back -- catching up after a stall, syncing, or switching forks -- commits
+// block start_block_num and lands LIB exactly on start_block_num before the firing height is ever
+// applied. Collecting the request at that point drops it unexecuted, and with it the stored HTTP
+// completion callback, closing the caller's connection with no response.
+// ---------------------------------------------------------------------------------------------------
+
+// Irreversibility reaching start_block_num must not collect the request: its firing height has not
+// been applied yet. Regression coverage for a create_snapshot API call hanging on a catching-up node.
+BOOST_AUTO_TEST_CASE(onetime_request_survives_lib_reaching_its_start_block) {
+   testing::tester            chain;
+   scheduler_callback_fixture f;
+   next_outcome               outcome;
+
+   chain.produce_block();
+   chain.control->abort_block(); // snapshot creation requires no pending block
+
+   // exactly the request shape producer_plugin::create_snapshot() builds
+   const uint32_t start_block_num = chain.control->head().block_num() + 1;
+
+   snapshot_request_information sri;
+   sri.block_spacing        = 0;
+   sri.start_block_num      = start_block_num;
+   sri.end_block_num        = std::numeric_limits<uint32_t>::max();
+   sri.snapshot_description = "on-demand snapshot racing a catching-up node";
+   f.scheduler.schedule_snapshot(sri, outcome.recorder());
+
+   // Block start_block_num is applied and commits, carrying LIB onto start_block_num -- all before
+   // block start_block_num + 1, whose block_start signal is what runs the request.
+   auto lib_block = chain.produce_block();
+   BOOST_REQUIRE_EQUAL(lib_block->block_num(), start_block_num);
+   f.scheduler.on_irreversible_block(lib_block, lib_block->calculate_id(), *chain.control);
+
+   BOOST_REQUIRE_EQUAL(f.scheduler.get_snapshot_requests().snapshot_requests.size(), 1u);
+   BOOST_TEST(outcome.successes == 0u);
+   BOOST_TEST(outcome.errors == 0u);
+
+   // block start_block_num + 1 begins applying; head is still start_block_num
+   chain.control->abort_block();
+   f.scheduler.on_start_block(start_block_num + 1, *chain.control);
+
+   // snapshot of head is pending until head becomes irreversible
+   BOOST_TEST(outcome.successes == 0u);
+   BOOST_TEST(f.cb1_count == 0u);
+
+   auto next_lib = chain.produce_block();
+   f.scheduler.on_irreversible_block(next_lib, next_lib->calculate_id(), *chain.control);
+
+   BOOST_TEST(outcome.successes == 1u);
+   BOOST_TEST(outcome.errors == 0u); // collecting the spent request must not re-resolve the callback
+   BOOST_TEST(f.cb1_count == 1u);
+   BOOST_TEST(f.cb2_count == 1u);
+
+   // spent request is collected once irreversibility passes its start block
+   BOOST_TEST(f.scheduler.get_snapshot_requests().snapshot_requests.empty());
+}
+
+// A one-time request whose firing height has gone by can never run. Collecting it is correct; doing
+// so without resolving its stored callback is not -- the caller would wait forever on a request the
+// scheduler has already given up on.
+BOOST_AUTO_TEST_CASE(expired_onetime_request_reports_failure_to_caller) {
+   testing::tester            chain;
+   scheduler_callback_fixture f;
+   next_outcome               outcome;
+
+   chain.produce_block();
+   const uint32_t start_block_num = chain.control->head().block_num() + 1;
+
+   snapshot_request_information sri;
+   sri.block_spacing        = 0;
+   sri.start_block_num      = start_block_num;
+   sri.end_block_num        = std::numeric_limits<uint32_t>::max();
+   sri.snapshot_description = "one-time request whose firing height is never applied";
+   f.scheduler.schedule_snapshot(sri, outcome.recorder());
+
+   // irreversibility moves past the firing height without on_start_block ever running the request
+   chain.produce_blocks(2);
+   auto lib_block = chain.produce_block();
+   BOOST_REQUIRE_GT(lib_block->block_num(), start_block_num);
+   f.scheduler.on_irreversible_block(lib_block, lib_block->calculate_id(), *chain.control);
+
+   BOOST_TEST(f.scheduler.get_snapshot_requests().snapshot_requests.empty());
+   BOOST_TEST(outcome.successes == 0u);
+   BOOST_TEST(outcome.errors == 1u); // caller gets an error, not a dropped connection
+   BOOST_TEST(f.cb1_count == 0u);    // nothing was ever snapshotted
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`/v1/producer/create_snapshot` can close its connection without a response, hanging the caller. Seen in CI as a `snapshot_api_test` failure on the ubsan shard — `http.client.RemoteDisconnected` on the second snapshot, with nodeop alive and exiting cleanly afterwards.

The request that endpoint schedules is a one-time request anchored at `head + 1`, and `snapshot_scheduler::on_start_block` runs it at `start_block_num + 1`. `unschedule_snapshot_requests` collected the request as soon as irreversibility reached `start_block_num`. Irreversibility never runs ahead of the applied head, so committing block `start_block_num` lands LIB exactly on the deletion threshold one block before the firing height is applied. The request is erased unexecuted, and destroying the stored completion callback releases the last reference to the caller's HTTP session. Under normal production irreversibility trails the head by two blocks, so the firing height is applied long before the threshold is reached; the window opens for any node applying a run of blocks back to back — catching up after a stall, syncing, or switching forks. In the CI failure the node's application thread was starved for 8.6s while blocks 224 through 232 accumulated, then applied them in one batch.

**Request lifetime.** One-time requests are collected at `lib_height > start_block_num`, a threshold first observed while the firing height is being applied, so it can never precede that block's `block_start` signal. `end_block_num` no longer bounds them at all: scheduling accepts `end_block_num == start_block_num` — the shape `/v1/producer/schedule_snapshot` builds when a caller pins a snapshot to one block, and what `Node.scheduleSnapshotAt` sends — and expiring on it collected the request one block before it could ever fire, losing it to the same ordering for exactly the requests most specific about which block they want. Recurring requests expire on their end block as before.

**Callback lifetime.** A request's caller is answered exactly once, and something always answers it. The callback lives in one consumable slot owned by the request and shared with everything that can reach the caller: the handler on each pending snapshot the request produces, and the removal path. Answering moves the callback out of that slot, so whoever gets there first is the only one — which matters because a request outlives its own snapshot in several ways. A snapshot that is forked out is discarded unfinalized and the still-scheduled request regenerates it on the adopted branch; a spent request stays scheduled until irreversibility passes its firing height; and a request can be cancelled at any point, including while a snapshot from it is pending.

**Removal.** `remove_request` is the only way a request leaves the container. Both expiry and explicit cancellation through `/v1/producer/unschedule_snapshot` go through it, and a caller still waiting is resolved with a `snapshot_execution_exception` rather than having its callback destroyed. An outstanding `create_snapshot` request is listed by `get_snapshot_requests`, so its id is available to cancel.

**Delivery.** The completion handler settles the scheduler's own bookkeeping before answering, and logs and drops what the callback throws. A caller failing on its own account — writing to a client that has gone away — previously escaped into the snapshot pipeline: `on_irreversible_block` skipped `notify_snapshot_finalized` for a snapshot that had finalized, which is how provider mode learns to vote on it, and `create_snapshot` re-entered the handler through `CATCH_AND_CALL` to report the caller's own failure back to it.

`tests/test_snapshot_scheduler.cpp` gains cases for each of these, every one failing with only its own fix reverted: the catch-up ordering for the open-ended and exact-range request shapes, a forked-out snapshot regenerating and answering the original caller, a throwing callback resolved once, and cancellation before execution, while a snapshot is in flight, and after delivery. `tests/nodeop_snapshot_forked_test.py` already issued a `create_snapshot` across a fork but discarded the result, so an unanswered request left a dead RPC thread rather than a failure; it now asserts the call came back with a snapshot.
