### PR TITLE
Test: stop nodeop_forked_chain_test failing on missed slots

### DIFF
--- a/tests/nodeop_forked_chain_test.py
+++ b/tests/nodeop_forked_chain_test.py
@@ -351,7 +351,7 @@ try:
             slotTime=0.5
             slotsDiff=int(timediff.total_seconds() / slotTime)
             if slotsDiff != 1:
-                slotTimeDelta=timedelta(slotTime)
+                slotTimeDelta=timedelta(seconds=slotTime)
                 first=lastTimestamp + slotTimeDelta
                 missed=first.strftime(Utils.TimeFmt)
                 if slotsDiff > 2:

--- a/tests/nodeop_forked_chain_test.py
+++ b/tests/nodeop_forked_chain_test.py
@@ -73,8 +73,13 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
     windowOfSlot=lambda slot: (slot - windowPhase) // windowSize
     cycle=[]
     counts={}
+    # What the censused rotation established, and separately what blocks past it merely suggest.
+    # Kept apart because the two carry different authority: an inferred owner is enough to hold later
+    # blocks to a consistent story, but not to certify that the rotation came round.
     windowToProducer={}
     producerToWindow={}
+    inferredOwner={}
+    inferredPosition={}
     blocksExamined=0
     result={"cycle":cycle, "counts":counts, "silentWindows":[], "wrapProducer":None, "blocksExamined":0, "error":None}
 
@@ -88,7 +93,6 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
     firstWindow=windowOfSlot(slot)
     endWindow=firstWindow + cycleLength   # exclusive, one full rotation
     lastWindow=firstWindow
-    silentPositions=None
 
     while True:
         window=windowOfSlot(slot)
@@ -99,13 +103,12 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
             # modulo the rotation because a silent window can carry the block past the wrap itself,
             # and where the position it lands on was also silent this cycle there is nobody to
             # compare it with and the walk goes on to the next block.
-            if silentPositions is None:
-                # Taken before the walk past the cycle can record an owner for any of them, since
-                # these are the positions the cycle itself never filled and that is what is reported.
-                silentPositions=[position for position in range(cycleLength)
-                                 if firstWindow+position not in windowToProducer]
-
             position=firstWindow + (window - firstWindow) % cycleLength
+
+            # Only an owner the cycle itself established can end the walk. A producer that merely
+            # turned up at a position the cycle never filled has confirmed nothing about the rotation
+            # coming round, so treating its next block as the wrap would leave everything after it
+            # unexamined, including the block that is actually wrong.
             owner=windowToProducer.get(position)
             if owner is not None:
                 if producer != owner:
@@ -117,20 +120,27 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
 
             # Nobody produced at this position during the cycle, so there is no owner to compare
             # against and the walk goes on rather than accepting the block on that alone. Everything
-            # that can be checked without an owner still is: the producer has to be one that was
-            # voted in, and it cannot be one that already owns a different position, since a producer
-            # owns exactly one per rotation. Taking the position here is what makes the next block to
-            # land on it comparable, so a second producer claiming it is caught as well.
+            # that can be checked without one still is: the producer has to be one that was voted in,
+            # and it cannot already hold a different position, since a producer owns exactly one per
+            # rotation. Noting who turned up here is what makes the next block to land on it
+            # comparable, so a second producer claiming the same position is caught as well.
             if producer not in scheduledProducers:
                 return fail("Producer %s, of block %d, was not one of the voted on producers" % (producer, blockNum))
 
-            claimed=producerToWindow.get(producer)
-            if claimed is not None and claimed != position:
-                return fail("Producer %s owns cycle position %d, but also produced block %d at position %d.  "
+            held=producerToWindow.get(producer, inferredPosition.get(producer))
+            if held is not None and held != position:
+                return fail("Producer %s holds cycle position %d, but also produced block %d at position %d.  "
                             "A producer is scheduled at most once per %d producer cycle." %
-                            (producer, claimed-firstWindow, blockNum, position-firstWindow, cycleLength))
-            windowToProducer[position]=producer
-            producerToWindow[producer]=position
+                            (producer, held-firstWindow, blockNum, position-firstWindow, cycleLength))
+
+            claimant=inferredOwner.get(position)
+            if claimant is not None and claimant != producer:
+                return fail("Block %d, at cycle position %d, was produced by %s, but %s already produced there after "
+                            "the cycle.  A position belongs to exactly one producer." %
+                            (blockNum, position-firstWindow, producer, claimant))
+
+            inferredOwner[position]=producer
+            inferredPosition[producer]=position
 
             if window - endWindow >= cycleLength:
                 break
@@ -175,7 +185,8 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
                         "at its start.  Producer runs are not aligned to this window grid." %
                         (precedingProducer, producer, blockNum, (slot - windowPhase) % windowSize, windowSize))
 
-    result["silentWindows"]=silentPositions
+    result["silentWindows"]=[position for position in range(cycleLength)
+                             if firstWindow+position not in windowToProducer]
     result["blocksExamined"]=blocksExamined
     return result
 

--- a/tests/nodeop_forked_chain_test.py
+++ b/tests/nodeop_forked_chain_test.py
@@ -45,18 +45,108 @@ def slotsBetween(earlier, later):
     """Return the number of production slots from one parsed block timestamp to another."""
     return round((later - earlier).total_seconds() / slotTime)
 
-def phasesAllowingRun(firstSlot, lastSlot, windowSize):
-    """Return the window grid phases under which one run of blocks fits inside a single window.
+def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycleLength, scheduledProducers):
+    """Attribute one full rotation of producers to the windows of a single schedule grid.
 
