### PR TITLE
fix(ci): serialize macOS gossip peering test

### DIFF
--- a/.github/workflows/macos_arm64_build.yaml
+++ b/.github/workflows/macos_arm64_build.yaml
@@ -131,8 +131,18 @@ jobs:
           echo "Running sharded NP/LR tests with ${test_jobs} jobs"
           ctest -j "${test_jobs}" \
             -L "(nonparallelizable_tests|long_running_tests)" \
+            -E "^auto_bp_gossip_peering_test$" \
             --timeout 2700 \
             2>&1 | tee "$RUNNER_TEMP/macos-arm64-np-lr-ctest.log"
+
+      - name: Run auto BP gossip peering test serially
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_sharded_np_lr) }}
+        run: |
+          cd "$BUILD_DIR"
+          # The 21-node gossip topology requires exclusive macOS host resources.
+          ctest -j 1 -R "^auto_bp_gossip_peering_test$" \
+            --output-on-failure --timeout 2700 \
+            2>&1 | tee "$RUNNER_TEMP/macos-arm64-auto-bp-gossip-peering-ctest.log"
 
       - name: Save CTest cost data
         if: ${{ always() && hashFiles(format('{0}/Testing/Temporary/CTestCostData.txt', env.BUILD_DIR)) != '' }}


### PR DESCRIPTION
## Summary

- Exclude `auto_bp_gossip_peering_test` from the macOS ARM64 sharded NP/LR CTest invocation.
- Run that test in the following workflow step with `ctest -j 1`.

## Root cause

The scheduled macOS job [failed in run 31472683700, job 93719281319](https://github.com/Wire-Network/wire-sysio/actions/runs/31472683700/job/93719281319). It runs the NP/LR suite with three CTest workers, which allowed the 21-node gossip-peering topology test to start concurrently with other integration tests.

## Impact

The test remains part of the scheduled/manual macOS suite, but now has exclusive use of the macOS test host. Other NP/LR tests remain sharded.

## Validation

- Parsed `.github/workflows/macos_arm64_build.yaml` successfully.
- Confirmed `ctest -N -j 1 -R '^auto_bp_gossip_peering_test$'` selects only the intended test.
- Ran `git diff --check`.