### PR TITLE
Fix(underwriter): bind the source-deposit hash to the caller's target amount

### DIFF
--- a/plugins/underwriter_plugin/include/sysio/underwriter_plugin/routing_detail.hpp
+++ b/plugins/underwriter_plugin/include/sysio/underwriter_plugin/routing_detail.hpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <map>
 #include <optional>
+#include <vector>
 
 namespace sysio::underwriter_detail {
 
@@ -129,6 +130,65 @@ find_endpoint_coverage_gap(const std::map<uint64_t, int>& registered_kinds,
          return endpoint_coverage_gap{chain_code, std::nullopt, config_kind};
    }
    return std::nullopt;
+}
+
+// ---------------------------------------------------------------------------
+//  Source-deposit hash preimage
+// ---------------------------------------------------------------------------
+
+/// The swap terms the SOURCE OUTPOST hashed when it accepted the deposit, in the
+/// order it hashed them. Both outposts commit to the same seven values plus the
+/// depositor: `ReserveManager.requestSwap`'s `abi.encodePacked(...)` on EVM and
+/// `request_swap.rs::correlation_hash` on SVM.
+struct swap_deposit_terms {
+   uint64_t src_amount             = 0;
+   uint64_t src_token_code         = 0;   ///< `fc::slug_name::value`
+   uint64_t src_reserve_code       = 0;   ///< `fc::slug_name::value`
+   uint64_t dst_chain_code         = 0;   ///< `fc::slug_name::value`
+   uint64_t dst_token_code         = 0;   ///< `fc::slug_name::value`
+   uint64_t dst_reserve_code       = 0;   ///< `fc::slug_name::value`
+   /// The destination amount the CALLER asked for (`SwapRequest.target_amount`).
+   ///
+   /// This is the field the outpost hashed, and it is deliberately NOT the
+   /// UWREQ's `dst_amount`: the depot overwrites that with its own AMM quote
+   /// (WNS-02), a number minted AFTER the deposit was hashed and one the outpost
+   /// never saw. Packing the quote here reproduces the wrong preimage for every
+   /// swap whose quote differs from the target -- i.e. every swap that pays a
+   /// WIRE-leg fee -- and the underwriter then silently declines to commit.
+   uint64_t target_amount          = 0;
+   uint32_t variance_tolerance_bps = 0;
+};
+
+/// Big-endian preimage of the source-deposit hash: `depositor || 7 x u64 || u32`.
+///
+/// The depositor rides in as raw bytes because it is the ONLY per-chain
+/// difference -- a 20-byte EVM address or a 32-byte Ed25519 pubkey -- so both
+/// verifiers share this one packing and cannot drift apart. Callers validate the
+/// depositor width (and therefore the total size) for their chain.
+inline std::vector<uint8_t> pack_swap_deposit_preimage(const std::vector<char>& depositor,
+                                                       const swap_deposit_terms& terms) {
+   std::vector<uint8_t> packed;
+   packed.reserve(depositor.size() + 8 * 7 + 4);
+   for (char byte : depositor) packed.push_back(static_cast<uint8_t>(byte));
+
+   auto append_u64_be = [&](uint64_t v) {
+      for (int shift = 56; shift >= 0; shift -= 8)
+         packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
+   };
+   auto append_u32_be = [&](uint32_t v) {
+      for (int shift = 24; shift >= 0; shift -= 8)
+         packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
+   };
+
+   append_u64_be(terms.src_amount);
+   append_u64_be(terms.src_token_code);
+   append_u64_be(terms.src_reserve_code);
+   append_u64_be(terms.dst_chain_code);
+   append_u64_be(terms.dst_token_code);
+   append_u64_be(terms.dst_reserve_code);
+   append_u64_be(terms.target_amount);
+   append_u32_be(terms.variance_tolerance_bps);
+   return packed;
 }
 
 } // namespace sysio::underwriter_detail