-    A run of consecutive blocks by one producer occupies slots firstSlot..lastSlot and must lie
-    within one window, so the window can begin anywhere from the run's own start back to the point
-    where the run ends on the window's last slot. Each of those starts implies a phase, and the
-    phases common to several runs are the ones the grid can actually have.
+    Each producer owns exactly one contiguous window of windowSize slots, and a slot that goes
+    unproduced leaves a hole inside its window: it never moves a window boundary and it never hands a
+    slot to the next producer.  The cycle is therefore derived from the window each block falls in
+    rather than from runs of consecutive blocks by the same producer.  Runs are only a proxy for the
+    schedule, and a loaded test machine breaks the proxy: a node that stalls past its slot leaves a
+    short run, or no run at all, with nothing wrong with the schedule.  Window boundaries are the
+    property actually under test and they do not move when a block is late.
+
+    getBlock(blockNum) supplies a block as (producer, slot), slots counted from an arbitrary origin.
+    windowPhase says which slots begin a window, modulo windowSize.  The grid the chain is running on
+    is not known ahead of time, so the caller tries each phase in turn: rather than exit on a
+    violation this returns it in "error", leaving the caller to decide whether some other grid
+    explains the same blocks.  "error" is None when this one explains all of them, and the rest of
+    the result then describes the rotation:
+
+      cycle          the producers in the order their windows come round
+      counts         how many blocks each of them signed
+      silentWindows  cycle positions whose producer signed nothing at all
+      blocksExamined how far the walk got, which ranks the grids against each other when they all
+                     fail and the most informative violation has to be picked out
     """
-    length=lastSlot - firstSlot + 1
-    if length > windowSize:
-        return set()
-    return set((firstSlot - offset) % windowSize for offset in range(0, windowSize - length + 1))
+    windowOfSlot=lambda slot: (slot - windowPhase) // windowSize
+    cycle=[]
+    counts={}
+    windowToProducer={}
+    producerToWindow={}
+    blocksExamined=0
+    result={"cycle":cycle, "counts":counts, "silentWindows":[], "blocksExamined":0, "error":None}
+
+    def fail(message):
+        result["blocksExamined"]=blocksExamined
+        result["error"]=message
+        return result
+
+    blockNum=firstBlockNum
+    producer,slot=getBlock(blockNum)
+    firstWindow=windowOfSlot(slot)
+    endWindow=firstWindow + cycleLength   # exclusive, one full rotation
+    lastWindow=firstWindow
+
+    while True:
+        window=windowOfSlot(slot)
+        if window >= endWindow:
+            # This look-ahead block is the first at or past the wrap, and it is checked rather than
+            # discarded: a producer granted a thirteenth consecutive slot would put its own block
+            # here, and only comparing against the producer that owns the window this cycle started
+            # on catches that.
+            if window == endWindow:
+                wrapped=windowToProducer.get(firstWindow)
+                if wrapped is not None and producer != wrapped:
+                    return fail("Block %d opens the next cycle at position %d but was produced by %s, where the cycle "
+                                "began with %s.  A cycle of %d producers must wrap onto the producer it started with." %
+                                (blockNum, window-firstWindow, producer, wrapped, cycleLength))
+            break
+
+        if producer not in scheduledProducers:
+            return fail("Producer %s, of block %d, was not one of the voted on producers" % (producer, blockNum))
+
+        if window < lastWindow:
+            return fail("Block %d, produced by %s, is at cycle position %d, behind position %d of the block before "
+                        "it." % (blockNum, producer, window-firstWindow, lastWindow-firstWindow))
+
+        owner=windowToProducer.get(window)
+        if owner is None:
+            if producer in producerToWindow:
+                return fail("Producer %s owns cycle position %d, but also produced block %d at position %d.  "
+                            "A producer is scheduled at most once per %d producer cycle." %
+                            (producer, producerToWindow[producer]-firstWindow, blockNum, window-firstWindow,
+                             cycleLength))
+            windowToProducer[window]=producer
+            producerToWindow[producer]=window
+            counts[producer]=0
+            cycle.append(producer)
+        elif owner != producer:
+            return fail("Block %d, %d slots into the walk, was produced by %s, but %s already produced at cycle "
+                        "position %d.  A window belongs to exactly one producer." %
+                        (blockNum, slot, producer, owner, window-firstWindow))
+
+        counts[producer]+=1
+        blocksExamined+=1
+        lastWindow=window
+
+        precedingProducer=producer
+        precedingSlot=slot
+        blockNum+=1
+        producer,slot=getBlock(blockNum)
+        if slot-precedingSlot==1 and producer!=precedingProducer and (slot - windowPhase) % windowSize != 0:
+            # A handover into the very next slot can only happen on a window boundary, so this block
+            # has to sit at offset 0 of its window.  Landing anywhere else means this handover and
+            # this grid disagree about where the boundaries are, which is a producer having been
+            # given a run of the wrong length.
+            return fail("Producer handover from %s to %s at block %d landed %d slots into a %d slot window instead of "
+                        "at its start.  Producer runs are not aligned to this window grid." %
+                        (precedingProducer, producer, blockNum, (slot - windowPhase) % windowSize, windowSize))
+
+    result["silentWindows"]=[position for position in range(cycleLength)
+                             if firstWindow+position not in windowToProducer]
+    result["blocksExamined"]=blocksExamined
+    return result
 
 def analyzeBPs(bps0, bps1, expectDivergence):
     start=0
@@ -299,64 +389,55 @@ try:
             self.waitIfNeeded(blockNum)
             return self.node.getBlock(blockNum)
 
-    # Establish the phase of the window grid, meaning which slots begin a producer's run of
-    # inRowCountPerProducer.  Every maximal run of consecutive blocks by one producer has to lie
-    # inside a single window, which constrains where that window can begin, and the phases common to
-    # several runs are the ones the grid can have.  Deriving it this way asks nothing of any
-    # particular handover: waiting for one that is slot adjacent would wait forever on a chain that
-    # misses the last slot of every window, since such a chain keeps advancing and never trips the
-    # block wait either.
-    #
-    # More than one phase can survive, when the missed slots fall in the same place in every window.
-    # That is harmless: under any surviving phase each run still lies in one window and consecutive
-    # runs in consecutive windows, which is all the census below asks of the grid.
     waiter=HeadWaiter(node, stalledChainLeewaySeconds)
     inRowCountPerProducer=12
 
-    block=waiter.getBlock(blockNum)
-    timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
-    timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
+    class BlockReader:
+        """Reads the walked blocks as (producer, slot), fetching each of them exactly once.
 
