### PR TITLE
Log: correct the rotating_file_sink max_size default to megabytes

### DIFF
--- a/libraries/libfc/include/fc/log/logger_config.hpp
+++ b/libraries/libfc/include/fc/log/logger_config.hpp
@@ -69,10 +69,18 @@ namespace fc {
          uint32_t       max_files = 0;
       };
 
+      /// Rotation threshold for rotating_file_sink, in MEGABYTES. configure_logging multiplies max_size by
+      /// 1 MiB when constructing the spdlog sink, so this is a count of megabytes and not a byte count.
+      inline constexpr uint32_t default_rotating_max_size_mb = 10;
+      /// Number of rotated files kept alongside the active one, matching spdlog's max_files semantics.
+      inline constexpr uint32_t default_rotating_max_files = 10;
+
+      /// Size-based rotating log file. Rotates once the active file reaches max_size megabytes, keeping at
+      /// most max_files rotated copies. max_size must be non-zero -- spdlog rejects a zero rotation size.
       struct rotating_file_sink_config {
          std::string    base_filename;
-         uint32_t       max_size = 1048576*10; // 10MB
-         uint32_t       max_files = 10;
+         uint32_t       max_size = default_rotating_max_size_mb;  // megabytes
+         uint32_t       max_files = default_rotating_max_files;
       };
 
       struct dmlog_sink_config {

--- a/libraries/libfc/src/log/logger_config.cpp
+++ b/libraries/libfc/src/log/logger_config.cpp
@@ -63,6 +63,9 @@ namespace fc {
    }
 
    namespace {
+      /// rotating_file_sink_config::max_size is expressed in megabytes; spdlog wants a byte count.
+      constexpr std::size_t bytes_per_mb = 1024 * 1024;
+
       std::unique_ptr<spdlog::formatter> build_formatter(const format_config& f, const std::string& sink_name) {
          if (f.type == "pattern") {
             std::string pattern;
@@ -157,8 +160,9 @@ namespace fc {
                log_config::get().sink_map[cfg.sinks[i].name] = sink;
             } else if (cfg.sinks[i].type == "rotating_file_sink") {
                auto config = cfg.sinks[i].args.as<sink::rotating_file_sink_config>();
+               FC_ASSERT(config.max_size > 0, "rotating_file_sink max_size must be greater than zero MB");
                auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-                       config.base_filename, std::size_t{config.max_size}*1024*1024, config.max_files);
+                       config.base_filename, std::size_t{config.max_size} * bytes_per_mb, config.max_files);
                log_config::get().sink_map[cfg.sinks[i].name] = sink;
             } else if (cfg.sinks[i].type == "dmlog_sink") {
                auto config = cfg.sinks[i].args.as<sink::dmlog_sink_config>();

--- a/libraries/libfc/test/log/test_json_formatter.cpp
+++ b/libraries/libfc/test/log/test_json_formatter.cpp
@@ -235,6 +235,91 @@ BOOST_AUTO_TEST_CASE(rotating_size_triggers_rollover) try {
    fs::remove_all(dir);
 } FC_LOG_AND_RETHROW()
 
+// rotating_file_sink_config::max_size is a MEGABYTE count that configure_logging scales by 1 MiB. A byte
+// count slipped in here silently turns rotation off: 1048576*10 reads as "10MB" but means ~10 TiB.
+static_assert(fc::sink::default_rotating_max_size_mb <= 1024,
+              "default_rotating_max_size_mb is a megabyte count -- a byte count here disables rotation");
+
+BOOST_AUTO_TEST_CASE(rotating_max_size_defaults_to_megabytes) try {
+   // Omitting max_size in logging.json must land on the documented megabyte default. The static_assert above
+   // guards the value itself; this covers the config path an operator actually exercises.
+   auto args_json = R"({ "base_filename": "/tmp/defaults.log", "max_files": 3 })";
+   auto cfg = fc::json::from_string(args_json).as<fc::sink::rotating_file_sink_config>();
+   BOOST_CHECK_EQUAL(cfg.max_size,  fc::sink::default_rotating_max_size_mb);
+   BOOST_CHECK_EQUAL(cfg.max_files, 3u);
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(configure_logging_rotating_max_size_is_megabytes) try {
+   // Pin the unit end to end: max_size = 1 must mean 1 MiB. A byte count would rotate on every record and
+   // run through max_files; a gigabyte count would never rotate at all.
+   auto dir     = make_temp_dir("mbunit");
+   auto cleanup = fc::make_scoped_exit([&]{ fs::remove_all(dir); });
+   auto restore = fc::make_scoped_exit([]{ fc::configure_logging(fc::logging_config::default_config()); });
+
+   auto file = dir / "mb.log";
+   fc::logging_config cfg;
+
+   fc::sink_config s;
+   s.name = "mb_rot";
+   s.type = "rotating_file_sink";
+   fc::sink::rotating_file_sink_config rot_cfg;
+   rot_cfg.base_filename = file.string();
+   rot_cfg.max_size  = 1; // 1 MiB
+   rot_cfg.max_files = 3;
+   s.args = fc::variant{rot_cfg};
+   cfg.sinks.push_back(s);
+
+   fc::logger_config lcfg;
+   lcfg.name    = "test_mb_unit_logger";
+   lcfg.level   = fc::log_level::info;
+   lcfg.enabled = true;
+   lcfg.sinks   = {"mb_rot"};
+   cfg.loggers.push_back(lcfg);
+
+   BOOST_REQUIRE(fc::configure_logging(cfg));
+   {
+      auto lgr = fc::log_config::get_logger("test_mb_unit_logger");
+      // ~1.2 MiB of payload: enough to cross a 1 MiB threshold exactly once.
+      const std::string payload(1024, 'x');
+      for (int i = 0; i < 1200; ++i) {
+         fc_ilog(lgr, "{}", payload);
+      }
+   }
+   // Drop the sink so the rotated files are closed and their sizes settle.
+   fc::configure_logging(fc::logging_config::default_config());
+
+   BOOST_REQUIRE(fs::exists(file));
+   BOOST_CHECK(fs::exists(dir / "mb.1.log"));  // rotated once -- so max_size is not gigabytes
+   BOOST_CHECK(!fs::exists(dir / "mb.2.log")); // and not bytes, which would have rotated on every record
+   BOOST_CHECK_LE(fs::file_size(file), std::size_t{1024} * 1024);
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(configure_logging_rejects_zero_max_size) try {
+   // spdlog rejects a zero rotation size; configure_logging must fail cleanly rather than propagate it.
+   auto dir     = make_temp_dir("zeromb");
+   auto cleanup = fc::make_scoped_exit([&]{ fs::remove_all(dir); });
+   auto restore = fc::make_scoped_exit([]{ fc::configure_logging(fc::logging_config::default_config()); });
+
+   fc::logging_config cfg;
+
+   fc::sink_config s;
+   s.name = "zero_rot";
+   s.type = "rotating_file_sink";
+   fc::sink::rotating_file_sink_config rot_cfg;
+   rot_cfg.base_filename = (dir / "zero.log").string();
+   rot_cfg.max_size  = 0;
+   rot_cfg.max_files = 3;
+   s.args = fc::variant{rot_cfg};
+   cfg.sinks.push_back(s);
+
+   fc::logger_config lcfg;
+   lcfg.name  = "test_zero_max_size_logger";
+   lcfg.sinks = {"zero_rot"};
+   cfg.loggers.push_back(lcfg);
+
+   BOOST_CHECK(!fc::configure_logging(cfg));
+} FC_LOG_AND_RETHROW()
+
 BOOST_AUTO_TEST_CASE(parse_config_from_json_text) try {
    // Full sink_config round-trip through fc::json. extra_fields must accept
    // the natural JSON-object form so operators can hand-edit logging.json.


### PR DESCRIPTION
## Summary

`rotating_file_sink` treats `max_size` as a **megabyte** count -- `configure_logging` multiplies it by 1 MiB before handing it to spdlog -- but the struct default was written as a byte count:

    uint32_t max_size = 1048576*10; // 10MB

Scaled by 1 MiB that asks for a ~10 TiB rotation threshold, so any `logging.json` that omits `max_size` never rotates. Before the `std::size_t` cast was added, the same expression wrapped uint32 arithmetic to exactly `0`, which spdlog rejects outright, failing the whole `configure_logging` call. Either way the default has never produced a working rotating sink; only configs that set `max_size` explicitly have worked.

This sets the default to 10 megabytes behind a named constant, documents the unit on the struct, and rejects a zero `max_size` with a specific message rather than a generic "Failed to configure logging".

No behavior change for any config that sets `max_size`: the megabyte interpretation at the use site is unchanged, and it is what every existing config and test already assumes.

Coverage: a `static_assert` rejects a byte-count-shaped default at compile time, a config-parse case pins the omitted-`max_size` path to the documented default, an end-to-end case drives ~1.2 MiB through `configure_logging` with `max_size = 1` to pin the megabyte unit against both a byte and a gigabyte reading, and a case covers the zero rejection.