### PR TITLE
WIRE-316: Bind source-deposit hash to target_amount

### DIFF
--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_constants.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_constants.hpp
@@ -12,6 +12,13 @@
 
 namespace sysio::underwriter {
 
+/// Byte length of an EVM address carried in `SwapRequest.actor.address`.
+inline constexpr size_t EVM_DEPOSITOR_SIZE = 20;
+
+/// Byte length of a Solana Ed25519 public key carried in
+/// `SwapRequest.actor.address`.
+inline constexpr size_t SVM_DEPOSITOR_SIZE = 32;
+
 /// ETH: maximum number of recent blocks one source-deposit `eth_getLogs`
 /// lookup may cover.
 ///

--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_hash_detail.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/source_deposit_hash_detail.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <type_traits>
+#include <vector>
+
+#include <fc/crypto/keccak256.hpp>
+
+namespace sysio::underwriter {
+
+/// Number of unsigned 64-bit fields in the outpost correlation-hash payload.
+inline constexpr size_t SOURCE_DEPOSIT_U64_FIELD_COUNT = 7;
+
+/// Immutable source-outpost fields covered by the `SwapDeposit` correlation
+/// hash. The outposts hash the user's accepted `target_amount`, not the depot's
+/// mutable AMM quote (`uwreq.dst_amount`). Keeping the two names distinct here
+/// prevents a later re-price from invalidating otherwise genuine deposits.
+struct source_deposit_hash_input {
+   std::span<const char> depositor;
+   uint64_t source_amount;
+   uint64_t source_token_code;
+   uint64_t source_reserve_code;
+   uint64_t target_chain_code;
+   uint64_t target_token_code;
+   uint64_t target_reserve_code;
+   uint64_t target_amount;
+   uint32_t target_tolerance_bps;
+};
+
+/// Reproduce the outposts' packed `SwapDeposit` correlation hash.
+inline fc::crypto::keccak256 source_deposit_hash(const source_deposit_hash_input& input) {
+   std::vector<uint8_t> packed;
+   packed.reserve(input.depositor.size() + SOURCE_DEPOSIT_U64_FIELD_COUNT * sizeof(uint64_t) +
+                  sizeof(uint32_t));
+   packed.insert(packed.end(), input.depositor.begin(), input.depositor.end());
+
+   const auto append_big_endian = [&](auto value) {
+      using value_type = decltype(value);
+      static_assert(std::is_unsigned_v<value_type>);
+      for (size_t remaining_bytes = sizeof(value_type); remaining_bytes > 0; --remaining_bytes) {
+         const size_t shift = (remaining_bytes - 1) * CHAR_BIT;
+         packed.push_back(static_cast<uint8_t>(value >> shift));
+      }
+   };
+
+   append_big_endian(input.source_amount);
+   append_big_endian(input.source_token_code);
+   append_big_endian(input.source_reserve_code);
+   append_big_endian(input.target_chain_code);
+   append_big_endian(input.target_token_code);
+   append_big_endian(input.target_reserve_code);
+   append_big_endian(input.target_amount);
+   append_big_endian(input.target_tolerance_bps);
+
+   return fc::crypto::keccak256::hash(
+      std::span<const uint8_t>{packed.data(), packed.size()});
+}
+
+} // namespace sysio::underwriter

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -24,6 +24,7 @@
 #include <sysio/signature_provider_manager_plugin/signature_provider_manager_plugin.hpp>
 #include <sysio/underwriter_plugin/underwriter_plugin.hpp>
 #include <sysio/underwriter_plugin/source_deposit_constants.hpp>
+#include <sysio/underwriter_plugin/source_deposit_hash_detail.hpp>
 #include <sysio/underwriter_plugin/solana_source_deposit_scanner.hpp>
 #include <sysio/underwriter_plugin/routing_detail.hpp>
 #include <sysio/underwriter_plugin/sync_detail.hpp>
@@ -85,6 +86,13 @@ struct uw_request {
    ChainKind               dst_chain;
    TokenKind               dst_token_kind;
    uint64_t                dst_amount;
+   /// The destination amount the caller ASKED for, retained as the fixed
+   /// reference the depot's slippage check measures against. Distinct from
+   /// `dst_amount`, which is the depot's AMM quote and is re-priced at
+   /// settlement. The outposts fold THIS field — never `dst_amount` — into the
+   /// `SwapDeposit` correlation hash, so it is the value the source-deposit
+   /// verifier must reproduce.
+   uint64_t                target_amount;
    /// Per-leg slug_name triples (v6 data-model). These are the authoritative
    /// identifiers for the depot's `rcrdcommit` routing and the
    /// `UnderwriteIntentCommit` (`chain_code` / `token_code` / `reserve_code`)
@@ -1373,6 +1381,7 @@ struct underwriter_plugin::impl {
          req.dst_token_code   = read_codename("dst_token_code");
          req.dst_reserve_code = read_codename("dst_reserve_code");
          req.dst_amount       = obj["dst_amount"].as_uint64();
+         req.target_amount    = obj["target_amount"].as_uint64();
          req.variance_tolerance_bps = obj.contains("variance_tolerance_bps")
             ? static_cast<uint32_t>(obj["variance_tolerance_bps"].as_uint64())
             : 0u;
@@ -1928,40 +1937,29 @@ struct underwriter_plugin::impl {
                std::string{data_view.substr(i * 2, 2)}, nullptr, 16));
          }
 
-         // (4) Recompute the hash from the UWREQ row's flat fields.
-         //     Layout MUST match ReserveManager.requestSwap's
-         //     abi.encodePacked(...) call exactly.
-         std::vector<uint8_t> packed;
-         packed.reserve(20 + 8 * 7 + 4);
-         packed.insert(packed.end(),
-                       req.depositor.begin(), req.depositor.end());
-         auto append_u64_be = [&](uint64_t v) {
-            for (int shift = 56; shift >= 0; shift -= 8) {
-               packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-            }
-         };
-         auto append_u32_be = [&](uint32_t v) {
-            for (int shift = 24; shift >= 0; shift -= 8) {
-               packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-            }
-         };
-         append_u64_be(req.src_amount);
-         append_u64_be(req.src_token_code.value);
-         append_u64_be(req.src_reserve_code.value);
-         append_u64_be(req.dst_chain_code.value);
-         append_u64_be(req.dst_token_code.value);
-         append_u64_be(req.dst_reserve_code.value);
-         append_u64_be(req.dst_amount);
-         append_u32_be(req.variance_tolerance_bps);
-         if (packed.size() != 20 + 8 * 7 + 4) {
+         // (4) Recompute the hash from the UWREQ row's immutable source-outpost
+         //     fields. Layout MUST match ReserveManagerLib.hashSwapDeposit's
+         //     abi.encodePacked(...) call exactly. In particular, the outpost
+         //     hashes the user's original `target_amount`, not the depot's
+         //     re-priced `dst_amount` settlement quote.
+         if (req.depositor.size() != underwriter::EVM_DEPOSITOR_SIZE) {
             elog("underwriter: source-deposit verify failed for uwreq {} — "
-                 "packed buffer size {} != expected {}",
-                 req.id, packed.size(), 20 + 8 * 7 + 4);
+                 "depositor has wrong size ({} bytes; expected {} for EVM "
+                 "address)", req.id, req.depositor.size(), underwriter::EVM_DEPOSITOR_SIZE);
             bump_mismatch();
             return false;
          }
-         auto recomputed = fc::crypto::keccak256::hash(
-            std::span<const uint8_t>{packed.data(), packed.size()});
+         const auto recomputed = underwriter::source_deposit_hash({
+            .depositor            = std::span<const char>{req.depositor},
+            .source_amount        = req.src_amount,
+            .source_token_code    = req.src_token_code.value,
+            .source_reserve_code  = req.src_reserve_code.value,
+            .target_chain_code    = req.dst_chain_code.value,
+            .target_token_code    = req.dst_token_code.value,
+            .target_reserve_code  = req.dst_reserve_code.value,
+            .target_amount        = req.target_amount,
+            .target_tolerance_bps = req.variance_tolerance_bps,
+         });
          if (std::memcmp(recomputed.data(), on_chain_hash.data(), 32) != 0) {
             const std::string got_hex = fc::to_hex(
                reinterpret_cast<const char*>(on_chain_hash.data()), 32);
@@ -2098,44 +2096,26 @@ struct underwriter_plugin::impl {
       // ── (4) Recompute the expected correlation hash from UWREQ fields ──
       // Layout MUST stay synchronized with the producer side
       // (`opp-outpost/src/instructions/request_swap.rs::correlation_hash`).
-      // 32 + 7×8 + 4 = 92 bytes total.
-      std::vector<uint8_t> packed;
-      packed.reserve(32 + 7 * 8 + 4);
-      if (req.depositor.size() != 32) {
+      // Like the EVM outpost, it hashes the user's original `target_amount`,
+      // not the depot's re-priced `dst_amount` settlement quote.
+      if (req.depositor.size() != underwriter::SVM_DEPOSITOR_SIZE) {
          elog("underwriter: source-deposit verify failed for uwreq {} — "
-              "depositor has wrong size ({} bytes; expected 32 for SVM "
-              "Ed25519 pubkey)", req.id, req.depositor.size());
+              "depositor has wrong size ({} bytes; expected {} for SVM "
+              "Ed25519 pubkey)", req.id, req.depositor.size(), underwriter::SVM_DEPOSITOR_SIZE);
          bump_mismatch();
          return false;
       }
-      packed.insert(packed.end(), req.depositor.begin(), req.depositor.end());
-      auto append_u64_be = [&](uint64_t v) {
-         for (int shift = 56; shift >= 0; shift -= 8) {
-            packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-         }
-      };
-      auto append_u32_be = [&](uint32_t v) {
-         for (int shift = 24; shift >= 0; shift -= 8) {
-            packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-         }
-      };
-      append_u64_be(req.src_amount);
-      append_u64_be(req.src_token_code.value);
-      append_u64_be(req.src_reserve_code.value);
-      append_u64_be(req.dst_chain_code.value);
-      append_u64_be(req.dst_token_code.value);
-      append_u64_be(req.dst_reserve_code.value);
-      append_u64_be(req.dst_amount);
-      append_u32_be(req.variance_tolerance_bps);
-      if (packed.size() != 32 + 7 * 8 + 4) {
-         elog("underwriter: source-deposit verify failed for uwreq {} — "
-              "packed buffer size {} != expected {}",
-              req.id, packed.size(), 32 + 7 * 8 + 4);
-         bump_mismatch();
-         return false;
-      }
-      const auto recomputed_hash = fc::crypto::keccak256::hash(
-         std::span<const uint8_t>{packed.data(), packed.size()});
+      const auto recomputed_hash = underwriter::source_deposit_hash({
+         .depositor            = std::span<const char>{req.depositor},
+         .source_amount        = req.src_amount,
+         .source_token_code    = req.src_token_code.value,
+         .source_reserve_code  = req.src_reserve_code.value,
+         .target_chain_code    = req.dst_chain_code.value,
+         .target_token_code    = req.dst_token_code.value,
+         .target_reserve_code  = req.dst_reserve_code.value,
+         .target_amount        = req.target_amount,
+         .target_tolerance_bps = req.variance_tolerance_bps,
+      });
 
       // Canonical marker the producer emits on `request_swap`. The
       // Solana JSON-RPC `meta.logMessages[]` array contains each

--- a/plugins/underwriter_plugin/test/test_underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/test/test_underwriter_plugin.cpp
@@ -13,6 +13,7 @@
 #include <fc/variant_object.hpp>
 #include <sysio/underwriter_plugin/solana_source_deposit_scanner.hpp>
 #include <sysio/underwriter_plugin/source_deposit_constants.hpp>
+#include <sysio/underwriter_plugin/source_deposit_hash_detail.hpp>
 #include <sysio/underwriter_plugin/underwriter_plugin.hpp>
 
 using namespace std::literals;
@@ -39,6 +40,14 @@ fc::crypto::keccak256 test_expected_hash() {
 /// Hex-encodes a 32-byte keccak hash the same way the Solana outpost log does.
 std::string hash_hex(const fc::crypto::keccak256& hash) {
    return fc::to_hex(reinterpret_cast<const char*>(hash.data()), 32);
+}
+
+/// Decodes a hex string into the `std::vector<char>` shape a UWREQ row's
+/// `depositor` field carries.
+std::vector<char> depositor_bytes(std::string_view hex) {
+   std::vector<char> bytes(hex.size() / 2);
+   fc::from_hex(hex, bytes.data(), bytes.size());
+   return bytes;
 }
 
 /// Builds the canonical SwapDeposit marker prefix for a deposit id.
@@ -583,6 +592,68 @@ BOOST_AUTO_TEST_CASE(solana_source_deposit_scan_skips_failed_listing_transaction
 
    BOOST_CHECK(result.status == sysio::underwriter::solana_source_deposit_page_status::not_found);
    BOOST_CHECK_EQUAL(fetch_count, 0);
+} FC_LOG_AND_RETHROW();
+
+// ── SwapDeposit correlation-hash preimage ──────────────────────────────
+//
+// Both outposts hash the user's accepted `target_amount`
+// (`ReserveManagerLib.hashSwapDeposit` on EVM,
+// `swap_correlation_hash` on SVM). The depot re-prices `dst_amount` at
+// ingestion, so the two diverge whenever the caller's target is not
+// exactly the depot's quote — which is the normal case, and precisely
+// what `variance_tolerance_bps` exists to bound.
+
+/// The EVM leg of a real ETH→SOL underwritten swap, captured from a live
+/// cluster run. `on_chain_swap_deposit_hash` is the `SwapDeposit` event's
+/// hash as `ReserveManager` emitted it.
+const std::vector<char> production_depositor =
+   depositor_bytes("cf2d5b3cbb4d7bf04e3f7bfa8e27081b52191f91");
+constexpr uint64_t production_source_amount        = 100000000;
+constexpr uint64_t production_source_token_code    = 23373212024832;
+constexpr uint64_t production_source_reserve_code  = 71615576876608;
+constexpr uint64_t production_target_chain_code    = 84606581215232;
+constexpr uint64_t production_target_token_code    = 84606560763904;
+constexpr uint64_t production_target_reserve_code  = 71615576876608;
+constexpr uint64_t production_target_amount        = 98039214;
+constexpr uint64_t production_settlement_quote     = 97747972;
+constexpr uint32_t production_tolerance_bps        = 50;
+constexpr auto     on_chain_swap_deposit_hash =
+   "fd8f16aad2443acf2847c6f49c41feac6f32feadc87682df25835ae328a76695";
+
+/// Build the production preimage, varying only the destination amount.
+sysio::underwriter::source_deposit_hash_input production_hash_input(uint64_t destination_amount) {
+   return {
+      .depositor            = std::span<const char>{production_depositor},
+      .source_amount        = production_source_amount,
+      .source_token_code    = production_source_token_code,
+      .source_reserve_code  = production_source_reserve_code,
+      .target_chain_code    = production_target_chain_code,
+      .target_token_code    = production_target_token_code,
+      .target_reserve_code  = production_target_reserve_code,
+      .target_amount        = destination_amount,
+      .target_tolerance_bps = production_tolerance_bps,
+   };
+}
+
+/// The recomputed hash matches the outpost's only when the preimage carries
+/// the caller's `target_amount`.
+BOOST_AUTO_TEST_CASE(source_deposit_hash_binds_the_callers_target_amount) try {
+   const auto recomputed = sysio::underwriter::source_deposit_hash(
+      production_hash_input(production_target_amount));
+
+   BOOST_CHECK_EQUAL(hash_hex(recomputed), on_chain_swap_deposit_hash);
+} FC_LOG_AND_RETHROW();
+
+/// The depot's re-priced settlement quote is NOT what the outpost hashed;
+/// feeding it in reproduces the divergence that stalls every UWREQ whose
+/// target differs from the quote.
+BOOST_AUTO_TEST_CASE(source_deposit_hash_rejects_the_depot_settlement_quote) try {
+   BOOST_REQUIRE_NE(production_settlement_quote, production_target_amount);
+
+   const auto recomputed = sysio::underwriter::source_deposit_hash(
+      production_hash_input(production_settlement_quote));
+
+   BOOST_CHECK_NE(hash_hex(recomputed), on_chain_swap_deposit_hash);
 } FC_LOG_AND_RETHROW();
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Jira ownership

Follow-up to [WIRE-316](https://wire-network.atlassian.net/browse/WIRE-316). PR #550 intentionally split the caller's immutable `target_amount` from the depot AMM quote; this PR fixes the resulting verifier regression. It is independent of logging-only WIRE-295 and terminal-payout semantics WIRE-332.

Split out of #543, which fixes this as part of a broader UIC-prevalidation refactor. It is isolated here because it is a live defect on `master` with a small, independently-reviewable fix, and #543 still has open design discussion on unrelated `sysio.uwrit` reject semantics.

## The defect

Both outposts fold the user's accepted `target_amount` into the `SwapDeposit` correlation hash:

- EVM — `ReserveManagerLib.hashSwapDeposit(sender, sourceAmountDepot, args)` packs `args.targetAmount`
- SVM — `swap_correlation_hash(..., target_amount, target_tolerance_bps)`

The underwriter's source-deposit verifier recomputed that preimage from `uwreq.dst_amount`.

Those were the same value until #550 split them. `dst_amount` is now the depot's AMM quote, re-priced at ingestion; `sysio.uwrit.hpp` states it is "**never** the caller's `SwapRequest.target_amount`". The recomputed hash therefore matches only when the caller's target happens to equal the depot's quote **exactly** — and a gap between the two is the *expected* case, which is what `variance_tolerance_bps` exists to bound. Any swap with a non-zero gap fails verification, the UWREQ never leaves `PENDING`, and no underwriter commits.

## Observed

A live ETH→SOL underwritten swap (`target_amount` 98039214, `dst_amount` 97747972) produced **148 consecutive** rejections against a single stable hash pair, until the flow timed out waiting for a CONFIRMED commitment:

```
underwriter: source-deposit verify failed for uwreq 11 — SwapDeposit hash mismatch (id=1):
  on-chain=fd8f16aad2443acf2847c6f49c41feac6f32feadc87682df25835ae328a76695
  recomputed=758ed0f49ec37030baebfdc586a4d57a36f88492c24fcb2758d8f5b4d8ffa2ff
```

Recomputing that preimage both ways confirms the split precisely:

| preimage destination amount | keccak256 | |
|---|---|---|
| `target_amount` = 98039214 | `fd8f16aa…` | the hash `ReserveManager` emitted |
| `dst_amount` = 97747972 | `758ed0f4…` | what the verifier computed |

## The fix

Carry `target_amount` on the plugin's `uw_request`, read it from the `uwreqs` row, and use it in the preimage.

The packing was **duplicated** across the EVM and SVM verifiers, which is how one wrong field became two. Both now call a single `source_deposit_hash` helper (lifted verbatim from #543, so that PR's rebase is a no-op) whose input struct names the field `target_amount` — the depot's mutable quote is no longer reachable from the preimage by accident. The EVM leg also gains the explicit depositor-size check the SVM leg already had; previously it was only implied by a post-hoc buffer-length assertion the helper makes unnecessary.

## Coverage

Two cases pin the preimage to the production vector above — the recomputed hash equals the `SwapDeposit` hash `ReserveManager` actually emitted, and the settlement quote demonstrably does not reproduce it.

Note the tests pin the **helper's** preimage layout and field semantics, not the two call sites' argument selection; the naming (`target_amount` vs `dst_amount` on the input struct) is what guards those.

## Verification

- `test_underwriter_plugin` — 50 cases, `*** No errors detected`
- `plugin_test` — `*** No errors detected`
- `nodeop` links clean

No `contracts/**` changes, so `contracts_unit_test` is not implicated.


[WIRE-316]: https://wire-network.atlassian.net/browse/WIRE-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