### PR TITLE
Rename outpost client CLI configuration

### DIFF
--- a/docs/outpost-client-plugins.md
+++ b/docs/outpost-client-plugins.md
@@ -35,17 +35,17 @@ The signer reference is validated during startup and must identify an explicit E
 chain IDs are locally authoritative for signing, and startup verifies them against `eth_chainId`
 reported by the configured RPC endpoint.
 
-The legacy option remains available and cannot be combined with the file option:
+The CLI option remains available and cannot be combined with the file option:
 
 ```sh
 --outpost-ethereum-client eth-anvil-local,eth-01,http://localhost:8545,31337
 ```
 
-The four-field legacy form also treats its chain ID as locally authoritative for signing and
-verifies it against the configured RPC endpoint. The historical three-field form remains
-compatible by resolving `eth_chainId` during startup. File-configured, four-field legacy, and
-three-field legacy clients all require a reachable RPC endpoint at startup; each client receives
-an independent five-second budget for chain ID verification or resolution. Legacy clients receive
+The four-field CLI form also treats its chain ID as locally authoritative for signing and
+verifies it against the configured RPC endpoint. The historical three-field CLI form remains
+compatible by resolving `eth_chainId` during startup. File-configured, four-field CLI, and
+three-field CLI clients all require a reachable RPC endpoint at startup; each client receives
+an independent five-second budget for chain ID verification or resolution. CLI clients receive
 `UINT256_MAX` expenditure caps, with the same compatibility-only warning above.
 
 Every signing-capable client enforces its local policy after the transaction is fully assembled

--- a/plugins/outpost_ethereum_client_plugin/include/sysio/outpost_ethereum_client_plugin.hpp
+++ b/plugins/outpost_ethereum_client_plugin/include/sysio/outpost_ethereum_client_plugin.hpp
@@ -156,7 +156,7 @@ public:
     * concern (batch operator wires OPP + OPPInbound; underwriter wires
     * OperatorRegistry; both share the same SPI surface).
     *
-    * @param eth_client_id     Id from the file configuration or legacy client option.
+    * @param eth_client_id     Id from the file configuration or CLI client option.
     * @param chain_code        Outpost id from `sysio.chains::chains`.
     * @param chain_id          Numeric chain id from the outpost row (e.g. 31337, 1).
     * @param opp_addr          Hex address of the `OPP.sol` contract, or empty.

--- a/plugins/outpost_ethereum_client_plugin/src/outpost_ethereum_client_plugin.cpp
+++ b/plugins/outpost_ethereum_client_plugin/src/outpost_ethereum_client_plugin.cpp
@@ -26,7 +26,7 @@ constexpr auto option_abi_file = "ethereum-abi-file";
 constexpr auto chain_id_resolution_timeout = fc::seconds(5);
 constexpr auto chain_id_resolution_initial_backoff = fc::milliseconds(200);
 constexpr auto chain_id_resolution_max_backoff = fc::seconds(1);
-constexpr std::string_view legacy_transaction_policy_client_id = "legacy-client";
+constexpr std::string_view cli_transaction_policy_client_id = "cli-client";
 constexpr auto unavailable_policy_limit = "n/a";
 constexpr std::string_view chain_id_resolution_operation = "ethereum-client:eth_chainId";
 constexpr std::string_view outbound_http_failure_prefix = "Outbound HTTP ";
@@ -73,7 +73,7 @@ enum class rpc_chain_id_validation {
 };
 
 /** Parse a positive decimal or Ethereum hex quantity without fixed-width wraparound. */
