### PR TITLE
Test: resubmit a setup transaction the node drops for objective cpu

### DIFF
--- a/tests/chain_test_utils.hpp
+++ b/tests/chain_test_utils.hpp
@@ -10,7 +10,9 @@
 #include <sysio/chain/controller.hpp>
 
 #include <fc/exception/exception.hpp>
+#include <fc/log/logger.hpp>
 
+#include <chrono>
 #include <exception>
 #include <future>
 #include <stdexcept>
@@ -88,18 +90,45 @@ inline auto make_bios_ro_trx(sysio::chain::controller& control) {
    return std::make_shared<packed_transaction>( std::move(trx) );
 }
 
-// Push an input transaction to controller and return trx trace
-// If account is sysio then signs with the default private key
-inline auto push_input_trx(appbase::scoped_app& app, sysio::chain::controller& control, account_name account, signed_transaction& trx) {
+/// A node drops a transaction that trips an objective cpu limit and leaves resubmission to the client. The helpers
+/// below only build the chain state a test starts from, so they resubmit rather than report such a drop as a test
+/// failure: deploying the bios contract bills a few milliseconds of the chain's 150ms max_transaction_cpu_usage, but a
+/// CI host running the whole suite in parallel can deschedule the producing thread mid-action for long enough to blow
+/// through that limit. Only the codes a resubmission can plausibly clear are retried; anything else is a real failure
+/// and propagates from the first attempt.
+/// @param e exception reported for the dropped transaction
+/// @return true when the same transaction is worth pushing again
+inline bool is_resubmittable_setup_failure( const fc::exception& e ) {
+   return e.code() == tx_cpu_usage_exceeded::code_value
+       || e.code() == block_cpu_usage_exceeded::code_value
+       || e.code() == deadline_exception::code_value;
+}
+
+/// Number of attempts a setup transaction is given before its failure is reported to the test.
+inline constexpr size_t max_setup_trx_attempts = 4;
+
+/// Push an input transaction to controller once and return its trx trace.
+/// If account is sysio then signs with the default private key.
+/// @param app        running application hosting the chain and producer plugins
+/// @param control    controller the transaction is stamped against
+/// @param account    authorizing account, also the signer
+/// @param trx        transaction to stamp, sign and push; restamped on every call
+/// @return trace of the executed transaction
+/// @throws fc::exception the node reported for the transaction, std::runtime_error if it did not execute in time
+inline transaction_trace_ptr push_input_trx_once( appbase::scoped_app& app, sysio::chain::controller& control,
+                                                  account_name account, signed_transaction& trx ) {
    trx.expiration = fc::time_point_sec{fc::time_point::now() + fc::seconds(30)};
    trx.set_reference_block( control.head().id() );
+   trx.signatures.clear(); // a resubmission signs the restamped transaction, it does not accumulate signatures
    trx.sign(get_private_key(account, "active"), control.get_chain_id());
    auto ptrx = std::make_shared<packed_transaction>( trx, packed_transaction::compression_type::none );
 
    auto trx_promise = std::make_shared<std::promise<transaction_trace_ptr>>();
    std::future<transaction_trace_ptr> trx_future = trx_promise->get_future();
 
-   app->executor().post( priority::low, exec_queue::read_write, [&ptrx, &app, trx_promise]() {
+   // ptrx is captured by value: on the timeout path below this function returns while the posted work may still be
+   // queued, so the lambda cannot reference a local of a frame that is already gone.
+   app->executor().post( priority::low, exec_queue::read_write, [ptrx, &app, trx_promise]() {
       app->get_method<plugin_interface::incoming::methods::transaction_async>()(ptrx,
                                                                                 false, // api_trx
                                                                                 transaction_metadata::trx_type::input, // trx_type
@@ -127,6 +156,32 @@ inline auto push_input_trx(appbase::scoped_app& app, sysio::chain::controller& c
       throw std::runtime_error("failed to execute trx: " + ptrx->get_transaction().actions.at(0).name.to_string() + " to account: " + account.to_string());
 
    return trx_future.get();
+}
+
+/// Push an input transaction to controller and return its trx trace, resubmitting the transaction while the node
+/// keeps dropping it for a transient objective-cpu failure.
+/// If account is sysio then signs with the default private key.
+/// @param app        running application hosting the chain and producer plugins
+/// @param control    controller the transaction is stamped against
+/// @param account    authorizing account, also the signer
+/// @param trx        transaction to stamp, sign and push; restamped on every attempt
+/// @return trace of the executed transaction
+/// @throws fc::exception the node reported on the final attempt, std::runtime_error if it did not execute in time
+inline transaction_trace_ptr push_input_trx( appbase::scoped_app& app, sysio::chain::controller& control,
+                                             account_name account, signed_transaction& trx ) {
+   for( size_t attempt = 1; ; ++attempt ) {
+      try {
+         return push_input_trx_once( app, control, account, trx );
+      } catch( const fc::exception& e ) {
+         if( attempt == max_setup_trx_attempts || !is_resubmittable_setup_failure( e ) )
+            throw;
+         wlog( "setup transaction dropped on attempt {} of {}, resubmitting: {}",
+               attempt, max_setup_trx_attempts, e.top_message() );
+         // Let the chain advance a block so the resubmission carries a new reference block, which keeps it distinct
+         // from the transaction just dropped.
+         std::this_thread::sleep_for( std::chrono::milliseconds(config::block_interval_ms) );
+      }
+   }
 }
 
 // Push setcode trx to controller and return trx trace

--- a/tests/chain_test_utils.hpp
+++ b/tests/chain_test_utils.hpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <exception>
 #include <future>
+#include <optional>
 #include <stdexcept>
 #include <thread>
 
@@ -110,22 +111,62 @@ inline constexpr size_t max_setup_trx_attempts = 4;
 /// How long a resubmission waits for the chain to advance past the block its predecessor was dropped from.
 inline constexpr std::chrono::seconds head_advance_timeout{5};
 
-/// How often that wait samples the head block.
+/// How long a single head read is given before the app is treated as no longer servicing its queues.
+inline constexpr std::chrono::seconds head_read_timeout{5};
+
+/// How often the head-advance wait samples the head block.
 inline constexpr std::chrono::milliseconds head_advance_poll_interval{10};
+
+/// What a caller needs from the controller's head block, copied on the thread that owns it.
+struct head_snapshot {
+   uint32_t                    block_num = 0;
+   sysio::chain::block_id_type id;
+};
+
+/// Read the controller's head block from the app thread.
+/// controller::head() is not thread-safe -- chain_head is a plain block_handle assigned as blocks are applied, and
+/// head() copies it -- so sampling it from a test thread races with block production. Posting the read serializes it
+/// against that work on the one queue the app thread alone drains, which is the same queue the pushes below go
+/// through; the copy then crosses back to the caller through the future.
+/// Must be called from a thread other than the app thread, which is the one that answers the post.
+/// @param app     running application whose thread owns the controller
+/// @param control controller to read from
+/// @return the head block number and id, or nullopt if the read did not complete before head_read_timeout
+inline std::optional<head_snapshot> read_head( appbase::scoped_app& app, sysio::chain::controller& control ) {
+   auto head_promise = std::make_shared<std::promise<head_snapshot>>();
+   std::future<head_snapshot> head_future = head_promise->get_future();
+
+   app->executor().post( priority::high, exec_queue::read_write, [&control, head_promise]() {
+      auto head = control.head();
+      head_promise->set_value( head_snapshot{ .block_num = head.block_num(), .id = head.id() } );
+   });
+
+   if( head_future.wait_for( head_read_timeout ) == std::future_status::timeout )
+      return std::nullopt;
+   return head_future.get();
+}
 
 /// Wait for the controller to report a head block past the one observed on entry.
 /// The wait is bounded: a chain that has stopped advancing is a failure for the caller to report, not one to spin on.
-/// @param control controller to observe, sampled from the calling thread as the push helpers already do
+/// @param app     running application whose thread owns the controller
+/// @param control controller to observe
 /// @return true if the head advanced before head_advance_timeout elapsed
-inline bool wait_for_head_block_advance( sysio::chain::controller& control ) {
-   const auto dropped_from = control.head().block_num();
-   const auto deadline     = std::chrono::steady_clock::now() + head_advance_timeout;
-   while( control.head().block_num() == dropped_from ) {
+inline bool wait_for_head_block_advance( appbase::scoped_app& app, sysio::chain::controller& control ) {
+   const auto dropped_from = read_head( app, control );
+   if( !dropped_from )
+      return false;
+
+   const auto deadline = std::chrono::steady_clock::now() + head_advance_timeout;
+   while( true ) {
+      const auto head = read_head( app, control );
+      if( !head )
+         return false;
+      if( head->block_num != dropped_from->block_num )
+         return true;
       if( std::chrono::steady_clock::now() >= deadline )
          return false;
       std::this_thread::sleep_for( head_advance_poll_interval );
    }
-   return true;
 }
 
 /// Push an input transaction to controller once and return its trx trace.
@@ -138,8 +179,12 @@ inline bool wait_for_head_block_advance( sysio::chain::controller& control ) {
 /// @throws fc::exception the node reported for the transaction, std::runtime_error if it did not execute in time
 inline transaction_trace_ptr push_input_trx_once( appbase::scoped_app& app, sysio::chain::controller& control,
                                                   account_name account, signed_transaction& trx ) {
+   const auto head = read_head( app, control );
+   if( !head )
+      throw std::runtime_error("failed to read head block to stamp trx for account: " + account.to_string());
+
    trx.expiration = fc::time_point_sec{fc::time_point::now() + fc::seconds(30)};
-   trx.set_reference_block( control.head().id() );
+   trx.set_reference_block( head->id );
    trx.signatures.clear(); // a resubmission signs the restamped transaction, it does not accumulate signatures
    trx.sign(get_private_key(account, "active"), control.get_chain_id());
    auto ptrx = std::make_shared<packed_transaction>( trx, packed_transaction::compression_type::none );
@@ -179,6 +224,33 @@ inline transaction_trace_ptr push_input_trx_once( appbase::scoped_app& app, sysi
    return trx_future.get();
 }
 
+/// Run a setup transaction through the resubmission policy: while the node keeps dropping it for a failure a
+/// resubmission can clear, wait for the chain to advance and push it again.
+/// The policy is kept separate from the push and wait mechanics so it can be exercised without a running node.
+/// @param push_once      makes one attempt, throwing whatever the node reported for the transaction
+/// @param wait_for_chain waits for the chain to advance before a resubmission, false if it stopped advancing
+/// @return trace of the executed transaction
+/// @throws whatever push_once threw on the last attempt made
+template<typename PushOnce, typename WaitForChain>
+transaction_trace_ptr resubmit_setup_trx( PushOnce&& push_once, WaitForChain&& wait_for_chain ) {
+   for( size_t attempt = 1; ; ++attempt ) {
+      try {
+         return push_once();
+      } catch( const fc::exception& e ) {
+         if( attempt == max_setup_trx_attempts || !is_resubmittable_setup_failure( e ) )
+            throw;
+         wlog( "setup transaction dropped on attempt {} of {}, resubmitting: {}",
+               attempt, max_setup_trx_attempts, e.top_message() );
+         // The resubmission has to carry a new reference block to stay distinct from the transaction just dropped, so
+         // wait for the chain to actually advance instead of assuming it does within one nominal block interval: the
+         // starvation that drops the transaction is just as able to delay the block that follows it. A chain that
+         // stops advancing altogether is reported as the drop that got us here rather than as a wait that timed out.
+         if( !wait_for_chain() )
+            throw;
+      }
+   }
+}
+
 /// Push an input transaction to controller and return its trx trace, resubmitting the transaction while the node
 /// keeps dropping it for a transient objective-cpu failure. Every resubmission waits for the chain to advance first.
 /// If account is sysio then signs with the default private key.
@@ -191,22 +263,8 @@ inline transaction_trace_ptr push_input_trx_once( appbase::scoped_app& app, sysi
 ///                       after which the chain stopped advancing; std::runtime_error if it did not execute in time
 inline transaction_trace_ptr push_input_trx( appbase::scoped_app& app, sysio::chain::controller& control,
                                              account_name account, signed_transaction& trx ) {
-   for( size_t attempt = 1; ; ++attempt ) {
-      try {
-         return push_input_trx_once( app, control, account, trx );
-      } catch( const fc::exception& e ) {
-         if( attempt == max_setup_trx_attempts || !is_resubmittable_setup_failure( e ) )
-            throw;
-         wlog( "setup transaction dropped on attempt {} of {}, resubmitting: {}",
-               attempt, max_setup_trx_attempts, e.top_message() );
-         // The resubmission has to carry a new reference block to stay distinct from the transaction just dropped, so
-         // wait for the chain to actually advance instead of assuming it does within one nominal block interval: the
-         // starvation that drops the transaction is just as able to delay the block that follows it. A chain that
-         // stops advancing altogether is reported as the drop that got us here rather than as a wait that timed out.
-         if( !wait_for_head_block_advance( control ) )
-            throw;
-      }
-   }
+   return resubmit_setup_trx( [&]() { return push_input_trx_once( app, control, account, trx ); },
+                              [&]() { return wait_for_head_block_advance( app, control ); } );
 }
 
 // Push setcode trx to controller and return trx trace

--- a/tests/chain_test_utils.hpp
+++ b/tests/chain_test_utils.hpp
@@ -107,6 +107,27 @@ inline bool is_resubmittable_setup_failure( const fc::exception& e ) {
 /// Number of attempts a setup transaction is given before its failure is reported to the test.
 inline constexpr size_t max_setup_trx_attempts = 4;
 
+/// How long a resubmission waits for the chain to advance past the block its predecessor was dropped from.
+inline constexpr std::chrono::seconds head_advance_timeout{5};
+
+/// How often that wait samples the head block.
+inline constexpr std::chrono::milliseconds head_advance_poll_interval{10};
+
+/// Wait for the controller to report a head block past the one observed on entry.
+/// The wait is bounded: a chain that has stopped advancing is a failure for the caller to report, not one to spin on.
+/// @param control controller to observe, sampled from the calling thread as the push helpers already do
+/// @return true if the head advanced before head_advance_timeout elapsed
+inline bool wait_for_head_block_advance( sysio::chain::controller& control ) {
+   const auto dropped_from = control.head().block_num();
+   const auto deadline     = std::chrono::steady_clock::now() + head_advance_timeout;
+   while( control.head().block_num() == dropped_from ) {
+      if( std::chrono::steady_clock::now() >= deadline )
+         return false;
+      std::this_thread::sleep_for( head_advance_poll_interval );
+   }
+   return true;
+}
+
 /// Push an input transaction to controller once and return its trx trace.
 /// If account is sysio then signs with the default private key.
 /// @param app        running application hosting the chain and producer plugins
@@ -159,14 +180,15 @@ inline transaction_trace_ptr push_input_trx_once( appbase::scoped_app& app, sysi
 }
 
 /// Push an input transaction to controller and return its trx trace, resubmitting the transaction while the node
-/// keeps dropping it for a transient objective-cpu failure.
+/// keeps dropping it for a transient objective-cpu failure. Every resubmission waits for the chain to advance first.
 /// If account is sysio then signs with the default private key.
 /// @param app        running application hosting the chain and producer plugins
 /// @param control    controller the transaction is stamped against
 /// @param account    authorizing account, also the signer
 /// @param trx        transaction to stamp, sign and push; restamped on every attempt
 /// @return trace of the executed transaction
-/// @throws fc::exception the node reported on the final attempt, std::runtime_error if it did not execute in time
+/// @throws fc::exception the node reported on the last attempt made, whether that is the final attempt or the one
+///                       after which the chain stopped advancing; std::runtime_error if it did not execute in time
 inline transaction_trace_ptr push_input_trx( appbase::scoped_app& app, sysio::chain::controller& control,
                                              account_name account, signed_transaction& trx ) {
    for( size_t attempt = 1; ; ++attempt ) {
@@ -177,9 +199,12 @@ inline transaction_trace_ptr push_input_trx( appbase::scoped_app& app, sysio::ch
             throw;
          wlog( "setup transaction dropped on attempt {} of {}, resubmitting: {}",
                attempt, max_setup_trx_attempts, e.top_message() );
-         // Let the chain advance a block so the resubmission carries a new reference block, which keeps it distinct
-         // from the transaction just dropped.
-         std::this_thread::sleep_for( std::chrono::milliseconds(config::block_interval_ms) );
+         // The resubmission has to carry a new reference block to stay distinct from the transaction just dropped, so
+         // wait for the chain to actually advance instead of assuming it does within one nominal block interval: the
+         // starvation that drops the transaction is just as able to delay the block that follows it. A chain that
+         // stops advancing altogether is reported as the drop that got us here rather than as a wait that timed out.
+         if( !wait_for_head_block_advance( control ) )
+            throw;
       }
    }
 }

--- a/tests/test_read_only_trx.cpp
+++ b/tests/test_read_only_trx.cpp
@@ -107,15 +107,17 @@ void test_trxs_common(std::vector<const char*>& specific_args) {
                   "-p", "sysio", "-e", // actual arguments follow
                   "--data-dir", temp_dir_str.c_str(),
                   "--config-dir", temp_dir_str.c_str(),
-                  // -1 == no wall-clock cap on write transactions. The setup step below deploys the
-                  // sysio.bios contract via setcode, a write transaction. Under heavy CI parallelism
-                  // (this binary runs alongside ~1800 wasm_spec_tests saturating every core) the
-                  // setcode is repeatedly descheduled: it bills ~0 cpu yet its wall-clock checktime
-                  // can run hundreds of ms, tripping a tight --max-transaction-time and failing the
-                  // run with tx_cpu_usage_exceeded. This test exercises read-only execution, not
-                  // write-trx cpu enforcement, so the cap only adds flake. The setup is still bounded
-                  // by push_input_trx's 5s future wait, and read-only transactions remain bounded by
-                  // read-only-read-window-time-us (effective ~390000us after the 10000us margin).
+                  // -1 == no node-configured wall-clock cap on write transactions. The setup step below
+                  // deploys the sysio.bios contract via setcode, a write transaction. Under heavy CI
+                  // parallelism (this binary runs alongside ~1800 wasm_spec_tests saturating every core)
+                  // the setcode is repeatedly descheduled, so the wall clock its cpu bill is measured
+                  // against runs far longer than the work it performs. This test exercises read-only
+                  // execution, not write-trx cpu enforcement, so the cap only adds flake. It removes the
+                  // subjective cap only: the chain's objective max_transaction_cpu_usage still applies and
+                  // can still drop the setcode, which push_input_trx recovers from by resubmitting. The
+                  // setup is still bounded by that helper's attempt limit and its 5s per-attempt future
+                  // wait, and read-only transactions remain bounded by read-only-read-window-time-us
+                  // (effective ~390000us after the 10000us margin).
                   "--max-transaction-time=-1",
                   "--abi-serializer-max-time-ms=999",
                   "--read-only-write-window-time-us=100000",

--- a/tests/test_setup_trx_retry.cpp
+++ b/tests/test_setup_trx_retry.cpp
@@ -1,0 +1,210 @@
+#include <boost/test/unit_test.hpp>
+
+#include <sysio/producer_plugin/producer_plugin.hpp>
+#include <sysio/chain/application.hpp>
+#include <sysio/chain/config.hpp>
+#include <sysio/chain/exceptions.hpp>
+#include <sysio/chain/trace.hpp>
+
+#include <contracts.hpp>
+#include "chain_test_utils.hpp"
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace {
+using namespace sysio;
+using namespace sysio::chain;
+using namespace sysio::test_utils;
+
+/// A drop the node attributes to an objective cpu limit, which a resubmission is expected to clear.
+/// Returned as the concrete type so throwing it does not slice away what the test is asserting on.
+tx_cpu_usage_exceeded resubmittable_drop() {
+   return tx_cpu_usage_exceeded( FC_LOG_MESSAGE( error, "injected objective cpu drop" ) );
+}
+
+/// A failure that says something is wrong with the transaction itself, which a resubmission cannot clear.
+sysio_assert_message_exception permanent_failure() {
+   return sysio_assert_message_exception( FC_LOG_MESSAGE( error, "injected contract assert" ) );
+}
+
+/// Apply a producer runtime option from the app thread that owns the producer plugin, and wait for it to land.
+/// @param app  running application whose thread owns the plugin
+/// @param prod producer plugin to reconfigure
+/// @param ms   new max-transaction-time in milliseconds, negative for no cap
+void set_max_transaction_time( appbase::scoped_app& app, producer_plugin* prod, int32_t ms ) {
+   auto applied = std::make_shared<std::promise<void>>();
+   std::future<void> applied_future = applied->get_future();
+
+   app->executor().post( priority::high, exec_queue::read_write, [prod, ms, applied]() {
+      prod->update_runtime_options( producer_plugin::runtime_options{ .max_transaction_time = ms } );
+      applied->set_value();
+   });
+
+   BOOST_REQUIRE( applied_future.wait_for( std::chrono::seconds(5) ) != std::future_status::timeout );
+}
+
+/// Build the setcode transaction that deploys the bios contract to the system account.
+/// This is the transaction the CI failure dropped, so it is the one worth driving through the policy.
+signed_transaction bios_setcode_trx() {
+   const auto& wasm = testing::contracts::sysio_bios_wasm();
+
+   signed_transaction trx;
+   trx.actions.emplace_back( std::vector<permission_level>{{config::system_account_name, config::active_name}},
+                             chain::setcode{
+                                .account   = config::system_account_name,
+                                .vmtype    = 0,
+                                .vmversion = 0,
+                                .code      = bytes( wasm.begin(), wasm.end() )
+                             });
+   return trx;
+}
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(setup_trx_retry)
+
+// The policy keeps pushing while the node reports a drop a resubmission can clear, and returns the trace of the
+// attempt the node finally accepted.
+BOOST_AUTO_TEST_CASE(resubmits_until_the_node_accepts) {
+   size_t pushes = 0;
+   size_t waits  = 0;
+   auto   accepted = std::make_shared<transaction_trace>();
+
+   auto trace = resubmit_setup_trx(
+      [&]() -> transaction_trace_ptr {
+         if( ++pushes == 1 )
+            throw resubmittable_drop();
+         return accepted;
+      },
+      [&]() { ++waits; return true; } );
+
+   BOOST_CHECK( trace == accepted );
+   BOOST_CHECK_EQUAL( pushes, 2u );
+   BOOST_CHECK_EQUAL( waits, 1u );  // the chain is waited on once, before the resubmission
+}
+
+// A node that keeps dropping the transaction is reported to the test rather than resubmitted at forever, and the
+// failure the test sees is the one from the last attempt.
+BOOST_AUTO_TEST_CASE(reports_the_drop_after_the_last_attempt) {
+   size_t pushes = 0;
+   size_t waits  = 0;
+
+   BOOST_CHECK_THROW( resubmit_setup_trx(
+                         [&]() -> transaction_trace_ptr { ++pushes; throw resubmittable_drop(); },
+                         [&]() { ++waits; return true; } ),
+                      tx_cpu_usage_exceeded );
+
+   BOOST_CHECK_EQUAL( pushes, max_setup_trx_attempts );
+   BOOST_CHECK_EQUAL( waits, max_setup_trx_attempts - 1 );  // no wait after the attempt that is reported
+}
+
+// A failure a resubmission cannot clear is a real test failure: it is reported from the first attempt, without
+// spending the remaining attempts or waiting on the chain.
+BOOST_AUTO_TEST_CASE(reports_a_failure_a_resubmission_cannot_clear) {
+   size_t pushes = 0;
+   size_t waits  = 0;
+
+   BOOST_CHECK_THROW( resubmit_setup_trx(
+                         [&]() -> transaction_trace_ptr { ++pushes; throw permanent_failure(); },
+                         [&]() { ++waits; return true; } ),
+                      sysio_assert_message_exception );
+
+   BOOST_CHECK_EQUAL( pushes, 1u );
+   BOOST_CHECK_EQUAL( waits, 0u );
+}
+
+// A chain that stops advancing is reported as the drop that got us there, not as a wait that timed out: resubmitting
+// against the same head would only repeat the transaction that was just dropped.
+BOOST_AUTO_TEST_CASE(reports_the_drop_when_the_chain_stops_advancing) {
+   size_t pushes = 0;
+   size_t waits  = 0;
+
+   BOOST_CHECK_THROW( resubmit_setup_trx(
+                         [&]() -> transaction_trace_ptr { ++pushes; throw resubmittable_drop(); },
+                         [&]() { ++waits; return false; } ),
+                      tx_cpu_usage_exceeded );
+
+   BOOST_CHECK_EQUAL( pushes, 1u );
+   BOOST_CHECK_EQUAL( waits, 1u );
+}
+
+// End to end against a producing node: a cap of 0ms guarantees the node drops the bios setcode on the first attempt,
+// and lifting the cap before the second guarantees it is accepted. That covers what the helper has to get right for a
+// resubmission to be a resubmission at all -- the chain advanced, and the transaction was restamped against the new
+// head and re-signed, so the node sees a distinct transaction rather than the one it just dropped.
+BOOST_AUTO_TEST_CASE(resubmits_a_setup_transaction_the_node_drops) {
+   fc::temp_directory  temp;
+   appbase::scoped_app app;
+   auto                temp_dir_str = temp.path().string();
+
+   std::promise<std::tuple<producer_plugin*, chain_plugin*>> plugin_promise;
+   std::future<std::tuple<producer_plugin*, chain_plugin*>>  plugin_fut = plugin_promise.get_future();
+
+   std::thread app_thread( [&]() {
+      try {
+         std::vector<const char*> argv = {
+            "test",
+            "-p", "sysio", "-e",
+            "--data-dir", temp_dir_str.c_str(),
+            "--config-dir", temp_dir_str.c_str(),
+            // 0 == every transaction is out of time before it starts, so the first attempt is dropped for certain.
+            "--max-transaction-time=0",
+            "--abi-serializer-max-time-ms=999"
+         };
+         app->initialize<chain_plugin, producer_plugin>( argv.size(), (char**)&argv[0] );
+         app->find_plugin<chain_plugin>()->chain();
+         app->startup();
+         app->executor().set_main_thread_id();
+         plugin_promise.set_value( {app->find_plugin<producer_plugin>(), app->find_plugin<chain_plugin>()} );
+         app->exec();
+         return;
+      } FC_LOG_AND_DROP()
+      BOOST_CHECK(!"app threw exception see logged error");
+   } );
+
+   auto shutdown = fc::make_scoped_exit( [&]() {
+      app->quit();
+      if( app_thread.joinable() )
+         app_thread.join();
+   } );
+
+   auto[prod_plug, chain_plug] = plugin_fut.get();
+   auto& control = chain_plug->chain();
+
+   const auto before = read_head( app, control );
+   BOOST_REQUIRE( before.has_value() );
+
+   size_t                     attempts = 0;
+   std::optional<fc::exception> first_failure;
+   auto                       trx      = bios_setcode_trx();
+   auto                       trace    = resubmit_setup_trx(
+      [&]() {
+         // Lift the cap for the resubmission only, so the first attempt is dropped and the second is not.
+         if( ++attempts == 2 )
+            set_max_transaction_time( app, prod_plug, -1 );
+         try {
+            return push_input_trx_once( app, control, config::system_account_name, trx );
+         } catch( const fc::exception& e ) {
+            if( !first_failure )
+               first_failure = e;
+            throw;
+         }
+      },
+      [&]() { return wait_for_head_block_advance( app, control ); } );
+
+   BOOST_CHECK_EQUAL( attempts, 2u );
+   BOOST_REQUIRE( first_failure.has_value() );  // the node really did drop the first attempt
+   BOOST_CHECK_EQUAL( first_failure->code(), tx_cpu_usage_exceeded::code_value );  // for the reason CI hit
+   BOOST_REQUIRE( !!trace );
+   BOOST_CHECK( !!trace->receipt );        // the resubmission was accepted into a block
+   BOOST_CHECK( !trace->except );
+
+   const auto after = read_head( app, control );
+   BOOST_REQUIRE( after.has_value() );
+   BOOST_CHECK_GT( after->block_num, before->block_num );  // the resubmission waited for a block it could reference
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

The `read_only_trxs` cases in `plugin_test` fail intermittently on master because the setup step that deploys the bios contract is dropped with `tx_cpu_usage_exceeded`, before the read-only behaviour under test is ever reached.

`--max-transaction-time=-1` in that test removes the node-configured wall-clock cap, but the chain's objective `max_transaction_cpu_usage` of 150ms still applies. A CI host running the whole suite in parallel deschedules the producing thread mid-`setcode`, so an action that bills 3-5ms of work on an idle machine billed 180ms in the failing run.

A node drops a transaction that trips an objective cpu limit and leaves resubmission to the client. The setup helper now does exactly that: it restamps, re-signs and pushes again for the exception codes a resubmission can plausibly clear, and reports anything else from the first attempt. Each resubmission waits a block interval so it carries a new reference block and stays distinct from the transaction just dropped. Attempts are bounded, so a genuinely broken setup still fails the test rather than spinning.

Also fixes a latent dangling capture in the same helper: the posted lambda held the packed transaction by reference, which the 5s timeout path leaves pointing at a frame that has already returned.

## Notes

The two failure modes are separately reachable, which is why the earlier `--max-transaction-time=-1` change did not settle this: that cap and the chain's objective limit are enforced independently, and only the first one was addressed.
