### PR TITLE
WIRE-295: Complete Solana remit effect manifests

### DIFF
--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
@@ -177,12 +177,9 @@ private:
    };
 
    /// Resolve the terminal-finalization facts for a per-reserve PDA:
-   /// `creator` from the `Reserve` account, custody (mint / decimals) from
-   /// the `OutpostConfig` maps keyed by `token_code`. The clean-room outpost
-   /// program resolves custody from `config.token_addresses_by_code` at
-   /// dispatch time (`Reserve` carries no custody fields), so the relay
-   /// mirrors that lookup to stay account-consistent with the on-chain
-   /// handlers.
+   /// creator and pinned custody (mint / decimals) from the `Reserve` account.
+   /// The relay mirrors the on-chain resolver so a later OutpostConfig change
+   /// cannot alter the terminal effect-account manifest.
    std::optional<reserve_terminal_info>
    reserve_info_for_codes(uint64_t token_code, uint64_t reserve_code);
 
@@ -198,10 +195,7 @@ using outpost_solana_client_ptr = std::shared_ptr<outpost_solana_client>;
 
 namespace outpost_solana_client_detail {
 
-/// Custody binding for a `token_code`, resolved from the outpost's
-/// `OutpostConfig` maps. The clean-room program pins custody on the config
-/// (`token_addresses_by_code` / `precision_by_token_code`) instead of
-/// denormalizing it onto each `Reserve` account.
+/// Custody binding pinned on a decoded Reserve account.
 struct token_custody_info {
    /// SPL mint for the token, or the all-zero system-program key when the
    /// token is native lamports (the on-chain zero-marker convention).
@@ -210,14 +204,10 @@ struct token_custody_info {
    uint8_t decimals = 0;
 };
 
-/// Resolve `token_code`'s custody binding from a decoded `OutpostConfig`
-/// account object. BOTH entries are required — same contract as
-/// wire-ethereum's `ReserveManager` (`WIRE_TokenPrecisionUnset`) and the
-/// program's own `PrecisionUnconfigured` / `TokenCodeNotConfigured` gates:
-/// a missing address or precision entry throws instead of silently
-/// defaulting. Native custody is expressed by an EXPLICIT zero-mint entry.
-token_custody_info resolve_token_custody(const fc::variant_object& outpost_config,
-                                         uint64_t token_code);
+/// Resolve custody from a decoded Reserve. Both pinned fields are required;
+/// a legacy/malformed account throws so delivery is retried rather than
+/// submitting metas derived from mutable configuration.
+token_custody_info resolve_reserve_custody(const fc::variant_object& reserve);
 
 /// Append `key` to `metas`, or merge its writable flag into the existing
 /// entry when an earlier terminal effect already required the same account.
@@ -304,7 +294,7 @@ struct swap_remit_spl_target {
 
 /// Walk every `SWAP_REMIT` attestation in `envelope_bytes` and collect
 /// the SPL-relevant tuple. Caller is responsible for resolving each
-/// `token_code` to a mint pubkey (cached from `OutpostConfig`) before
+/// Reserve's pinned mint before
 /// deriving the recipient ATA + including it in `remaining_accounts`.
 std::vector<swap_remit_spl_target>
 extract_inbound_swap_remit_spl_targets(const std::vector<char>& envelope_bytes);

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <optional>
 #include <span>
@@ -59,6 +60,19 @@ namespace latest_envelope {
 namespace outpost_solana_client_detail {
 
 namespace {
+
+/// A terminal manifest is part of the delivery contract, not a best-effort
+/// optimization. Fail before submitting an account-incomplete `epoch_in`;
+/// `outpost_opp_job` leaves the epoch unmarked and retries on its next tick.
+sysio::opp::Envelope parse_terminal_manifest_envelope(
+   const std::vector<char>& envelope_bytes) {
+   sysio::opp::Envelope env;
+   FC_ASSERT(env.ParseFromArray(envelope_bytes.data(),
+                                static_cast<int>(envelope_bytes.size())),
+             "outpost_solana_client: cannot decode envelope for terminal "
+             "effect-account manifest; delivery will be retried");
+   return env;
+}
 
 /// Wrap a 32-byte address slice from `op_address.address` /
 /// `depositor.address` into a `solana_public_key`. Returns nullopt
@@ -383,16 +397,7 @@ fc::network::solana::solana_public_key derive_reserve_vault_pda(
 std::vector<fc::network::solana::solana_public_key>
 extract_inbound_recipient_pubkeys(const std::vector<char>& envelope_bytes) {
    std::vector<fc::network::solana::solana_public_key> recipients;
-
-   sysio::opp::Envelope env;
-   if (!env.ParseFromArray(envelope_bytes.data(),
-                           static_cast<int>(envelope_bytes.size()))) {
-      wlog("outpost_solana_client: envelope decode for remaining-accounts "
-           "extraction failed; submitting epoch_in with no extras "
-           "(WITHDRAW_REMIT/DEPOSIT_REVERT/SWAP native transfers may "
-           "log-and-skip on-chain if any are present)");
-      return recipients;
-   }
+   const auto env = parse_terminal_manifest_envelope(envelope_bytes);
 
    auto record_unique = [&recipients](const fc::network::solana::solana_public_key& pk) {
       if (std::find(recipients.begin(), recipients.end(), pk) == recipients.end()) {
@@ -451,16 +456,7 @@ extract_inbound_recipient_pubkeys(const std::vector<char>& envelope_bytes) {
 std::vector<swap_remit_spl_target>
 extract_inbound_swap_remit_spl_targets(const std::vector<char>& envelope_bytes) {
    std::vector<swap_remit_spl_target> targets;
-
-   sysio::opp::Envelope env;
-   if (!env.ParseFromArray(envelope_bytes.data(),
-                           static_cast<int>(envelope_bytes.size()))) {
-      wlog("outpost_solana_client: envelope decode for SPL swap-remit "
-           "target extraction failed; submitting epoch_in with no SPL "
-           "extras (any SPL SwapRemit attestations present will log-and-skip "
-           "if their effect accounts are missing)");
-      return targets;
-   }
+   const auto env = parse_terminal_manifest_envelope(envelope_bytes);
 
    for (const auto& message : env.messages()) {
       for (const auto& entry : message.payload().attestations()) {
@@ -483,16 +479,7 @@ extract_inbound_swap_remit_spl_targets(const std::vector<char>& envelope_bytes) 
 std::vector<swap_remit_spl_target>
 extract_inbound_swap_revert_spl_targets(const std::vector<char>& envelope_bytes) {
    std::vector<swap_remit_spl_target> targets;
-
-   sysio::opp::Envelope env;
-   if (!env.ParseFromArray(envelope_bytes.data(),
-                           static_cast<int>(envelope_bytes.size()))) {
-      wlog("outpost_solana_client: envelope decode for SPL swap-revert "
-           "target extraction failed; submitting epoch_in with no SPL "
-           "revert extras (any SPL SwapRevert attestations present will "
-           "log-and-skip on-chain)");
-      return targets;
-   }
+   const auto env = parse_terminal_manifest_envelope(envelope_bytes);
 
    for (const auto& message : env.messages()) {
       for (const auto& entry : message.payload().attestations()) {
@@ -515,16 +502,7 @@ extract_inbound_swap_revert_spl_targets(const std::vector<char>& envelope_bytes)
 std::vector<reserve_pda_seeds>
 extract_inbound_swap_remit_reserve_seeds(const std::vector<char>& envelope_bytes) {
    std::vector<reserve_pda_seeds> seeds;
-
-   sysio::opp::Envelope env;
-   if (!env.ParseFromArray(envelope_bytes.data(),
-                           static_cast<int>(envelope_bytes.size()))) {
-      wlog("outpost_solana_client: envelope decode for swap-remit reserve "
-           "seeds extraction failed; submitting epoch_in with no Reserve "
-           "PDAs (SWAP_REMIT lamport transfers will log-and-skip on-chain "
-           "if any are present)");
-      return seeds;
-   }
+   const auto env = parse_terminal_manifest_envelope(envelope_bytes);
 
    auto record_unique = [&seeds](uint64_t token_code, uint64_t reserve_code) {
       auto matches = [&](const reserve_pda_seeds& s) {
@@ -584,15 +562,7 @@ extract_inbound_swap_remit_reserve_seeds(const std::vector<char>& envelope_bytes
 std::vector<reserve_pda_seeds>
 extract_inbound_reserve_create_cancelled_seeds(const std::vector<char>& envelope_bytes) {
    std::vector<reserve_pda_seeds> seeds;
-
-   sysio::opp::Envelope env;
-   if (!env.ParseFromArray(envelope_bytes.data(),
-                           static_cast<int>(envelope_bytes.size()))) {
-      wlog("outpost_solana_client: envelope decode for reserve-cancel "
-           "target extraction failed; terminal manifest may omit refund "
-           "accounts");
-      return seeds;
-   }
+   const auto env = parse_terminal_manifest_envelope(envelope_bytes);
 
    auto record_unique = [&seeds](uint64_t token_code, uint64_t reserve_code) {
       auto matches = [&](const reserve_pda_seeds& s) {
@@ -615,42 +585,18 @@ extract_inbound_reserve_create_cancelled_seeds(const std::vector<char>& envelope
    return seeds;
 }
 
-token_custody_info resolve_token_custody(const fc::variant_object& outpost_config,
-                                         uint64_t token_code) {
+token_custody_info resolve_reserve_custody(const fc::variant_object& reserve) {
    token_custody_info custody;
-   bool address_found   = false;
-   bool precision_found = false;
-
-   if (outpost_config.contains("token_addresses_by_code")) {
-      for (const auto& entry_v : outpost_config["token_addresses_by_code"].get_array()) {
-         const auto& entry = entry_v.get_object();
-         if (entry["token_code"].as_uint64() == token_code) {
-            custody.mint =
-               fc::network::solana::solana_public_key::from_base58_string(entry["mint"].as_string());
-            address_found = true;
-            break;
-         }
-      }
-   }
-   FC_ASSERT(address_found,
-             "token address binding unconfigured for token_code {} — the outpost's "
-             "token_addresses_by_code map must carry an explicit entry (zero mint = native)",
-             token_code);
-
-   if (outpost_config.contains("precision_by_token_code")) {
-      for (const auto& entry_v : outpost_config["precision_by_token_code"].get_array()) {
-         const auto& entry = entry_v.get_object();
-         if (entry["token_code"].as_uint64() == token_code) {
-            custody.decimals  = static_cast<uint8_t>(entry["decimals"].as_uint64());
-            precision_found = true;
-            break;
-         }
-      }
-   }
-   FC_ASSERT(precision_found,
-             "token precision unconfigured for token_code {} — required, same as "
-             "wire-ethereum's WIRE_TokenPrecisionUnset and the program's PrecisionUnconfigured",
-             token_code);
+   FC_ASSERT(reserve.contains("custody_mint"),
+             "Reserve account missing pinned custody_mint field");
+   FC_ASSERT(reserve.contains("custody_decimals"),
+             "Reserve account missing pinned custody_decimals field");
+   custody.mint = fc::network::solana::solana_public_key::from_base58_string(
+      reserve["custody_mint"].as_string());
+   const auto decimals = reserve["custody_decimals"].as_uint64();
+   FC_ASSERT(decimals <= std::numeric_limits<uint8_t>::max(),
+             "Reserve custody_decimals {} exceeds uint8", decimals);
+   custody.decimals = static_cast<uint8_t>(decimals);
 
    return custody;
 }
@@ -709,7 +655,8 @@ outpost_solana_client::reserve_info_for_codes(uint64_t token_code, uint64_t rese
    const auto account_info = _entry->client->get_account_info(reserve_pda);
    if (!account_info.has_value()) {
       wlog("outpost_solana_client[{}]: Reserve({}, {}) absent at {}; "
-           "terminal manifest will omit branch-specific accounts for this reserve",
+           "terminal manifest will carry only its canonical Reserve PDA so the "
+           "outpost records this non-repairable state",
            to_string(),
            token_code,
            reserve_code,
@@ -727,18 +674,10 @@ outpost_solana_client::reserve_info_for_codes(uint64_t token_code, uint64_t rese
    const auto& reserve = reserve_v.get_object();
    FC_ASSERT(reserve.contains("creator"), "Reserve account missing creator field");
 
-   // Custody (mint / decimals) lives on the OutpostConfig maps keyed by
-   // token_code — the clean-room program resolves it there at dispatch time,
-   // so the relay mirrors that lookup to stay account-consistent with the
-   // on-chain handlers.
-   const auto config_info = _entry->client->get_account_info(_program_client->config_pda);
-   FC_ASSERT(config_info.has_value() && !config_info->data.empty(),
-             "OutpostConfig account missing at {} — outpost not initialized",
-             _program_client->config_pda.to_string(fc::yield_function_t{}));
-   const auto config_v =
-      _program_client->decode_account_info_data("OutpostConfig", config_info->data);
+   // Mirror the on-chain handler exactly: a Reserve pins custody facts at
+   // creation, so later OutpostConfig changes cannot alter settlement.
    const auto custody =
-      outpost_solana_client_detail::resolve_token_custody(config_v.get_object(), token_code);
+      outpost_solana_client_detail::resolve_reserve_custody(reserve);
 
    return reserve_terminal_info{
       fc::network::solana::solana_public_key::from_base58_string(reserve["creator"].as_string()),
@@ -830,11 +769,15 @@ std::string outpost_solana_client::deliver_outbound_envelope(
          outpost_solana_client_detail::derive_reserve_vault_pda(
             _program_id, target.token_code, target.reserve_code),
          true);
+      add_terminal_account(info.custody_mint, false);
+      add_terminal_account(target.recipient, true);
       add_terminal_account(
          fc::network::solana::system::get_associated_token_address(
             target.recipient, info.custody_mint),
          true);
       add_terminal_account(token_program_id, false);
+      add_terminal_account(associated_token_program_id, false);
+      add_terminal_account(system_program_id, false);
       spl_accounts_added += terminal_accounts.size() - before;
    }
 

--- a/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
@@ -515,58 +515,28 @@ BOOST_AUTO_TEST_CASE(outpost_program_name_default_is_opp_outpost) try {
    BOOST_CHECK_EQUAL(std::string{sysio::OPP_SOLANA_OUTPOST_PROGRAM_NAME}, "opp_outpost");
 } FC_LOG_AND_RETHROW();
 
-BOOST_AUTO_TEST_CASE(resolve_token_custody_reads_outpost_config_maps) try {
-   using sysio::outpost_solana_client_detail::resolve_token_custody;
+BOOST_AUTO_TEST_CASE(resolve_reserve_custody_reads_pinned_fields) try {
+   using sysio::outpost_solana_client_detail::resolve_reserve_custody;
 
-   const auto spl_mint      = measurement_pubkey(77);
-   const auto native_marker = system::program_ids::SYSTEM_PROGRAM;
-
-   fc::variants addresses;
-   addresses.push_back(fc::mutable_variant_object("token_code", 111)(
-      "mint", spl_mint.to_string(fc::yield_function_t{})));
-   addresses.push_back(fc::mutable_variant_object("token_code", 222)(
-      "mint", native_marker.to_string(fc::yield_function_t{})));
-   fc::variants precisions;
-   precisions.push_back(fc::mutable_variant_object("token_code", 111)("decimals", 6));
-   precisions.push_back(fc::mutable_variant_object("token_code", 222)("decimals", 9));
-
-   const fc::variant_object config =
-      fc::mutable_variant_object("token_addresses_by_code", std::move(addresses))(
-         "precision_by_token_code", std::move(precisions));
-
-   // SPL binding: configured mint + configured decimals.
-   const auto spl = resolve_token_custody(config, 111);
+   const auto spl_mint = measurement_pubkey(77);
+   const fc::variant_object reserve =
+      fc::mutable_variant_object(
+         "custody_mint", spl_mint.to_string(fc::yield_function_t{}))(
+         "custody_decimals", 6);
+   const auto spl = resolve_reserve_custody(reserve);
    BOOST_CHECK(spl.mint == spl_mint);
    BOOST_CHECK_EQUAL(static_cast<unsigned>(spl.decimals), 6u);
-
-   // Explicit zero-mint binding (the harness registers native SOL this way):
-   // native custody + its configured precision.
-   const auto native = resolve_token_custody(config, 222);
-   BOOST_CHECK(native.mint == native_marker);
-   BOOST_CHECK_EQUAL(static_cast<unsigned>(native.decimals), 9u);
 } FC_LOG_AND_RETHROW();
 
-BOOST_AUTO_TEST_CASE(resolve_token_custody_requires_both_config_entries) try {
-   using sysio::outpost_solana_client_detail::resolve_token_custody;
+BOOST_AUTO_TEST_CASE(resolve_reserve_custody_requires_both_pinned_fields) try {
+   using sysio::outpost_solana_client_detail::resolve_reserve_custody;
 
    const auto spl_mint = measurement_pubkey(78);
-   fc::variants addresses;
-   addresses.push_back(fc::mutable_variant_object("token_code", 111)(
-      "mint", spl_mint.to_string(fc::yield_function_t{})));
-
-   // Address bound but precision missing -> throws (wire-ethereum
-   // WIRE_TokenPrecisionUnset parity; program PrecisionUnconfigured parity).
-   const fc::variant_object address_only =
-      fc::mutable_variant_object("token_addresses_by_code", addresses)(
-         "precision_by_token_code", fc::variants{});
-   BOOST_CHECK_THROW(resolve_token_custody(address_only, 111), fc::assert_exception);
-
-   // Unknown token_code entirely -> throws on the address requirement.
-   BOOST_CHECK_THROW(resolve_token_custody(address_only, 999), fc::assert_exception);
-
-   // Config carrying no maps at all -> throws.
+   const fc::variant_object mint_only = fc::mutable_variant_object(
+      "custody_mint", spl_mint.to_string(fc::yield_function_t{}));
+   BOOST_CHECK_THROW(resolve_reserve_custody(mint_only), fc::assert_exception);
    BOOST_CHECK_THROW(
-      resolve_token_custody(fc::variant_object{fc::mutable_variant_object{}}, 111),
+      resolve_reserve_custody(fc::variant_object{fc::mutable_variant_object{}}),
       fc::assert_exception);
 } FC_LOG_AND_RETHROW();
 
@@ -1005,10 +975,11 @@ BOOST_AUTO_TEST_CASE(extract_pubkeys_skips_malformed_address_length) try {
    BOOST_CHECK(pks.empty());
 } FC_LOG_AND_RETHROW();
 
-BOOST_AUTO_TEST_CASE(extract_pubkeys_returns_empty_on_garbage_envelope) try {
+BOOST_AUTO_TEST_CASE(extract_pubkeys_retries_on_garbage_envelope) try {
    std::vector<char> garbage = {char(0xFF), char(0xFF), char(0xFF), char(0xFF)};
-   auto pks = sysio::outpost_solana_client_detail::extract_inbound_recipient_pubkeys(garbage);
-   BOOST_CHECK(pks.empty());
+   BOOST_CHECK_THROW(
+      sysio::outpost_solana_client_detail::extract_inbound_recipient_pubkeys(garbage),
+      fc::assert_exception);
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_CASE(extract_pubkeys_mixed_remit_and_revert_preserved_order) try {

--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_constants.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_constants.hpp
@@ -12,6 +12,13 @@
 
 namespace sysio::underwriter {
 
+/// Byte length of an EVM address carried in `SwapRequest.actor.address`.
+inline constexpr size_t EVM_DEPOSITOR_SIZE = 20;
+
+/// Byte length of a Solana Ed25519 public key carried in
+/// `SwapRequest.actor.address`.
+inline constexpr size_t SVM_DEPOSITOR_SIZE = 32;
+
 /// ETH: maximum number of recent blocks one source-deposit `eth_getLogs`
 /// lookup may cover.
 ///

--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_hash_detail.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_hash_detail.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <type_traits>
+#include <vector>
+
+#include <fc/crypto/keccak256.hpp>
+
+namespace sysio::underwriter {
+
+/// Number of unsigned 64-bit fields in the outpost correlation-hash payload.
+inline constexpr size_t SOURCE_DEPOSIT_U64_FIELD_COUNT = 7;
+
+/// Immutable source-outpost fields covered by the `SwapDeposit` correlation
+/// hash. The outposts hash the user's accepted `target_amount`, not the depot's
+/// mutable AMM quote (`uwreq.dst_amount`). Keeping the two names distinct here
+/// prevents a later re-price from invalidating otherwise genuine deposits.
+struct source_deposit_hash_input {
+   std::span<const char> depositor;
+   uint64_t source_amount;
+   uint64_t source_token_code;
+   uint64_t source_reserve_code;
+   uint64_t target_chain_code;
+   uint64_t target_token_code;
+   uint64_t target_reserve_code;
+   uint64_t target_amount;
+   uint32_t target_tolerance_bps;
+};
+
+/// Reproduce the outposts' packed `SwapDeposit` correlation hash.
+inline fc::crypto::keccak256 source_deposit_hash(const source_deposit_hash_input& input) {
+   std::vector<uint8_t> packed;
+   packed.reserve(input.depositor.size() + SOURCE_DEPOSIT_U64_FIELD_COUNT * sizeof(uint64_t) +
+                  sizeof(uint32_t));
+   packed.insert(packed.end(), input.depositor.begin(), input.depositor.end());
+
+   const auto append_big_endian = [&](auto value) {
+      using value_type = decltype(value);
+      static_assert(std::is_unsigned_v<value_type>);
+      for (size_t remaining_bytes = sizeof(value_type); remaining_bytes > 0; --remaining_bytes) {
+         const size_t shift = (remaining_bytes - 1) * CHAR_BIT;
+         packed.push_back(static_cast<uint8_t>(value >> shift));
+      }
+   };
+
+   append_big_endian(input.source_amount);
+   append_big_endian(input.source_token_code);
+   append_big_endian(input.source_reserve_code);
+   append_big_endian(input.target_chain_code);
+   append_big_endian(input.target_token_code);
+   append_big_endian(input.target_reserve_code);
+   append_big_endian(input.target_amount);
+   append_big_endian(input.target_tolerance_bps);
+
+   return fc::crypto::keccak256::hash(
+      std::span<const uint8_t>{packed.data(), packed.size()});
+}
+
+} // namespace sysio::underwriter

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -24,6 +24,7 @@
 #include <sysio/signature_provider_manager_plugin/signature_provider_manager_plugin.hpp>
 #include <sysio/underwriter_plugin/underwriter_plugin.hpp>
 #include <sysio/underwriter_plugin/source_deposit_constants.hpp>
+#include <sysio/underwriter_plugin/source_deposit_hash_detail.hpp>
 #include <sysio/underwriter_plugin/solana_source_deposit_scanner.hpp>
 #include <sysio/underwriter_plugin/routing_detail.hpp>
 #include <sysio/underwriter_plugin/sync_detail.hpp>
@@ -85,6 +86,13 @@ struct uw_request {
    ChainKind               dst_chain;
    TokenKind               dst_token_kind;
    uint64_t                dst_amount;
+   /// The destination amount the caller ASKED for, retained as the fixed
+   /// reference the depot's slippage check measures against. Distinct from
+   /// `dst_amount`, which is the depot's AMM quote and is re-priced at
+   /// settlement. The outposts fold THIS field — never `dst_amount` — into the
+   /// `SwapDeposit` correlation hash, so it is the value the source-deposit
+   /// verifier must reproduce.
+   uint64_t                target_amount;
    /// Per-leg slug_name triples (v6 data-model). These are the authoritative
    /// identifiers for the depot's `rcrdcommit` routing and the
    /// `UnderwriteIntentCommit` (`chain_code` / `token_code` / `reserve_code`)
@@ -1373,6 +1381,7 @@ struct underwriter_plugin::impl {
          req.dst_token_code   = read_codename("dst_token_code");
          req.dst_reserve_code = read_codename("dst_reserve_code");
          req.dst_amount       = obj["dst_amount"].as_uint64();
+         req.target_amount    = obj["target_amount"].as_uint64();
          req.variance_tolerance_bps = obj.contains("variance_tolerance_bps")
             ? static_cast<uint32_t>(obj["variance_tolerance_bps"].as_uint64())
             : 0u;
@@ -1928,40 +1937,29 @@ struct underwriter_plugin::impl {
                std::string{data_view.substr(i * 2, 2)}, nullptr, 16));
          }
 
-         // (4) Recompute the hash from the UWREQ row's flat fields.
-         //     Layout MUST match ReserveManager.requestSwap's
-         //     abi.encodePacked(...) call exactly.
-         std::vector<uint8_t> packed;
-         packed.reserve(20 + 8 * 7 + 4);
-         packed.insert(packed.end(),
-                       req.depositor.begin(), req.depositor.end());
-         auto append_u64_be = [&](uint64_t v) {
-            for (int shift = 56; shift >= 0; shift -= 8) {
-               packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-            }
-         };
-         auto append_u32_be = [&](uint32_t v) {
-            for (int shift = 24; shift >= 0; shift -= 8) {
-               packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-            }
-         };
-         append_u64_be(req.src_amount);
-         append_u64_be(req.src_token_code.value);
-         append_u64_be(req.src_reserve_code.value);
-         append_u64_be(req.dst_chain_code.value);
-         append_u64_be(req.dst_token_code.value);
-         append_u64_be(req.dst_reserve_code.value);
-         append_u64_be(req.dst_amount);
-         append_u32_be(req.variance_tolerance_bps);
-         if (packed.size() != 20 + 8 * 7 + 4) {
+         // (4) Recompute the hash from the UWREQ row's immutable source-outpost
+         //     fields. Layout MUST match ReserveManagerLib.hashSwapDeposit's
+         //     abi.encodePacked(...) call exactly. In particular, the outpost
+         //     hashes the user's original `target_amount`, not the depot's
+         //     re-priced `dst_amount` settlement quote.
+         if (req.depositor.size() != underwriter::EVM_DEPOSITOR_SIZE) {
             elog("underwriter: source-deposit verify failed for uwreq {} — "
-                 "packed buffer size {} != expected {}",
-                 req.id, packed.size(), 20 + 8 * 7 + 4);
+                 "depositor has wrong size ({} bytes; expected {} for EVM "
+                 "address)", req.id, req.depositor.size(), underwriter::EVM_DEPOSITOR_SIZE);
             bump_mismatch();
             return false;
          }
-         auto recomputed = fc::crypto::keccak256::hash(
-            std::span<const uint8_t>{packed.data(), packed.size()});
+         const auto recomputed = underwriter::source_deposit_hash({
+            .depositor            = std::span<const char>{req.depositor},
+            .source_amount        = req.src_amount,
+            .source_token_code    = req.src_token_code.value,
+            .source_reserve_code  = req.src_reserve_code.value,
+            .target_chain_code    = req.dst_chain_code.value,
+            .target_token_code    = req.dst_token_code.value,
+            .target_reserve_code  = req.dst_reserve_code.value,
+            .target_amount        = req.target_amount,
+            .target_tolerance_bps = req.variance_tolerance_bps,
+         });
          if (std::memcmp(recomputed.data(), on_chain_hash.data(), 32) != 0) {
             const std::string got_hex = fc::to_hex(
                reinterpret_cast<const char*>(on_chain_hash.data()), 32);
@@ -2098,44 +2096,26 @@ struct underwriter_plugin::impl {
       // ── (4) Recompute the expected correlation hash from UWREQ fields ──
       // Layout MUST stay synchronized with the producer side
       // (`opp-outpost/src/instructions/request_swap.rs::correlation_hash`).
-      // 32 + 7×8 + 4 = 92 bytes total.
-      std::vector<uint8_t> packed;
-      packed.reserve(32 + 7 * 8 + 4);
-      if (req.depositor.size() != 32) {
+      // Like the EVM outpost, it hashes the user's original `target_amount`,
+      // not the depot's re-priced `dst_amount` settlement quote.
+      if (req.depositor.size() != underwriter::SVM_DEPOSITOR_SIZE) {
          elog("underwriter: source-deposit verify failed for uwreq {} — "
-              "depositor has wrong size ({} bytes; expected 32 for SVM "
-              "Ed25519 pubkey)", req.id, req.depositor.size());
+              "depositor has wrong size ({} bytes; expected {} for SVM "
+              "Ed25519 pubkey)", req.id, req.depositor.size(), underwriter::SVM_DEPOSITOR_SIZE);
          bump_mismatch();
          return false;
       }
-      packed.insert(packed.end(), req.depositor.begin(), req.depositor.end());
-      auto append_u64_be = [&](uint64_t v) {
-         for (int shift = 56; shift >= 0; shift -= 8) {
-            packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-         }
-      };
-      auto append_u32_be = [&](uint32_t v) {
-         for (int shift = 24; shift >= 0; shift -= 8) {
-            packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-         }
-      };
-      append_u64_be(req.src_amount);
-      append_u64_be(req.src_token_code.value);
-      append_u64_be(req.src_reserve_code.value);
-      append_u64_be(req.dst_chain_code.value);
-      append_u64_be(req.dst_token_code.value);
-      append_u64_be(req.dst_reserve_code.value);
-      append_u64_be(req.dst_amount);
-      append_u32_be(req.variance_tolerance_bps);
-      if (packed.size() != 32 + 7 * 8 + 4) {
-         elog("underwriter: source-deposit verify failed for uwreq {} — "
-              "packed buffer size {} != expected {}",
-              req.id, packed.size(), 32 + 7 * 8 + 4);
-         bump_mismatch();
-         return false;
-      }
-      const auto recomputed_hash = fc::crypto::keccak256::hash(
-         std::span<const uint8_t>{packed.data(), packed.size()});
+      const auto recomputed_hash = underwriter::source_deposit_hash({
+         .depositor            = std::span<const char>{req.depositor},
+         .source_amount        = req.src_amount,
+         .source_token_code    = req.src_token_code.value,
+         .source_reserve_code  = req.src_reserve_code.value,
+         .target_chain_code    = req.dst_chain_code.value,
+         .target_token_code    = req.dst_token_code.value,
+         .target_reserve_code  = req.dst_reserve_code.value,
+         .target_amount        = req.target_amount,
+         .target_tolerance_bps = req.variance_tolerance_bps,
+      });
 
       // Canonical marker the producer emits on `request_swap`. The
       // Solana JSON-RPC `meta.logMessages[]` array contains each

--- a/plugins/underwriter_plugin/test/test_underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/test/test_underwriter_plugin.cpp
@@ -13,6 +13,7 @@
 #include <fc/variant_object.hpp>
 #include <sysio/underwriter_plugin/solana_source_deposit_scanner.hpp>
 #include <sysio/underwriter_plugin/source_deposit_constants.hpp>
+#include <sysio/underwriter_plugin/source_deposit_hash_detail.hpp>
 #include <sysio/underwriter_plugin/underwriter_plugin.hpp>
 
 using namespace std::literals;
@@ -39,6 +40,14 @@ fc::crypto::keccak256 test_expected_hash() {
 /// Hex-encodes a 32-byte keccak hash the same way the Solana outpost log does.
 std::string hash_hex(const fc::crypto::keccak256& hash) {
    return fc::to_hex(reinterpret_cast<const char*>(hash.data()), 32);
+}
+
+/// Decodes a hex string into the `std::vector<char>` shape a UWREQ row's
+/// `depositor` field carries.
+std::vector<char> depositor_bytes(std::string_view hex) {
+   std::vector<char> bytes(hex.size() / 2);
+   fc::from_hex(hex, bytes.data(), bytes.size());
+   return bytes;
 }
 
 /// Builds the canonical SwapDeposit marker prefix for a deposit id.
@@ -583,6 +592,68 @@ BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_skips_failed_listing_transaction
 
    BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::not_found);
    BOOST_CHECK_EQUAL(fetch_count, 0);
+} FC_LOG_AND_RETHROW();
+
+// ── SwapDeposit correlation-hash preimage ──────────────────────────────
+//
+// Both outposts hash the user's accepted `target_amount`
+// (`ReserveManagerLib.hashSwapDeposit` on EVM,
+// `swap_correlation_hash` on SVM). The depot re-prices `dst_amount` at
+// ingestion, so the two diverge whenever the caller's target is not
+// exactly the depot's quote — which is the normal case, and precisely
+// what `variance_tolerance_bps` exists to bound.
+
+/// The EVM leg of a real ETH→SOL underwritten swap, captured from a live
+/// cluster run. `on_chain_swap_deposit_hash` is the `SwapDeposit` event's
+/// hash as `ReserveManager` emitted it.
+const std::vector<char> production_depositor =
+   depositor_bytes("cf2d5b3cbb4d7bf04e3f7bfa8e27081b52191f91");
+constexpr uint64_t production_source_amount        = 100000000;
+constexpr uint64_t production_source_token_code    = 23373212024832;
+constexpr uint64_t production_source_reserve_code  = 71615576876608;
+constexpr uint64_t production_target_chain_code    = 84606581215232;
+constexpr uint64_t production_target_token_code    = 84606560763904;
+constexpr uint64_t production_target_reserve_code  = 71615576876608;
+constexpr uint64_t production_target_amount        = 98039214;
+constexpr uint64_t production_settlement_quote     = 97747972;
+constexpr uint32_t production_tolerance_bps        = 50;
+constexpr auto     on_chain_swap_deposit_hash =
+   "fd8f16aad2443acf2847c6f49c41feac6f32feadc87682df25835ae328a76695";
+
+/// Build the production preimage, varying only the destination amount.
+sysio::underwriter::source_deposit_hash_input production_hash_input(uint64_t destination_amount) {
+   return {
+      .depositor            = std::span<const char>{production_depositor},
+      .source_amount        = production_source_amount,
+      .source_token_code    = production_source_token_code,
+      .source_reserve_code  = production_source_reserve_code,
+      .target_chain_code    = production_target_chain_code,
+      .target_token_code    = production_target_token_code,
+      .target_reserve_code  = production_target_reserve_code,
+      .target_amount        = destination_amount,
+      .target_tolerance_bps = production_tolerance_bps,
+   };
+}
+
+/// The recomputed hash matches the outpost's only when the preimage carries
+/// the caller's `target_amount`.
+BOOST_AUTO_TEST_CASE(source_deposit_hash_binds_the_callers_target_amount) try {
+   const auto recomputed = sysio::underwriter::source_deposit_hash(
+      production_hash_input(production_target_amount));
+
+   BOOST_CHECK_EQUAL(hash_hex(recomputed), on_chain_swap_deposit_hash);
+} FC_LOG_AND_RETHROW();
+
+/// The depot's re-priced settlement quote is NOT what the outpost hashed;
+/// feeding it in reproduces the divergence that stalls every UWREQ whose
+/// target differs from the quote.
+BOOST_AUTO_TEST_CASE(source_deposit_hash_rejects_the_depot_settlement_quote) try {
+   BOOST_REQUIRE_NE(production_settlement_quote, production_target_amount);
+
+   const auto recomputed = sysio::underwriter::source_deposit_hash(
+      production_hash_input(production_settlement_quote));
+
+   BOOST_CHECK_NE(hash_hex(recomputed), on_chain_swap_deposit_hash);
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- make terminal effect-account extraction fail closed so malformed envelopes are retried instead of submitted with incomplete manifests
- derive custody mint and decimals from each Reserve's pinned fields, matching the Solana outpost resolver
- include the complete SWAP_REMIT SPL account surface needed for validation and on-demand ATA creation
- retain canonical-Reserve-only delivery for an absent Reserve so the program can record that non-repairable state without stalling the epoch
- integrate the narrow source-deposit verification fix from [wire-sysio#556](https://github.com/Wire-Network/wire-sysio/pull/556), binding the EVM/SVM correlation hash to the caller's immutable `target_amount` rather than the depot's post-#550 AMM quote

## Coordination

Companion to [wire-solana#403](https://github.com/Wire-Network/wire-solana/pull/403) and [wire-ethereum#173](https://github.com/Wire-Network/wire-ethereum/pull/173) for WIRE-295. The Solana program and cranker changes must ship together because error 6064 deliberately rejects caller-repairable missing/read-only remit metas and retries terminal delivery atomically.

The current head contains `wire-sysio#556` at exact commit `2ae183b8fbf04c04df829e1700317f7ea06322a5`. That upstream fix is required with current `master`: #550 intentionally split the caller's target from the settlement quote, while the underwriter verifier still recomputed the outpost hash from the quote. The flow gate pins `wire-tools-ts@4c9195b69303d60520ea7cd312ce19cc15ecfd10`, current `master`, which contains merged [PR #59](https://github.com/Wire-Network/wire-tools-ts/pull/59) for the quote mirror and [PR #58](https://github.com/Wire-Network/wire-tools-ts/pull/58) for the request-fixture compatibility fix.

## Validation

- focused Release build of `test_underwriter_plugin` and `test_outpost_solana_client_plugin`
- `test_underwriter_plugin`: 50 test cases passed, including the production target-vs-quote hash vector
- `test_outpost_solana_client_plugin`: 48 test cases passed
- `git diff --check`
- current combined-head CI passed: [Linux](https://github.com/Wire-Network/wire-sysio/actions/runs/31413904109) and [macOS](https://github.com/Wire-Network/wire-sysio/actions/runs/31413900276)

## E2E

Passed [platform E2E #31440257605](https://github.com/Wire-Network/wire-platform-build-system/actions/runs/31440257605) in Release mode: **12/12 flows passed, 0 failed**.

Exact resolved revisions:

- `wire-sysio`: `caedae4c688d35db2d0a11c3f3d61814e02448ed`
- `wire-tools-ts`: `4c9195b69303d60520ea7cd312ce19cc15ecfd10`
- `wire-solana`: `d91c76540029a67258b2cc538eccb3cd18858653`
- `wire-ethereum`: `4a006436159e5b4e7978caaacbc079c1c952efab`

Passing flows: `batch-operator-slashing`, `batch-operator-termination`, `emissions-soak`, `operator-collateral-deposit`, `reserve-lifecycle`, `swap-from-wire`, `swap-non-native-tokens`, `swap-private-reserves`, `swap-to-wire`, `swap-variance-revert`, `swap-with-underwriting`, and `yield-distribution`.

`flow-node-owner-nft` was explicitly excluded because of its separately known unrelated baseline failure; no WIRE-295 flow was excluded.

The superseded [attempt #31437824369](https://github.com/Wire-Network/wire-platform-build-system/actions/runs/31437824369) stopped before flows during the platform build because it pinned the obsolete, already-merged `wire-tools-ts` PR head. The passing run pins current `wire-tools-ts` master, which contains merged PR #59 and the request-fixture compatibility fix from PR #58.