-    originTimestamp=timestamp
-    candidatePhases=set(range(inRowCountPerProducer))
-    runProducer=blockProducer
-    runFirstSlot=0
-    runLastSlot=0
-    # Runs are what carry information, and a single complete run pins the phase outright, so the
-    # search is bounded by runs rather than blocks. Where runs are short the surviving set stops
-    # shrinking almost immediately and further runs tell us nothing, so a handful is enough; bounding
-    # it at all is what stops a chain that never yields a usable run from spinning forever.
-    runsToExamine=3
-    runsExamined=0
+        The census is replayed against one candidate window grid after another, so the same blocks
+        are read several times over and holding them is what keeps that from costing a refetch.  It
+        is also where the missed slots are recorded, since a walk that gets repeated is no place to
+        count anything.  Slots are counted from the block the walk begins on: the grid is anchored to
+        an observed block rather than to an absolute slot number, so the chain's timestamp epoch
+        never enters into it.
+        """
+        def __init__(self, waiter, firstBlockNum):
+            self.waiter=waiter
+            self.nextBlockNum=firstBlockNum
+            self.blocks={}
+            self.missedSlotAfter=[]
+            self.originTimestamp=None
+            self.lastTimestamp=None
 
-    while len(candidatePhases) > 1 and runsExamined < runsToExamine:
-        blockNum+=1
-        block=waiter.getBlock(blockNum)
-        blockProducer=Node.getBlockAttribute(block, "producer", blockNum)
-        timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
-        timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
-        slot=slotsBetween(originTimestamp, timestamp)
+        def get(self, blockNum):
+            entry=self.blocks.get(blockNum)
+            if entry is not None:
+                return entry
+            if blockNum != self.nextBlockNum:
+                Utils.errorExit("Block %d was read before block %d, but the walk only ever moves forward." %
+                                (blockNum, self.nextBlockNum))
+            block=self.waiter.getBlock(blockNum)
+            producer=Node.getBlockAttribute(block, "producer", blockNum)
+            timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
+            timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
+            if self.originTimestamp is None:
+                self.originTimestamp=timestamp
+            else:
+                slotsDiff=slotsBetween(self.lastTimestamp, timestamp)
+                if slotsDiff != 1:
+                    slotTimeDelta=timedelta(seconds=slotTime)
+                    missed=(self.lastTimestamp + slotTimeDelta).strftime(Utils.TimeFmt)
+                    if slotsDiff > 2:
+                        missed+= " thru " + (timestamp - slotTimeDelta).strftime(Utils.TimeFmt)
+                    self.missedSlotAfter.append("%d (%s)" % (blockNum-1, missed))
+            self.lastTimestamp=timestamp
+            entry=(producer, slotsBetween(self.originTimestamp, timestamp))
+            self.blocks[blockNum]=entry
+            self.nextBlockNum=blockNum+1
+            return entry
 
-        if blockProducer==runProducer:
-            runLastSlot=slot
-            continue
-
-        allowed=phasesAllowingRun(runFirstSlot, runLastSlot, inRowCountPerProducer)
-        candidatePhases &= allowed
-        if len(candidatePhases)==0:
-            Utils.errorExit("Producer %s held slots %d through %d, which no %d slot window can contain, so the "
-                            "producer schedule is not running in windows of %d." %
-                            (runProducer, runFirstSlot, runLastSlot, inRowCountPerProducer, inRowCountPerProducer))
-        runsExamined+=1
-        runProducer=blockProducer
-        runFirstSlot=slot
-        runLastSlot=slot
-
-    if len(candidatePhases) > 1:
-        Print("NOTE: the window grid phase is still ambiguous after %d producer runs, %s all fit them.  "
-              "Each describes the same windows for these blocks, so the census uses the lowest." %
-              (runsExamined, sorted(candidatePhases)))
-    windowPhase=min(candidatePhases)
+    reader=BlockReader(waiter, blockNum)
 
     shipNode = cluster.getNode(0)
     block_range = 1000
@@ -390,113 +471,51 @@ try:
 
     # ***   Identify what the production cycle is   ***
 
-    # Each producer owns exactly one contiguous window of inRowCountPerProducer slots, and a slot
-    # that goes unproduced leaves a hole inside its window: it never moves a window boundary and it
-    # never hands a slot to the next producer.  The cycle is therefore derived from the window each
-    # block falls in rather than from runs of consecutive blocks by the same producer.  Runs are only
-    # a proxy for the schedule, and a loaded test machine breaks the proxy: a node that stalls past
-    # its slot leaves a short run, or no run at all, with nothing wrong with the schedule.  Window
-    # boundaries are the property actually under test and they do not move when a block is late.
+    # Which slots begin a producer's window is not known ahead of time, so the walk is run against
+    # each of the inRowCountPerProducer grids in turn and the first that explains every block is the
+    # one the chain is running on.  Deriving a single grid up front instead, from how the earliest
+    # runs of consecutive blocks sit, does not work: it asks the same question the walk itself asks,
+    # only of fewer blocks, so the answer can be ambiguous and committing to one of the survivors
+    # rejects chains the surviving alternative accepts.  It also has nowhere to stop, since a
+    # producer that never yields leaves the run count standing still while the chain advances happily
+    # underneath it.
     #
-    # Windows are numbered off the grid phase derived above.
-    productionCycle=[]
-    producerToWindow={}
-    windowToProducer={}
-    missedSlotAfter=[]
-    headBlockNum=node.getBlockNum()
-
-    windowOfSlot=lambda s: (s - windowPhase) // inRowCountPerProducer
-    firstWindow=windowOfSlot(slotsBetween(originTimestamp, timestamp))
-    endWindow=firstWindow + maxActiveProducers   # exclusive, one full rotation
-    lastTimestamp=timestamp
-    lastWindow=firstWindow
-
-    while True:
-        slotFromOrigin=slotsBetween(originTimestamp, timestamp)
-        window=windowOfSlot(slotFromOrigin)
-        if window >= endWindow:
-            # This look-ahead block is the first at or past the wrap, and it is checked rather than
-            # discarded: a producer granted a thirteenth consecutive slot would put its own block
-            # here, and only comparing against the producer that owns the window this cycle started
-            # on catches that.
-            if window == endWindow:
-                wrapped=windowToProducer.get(firstWindow)
-                if wrapped is not None and blockProducer != wrapped:
-                    Utils.errorExit("Block %d opens the next cycle in schedule window %d but was produced by %s, "
-                                    "where the cycle began with %s.  A cycle of %d producers must wrap onto the "
-                                    "producer it started with." %
-                                    (blockNum, window, blockProducer, wrapped, maxActiveProducers))
+    # Grids the chain is not running on are rejected almost immediately: a producer's run straddles
+    # their boundaries and it ends up owning two windows, which the walk refuses.
+    census=None
+    failedCensuses=[]
+    for windowPhase in range(inRowCountPerProducer):
+        attempt=censusProductionCycle(reader.get, blockNum, windowPhase, inRowCountPerProducer,
+                                      maxActiveProducers, producers)
+        if attempt["error"] is None:
+            census=attempt
             break
+        failedCensuses.append(attempt)
 
-        if blockProducer not in producers:
-            Utils.errorExit("Producer %s, of block %d, was not one of the voted on producers" % (blockProducer, blockNum))
-
-        if window < lastWindow:
-            Utils.errorExit("Block %d, produced by %s, is in schedule window %d, behind window %d of the block before it." %
-                            (blockNum, blockProducer, window, lastWindow))
-
-        owner=windowToProducer.get(window)
-        if owner is None:
-            if blockProducer in producerToWindow:
-                Utils.errorExit("Producer %s owns schedule window %d, but also produced block %d in window %d.  "
-                                "A producer is scheduled at most once per %d producer cycle." %
-                                (blockProducer, producerToWindow[blockProducer]["window"], blockNum, window, maxActiveProducers))
-            windowToProducer[window]=blockProducer
-            producerToWindow[blockProducer]={"window":window, "count":0}
-            productionCycle.append(blockProducer)
-        elif owner != blockProducer:
-            Utils.errorExit("Block %d, %d slots into the cycle, was produced by %s, but %s already produced in schedule window %d.  "
-                            "A window belongs to exactly one producer." %
-                            (blockNum, slotFromOrigin, blockProducer, owner, window))
-
-        producerToWindow[blockProducer]["count"]+=1
-        lastWindow=window
-
-        precedingProducer=blockProducer
-        blockNum+=1
-        block=waiter.getBlock(blockNum)
-        blockProducer=Node.getBlockAttribute(block, "producer", blockNum)
-        timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
-        timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
-        slotsDiff=slotsBetween(lastTimestamp, timestamp)
-        offsetInWindow=(slotsBetween(originTimestamp, timestamp) - windowPhase) % inRowCountPerProducer
-        if slotsDiff==1 and blockProducer!=precedingProducer and offsetInWindow != 0:
-            # A handover into the very next slot can only happen on a window boundary, so this block
-            # has to sit at offset 0 of its window.  Landing anywhere else means this handover and
-            # the derived grid disagree about where the boundaries are, which is a producer having
-            # been given a run of the wrong length.
-            Utils.errorExit("Producer handover from %s to %s at block %d landed %d slots into a %d slot window instead of at its start.  "
-                            "Producer runs are not aligned to a single window grid." %
-                            (precedingProducer, blockProducer, blockNum, offsetInWindow, inRowCountPerProducer))
-        if slotsDiff != 1:
-            slotTimeDelta=timedelta(seconds=slotTime)
-            first=lastTimestamp + slotTimeDelta
-            missed=first.strftime(Utils.TimeFmt)
-            if slotsDiff > 2:
-                last=timestamp - slotTimeDelta
-                missed+= " thru " + last.strftime(Utils.TimeFmt)
-            missedSlotAfter.append("%d (%s)" % (blockNum-1, missed))
-        lastTimestamp=timestamp
+    if census is None:
+        # Every grid failed, so the schedule really is not running in windows of this size.  The one
+        # that got furthest is the chain's own grid, and so the one whose complaint describes what is
+        # actually wrong.
+        furthest=max(failedCensuses, key=lambda attempt: attempt["blocksExamined"])
+        Utils.errorExit("No grid of %d slot windows accounts for the blocks produced over a full cycle, so the "
+                        "producer schedule is not running in windows of %d.  The grid that accounted for the most "
+                        "blocks, %d of them, reports: %s" %
+                        (inRowCountPerProducer, inRowCountPerProducer, furthest["blocksExamined"], furthest["error"]))
 
     # Unproduced slots are a liveness property of the machine the test is running on, not of the
     # schedule, and the schedule was verified window by window above.  Report them, do not fail on
     # them.
-    if len(missedSlotAfter) > 0:
-        Print("WARNING: slots went unproduced after the following blocks: %s" % (", ".join(missedSlotAfter)))
+    if len(reader.missedSlotAfter) > 0:
+        Print("WARNING: slots went unproduced after the following blocks: %s" % (", ".join(reader.missedSlotAfter)))
 
-    silentWindows=[window for window in range(firstWindow, endWindow) if window not in windowToProducer]
-    if len(silentWindows) > 0:
+    if len(census["silentWindows"]) > 0:
         Print("WARNING: %d of the %d producers in the cycle produced no block in their window, at cycle positions: %s" %
-              (len(silentWindows), maxActiveProducers, ", ".join(str(window - firstWindow) for window in silentWindows)))
+              (len(census["silentWindows"]), maxActiveProducers,
+               ", ".join(str(position) for position in census["silentWindows"])))
 
-    output=None
-    for blockProducer in productionCycle:
-        if output is None:
-            output=""
-        else:
-            output+=", "
-        output+=blockProducer+":"+str(producerToWindow[blockProducer]["count"])
-    Print("ProductionCycle ->> {\n%s\n}" % output)
+    productionCycle=census["cycle"]
+    Print("ProductionCycle ->> {\n%s\n}" %
+          (", ".join(blockProducer+":"+str(census["counts"][blockProducer]) for blockProducer in productionCycle)))
 
     #retrieve the info for all the nodes to report the status for each
     for node in cluster.getNodes():

--- a/tests/nodeop_forked_chain_test.py
+++ b/tests/nodeop_forked_chain_test.py
@@ -66,6 +66,7 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
       cycle          the producers in the order their windows come round
       counts         how many blocks each of them signed
       silentWindows  cycle positions whose producer signed nothing at all
+      wrapProducer   the producer checked at the wrap, or None if none could be
       blocksExamined how far the walk got, which ranks the grids against each other when they all
                      fail and the most informative violation has to be picked out
     """
