### PR TITLE
batch_operator: report the group actually on duty when logging a non-election

### DIFF
--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -152,6 +152,10 @@ struct batch_operator_plugin::impl {
    // Epoch state tracked across polls
    uint32_t                 current_epoch = 0;
    uint8_t                  my_group = 255;
+   /// The group index ON DUTY, straight from `epochstate.current_batch_op_group`.
+   /// Retained across polls because the election decision is made in
+   /// `parse_epoch_state` but reported in `do_poll_epoch_state`.
+   uint8_t                  current_group = 255;
    bool                     is_elected = false;
    fc::time_point           epoch_start;
    fc::time_point           next_epoch_start;
@@ -458,6 +462,7 @@ struct batch_operator_plugin::impl {
          }
       }
 
+      current_group = cur_group;
       is_elected = (my_group == cur_group);
 
       // Parse epoch timing
@@ -492,7 +497,7 @@ struct batch_operator_plugin::impl {
       if (!is_elected) {
          if (epoch_index != current_epoch) {
             ilog("batch_operator: not elected for epoch {} (my_group={}, active_group={})",
-                 epoch_index, my_group, (epoch_index % 3));
+                 epoch_index, my_group, current_group);
          }
          // Keep current_epoch fresh even when not elected: per-outpost jobs
          // consult it via depot_ops, and they bail on !is_elected anyway.

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -13,6 +13,7 @@
 #include <string_view>
 
 #include "async_action_completion.hpp"
+#include "group_election.hpp"
 
 #include <sysio/batch_operator_plugin/batch_operator_plugin.hpp>
 #include <sysio/batch_operator_plugin/depot_ops.hpp>
@@ -51,10 +52,6 @@ namespace {
    constexpr std::size_t EPOCH_TICK_CRON_JOBS = 1;
    /// Exact secondary-index lookups should return at most the matching row.
    constexpr uint32_t EXACT_LOOKUP_LIMIT = 1;
-
-   /// Group-index sentinel. For `my_group` it means "we are not in any
-   /// batch-op group"; for `current_group`, "no epoch state parsed yet".
-   constexpr uint8_t GROUP_NONE = 255;
 
    // ── WIRE contract identifiers (actions, tables, indexes, field names) ──
    // Centralised so a contract rename/refactor shows up as one search hit,
@@ -152,15 +149,12 @@ struct batch_operator_plugin::impl {
 
    // Epoch state tracked across polls
    uint32_t                 current_epoch = 0;
-   uint8_t                  my_group = GROUP_NONE;
-   /// The group index ON DUTY, straight from `epochstate.current_batch_op_group`.
-   /// Retained across polls because the election decision is made in
-   /// `parse_epoch_state` but reported in `do_poll_epoch_state`.
-   uint8_t                  current_group = GROUP_NONE;
-   bool                     is_elected = false;
+   /// This operator's standing for `current_epoch`. Retained across polls
+   /// because the election is decided in `parse_epoch_state` but reported in
+   /// `do_poll_epoch_state`.
+   batch_operator_detail::group_election election;
    fc::time_point           epoch_start;
    fc::time_point           next_epoch_start;
-   std::vector<chain::name> current_group_members;
    std::vector<outpost_descriptor> outposts;
 
    // Operator awareness — set by `poll_own_status()` from sysio.opreg::operators.
@@ -273,7 +267,7 @@ struct batch_operator_plugin::impl {
       }
 
       bool     within_epoch_window() const override { return _impl.within_epoch_window(); }
-      bool     is_elected()         const override { return _impl.is_elected; }
+      bool     is_elected()         const override { return _impl.election.is_elected; }
       uint32_t current_epoch()      const override { return _impl.current_epoch; }
       bool     is_epoch_boundary_past() const override {
          // `next_epoch_start` is cached on `_impl` from
@@ -351,7 +345,7 @@ struct batch_operator_plugin::impl {
       // chkcons advances the epoch on consensus. Only the elected operator
       // should push it — the contract verifies authorization regardless,
       // but pushing from every batch op wastes trx slots.
-      if (is_elected) {
+      if (election.is_elected) {
          try {
             push_action(msgch::account, msgch::action_chkcons, operator_account,
                         fc::mutable_variant_object());
@@ -437,40 +431,22 @@ struct batch_operator_plugin::impl {
       bool     paused      = obj[epoch::field::is_paused].as_bool();
 
       if (paused) {
-         if (is_elected) {
+         if (election.is_elected) {
             ilog("batch_operator: epoch paused, suspending");
-            is_elected = false;
+            election.is_elected = false;
          }
          return {false, 0};
       }
 
       // Determine group assignment
-      my_group = GROUP_NONE;
-      current_group_members.clear();
-      auto groups_arr = obj[epoch::field::batch_op_groups].get_array(); // copy, not reference
-
-      for (uint8_t g = 0; g < groups_arr.size(); ++g) {
-         auto grp = groups_arr[g].get_array(); // copy
-         for (auto& member : grp) {
-            if (chain::name(member.as_string()) == operator_account) {
-               my_group = g;
-            }
-         }
-         if (g == cur_group) {
-            for (auto& member : grp) {
-               current_group_members.push_back(chain::name(member.as_string()));
-            }
-         }
-      }
-
-      current_group = cur_group;
-      is_elected = (my_group == cur_group);
+      election = batch_operator_detail::evaluate_group_election(
+         cur_group, obj[epoch::field::batch_op_groups].get_array(), operator_account);
 
       // Parse epoch timing
       fc::from_variant(obj[epoch::field::current_epoch_start], epoch_start);
       fc::from_variant(obj[epoch::field::next_epoch_start],    next_epoch_start);
 
-      if (is_elected) {
+      if (election.is_elected) {
          ilog("batch_operator: current_epoch={}", epoch_index);
       }
 
@@ -495,10 +471,9 @@ struct batch_operator_plugin::impl {
       // recorded during `evalcons` dispatch and the epoch time gate are met —
       // but they never AUTHORIZE bootstrap or advance directly.
 
-      if (!is_elected) {
+      if (!election.is_elected) {
          if (epoch_index != current_epoch) {
-            ilog("batch_operator: not elected for epoch {} (my_group={}, active_group={})",
-                 epoch_index, my_group, current_group);
+            ilog("{}", batch_operator_detail::not_elected_message(epoch_index, election));
          }
          // Keep current_epoch fresh even when not elected: per-outpost jobs
          // consult it via depot_ops, and they bail on !is_elected anyway.
@@ -508,7 +483,7 @@ struct batch_operator_plugin::impl {
 
       if (epoch_index != current_epoch) {
          ilog("batch_operator: ELECTED for epoch {} (group {}, {} members)",
-              epoch_index, my_group, current_group_members.size());
+              epoch_index, election.my_group, election.current_group_members.size());
       }
       current_epoch = epoch_index;
       // Refresh the outpost list so governance-added outposts become visible.

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -52,7 +52,8 @@ namespace {
    /// Exact secondary-index lookups should return at most the matching row.
    constexpr uint32_t EXACT_LOOKUP_LIMIT = 1;
 
-   /// my_group sentinel meaning "we are not in any batch-op group".
+   /// Group-index sentinel. For `my_group` it means "we are not in any
+   /// batch-op group"; for `current_group`, "no epoch state parsed yet".
    constexpr uint8_t GROUP_NONE = 255;
 
    // ── WIRE contract identifiers (actions, tables, indexes, field names) ──
@@ -151,11 +152,11 @@ struct batch_operator_plugin::impl {
 
    // Epoch state tracked across polls
    uint32_t                 current_epoch = 0;
-   uint8_t                  my_group = 255;
+   uint8_t                  my_group = GROUP_NONE;
    /// The group index ON DUTY, straight from `epochstate.current_batch_op_group`.
    /// Retained across polls because the election decision is made in
    /// `parse_epoch_state` but reported in `do_poll_epoch_state`.
-   uint8_t                  current_group = 255;
+   uint8_t                  current_group = GROUP_NONE;
    bool                     is_elected = false;
    fc::time_point           epoch_start;
    fc::time_point           next_epoch_start;

--- a/plugins/batch_operator_plugin/src/group_election.hpp
+++ b/plugins/batch_operator_plugin/src/group_election.hpp
@@ -1,0 +1,72 @@
+#pragma once
+/**
+ * @file group_election.hpp
+ * @brief One operator's batch-op group standing for one epoch, plus the
+ *        diagnostic that reports a non-election.
+ */
+
+#include <cstdint>
+#include <format>
+#include <string>
+#include <vector>
+
+#include <fc/variant.hpp>
+#include <sysio/chain/name.hpp>
+
+namespace sysio::batch_operator_detail {
+
+/// Group-index sentinel. For `my_group` it means "we are not in any
+/// batch-op group"; for `current_group`, "no epoch state parsed yet".
+inline constexpr uint8_t GROUP_NONE = 255;
+
+/// This operator's standing against one `sysio.epoch::epochstate` reading.
+///
+/// `current_group` is the group ON DUTY, taken verbatim from
+/// `epochstate.current_batch_op_group`. The sliding window keeps the group on
+/// duty at the FRONT of `batch_op_groups` — `sysio.epoch::advance` pops the
+/// expiring group off — so the on-duty index is NOT a function of the epoch
+/// index. Anything reporting the active group reads it from here; deriving it
+/// (`epoch_index % groups`) is the static-rotation anti-pattern the sliding
+/// window replaced.
+struct group_election {
+   uint8_t                  my_group      = GROUP_NONE;
+   uint8_t                  current_group = GROUP_NONE;
+   bool                     is_elected    = false;
+   std::vector<chain::name> current_group_members;
+};
+
+/// Evaluates `operator_account`'s standing from the epochstate's on-duty group
+/// index and its `batch_op_groups` window.
+inline group_election evaluate_group_election(uint8_t             current_batch_op_group,
+                                              const fc::variants& batch_op_groups,
+                                              chain::name         operator_account) {
+   group_election election;
+   election.current_group = current_batch_op_group;
+
+   for (uint8_t g = 0; g < batch_op_groups.size(); ++g) {
+      const auto& group = batch_op_groups[g].get_array();
+      for (const auto& member : group) {
+         if (chain::name(member.as_string()) == operator_account) {
+            election.my_group = g;
+         }
+      }
+      if (g == election.current_group) {
+         for (const auto& member : group) {
+            election.current_group_members.push_back(chain::name(member.as_string()));
+         }
+      }
+   }
+
+   election.is_elected = (election.my_group == election.current_group);
+   return election;
+}
+
+/// The non-election diagnostic. `active_group` is `election.current_group` —
+/// the value the election itself compared against — so the line can never name
+/// a group the decision did not consult.
+inline std::string not_elected_message(uint32_t epoch_index, const group_election& election) {
+   return std::format("batch_operator: not elected for epoch {} (my_group={}, active_group={})",
+                      epoch_index, election.my_group, election.current_group);
+}
+
+} // namespace sysio::batch_operator_detail

--- a/plugins/batch_operator_plugin/test/test_group_election.cpp
+++ b/plugins/batch_operator_plugin/test/test_group_election.cpp
@@ -1,0 +1,103 @@
+#include "../src/group_election.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <string>
+
+#include <fc/exception/exception.hpp>
+#include <fc/variant.hpp>
+
+using namespace sysio::batch_operator_detail;
+
+namespace {
+
+/// A three-group sliding window; `self` sits in group 1.
+constexpr auto self         = "batchop.b";
+constexpr auto on_duty_peer = "batchop.a";
+constexpr auto group_peer   = "batchop.c";
+constexpr auto stranger     = "batchop.d";
+
+constexpr uint8_t on_duty_group = 0;
+constexpr uint8_t self_group    = 1;
+constexpr uint8_t idle_group    = 2;
+
+/// The epoch whose modulo-3 rotation index (1) differs from the group actually
+/// on duty (0) — the exact reading that made the old diagnostic self-contradict.
+constexpr uint32_t epoch_index = 1;
+
+constexpr std::size_t on_duty_group_size = 2;
+
+fc::variants group(std::initializer_list<const char*> members) {
+   fc::variants accounts;
+   for (const auto* member : members) {
+      accounts.emplace_back(std::string(member));
+   }
+   return accounts;
+}
+
+/// `batch_op_groups` as the epochstate carries it: group 0 on duty, `self` in 1.
+fc::variants sliding_window() {
+   return fc::variants{fc::variant(group({on_duty_peer, stranger})),
+                       fc::variant(group({self, group_peer})),
+                       fc::variant(group({stranger, group_peer}))};
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(batch_operator_group_election_tests)
+
+/// An operator seated in a group that is not on duty is not elected, and the
+/// diagnostic names the group the decision actually consulted.
+///
+/// Regression guard: the message once printed `epoch_index % 3`, the
+/// static-rotation index the sliding window replaced. At epoch 1 that yields 1
+/// — equal to `my_group` — so the line read "not elected (my_group=1,
+/// active_group=1)". Any return to a derived active group fails here.
+BOOST_AUTO_TEST_CASE(not_elected_reports_the_group_on_duty) try {
+   const auto election = evaluate_group_election(on_duty_group, sliding_window(), sysio::chain::name(self));
+
+   BOOST_CHECK_EQUAL(static_cast<unsigned>(election.my_group), static_cast<unsigned>(self_group));
+   BOOST_CHECK_EQUAL(static_cast<unsigned>(election.current_group), static_cast<unsigned>(on_duty_group));
+   BOOST_CHECK(!election.is_elected);
+
+   BOOST_CHECK_EQUAL(not_elected_message(epoch_index, election),
+                     std::string("batch_operator: not elected for epoch 1 (my_group=1, active_group=0)"));
+} FC_LOG_AND_RETHROW();
+
+/// The on-duty group's roster is captured for the operator seated in it.
+BOOST_AUTO_TEST_CASE(elected_captures_the_on_duty_roster) try {
+   const auto election =
+      evaluate_group_election(on_duty_group, sliding_window(), sysio::chain::name(on_duty_peer));
+
+   BOOST_CHECK_EQUAL(static_cast<unsigned>(election.my_group), static_cast<unsigned>(on_duty_group));
+   BOOST_CHECK_EQUAL(static_cast<unsigned>(election.current_group), static_cast<unsigned>(on_duty_group));
+   BOOST_CHECK(election.is_elected);
+   BOOST_CHECK_EQUAL(election.current_group_members.size(), on_duty_group_size);
+   BOOST_CHECK_EQUAL(election.current_group_members[0].to_string(), std::string(on_duty_peer));
+} FC_LOG_AND_RETHROW();
+
+/// The on-duty roster is read from the group on duty, not from the epoch index.
+/// With group 2 on duty at epoch 1, a modulo-3 reading would collect group 1.
+BOOST_AUTO_TEST_CASE(on_duty_roster_follows_the_window_not_the_epoch) try {
+   const auto election = evaluate_group_election(idle_group, sliding_window(), sysio::chain::name(self));
+
+   BOOST_CHECK_EQUAL(static_cast<unsigned>(election.current_group), static_cast<unsigned>(idle_group));
+   BOOST_CHECK(!election.is_elected);
+   BOOST_CHECK_EQUAL(election.current_group_members[0].to_string(), std::string(stranger));
+   BOOST_CHECK_EQUAL(not_elected_message(epoch_index, election),
+                     std::string("batch_operator: not elected for epoch 1 (my_group=1, active_group=2)"));
+} FC_LOG_AND_RETHROW();
+
+/// An operator seated in no group keeps the sentinel and is never elected.
+BOOST_AUTO_TEST_CASE(unseated_operator_keeps_the_group_sentinel) try {
+   const auto election =
+      evaluate_group_election(on_duty_group, sliding_window(), sysio::chain::name("batchop.z"));
+
+   BOOST_CHECK_EQUAL(static_cast<unsigned>(election.my_group), static_cast<unsigned>(GROUP_NONE));
+   BOOST_CHECK(!election.is_elected);
+   BOOST_CHECK_EQUAL(not_elected_message(epoch_index, election),
+                     std::string("batch_operator: not elected for epoch 1 (my_group=255, active_group=0)"));
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Follow-up to #573 (closed). That PR's backfill regressed `flow-batch-operator-termination` and carried two unresolved `[P1]`s, so it was closed rather than iterated. Two items surfaced during that investigation were real and independent of the backfill; this PR carries the one that is unambiguous.

## The fix

The not-elected log printed `epoch_index % 3` as `active_group`:

```cpp
ilog("batch_operator: not elected for epoch {} (my_group={}, active_group={})",
     epoch_index, my_group, (epoch_index % 3));
```

That is the **static-rotation** value from the design the sliding window replaced — the exact shape `.claude/rules/batch-operator-schedule-window.md` calls out:

> *"Look for `current_batch_op_group = current_epoch_index % batch_op_groups` style code — that's the static-rotation anti-pattern this rule replaces."*

The branch it narrates compares `my_group` against `epochstate.current_batch_op_group`, which the window keeps pinned at **0** (`advance` pops the expiring group off the front, so the front is always the group on duty). The printed value is not the one the decision used.

The two agree only when `epoch_index % 3 == 0`. Otherwise the line names a group that was never consulted — and it reads as a flat contradiction when the printed value happens to equal `my_group`. From a real flow run:

```
batch_operator: not elected for epoch 1 (my_group=1, active_group=1)
batch_operator: not elected for epoch 4 (my_group=1, active_group=1)
```

Equal values, yet "not elected". Nothing is wrong with the election — `my_group == 1`, `cur_group == 0`, correctly not elected — only with the message. That apparent contradiction is what sent one investigation looking for a bug in the election path rather than in the line describing it.

`cur_group` is a local in `parse_epoch_state`, while the log sits in `do_poll_epoch_state`, which is presumably why the original reached for an expression instead of the value. The fix retains it as `current_group` beside `my_group` — both are per-poll election state, and the existing `current_group_members` establishes the name — and prints that. (Round 2 below moves all four onto a `group_election` struct.)

**No behavior change — in this commit or in the two review rounds that follow.** The election reads the same values in the same order throughout; what changed is the diagnostic's content, and where the election lives.

## Naming the sentinel (review round 1)

`GROUP_NONE` already named the `255` group sentinel, and `parse_epoch_state` already assigned it to `my_group` — but the *declaration* of `my_group` carried the bare literal, which `current_group` then copied — a third spelling of one value. Both declarations now initialize from the constant, and its comment carries both meanings it holds:

```cpp
/// Group-index sentinel. For `my_group` it means "we are not in any
/// batch-op group"; for `current_group`, "no epoch state parsed yet".
constexpr uint8_t GROUP_NONE = 255;
```

## Extracting the election, and covering it (review round 2)

The corrected line had nothing reaching it: `parse_epoch_state` and `do_poll_epoch_state` are members of `impl` inside the .cpp, and the election ran inline in the former — so no test could observe either the on-duty group or the message reporting it. That gap is what let the modulo expression sit there.

Both moved into `plugins/batch_operator_plugin/src/group_election.hpp`, beside `async_action_completion.hpp`, which already keeps its log strings as named constants for the same reason:

- **`group_election`** — the per-poll standing (`my_group`, `current_group`, `is_elected`, `current_group_members`), replacing four loose `impl` fields with the one thing they always described together.
- **`evaluate_group_election(current_batch_op_group, batch_op_groups, operator_account)`** — the group-assignment loop, verbatim.
- **`not_elected_message(epoch_index, election)`** — the diagnostic itself, so the reported `active_group` **is** `election.current_group` by construction. The call site is now `ilog("{}", not_elected_message(epoch_index, election))` — there is no longer a slot for an expression.

`plugins/batch_operator_plugin/test/test_group_election.cpp` adds four cases:

| Case | Asserts |
|---|---|
| `not_elected_reports_the_group_on_duty` | epoch 1, on-duty group 0, this operator in group 1 → the exact line `batch_operator: not elected for epoch 1 (my_group=1, active_group=0)` |
| `elected_captures_the_on_duty_roster` | the operator seated in the on-duty group is elected, and that group's roster is captured |
| `on_duty_roster_follows_the_window_not_the_epoch` | on-duty group 2 — neither the window front nor `epoch_index % 3`, so a derived reading cannot pass by coincidence |
| `unseated_operator_keeps_the_group_sentinel` | an operator in no group keeps `GROUP_NONE` and is never elected |

## Not included, deliberately

The other item was the pre-mutation pool read in `sysio.epoch::advance` — `slashop` / `recorddel` / `termcheck` are inline actions that execute only after `advance` returns, so the pool scan reads operators queued for demotion as still ACTIVE.

It is **not** carried here, because master already documents that ordering as a deliberate invariant:

> *"opreg::slash THROWS on an already-SLASHED operator, which would abort advance and stall OPP epoch advancement. These inline slashes execute only after advance returns, so the schedule slide below can temporarily place a just-slashed operator in its new tail while the operator still reads ACTIVE. That member cannot create a later non-canonical observation: sysio.msgch::deliver requires its current sysio.opreg status to be ACTIVE before accepting delivery."*

And since #569, `sysio.msgch::eligible_batch_operators()` intersects the seated group with **live** opreg ACTIVE status and sizes `group_size` from the result, so a seated-then-slashed member is excluded and the threshold adapts rather than becoming unreachable.

Changing that ordering means touching an invariant whose own comment warns the alternative aborts `advance` and stalls OPP advancement chain-wide. That is a design discussion, not a drive-by change — raising it separately.

## Validation

Verified as a regression guard, not merely a passing test. Restoring `epoch_index % 3` in `not_elected_message` fails 3 of the 4 cases and reproduces the original contradiction verbatim:

```
check not_elected_message(epoch_index, election) == ... has failed
  [batch_operator: not elected for epoch 1 (my_group=1, active_group=1)
!= batch_operator: not elected for epoch 1 (my_group=1, active_group=0)]
```

With it restored: **40/40** in `test_batch_operator_plugin` (36 existing + 4 new). Built by compiling the plugin translation units and every test translation unit from this branch against the release build's flags and linking with its own link line.

No contract, ABI, or WASM changes, so the post-contract-refactor rebuild chain does not apply.