-std::optional<uint32_t> parse_legacy_chain_id(std::string_view text) {
+std::optional<uint32_t> parse_cli_chain_id(std::string_view text) {
    if (text.empty()) return std::nullopt;
 
    uint32_t base = 10;
@@ -118,12 +118,12 @@ ethereum_transaction_policy maximum_policy(std::string client_id, uint32_t chain
    };
 }
 
-/** Preserve legacy client names while keeping the new structured policy log label safe. */
+/** Preserve CLI client names while keeping the structured policy log label safe. */
 std::string transaction_policy_client_label(std::string_view client_id) {
    if (fc::network::ethereum::is_safe_transaction_policy_identifier(client_id)) {
       return std::string(client_id);
    }
-   return std::string(legacy_transaction_policy_client_id);
+   return std::string(cli_transaction_policy_client_id);
 }
 
 /** Convert a validated protobuf client policy to the runtime transaction-policy model. */
@@ -343,8 +343,8 @@ client_map load_file_clients(
    return clients;
 }
 
-/** Load legacy command-line client specifications with maximum compatibility policies. */
-client_map load_legacy_clients(
+/** Load command-line client specifications with maximum compatibility policies. */
+client_map load_cli_clients(
    const std::vector<std::string>& client_specs,
    signature_provider_manager_plugin& signature_provider_manager,
    const fc::network::json_rpc::client_options& rpc_options) {
@@ -376,7 +376,7 @@ client_map load_legacy_clients(
 
       uint32_t chain_id = 0;
       if (parts.size() == 4) {
-         const auto parsed = parse_legacy_chain_id(parts[3]);
+         const auto parsed = parse_cli_chain_id(parts[3]);
          SYS_ASSERT(parsed,
                     chain::plugin_config_exception,
                     "Invalid {} spec for client '{}': chain id must be a positive 32-bit decimal or hex integer",
@@ -459,8 +459,8 @@ void outpost_ethereum_client_plugin::plugin_initialize(const variables_map& opti
    }
 
    const bool has_file = options.contains(option_name_client_config_file);
-   const bool has_legacy = options.contains(option_name_client);
-   SYS_ASSERT(has_file != has_legacy,
+   const bool has_cli = options.contains(option_name_client);
+   SYS_ASSERT(has_file != has_cli,
               chain::plugin_config_exception,
               "Configure exactly one of --{} or --{}",
               option_name_client_config_file,
@@ -476,7 +476,7 @@ void outpost_ethereum_client_plugin::plugin_initialize(const variables_map& opti
             signature_provider_manager,
             rpc_options));
       } else {
-         my->set_clients(load_legacy_clients(
+         my->set_clients(load_cli_clients(
             options.at(option_name_client).as<std::vector<std::string>>(),
             signature_provider_manager,
             rpc_options));
@@ -512,7 +512,7 @@ void outpost_ethereum_client_plugin::set_program_options(options_description& cl
    cfg.add_options()
       (option_name_client,
        boost::program_options::value<std::vector<std::string>>()->multitoken(),
-       "Legacy outpost Ethereum client spec: "
+       "CLI outpost Ethereum client spec: "
        "<client-id>,<signature-provider-id>,<rpc-url>[,<chain-id>]. A three-field spec resolves "
        "eth_chainId during startup; a four-field chain id controls signing and is verified against the endpoint.")
       (option_name_client_config_file,

--- a/plugins/outpost_ethereum_client_plugin/test/test_ethereum_transaction_policy.cpp
+++ b/plugins/outpost_ethereum_client_plugin/test/test_ethereum_transaction_policy.cpp
@@ -46,7 +46,7 @@ constexpr std::string_view test_chain_id_quantity = "0x7a69";
 constexpr std::string_view ethereum_mainnet_chain_id_quantity = "0x1";
 using tcp = boost::asio::ip::tcp;
 
-/** One-shot JSON-RPC endpoint used to preserve coverage of the legacy three-field client form. */
+/** One-shot JSON-RPC endpoint used to preserve coverage of the historical three-field CLI client form. */
 class chain_id_rpc_server {
 public:
    /** Start a loopback server that returns the supplied chain id once. */
@@ -648,7 +648,7 @@ BOOST_AUTO_TEST_CASE(file_configuration_does_not_publish_a_partial_client_map) {
    BOOST_CHECK_EQUAL(initialize_rejected_file_and_observe_published_clients(path), 0u);
 }
 
-BOOST_AUTO_TEST_CASE(legacy_client_option_uses_default_policy_with_explicit_chain_id) {
+BOOST_AUTO_TEST_CASE(cli_client_option_uses_default_policy_with_explicit_chain_id) {
    chain_id_rpc_server rpc_server;
    const auto clients = initialize_outpost_plugin(
       {"--outpost-ethereum-client", "client-a,signer-a," + rpc_server.url() + ",31337"});
@@ -658,17 +658,17 @@ BOOST_AUTO_TEST_CASE(legacy_client_option_uses_default_policy_with_explicit_chai
    BOOST_CHECK_EQUAL(clients.front()->client->transaction_policy().max_fee_per_gas, maximum);
 }
 
-BOOST_AUTO_TEST_CASE(legacy_client_option_preserves_nonempty_identifier_compatibility) {
+BOOST_AUTO_TEST_CASE(cli_client_option_preserves_nonempty_identifier_compatibility) {
    chain_id_rpc_server rpc_server;
    const auto clients = initialize_outpost_plugin(
-      {"--outpost-ethereum-client", "legacy/client,prod/signing," + rpc_server.url() + ",31337"},
+      {"--outpost-ethereum-client", "cli/client,prod/signing," + rpc_server.url() + ",31337"},
       "prod/signing");
    BOOST_REQUIRE_EQUAL(clients.size(), 1u);
-   BOOST_CHECK_EQUAL(clients.front()->id, "legacy/client");
-   BOOST_CHECK_EQUAL(clients.front()->client->transaction_policy().client_id, "legacy-client");
+   BOOST_CHECK_EQUAL(clients.front()->id, "cli/client");
+   BOOST_CHECK_EQUAL(clients.front()->client->transaction_policy().client_id, "cli-client");
 }
 
-BOOST_AUTO_TEST_CASE(legacy_three_field_client_resolves_chain_id_from_rpc) {
+BOOST_AUTO_TEST_CASE(cli_three_field_client_resolves_chain_id_from_rpc) {
    chain_id_rpc_server rpc_server;
    const auto clients = initialize_outpost_plugin(
       {"--outpost-ethereum-client", "client-a,signer-a," + rpc_server.url()});
@@ -677,7 +677,7 @@ BOOST_AUTO_TEST_CASE(legacy_three_field_client_resolves_chain_id_from_rpc) {
    BOOST_CHECK_EQUAL(clients.front()->client->get_chain_id(), 31337);
 }
 
-BOOST_AUTO_TEST_CASE(plugin_startup_rejects_mixed_unified_and_legacy_modes) {
+BOOST_AUTO_TEST_CASE(plugin_startup_rejects_mixed_unified_and_cli_modes) {
    fc::temp_directory directory;
    const auto path = write_client_configuration_file(
       directory, R"json({"schema_version":1,"clients":[]})json");

--- a/programs/examples/cranker-example/README.md
+++ b/programs/examples/cranker-example/README.md
@@ -34,7 +34,7 @@ and optional per-client transaction policies. See
 [`docs/ethereum-client-config.example.json`](../../../docs/ethereum-client-config.example.json) and the
 [outpost client configuration guide](../../../docs/outpost-client-plugins.md).
 
-The legacy
+The CLI
 `--outpost-ethereum-client <eth-client-id>,<sig-provider-id>,<eth-node-url>[,<eth-chain-id>]` option remains
 available. It assigns maximum-value policy defaults and cannot be combined with
 `--outpost-ethereum-client-config-file`. Those defaults preserve compatibility only, provide no

--- a/programs/examples/cranker-example/README.md
+++ b/programs/examples/cranker-example/README.md
@@ -47,5 +47,5 @@ Path to an Ethereum contract ABI file (relative from current working directory o
 ## Minimum Configuration
 To successfully start the application, the following are required:
 1.  At least **one** Ethereum signature provider.
-2.  At least **one** Ethereum outpost client, from the unified file or legacy option.
+2.  At least **one** Ethereum outpost client, from the unified file or CLI option.
 3.  At least **one** Ethereum ABI file reference.


### PR DESCRIPTION
## Summary

- Rename the direct Ethereum outpost-client configuration mode from “legacy” to “CLI”.
- Preserve the public flags, parsing behavior, chain-ID validation, and compatibility policy behavior.
- Update focused tests and operator documentation, including the cranker example’s defining CLI-option paragraph.

## Validation

- `cmake --build build/cli-terminology -- -j6` (complete target set; 769/769)
- `build/cli-terminology/plugins/outpost_ethereum_client_plugin/test_outpost_ethereum_client_plugin` (55 tests passed)
- `git diff --check` after the review follow-up

## Notes

- No on-chain behavior changes in `wire-ethereum` or `wire-solana`.
- The diagnostic fallback label changes from `legacy-client` to `cli-client`.