@@ -75,7 +76,7 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
     windowToProducer={}
     producerToWindow={}
     blocksExamined=0
-    result={"cycle":cycle, "counts":counts, "silentWindows":[], "blocksExamined":0, "error":None}
+    result={"cycle":cycle, "counts":counts, "silentWindows":[], "wrapProducer":None, "blocksExamined":0, "error":None}
 
     def fail(message):
         result["blocksExamined"]=blocksExamined
@@ -91,44 +92,49 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
     while True:
         window=windowOfSlot(slot)
         if window >= endWindow:
-            # This look-ahead block is the first at or past the wrap, and it is checked rather than
-            # discarded: a producer granted a thirteenth consecutive slot would put its own block
-            # here, and only comparing against the producer that owns the window this cycle started
-            # on catches that.
-            if window == endWindow:
-                wrapped=windowToProducer.get(firstWindow)
-                if wrapped is not None and producer != wrapped:
-                    return fail("Block %d opens the next cycle at position %d but was produced by %s, where the cycle "
-                                "began with %s.  A cycle of %d producers must wrap onto the producer it started with." %
-                                (blockNum, window-firstWindow, producer, wrapped, cycleLength))
-            break
+            # The first block past the cycle is checked rather than discarded: a producer granted a
+            # thirteenth consecutive slot puts its own block here, and only comparing it against the
+            # producer that owns this position in the rotation catches that.  The comparison is made
+            # modulo the rotation because a silent window can carry the block past the wrap itself,
+            # and where the position it lands on was also silent this cycle there is nobody to
+            # compare it with and the walk goes on to the next block.
+            owner=windowToProducer.get(firstWindow + (window - firstWindow) % cycleLength)
+            if owner is not None:
+                if producer != owner:
+                    return fail("Block %d, at cycle position %d, was produced by %s where %s owns that position in the "
+                                "rotation.  A cycle of %d producers must come round to the producers it started with." %
+                                (blockNum, window-firstWindow, producer, owner, cycleLength))
+                result["wrapProducer"]=owner
+                break
+            if window - endWindow >= cycleLength:
+                break
+        else:
+            if producer not in scheduledProducers:
+                return fail("Producer %s, of block %d, was not one of the voted on producers" % (producer, blockNum))
 
-        if producer not in scheduledProducers:
-            return fail("Producer %s, of block %d, was not one of the voted on producers" % (producer, blockNum))
+            if window < lastWindow:
+                return fail("Block %d, produced by %s, is at cycle position %d, behind position %d of the block before "
+                            "it." % (blockNum, producer, window-firstWindow, lastWindow-firstWindow))
 
-        if window < lastWindow:
-            return fail("Block %d, produced by %s, is at cycle position %d, behind position %d of the block before "
-                        "it." % (blockNum, producer, window-firstWindow, lastWindow-firstWindow))
+            owner=windowToProducer.get(window)
+            if owner is None:
+                if producer in producerToWindow:
+                    return fail("Producer %s owns cycle position %d, but also produced block %d at position %d.  "
+                                "A producer is scheduled at most once per %d producer cycle." %
+                                (producer, producerToWindow[producer]-firstWindow, blockNum, window-firstWindow,
+                                 cycleLength))
+                windowToProducer[window]=producer
+                producerToWindow[producer]=window
+                counts[producer]=0
+                cycle.append(producer)
+            elif owner != producer:
+                return fail("Block %d, %d slots into the walk, was produced by %s, but %s already produced at cycle "
+                            "position %d.  A window belongs to exactly one producer." %
+                            (blockNum, slot, producer, owner, window-firstWindow))
 
-        owner=windowToProducer.get(window)
-        if owner is None:
-            if producer in producerToWindow:
-                return fail("Producer %s owns cycle position %d, but also produced block %d at position %d.  "
-                            "A producer is scheduled at most once per %d producer cycle." %
-                            (producer, producerToWindow[producer]-firstWindow, blockNum, window-firstWindow,
-                             cycleLength))
-            windowToProducer[window]=producer
-            producerToWindow[producer]=window
-            counts[producer]=0
-            cycle.append(producer)
-        elif owner != producer:
-            return fail("Block %d, %d slots into the walk, was produced by %s, but %s already produced at cycle "
-                        "position %d.  A window belongs to exactly one producer." %
-                        (blockNum, slot, producer, owner, window-firstWindow))
-
-        counts[producer]+=1
-        blocksExamined+=1
-        lastWindow=window
+            counts[producer]+=1
+            blocksExamined+=1
+            lastWindow=window
 
         precedingProducer=producer
         precedingSlot=slot
@@ -512,6 +518,10 @@ try:
         Print("WARNING: %d of the %d producers in the cycle produced no block in their window, at cycle positions: %s" %
               (len(census["silentWindows"]), maxActiveProducers,
                ", ".join(str(position) for position in census["silentWindows"])))
