### PR TITLE
fix(cmake): expose build-tree softfloat/wasm-jit includes to SysioTester consumers

### DIFF
--- a/cmake/SysioTester.cmake.in
+++ b/cmake/SysioTester.cmake.in
@@ -272,6 +272,31 @@ if(IS_DIRECTORY "${sysioPrefixDir}/libraries")
         list(APPEND _sysio_build_tree_include_dirs "${_inc_dir}")
     endforeach()
 endif()
+# Build-tree equivalents of the install-tree include entries in the
+# target_include_directories() call below. A consumer that resolves this package
+# from the BUILD tree (sysio_DIR=<build>/lib/cmake/sysio -- e.g. wire-cdt's
+# integration tests) has nothing installed, so @CMAKE_INSTALL_FULL_INCLUDEDIR@
+# names a prefix that does not exist and the headers it is meant to expose are
+# unreachable.
+#
+# softfloat is vcpkg-provided. Its softfloat.hpp does `#include <softfloat_types.h>`
+# -- an ANGLED include, so the including file's own directory is NOT searched and
+# the softfloat/ directory itself must be on the include path, not merely its
+# parent.
+set(_sysio_vcpkg_include_dir "${sysioPrefixDir}/vcpkg_installed/${_sysio_vcpkg_triplet}/include")
+if(IS_DIRECTORY "${_sysio_vcpkg_include_dir}")
+    list(APPEND _sysio_build_tree_include_dirs "${_sysio_vcpkg_include_dir}")
+    if(IS_DIRECTORY "${_sysio_vcpkg_include_dir}/softfloat")
+        list(APPEND _sysio_build_tree_include_dirs "${_sysio_vcpkg_include_dir}/softfloat")
+    endif()
+endif()
+# wasm-jit ships its headers under libraries/wasm-jit/Include (capital I), which
+# the lowercase libraries/*/include glob above does not match. The install tree
+# exposes them as <includedir>/wasm-jit; this is the build-tree spelling.
+if(IS_DIRECTORY "${_sysio_source_dir}/libraries/wasm-jit/Include")
+    list(APPEND _sysio_build_tree_include_dirs "${_sysio_source_dir}/libraries/wasm-jit/Include")
+endif()
+
 if(_sysio_build_tree_include_dirs)
     list(REMOVE_DUPLICATES _sysio_build_tree_include_dirs)
 endif()


### PR DESCRIPTION
## Problem

The exported `SysioChain` interface advertises three **install-tree** include dirs:

```cmake
target_include_directories(SysioChain INTERFACE
        ...
        @CMAKE_INSTALL_PREFIX@
        @CMAKE_INSTALL_FULL_INCLUDEDIR@
        @CMAKE_INSTALL_FULL_INCLUDEDIR@/wasm-jit
        @CMAKE_INSTALL_FULL_INCLUDEDIR@/softfloat)
```

A consumer that resolves this package from the **build tree**
(`sysio_DIR=<build>/lib/cmake/sysio`) has nothing installed, so those expand to a
prefix that does not exist — on a default configure, `/usr/local/include` — and the
headers they are meant to expose are unreachable.

`wire-cdt`'s integration tests (`tests/integration/CMakeLists.txt` → `find_package(sysio)`)
resolve sysio exactly that way, so **every** translation unit failed:

```
vcpkg_installed/x64-linux/include/softfloat/softfloat.hpp:4:10: error:
  'softfloat_types.h' file not found with <angled> include; use "quotes" instead
```

`softfloat.hpp` reaches its sibling with an **angled** include, so the including file's
own directory is not searched and the `softfloat/` directory itself must be on the
include path — its parent alone does not resolve it. That parent was already present via
`-isystem`, which is why this presented as a missing *package* rather than a missing
*include dir*.

## Fix

Extend the include auto-discovery block that already exists in this file with the
build-tree spellings of those entries — `IS_DIRECTORY`-guarded, and derived from
variables the file already computes (`sysioPrefixDir`, `_sysio_vcpkg_triplet`,
`_sysio_source_dir`):

| Entry | Build-tree location |
|---|---|
| `softfloat` | `vcpkg_installed/<triplet>/include` **and** its `softfloat/` subdir |
| `wasm-jit` | `libraries/wasm-jit/Include` — capital `I`, which the lowercase `libraries/*/include` glob never matched |

Fixed here rather than with a local `-I` in `wire-cdt`, because the gap is in what this
package publishes: every build-tree consumer inherits it.

## Compatibility

- Install-tree consumers are unaffected — the existing entries are untouched.
- A tree without `vcpkg_installed` adds nothing (both guards fail), so behaviour is
  unchanged rather than newly broken.
- `wasm-jit` was not failing yet; it is the same latent defect, fixed alongside.

## Verification

`wire-cdt` with `ENABLE_INTEGRATION_TESTS=ON` (upstream default is `OFF`, which is why
this went unnoticed):

| | Before | After |
|---|---|---|
| `.o` files for `integration_tests` | 0 — had never compiled | 17 |
| `integration_tests` binary | absent | built |
| `softfloat_types.h` errors | 34 | 0 |
| Failed objects | 18 | 0 |
| Test result | could not run | **106/106 cases, 186/186 assertions** |

`kv_cached_tests` passes 4/4 cases, 9/9 assertions.

No contract sources, ABIs, or WASM are touched — CMake export metadata only.