--- a/plugins/underwriter_plugin/src/underwriter_plugin.cpp
+++ b/plugins/underwriter_plugin/src/underwriter_plugin.cpp
@@ -84,7 +84,14 @@ struct uw_request {
    uint64_t                src_amount;
    ChainKind               dst_chain;
    TokenKind               dst_token_kind;
+   /// The depot's AMM quote — what settlement pays out (WNS-02). NOT what the
+   /// caller asked for, and NOT what the source outpost hashed.
    uint64_t                dst_amount;
+   /// The destination amount the CALLER asked for (`SwapRequest.target_amount`).
+   /// The source outpost hashed this into its `SwapDeposit` / correlation hash
+   /// before the depot ever quoted, so it — not `dst_amount` — is what the
+   /// source-deposit verifiers must repack to reproduce that hash.
+   uint64_t                target_amount{};
    /// Per-leg slug_name triples (v6 data-model). These are the authoritative
    /// identifiers for the depot's `rcrdcommit` routing and the
    /// `UnderwriteIntentCommit` (`chain_code` / `token_code` / `reserve_code`)
@@ -1373,6 +1380,7 @@ struct underwriter_plugin::impl {
          req.dst_token_code   = read_codename("dst_token_code");
          req.dst_reserve_code = read_codename("dst_reserve_code");
          req.dst_amount       = obj["dst_amount"].as_uint64();
+         req.target_amount    = obj["target_amount"].as_uint64();
          req.variance_tolerance_bps = obj.contains("variance_tolerance_bps")
             ? static_cast<uint32_t>(obj["variance_tolerance_bps"].as_uint64())
             : 0u;
@@ -1710,6 +1718,23 @@ struct underwriter_plugin::impl {
    /// empty here means either the depot's reject regressed OR the plugin
    /// read a row pre-validation; either way the safe move is to refuse to
    /// commit until the data is whole.
+   /// Project a UWREQ row onto the outpost-hashed swap terms. The single place
+   /// the plugin's `uw_request` meets the pure preimage packer, so the
+   /// `target_amount` (not `dst_amount`) choice is made once for both chains.
+   static sysio::underwriter_detail::swap_deposit_terms
+   swap_deposit_terms_of(const uw_request& req) {
+      return {
+         .src_amount             = req.src_amount,
+         .src_token_code         = req.src_token_code.value,
+         .src_reserve_code       = req.src_reserve_code.value,
+         .dst_chain_code         = req.dst_chain_code.value,
+         .dst_token_code         = req.dst_token_code.value,
+         .dst_reserve_code       = req.dst_reserve_code.value,
+         .target_amount          = req.target_amount,
+         .variance_tolerance_bps = req.variance_tolerance_bps,
+      };
+   }
+
    bool verify_source_deposit(const uw_request& req) {
       if (req.src_is_depot) {
          // Swap-from-WIRE: the source funds were escrowed ON the depot by
@@ -1928,31 +1953,13 @@ struct underwriter_plugin::impl {
                std::string{data_view.substr(i * 2, 2)}, nullptr, 16));
          }
 
-         // (4) Recompute the hash from the UWREQ row's flat fields.
-         //     Layout MUST match ReserveManager.requestSwap's
-         //     abi.encodePacked(...) call exactly.
-         std::vector<uint8_t> packed;
-         packed.reserve(20 + 8 * 7 + 4);
-         packed.insert(packed.end(),
-                       req.depositor.begin(), req.depositor.end());
-         auto append_u64_be = [&](uint64_t v) {
-            for (int shift = 56; shift >= 0; shift -= 8) {
-               packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-            }
-         };
-         auto append_u32_be = [&](uint32_t v) {
-            for (int shift = 24; shift >= 0; shift -= 8) {
-               packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-            }
-         };
-         append_u64_be(req.src_amount);
-         append_u64_be(req.src_token_code.value);
-         append_u64_be(req.src_reserve_code.value);
-         append_u64_be(req.dst_chain_code.value);
-         append_u64_be(req.dst_token_code.value);
-         append_u64_be(req.dst_reserve_code.value);
-         append_u64_be(req.dst_amount);
-         append_u32_be(req.variance_tolerance_bps);
+         // (4) Recompute the hash from the UWREQ row's flat fields. Layout MUST
+         //     match ReserveManager.requestSwap's abi.encodePacked(...) exactly
+         //     — see `pack_swap_deposit_preimage`, shared with the SVM verifier
+         //     so the two can never drift, and note there why the destination
+         //     slot is `target_amount` and never `dst_amount`.
+         auto packed = sysio::underwriter_detail::pack_swap_deposit_preimage(
+            req.depositor, swap_deposit_terms_of(req));
          if (packed.size() != 20 + 8 * 7 + 4) {
             elog("underwriter: source-deposit verify failed for uwreq {} — "
                  "packed buffer size {} != expected {}",
@@ -2098,9 +2105,9 @@ struct underwriter_plugin::impl {
       // ── (4) Recompute the expected correlation hash from UWREQ fields ──
       // Layout MUST stay synchronized with the producer side
       // (`opp-outpost/src/instructions/request_swap.rs::correlation_hash`).
-      // 32 + 7×8 + 4 = 92 bytes total.
-      std::vector<uint8_t> packed;
-      packed.reserve(32 + 7 * 8 + 4);
+      // 32 + 7×8 + 4 = 92 bytes total. Shared packing with the EVM verifier —
+      // see `pack_swap_deposit_preimage`, and note there why the destination
+      // slot is `target_amount` and never `dst_amount`.
       if (req.depositor.size() != 32) {
          elog("underwriter: source-deposit verify failed for uwreq {} — "
               "depositor has wrong size ({} bytes; expected 32 for SVM "
@@ -2108,25 +2115,8 @@ struct underwriter_plugin::impl {
          bump_mismatch();
          return false;
       }
-      packed.insert(packed.end(), req.depositor.begin(), req.depositor.end());
-      auto append_u64_be = [&](uint64_t v) {
-         for (int shift = 56; shift >= 0; shift -= 8) {
-            packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-         }
-      };
-      auto append_u32_be = [&](uint32_t v) {
-         for (int shift = 24; shift >= 0; shift -= 8) {
-            packed.push_back(static_cast<uint8_t>((v >> shift) & 0xff));
-         }
-      };
-      append_u64_be(req.src_amount);
-      append_u64_be(req.src_token_code.value);
-      append_u64_be(req.src_reserve_code.value);
-      append_u64_be(req.dst_chain_code.value);
-      append_u64_be(req.dst_token_code.value);
-      append_u64_be(req.dst_reserve_code.value);
-      append_u64_be(req.dst_amount);
-      append_u32_be(req.variance_tolerance_bps);
+      auto packed = sysio::underwriter_detail::pack_swap_deposit_preimage(
+         req.depositor, swap_deposit_terms_of(req));
       if (packed.size() != 32 + 7 * 8 + 4) {
          elog("underwriter: source-deposit verify failed for uwreq {} — "
               "packed buffer size {} != expected {}",

--- a/plugins/underwriter_plugin/test/test_underwriter_source_deposit.cpp
+++ b/plugins/underwriter_plugin/test/test_underwriter_source_deposit.cpp
@@ -1,0 +1,132 @@
+#include <boost/test/unit_test.hpp>
+
+#include <sysio/underwriter_plugin/routing_detail.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+/**
+ * Regression tests for the source-deposit hash preimage the underwriter
+ * recomputes before it will commit to a swap.
+ *
+ * The preimage must reproduce, byte for byte, what the SOURCE OUTPOST hashed
+ * when it accepted the deposit — `ReserveManager.requestSwap`'s
+ * `abi.encodePacked(...)` on EVM, `request_swap.rs::correlation_hash` on SVM.
+ * The outpost hashes the terms the CALLER submitted, so the destination slot is
+ * `SwapRequest.target_amount`.
+ *
+ * The bug these pin: the depot overwrites the UWREQ's `dst_amount` with its own
+ * AMM quote (WNS-02), minted long after the outpost hashed the deposit. Packing
+ * that quote reproduces the wrong preimage for every swap whose quote differs
+ * from the target — i.e. every swap that pays a WIRE-leg fee — and the
+ * underwriter then declines to commit with a bare "SwapDeposit hash mismatch",
+ * stalling the swap rather than failing loudly.
+ *
+ * Boost.Test module is defined once in `test/main.cpp`; this file only adds a
+ * suite.
+ */
+
+using namespace sysio::underwriter_detail;
+
+namespace {
+
+/// Distinct, easily-spotted values for every slot, so a transposition shows up
+/// as a wrong byte rather than a coincidental match.
+swap_deposit_terms sample_terms() {
+   return {
+      .src_amount             = 0x1122334455667788ull,
+      .src_token_code         = 0x0000000000000011ull,
+      .src_reserve_code       = 0x0000000000000022ull,
+      .dst_chain_code         = 0x0000000000000033ull,
+      .dst_token_code         = 0x0000000000000044ull,
+      .dst_reserve_code       = 0x0000000000000055ull,
+      .target_amount          = 0x00000000000003e8ull,   // 1000 — the caller's ask
+      .variance_tolerance_bps = 0x00000032u,             // 50
+   };
+}
+
+/// Read a big-endian uint64 back out of the packed buffer.
+uint64_t be64_at(const std::vector<uint8_t>& packed, size_t offset) {
+   uint64_t v = 0;
+   for (size_t i = 0; i < 8; ++i) v = (v << 8) | packed[offset + i];
+   return v;
+}
+
+/// Read a big-endian uint32 back out of the packed buffer.
+uint32_t be32_at(const std::vector<uint8_t>& packed, size_t offset) {
+   uint32_t v = 0;
+   for (size_t i = 0; i < 4; ++i) v = (v << 8) | packed[offset + i];
+   return v;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(underwriter_source_deposit_tests)
+
+// The EVM preimage: 20-byte address, then the seven u64s in outpost order, then
+// the tolerance. Sizes and offsets are the contract with ReserveManager.
+BOOST_AUTO_TEST_CASE(evm_preimage_layout) {
+   const std::vector<char> depositor(20, '\x0a');
+   const auto terms  = sample_terms();
+   const auto packed = pack_swap_deposit_preimage(depositor, terms);
+
+   BOOST_REQUIRE_EQUAL(packed.size(), 20u + 8 * 7 + 4);
+   for (size_t i = 0; i < 20; ++i) BOOST_REQUIRE_EQUAL(packed[i], 0x0a);
+
+   BOOST_REQUIRE_EQUAL(be64_at(packed, 20 + 0 * 8), terms.src_amount);
+   BOOST_REQUIRE_EQUAL(be64_at(packed, 20 + 1 * 8), terms.src_token_code);
+   BOOST_REQUIRE_EQUAL(be64_at(packed, 20 + 2 * 8), terms.src_reserve_code);
+   BOOST_REQUIRE_EQUAL(be64_at(packed, 20 + 3 * 8), terms.dst_chain_code);
+   BOOST_REQUIRE_EQUAL(be64_at(packed, 20 + 4 * 8), terms.dst_token_code);
+   BOOST_REQUIRE_EQUAL(be64_at(packed, 20 + 5 * 8), terms.dst_reserve_code);
+   // The destination slot carries the caller's ask.
+   BOOST_REQUIRE_EQUAL(be64_at(packed, 20 + 6 * 8), terms.target_amount);
+   BOOST_REQUIRE_EQUAL(be32_at(packed, 20 + 7 * 8), terms.variance_tolerance_bps);
+}
+
+// The SVM preimage differs ONLY in the depositor width (32-byte Ed25519 pubkey);
+// every other offset shifts by the same 12 bytes and nothing else changes.
+BOOST_AUTO_TEST_CASE(svm_preimage_layout) {
+   const std::vector<char> depositor(32, '\x0b');
+   const auto terms  = sample_terms();
+   const auto packed = pack_swap_deposit_preimage(depositor, terms);
+
+   BOOST_REQUIRE_EQUAL(packed.size(), 32u + 8 * 7 + 4);
+   for (size_t i = 0; i < 32; ++i) BOOST_REQUIRE_EQUAL(packed[i], 0x0b);
+
+   BOOST_REQUIRE_EQUAL(be64_at(packed, 32 + 0 * 8), terms.src_amount);
+   BOOST_REQUIRE_EQUAL(be64_at(packed, 32 + 6 * 8), terms.target_amount);
+   BOOST_REQUIRE_EQUAL(be32_at(packed, 32 + 7 * 8), terms.variance_tolerance_bps);
+
+   // Same terms, same trailing bytes on both chains — the two verifiers cannot
+   // drift because they share this one packing.
+   const auto evm = pack_swap_deposit_preimage(std::vector<char>(20, '\x0a'), terms);
+   BOOST_REQUIRE(std::equal(packed.begin() + 32, packed.end(), evm.begin() + 20));
+}
+
+// The whole point: the preimage tracks the caller's target, so a depot quote
+// that lands anywhere else cannot change it. Two swaps identical except for the
+// amount the caller asked for must hash differently; the same ask must hash the
+// same however the depot later re-prices it (the quote is not an input here at
+// all — `swap_deposit_terms` has no `dst_amount` field to pass it through).
+BOOST_AUTO_TEST_CASE(preimage_binds_the_callers_target_not_the_depot_quote) {
+   const std::vector<char> depositor(20, '\x0a');
+
+   auto asked_1000 = sample_terms();
+   auto asked_997  = sample_terms();
+   asked_997.target_amount = 997;   // e.g. a 30 bps WIRE-leg fee off 1000
+
+   const auto packed_1000 = pack_swap_deposit_preimage(depositor, asked_1000);
+   const auto packed_997  = pack_swap_deposit_preimage(depositor, asked_997);
+
+   BOOST_REQUIRE(packed_1000 != packed_997);
+   BOOST_REQUIRE_EQUAL(be64_at(packed_1000, 20 + 6 * 8), 1000u);
+   BOOST_REQUIRE_EQUAL(be64_at(packed_997,  20 + 6 * 8), 997u);
+
+   // Re-packing the untouched terms is stable — nothing in the preimage depends
+   // on depot-side state that settlement may have moved.
+   BOOST_REQUIRE(pack_swap_deposit_preimage(depositor, asked_1000) == packed_1000);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The underwriter reproduces the source outpost's deposit hash before it will commit to a swap. Both verifiers packed the UWREQ's `dst_amount` — which #550 repurposed to hold the depot's own AMM quote, a number minted long after the outpost hashed the deposit and one it never saw. The outpost hashed `SwapRequest.target_amount`, so the recompute now misses for every swap whose quote differs from the target: every swap that pays a WIRE-leg fee.

The failure is silent. `verify_source_deposit` returns false, the underwriter logs `SwapDeposit hash mismatch` and skips the request, and retries on the next scan cycle — forever. Nothing aborts, so the swap simply never gets a commitment.

```
underwriter: source-deposit verify failed for uwreq 11 — SwapDeposit hash mismatch (id=1):
  on-chain=fd8f16aa...  recomputed=758ed0f4...
underwriter: skipping uwreq 11 — source-deposit verify failed
  (repeats every 5s until the flow's capture step times out at 840s)
```

## The fix

Pack `target_amount`. The field already exists on the row — #550 added it for exactly this reason ("the destination amount the caller ASKED for") — and the plugin simply never read it.

The packing moves into `routing_detail.hpp` as `pack_swap_deposit_preimage`, shared by both verifiers. The EVM and SVM bodies were near-identical, differing only in depositor width (20-byte address vs 32-byte Ed25519 pubkey), and they had already drifted once — this is the second time a change had to be made in two places and landed in neither. `swap_deposit_terms` deliberately has no `dst_amount` field, so the quote cannot be packed here by mistake; the single `uw_request` adapter makes that choice once for both chains.

No compatibility fallback on the decode: the chain is unlaunched, so there are no pre-split rows to read.

## Tests

`underwriter_source_deposit_tests` pins the byte layout for both chains (depositor bytes, seven big-endian u64s in outpost order, then the tolerance), that the EVM and SVM preimages share identical trailing bytes so the two verifiers cannot drift, and that the preimage tracks the caller's target rather than anything the depot re-prices.

The verifiers themselves need live RPC, so the end-to-end proof is a swap confirming on a cluster — that needs this merged and a gate run, and I have not claimed it here.

## Scope

This affects any outpost-originated underwritten swap on master, not one flow. `flow-swap-with-underwriting` should be failing the same way right now. If a recent gate run on master is green, my model is incomplete and I would like to know why before this merges.

Found while re-running the e2e gate for #549 after merging master: that branch's `flow-underwriter-slashing` timed out waiting for a commitment, with the log above. #549 stays gate-blocked until this lands.