+
+    if census["wrapProducer"] is None:
+        Print("WARNING: the producers that followed the cycle all fell in windows that went silent during it, so the "
+              "cycle could not be checked for coming round to the producers it started with.")
 
     productionCycle=census["cycle"]
     Print("ProductionCycle ->> {\n%s\n}" %

--- a/tests/nodeop_forked_chain_test.py
+++ b/tests/nodeop_forked_chain_test.py
@@ -88,6 +88,7 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
     firstWindow=windowOfSlot(slot)
     endWindow=firstWindow + cycleLength   # exclusive, one full rotation
     lastWindow=firstWindow
+    silentPositions=None
 
     while True:
         window=windowOfSlot(slot)
@@ -98,7 +99,14 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
             # modulo the rotation because a silent window can carry the block past the wrap itself,
             # and where the position it lands on was also silent this cycle there is nobody to
             # compare it with and the walk goes on to the next block.
-            owner=windowToProducer.get(firstWindow + (window - firstWindow) % cycleLength)
+            if silentPositions is None:
+                # Taken before the walk past the cycle can record an owner for any of them, since
+                # these are the positions the cycle itself never filled and that is what is reported.
+                silentPositions=[position for position in range(cycleLength)
+                                 if firstWindow+position not in windowToProducer]
+
+            position=firstWindow + (window - firstWindow) % cycleLength
+            owner=windowToProducer.get(position)
             if owner is not None:
                 if producer != owner:
                     return fail("Block %d, at cycle position %d, was produced by %s where %s owns that position in the "
@@ -106,6 +114,24 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
                                 (blockNum, window-firstWindow, producer, owner, cycleLength))
                 result["wrapProducer"]=owner
                 break
+
+            # Nobody produced at this position during the cycle, so there is no owner to compare
+            # against and the walk goes on rather than accepting the block on that alone. Everything
+            # that can be checked without an owner still is: the producer has to be one that was
+            # voted in, and it cannot be one that already owns a different position, since a producer
+            # owns exactly one per rotation. Taking the position here is what makes the next block to
+            # land on it comparable, so a second producer claiming it is caught as well.
+            if producer not in scheduledProducers:
+                return fail("Producer %s, of block %d, was not one of the voted on producers" % (producer, blockNum))
+
+            claimed=producerToWindow.get(producer)
+            if claimed is not None and claimed != position:
+                return fail("Producer %s owns cycle position %d, but also produced block %d at position %d.  "
+                            "A producer is scheduled at most once per %d producer cycle." %
+                            (producer, claimed-firstWindow, blockNum, position-firstWindow, cycleLength))
+            windowToProducer[position]=producer
+            producerToWindow[producer]=position
+
             if window - endWindow >= cycleLength:
                 break
         else:
@@ -149,8 +175,7 @@ def censusProductionCycle(getBlock, firstBlockNum, windowPhase, windowSize, cycl
                         "at its start.  Producer runs are not aligned to this window grid." %
                         (precedingProducer, producer, blockNum, (slot - windowPhase) % windowSize, windowSize))
 
-    result["silentWindows"]=[position for position in range(cycleLength)
-                             if firstWindow+position not in windowToProducer]
+    result["silentWindows"]=silentPositions
     result["blocksExamined"]=blocksExamined
     return result
 

--- a/tests/nodeop_forked_chain_test.py
+++ b/tests/nodeop_forked_chain_test.py
@@ -45,6 +45,19 @@ def slotsBetween(earlier, later):
     """Return the number of production slots from one parsed block timestamp to another."""
     return round((later - earlier).total_seconds() / slotTime)
 
+def phasesAllowingRun(firstSlot, lastSlot, windowSize):
+    """Return the window grid phases under which one run of blocks fits inside a single window.
+
+    A run of consecutive blocks by one producer occupies slots firstSlot..lastSlot and must lie
+    within one window, so the window can begin anywhere from the run's own start back to the point
+    where the run ends on the window's last slot. Each of those starts implies a phase, and the
+    phases common to several runs are the ones the grid can actually have.
+    """
+    length=lastSlot - firstSlot + 1
+    if length > windowSize:
+        return set()
+    return set((firstSlot - offset) % windowSize for offset in range(0, windowSize - length + 1))
+
 def analyzeBPs(bps0, bps1, expectDivergence):
     start=0
     index=None
@@ -286,30 +299,64 @@ try:
             self.waitIfNeeded(blockNum)
             return self.node.getBlock(blockNum)
 
-    # Advance to the first block of a producer's window.  A producer owns a contiguous run of
-    # inRowCountPerProducer slots, so a handover into the immediately following slot can only happen
-    # on a window boundary: such a block is at offset 0 of its window and anchors the window grid for
-    # everything below, without this test needing to know the chain's block timestamp epoch.  A
-    # handover that is not slot adjacent means the boundary slot itself went unproduced, which says
-    # nothing about where the boundary was, so keep looking in that case.
+    # Establish the phase of the window grid, meaning which slots begin a producer's run of
+    # inRowCountPerProducer.  Every maximal run of consecutive blocks by one producer has to lie
+    # inside a single window, which constrains where that window can begin, and the phases common to
+    # several runs are the ones the grid can have.  Deriving it this way asks nothing of any
+    # particular handover: waiting for one that is slot adjacent would wait forever on a chain that
+    # misses the last slot of every window, since such a chain keeps advancing and never trips the
+    # block wait either.
+    #
+    # More than one phase can survive, when the missed slots fall in the same place in every window.
+    # That is harmless: under any surviving phase each run still lies in one window and consecutive
+    # runs in consecutive windows, which is all the census below asks of the grid.
     waiter=HeadWaiter(node, stalledChainLeewaySeconds)
+    inRowCountPerProducer=12
 
     block=waiter.getBlock(blockNum)
     timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
     timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
 
-    windowAnchorTimestamp=None
-    while windowAnchorTimestamp is None:
-        lastBlockProducer=blockProducer
-        lastTimestamp=timestamp
+    originTimestamp=timestamp
+    candidatePhases=set(range(inRowCountPerProducer))
+    runProducer=blockProducer
+    runFirstSlot=0
+    runLastSlot=0
+    # Runs are what carry information, and a single complete run pins the phase outright, so the
+    # search is bounded by runs rather than blocks. Where runs are short the surviving set stops
+    # shrinking almost immediately and further runs tell us nothing, so a handful is enough; bounding
+    # it at all is what stops a chain that never yields a usable run from spinning forever.
+    runsToExamine=3
+    runsExamined=0
+
+    while len(candidatePhases) > 1 and runsExamined < runsToExamine:
         blockNum+=1
         block=waiter.getBlock(blockNum)
-        Utils.Print("Block num: %d, block: %s" % (blockNum, json.dumps(block, indent=4, sort_keys=True)))
         blockProducer=Node.getBlockAttribute(block, "producer", blockNum)
         timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
         timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
-        if blockProducer!=lastBlockProducer and slotsBetween(lastTimestamp, timestamp)==1:
-            windowAnchorTimestamp=timestamp
+        slot=slotsBetween(originTimestamp, timestamp)
+
+        if blockProducer==runProducer:
+            runLastSlot=slot
+            continue
+
+        allowed=phasesAllowingRun(runFirstSlot, runLastSlot, inRowCountPerProducer)
+        candidatePhases &= allowed
+        if len(candidatePhases)==0:
+            Utils.errorExit("Producer %s held slots %d through %d, which no %d slot window can contain, so the "
+                            "producer schedule is not running in windows of %d." %
+                            (runProducer, runFirstSlot, runLastSlot, inRowCountPerProducer, inRowCountPerProducer))
+        runsExamined+=1
+        runProducer=blockProducer
+        runFirstSlot=slot
+        runLastSlot=slot
+
+    if len(candidatePhases) > 1:
+        Print("NOTE: the window grid phase is still ambiguous after %d producer runs, %s all fit them.  "
+              "Each describes the same windows for these blocks, so the census uses the lowest." %
+              (runsExamined, sorted(candidatePhases)))
+    windowPhase=min(candidatePhases)
 
     shipNode = cluster.getNode(0)
     block_range = 1000
@@ -351,22 +398,34 @@ try:
     # its slot leaves a short run, or no run at all, with nothing wrong with the schedule.  Window
     # boundaries are the property actually under test and they do not move when a block is late.
     #
-    # Windows are counted from windowAnchorTimestamp, a block known to sit at offset 0 of its window.
+    # Windows are numbered off the grid phase derived above.
     productionCycle=[]
     producerToWindow={}
     windowToProducer={}
     missedSlotAfter=[]
-    inRowCountPerProducer=12
     headBlockNum=node.getBlockNum()
 
-    endWindow=maxActiveProducers   # exclusive, one full rotation from the anchor
+    windowOfSlot=lambda s: (s - windowPhase) // inRowCountPerProducer
+    firstWindow=windowOfSlot(slotsBetween(originTimestamp, timestamp))
+    endWindow=firstWindow + maxActiveProducers   # exclusive, one full rotation
     lastTimestamp=timestamp
-    lastWindow=0
+    lastWindow=firstWindow
 
     while True:
-        slotsFromAnchor=slotsBetween(windowAnchorTimestamp, timestamp)
-        window=slotsFromAnchor // inRowCountPerProducer
+        slotFromOrigin=slotsBetween(originTimestamp, timestamp)
+        window=windowOfSlot(slotFromOrigin)
         if window >= endWindow:
+            # This look-ahead block is the first at or past the wrap, and it is checked rather than
+            # discarded: a producer granted a thirteenth consecutive slot would put its own block
+            # here, and only comparing against the producer that owns the window this cycle started
+            # on catches that.
+            if window == endWindow:
+                wrapped=windowToProducer.get(firstWindow)
+                if wrapped is not None and blockProducer != wrapped:
+                    Utils.errorExit("Block %d opens the next cycle in schedule window %d but was produced by %s, "
+                                    "where the cycle began with %s.  A cycle of %d producers must wrap onto the "
+                                    "producer it started with." %
+                                    (blockNum, window, blockProducer, wrapped, maxActiveProducers))
             break
 
         if blockProducer not in producers:
@@ -388,7 +447,7 @@ try:
         elif owner != blockProducer:
             Utils.errorExit("Block %d, %d slots into the cycle, was produced by %s, but %s already produced in schedule window %d.  "
                             "A window belongs to exactly one producer." %
-                            (blockNum, slotsFromAnchor, blockProducer, owner, window))
+                            (blockNum, slotFromOrigin, blockProducer, owner, window))
 
         producerToWindow[blockProducer]["count"]+=1
         lastWindow=window
@@ -400,15 +459,15 @@ try:
         timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
         timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
         slotsDiff=slotsBetween(lastTimestamp, timestamp)
-        if slotsDiff==1 and blockProducer!=precedingProducer and slotsBetween(windowAnchorTimestamp, timestamp) % inRowCountPerProducer != 0:
+        offsetInWindow=(slotsBetween(originTimestamp, timestamp) - windowPhase) % inRowCountPerProducer
+        if slotsDiff==1 and blockProducer!=precedingProducer and offsetInWindow != 0:
             # A handover into the very next slot can only happen on a window boundary, so this block
             # has to sit at offset 0 of its window.  Landing anywhere else means this handover and
-            # the anchor disagree about where the boundaries are, which is a producer having been
-            # given a run of the wrong length.
+            # the derived grid disagree about where the boundaries are, which is a producer having
+            # been given a run of the wrong length.
             Utils.errorExit("Producer handover from %s to %s at block %d landed %d slots into a %d slot window instead of at its start.  "
                             "Producer runs are not aligned to a single window grid." %
-                            (precedingProducer, blockProducer, blockNum,
-                             slotsBetween(windowAnchorTimestamp, timestamp) % inRowCountPerProducer, inRowCountPerProducer))
+                            (precedingProducer, blockProducer, blockNum, offsetInWindow, inRowCountPerProducer))
         if slotsDiff != 1:
             slotTimeDelta=timedelta(seconds=slotTime)
             first=lastTimestamp + slotTimeDelta
@@ -425,10 +484,10 @@ try:
     if len(missedSlotAfter) > 0:
         Print("WARNING: slots went unproduced after the following blocks: %s" % (", ".join(missedSlotAfter)))
 
-    silentWindows=[window for window in range(0, endWindow) if window not in windowToProducer]
+    silentWindows=[window for window in range(firstWindow, endWindow) if window not in windowToProducer]
     if len(silentWindows) > 0:
         Print("WARNING: %d of the %d producers in the cycle produced no block in their window, at cycle positions: %s" %
-              (len(silentWindows), maxActiveProducers, ", ".join(str(window) for window in silentWindows)))
+              (len(silentWindows), maxActiveProducers, ", ".join(str(window - firstWindow) for window in silentWindows)))
 
     output=None
     for blockProducer in productionCycle:

--- a/tests/nodeop_forked_chain_test.py
+++ b/tests/nodeop_forked_chain_test.py
@@ -256,9 +256,18 @@ try:
     Print("Validating blockNum=%s, producer=%s" % (blockNum, blockProducer))
     cluster.biosNode.kill(signal.SIGTERM)
 
+    # Every slot that goes unproduced pushes the next block a further slotTime out in wall clock, and
+    # the walk below is deliberately tolerant of missed slots, so the wait for each block has to
+    # outlast a stall rather than abort on it.  The original three second leeway is shorter than
+    # stalls that have actually been seen on loaded CI machines, so when caught up to the head this
+    # gave the walk four seconds and it aborted before the gap it is now meant to record.  The leeway
+    # is what bounds how long the chain may go dark before the test declares it dead.
+    stalledChainLeewaySeconds=60
+
     class HeadWaiter:
-        def __init__(self, node):
+        def __init__(self, node, leewaySeconds):
             self.node=node
+            self.leewaySeconds=leewaySeconds
             self.cachedHeadBlockNum=node.getBlockNum()
 
         def waitIfNeeded(self, blockNum):
@@ -267,7 +276,7 @@ try:
                 return
             previousHeadBlockNum=self.cachedHeadBlockNum
             delta=-1*delta
-            timeout=(delta+1)/2 + 3 # round up to nearest second and 3 second extra leeway
+            timeout=(delta+1)/2 + self.leewaySeconds # round up to nearest second, plus the stall leeway
             self.node.waitForBlock(blockNum, timeout=timeout)
             self.cachedHeadBlockNum=node.getBlockNum()
             if blockNum > self.cachedHeadBlockNum:
@@ -283,7 +292,7 @@ try:
     # everything below, without this test needing to know the chain's block timestamp epoch.  A
     # handover that is not slot adjacent means the boundary slot itself went unproduced, which says
     # nothing about where the boundary was, so keep looking in that case.
-    waiter=HeadWaiter(node)
+    waiter=HeadWaiter(node, stalledChainLeewaySeconds)
 
     block=waiter.getBlock(blockNum)
     timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)

--- a/tests/nodeop_forked_chain_test.py
+++ b/tests/nodeop_forked_chain_test.py
@@ -36,6 +36,15 @@ from TestHarness.TestHelper import AppArgs
 
 Print=Utils.Print
 
+# Block timestamps advance one production slot at a time, so the gap between two of them is a whole
+# number of slots.  Only the slot interval is needed here; the chain's timestamp epoch is not, since
+# the schedule grid is anchored to an observed block rather than to an absolute slot number.
+slotTime=0.5
+
+def slotsBetween(earlier, later):
+    """Return the number of production slots from one parsed block timestamp to another."""
+    return round((later - earlier).total_seconds() / slotTime)
+
 def analyzeBPs(bps0, bps1, expectDivergence):
     start=0
     index=None
@@ -268,19 +277,30 @@ try:
             self.waitIfNeeded(blockNum)
             return self.node.getBlock(blockNum)
 
-    #advance to the next block of 12
-    lastBlockProducer=blockProducer
-
+    # Advance to the first block of a producer's window.  A producer owns a contiguous run of
+    # inRowCountPerProducer slots, so a handover into the immediately following slot can only happen
+    # on a window boundary: such a block is at offset 0 of its window and anchors the window grid for
+    # everything below, without this test needing to know the chain's block timestamp epoch.  A
+    # handover that is not slot adjacent means the boundary slot itself went unproduced, which says
+    # nothing about where the boundary was, so keep looking in that case.
     waiter=HeadWaiter(node)
 
-    while blockProducer==lastBlockProducer:
+    block=waiter.getBlock(blockNum)
+    timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
+    timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
+
+    windowAnchorTimestamp=None
+    while windowAnchorTimestamp is None:
+        lastBlockProducer=blockProducer
+        lastTimestamp=timestamp
         blockNum+=1
         block=waiter.getBlock(blockNum)
         Utils.Print("Block num: %d, block: %s" % (blockNum, json.dumps(block, indent=4, sort_keys=True)))
         blockProducer=Node.getBlockAttribute(block, "producer", blockNum)
-
-    timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
-    timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
+        timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
+        timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
+        if blockProducer!=lastBlockProducer and slotsBetween(lastTimestamp, timestamp)==1:
+            windowAnchorTimestamp=timestamp
 
     shipNode = cluster.getNode(0)
     block_range = 1000
@@ -314,65 +334,92 @@ try:
 
     # ***   Identify what the production cycle is   ***
 
+    # Each producer owns exactly one contiguous window of inRowCountPerProducer slots, and a slot
+    # that goes unproduced leaves a hole inside its window: it never moves a window boundary and it
+    # never hands a slot to the next producer.  The cycle is therefore derived from the window each
+    # block falls in rather than from runs of consecutive blocks by the same producer.  Runs are only
+    # a proxy for the schedule, and a loaded test machine breaks the proxy: a node that stalls past
+    # its slot leaves a short run, or no run at all, with nothing wrong with the schedule.  Window
+    # boundaries are the property actually under test and they do not move when a block is late.
+    #
+    # Windows are counted from windowAnchorTimestamp, a block known to sit at offset 0 of its window.
     productionCycle=[]
-    producerToSlot={}
-    slot=-1
+    producerToWindow={}
+    windowToProducer={}
+    missedSlotAfter=[]
     inRowCountPerProducer=12
-    minNumBlocksPerProducer=10
-    lastTimestamp=timestamp
     headBlockNum=node.getBlockNum()
-    firstBlockForWindowMissedSlot=None
+
+    endWindow=maxActiveProducers   # exclusive, one full rotation from the anchor
+    lastTimestamp=timestamp
+    lastWindow=0
+
     while True:
-        if blockProducer not in producers:
-            Utils.errorExit("Producer %s was not one of the voted on producers" % blockProducer)
-
-        productionCycle.append(blockProducer)
-        slot+=1
-        if blockProducer in producerToSlot:
-            Utils.errorExit("Producer %s was first seen in slot %d, but is repeated in slot %d" % (blockProducer, producerToSlot[blockProducer], slot))
-
-        producerToSlot[blockProducer]={"slot":slot, "count":0}
-        lastBlockProducer=blockProducer
-        blockSkip=[]
-        roundSkips=0
-        missedSlotAfter=[]
-        if firstBlockForWindowMissedSlot is not None:
-            missedSlotAfter.append(firstBlockForWindowMissedSlot)
-            firstBlockForWindowMissedSlot=None
-
-        while blockProducer==lastBlockProducer:
-            producerToSlot[blockProducer]["count"]+=1
-            blockNum+=1
-            block=waiter.getBlock(blockNum)
-            blockProducer=Node.getBlockAttribute(block, "producer", blockNum)
-            timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
-            timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
-            timediff=timestamp-lastTimestamp
-            slotTime=0.5
-            slotsDiff=int(timediff.total_seconds() / slotTime)
-            if slotsDiff != 1:
-                slotTimeDelta=timedelta(seconds=slotTime)
-                first=lastTimestamp + slotTimeDelta
-                missed=first.strftime(Utils.TimeFmt)
-                if slotsDiff > 2:
-                    last=timestamp - slotTimeDelta
-                    missed+= " thru " + last.strftime(Utils.TimeFmt)
-                missedSlotAfter.append("%d (%s)" % (blockNum-1, missed))
-            lastTimestamp=timestamp
-
-        if producerToSlot[lastBlockProducer]["count"] < minNumBlocksPerProducer or producerToSlot[lastBlockProducer]["count"] > inRowCountPerProducer:
-            Utils.errorExit("Producer %s, in slot %d, expected to produce %d blocks but produced %d blocks.  At block number %d. " %
-                            (lastBlockProducer, slot, inRowCountPerProducer, producerToSlot[lastBlockProducer]["count"], blockNum-1) +
-                            "Slots were missed after the following blocks: %s" % (", ".join(missedSlotAfter)))
-
-        if len(missedSlotAfter) > 0:
-            # it may be the most recent producer missed a slot
-            possibleMissed=missedSlotAfter[-1]
-            if possibleMissed == blockNum - 1:
-                firstBlockForWindowMissedSlot=possibleMissed
-
-        if blockProducer==productionCycle[0]:
+        slotsFromAnchor=slotsBetween(windowAnchorTimestamp, timestamp)
+        window=slotsFromAnchor // inRowCountPerProducer
+        if window >= endWindow:
             break
+
+        if blockProducer not in producers:
+            Utils.errorExit("Producer %s, of block %d, was not one of the voted on producers" % (blockProducer, blockNum))
+
+        if window < lastWindow:
+            Utils.errorExit("Block %d, produced by %s, is in schedule window %d, behind window %d of the block before it." %
+                            (blockNum, blockProducer, window, lastWindow))
+
+        owner=windowToProducer.get(window)
+        if owner is None:
+            if blockProducer in producerToWindow:
+                Utils.errorExit("Producer %s owns schedule window %d, but also produced block %d in window %d.  "
+                                "A producer is scheduled at most once per %d producer cycle." %
+                                (blockProducer, producerToWindow[blockProducer]["window"], blockNum, window, maxActiveProducers))
+            windowToProducer[window]=blockProducer
+            producerToWindow[blockProducer]={"window":window, "count":0}
+            productionCycle.append(blockProducer)
+        elif owner != blockProducer:
+            Utils.errorExit("Block %d, %d slots into the cycle, was produced by %s, but %s already produced in schedule window %d.  "
+                            "A window belongs to exactly one producer." %
+                            (blockNum, slotsFromAnchor, blockProducer, owner, window))
+
+        producerToWindow[blockProducer]["count"]+=1
+        lastWindow=window
+
+        precedingProducer=blockProducer
+        blockNum+=1
+        block=waiter.getBlock(blockNum)
+        blockProducer=Node.getBlockAttribute(block, "producer", blockNum)
+        timestampStr=Node.getBlockAttribute(block, "timestamp", blockNum)
+        timestamp=datetime.strptime(timestampStr, Utils.TimeFmt)
+        slotsDiff=slotsBetween(lastTimestamp, timestamp)
+        if slotsDiff==1 and blockProducer!=precedingProducer and slotsBetween(windowAnchorTimestamp, timestamp) % inRowCountPerProducer != 0:
+            # A handover into the very next slot can only happen on a window boundary, so this block
+            # has to sit at offset 0 of its window.  Landing anywhere else means this handover and
+            # the anchor disagree about where the boundaries are, which is a producer having been
+            # given a run of the wrong length.
+            Utils.errorExit("Producer handover from %s to %s at block %d landed %d slots into a %d slot window instead of at its start.  "
+                            "Producer runs are not aligned to a single window grid." %
+                            (precedingProducer, blockProducer, blockNum,
+                             slotsBetween(windowAnchorTimestamp, timestamp) % inRowCountPerProducer, inRowCountPerProducer))
+        if slotsDiff != 1:
+            slotTimeDelta=timedelta(seconds=slotTime)
+            first=lastTimestamp + slotTimeDelta
+            missed=first.strftime(Utils.TimeFmt)
+            if slotsDiff > 2:
+                last=timestamp - slotTimeDelta
+                missed+= " thru " + last.strftime(Utils.TimeFmt)
+            missedSlotAfter.append("%d (%s)" % (blockNum-1, missed))
+        lastTimestamp=timestamp
+
+    # Unproduced slots are a liveness property of the machine the test is running on, not of the
+    # schedule, and the schedule was verified window by window above.  Report them, do not fail on
+    # them.
+    if len(missedSlotAfter) > 0:
+        Print("WARNING: slots went unproduced after the following blocks: %s" % (", ".join(missedSlotAfter)))
+
+    silentWindows=[window for window in range(0, endWindow) if window not in windowToProducer]
+    if len(silentWindows) > 0:
+        Print("WARNING: %d of the %d producers in the cycle produced no block in their window, at cycle positions: %s" %
+              (len(silentWindows), maxActiveProducers, ", ".join(str(window) for window in silentWindows)))
 
     output=None
     for blockProducer in productionCycle:
@@ -380,7 +427,7 @@ try:
             output=""
         else:
             output+=", "
-        output+=blockProducer+":"+str(producerToSlot[blockProducer]["count"])
+        output+=blockProducer+":"+str(producerToWindow[blockProducer]["count"])
     Print("ProductionCycle ->> {\n%s\n}" % output)
 
     #retrieve the info for all the nodes to report the status for each


### PR DESCRIPTION
Two commits against the preamble of `nodeop_forked_chain_test`, the walk that establishes the production cycle before the network is forked.

## 1. `test: report the correct missed-slot window in nodeop_forked_chain_test`

The missed-slot diagnostic printed a time range that ended nearly a day before it began. The ubsan failure on run 31732928473 reported:

    Slots were missed after the following blocks: 392 (2026-08-14T07:12:44 thru 2026-08-13T07:12:54.5)

`timedelta`'s first positional parameter is `days`, so `timedelta(0.5)` is twelve hours rather than half a second: the start of the window was pushed 12h forward and the end of it 12h back. The same two blocks now report `392 (2026-08-13T19:12:44.500 thru 2026-08-13T19:12:54.000)`, the 20 slots that actually went unproduced.

## 2. `test: derive the production cycle from slot windows, not runs of blocks`

The walk established the cycle by counting how many blocks each producer signed in a row and requiring between 10 and 12. That is a proxy for the schedule rather than the schedule itself, and a loaded machine breaks the proxy. On that same ubsan run one node's block-processing thread stalled for 10.5 seconds: `defproducern` signed 5 of its 12 slots, `defproducero`'s window elapsed with no block at all, and the test failed even though every block that was produced was produced by the right producer at the right time. Block 392 carried no transactions, and the node was stalled between `accepted_block_header` and `accepted_block`, so nothing about the chain was at fault.

Each producer owns one contiguous window of 12 slots. An unproduced slot leaves a hole inside its window; it never moves a boundary and never hands a slot to the next producer. So each block is now attributed to its window and the schedule is checked directly:

- a window belongs to exactly one producer
- a producer appears at most once per cycle
- any handover into the immediately following slot lands at the start of a window, which pins producer runs to a single grid and catches a run of the wrong length

The grid is anchored on an observed block rather than an absolute slot number: a handover into the very next slot can only happen on a boundary, so the first such block identifies offset 0 and the test needs no knowledge of the chain's block timestamp epoch. Unproduced slots and entirely silent windows are reported rather than failing the run, since they describe the machine the test is running on and not the schedule.

This also removes a second spurious failure mode. The old walk terminated on seeing the first producer of the cycle again, so a producer whose entire window was lost shifted the wrap point and tripped the "repeated in slot" check instead.

The trade is deliberate: the old check would notice a producer that merely produced fewer blocks than scheduled, and the new one will not, because that is exactly the environmental symptom. What replaces it is a direct check of the schedule rule itself.

## 3. `test: let the schedule walk wait out a missed-slot stall`

Addressing the review finding. The walk tolerates missed slots in its accounting, but it still has to fetch every block, and `HeadWaiter` aborted that fetch after four seconds once caught up to the head. A stall long enough to skip slots is long enough to end the walk before it can record the gap, so the flake survived in the fetch path:

    BEFORE (leeway=3)   caught up to head    timeout= 4.0s vs 10.5s stall -> ABORTS
    AFTER  (leeway=60)  caught up to head    timeout=61.0s vs 10.5s stall -> waits it out

The leeway is now an argument rather than a fixed three seconds, since it is what bounds how long the chain may go dark before the test calls it dead. This did not fire in the recorded incident only because the walk happened to be running behind the head at that moment; under slightly different timing it would have.

## Verification

`nodeop_forked_chain_test` passes locally end to end, on two separate runs. Each hit four missed-slot gaps of its own, and each left two producers at 10 or 11 blocks against the old lower bound of 10, so the flake reproduced incidentally on an idle machine both times. All 21 producers were found in correct rotation with no silent windows and every handover on a window boundary, which confirms the anchor-derived grid against a real chain.

The block sequence from the failed ubsan run was also extracted from the archived node logs and replayed through the new walk, which accepts it and reports `defproducern:5` with `defproducero` silent. A block moved into another producer's window, a producer scheduled twice, and a producer given a 13 slot run are each still rejected.
