### PR TITLE
batch_operator: crank chkdispute so a resolved dispute can unpause the epoch

### DIFF
--- a/contracts/sysio.chalg/src/sysio.chalg.cpp
+++ b/contracts/sysio.chalg/src/sysio.chalg.cpp
@@ -343,7 +343,11 @@ void chalg::votedispute(name owner, uint64_t dispute_id, checksum256 chosen_chec
 //  chkdispute — tally votes; on resolution dispatch the winner and unpause
 // ---------------------------------------------------------------------------
 void chalg::chkdispute(uint64_t dispute_id) {
-   // Permissionless crank — batch operators call this on their ~15s cadence.
+   // Permissionless crank, driven by `batch_operator_plugin`'s epoch tick
+   // (`--batch-epoch-poll-ms`, 15s default) from every ACTIVE batch operator.
+   // That cadence is this action's ONLY driver: unlike `chkuwchal`, which
+   // `sysio.uwrit::chklocks` pokes from every `sysio.epoch::advance`, a dispute
+   // pauses `advance` itself, so no inline poke can reach here.
    disputes_t disputes(get_self());
    auto d_pk = dispute_key{dispute_id};
    auto d = disputes.get(d_pk, "dispute not found");

--- a/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
+++ b/plugins/batch_operator_plugin/src/batch_operator_plugin.cpp
@@ -105,6 +105,18 @@ namespace {
       }
    }
 
+   namespace chalg {
+      constexpr auto account           = "sysio.chalg";
+      constexpr auto table_disputes    = "disputes";
+      constexpr auto action_chkdispute = "chkdispute";
+      /// Field names on `dispute_entry` rows, plus the `chkdispute` action arg.
+      namespace field {
+         constexpr auto id         = "id";
+         constexpr auto status     = "status";
+         constexpr auto dispute_id = "dispute_id";
+      }
+   }
+
    /// v6: chain registry was split out of `sysio.epoch` onto its own
    /// `sysio.chains` contract. The `outposts` table was replaced by the
    /// `chains` KV table, keyed by slug_name (uint64 packed).
@@ -352,6 +364,70 @@ struct batch_operator_plugin::impl {
                         fc::mutable_variant_object());
          } catch (const fc::exception& e) {
             dlog("batch_operator: chkcons: {}", e.to_string());
+         }
+      }
+
+      // Tally any OPEN envelope dispute. Deliberately NOT gated on `is_elected`
+      // — see crank_open_disputes.
+      try {
+         crank_open_disputes();
+      } FC_LOG_AND_DROP();
+   }
+
+   /**
+    * Crank `sysio.chalg::chkdispute` for every OPEN envelope dispute.
+    *
+    * `sysio.chalg::opendispute` sends `sysio.epoch::pause`, and `chkdispute` is
+    * the ONLY action that tallies the Tier-1 votes, dispatches the winning
+    * envelope and lifts that pause. Nothing on chain drives it: its sibling
+    * `chkuwchal` needs no cadence because `sysio.uwrit::chklocks` pokes it from
+    * every `sysio.epoch::advance` — which works precisely because an
+    * underwriter challenge does NOT pause the chain. An envelope dispute halts
+    * `advance` itself, so no inline poke can reach it. Without this crank a
+    * dispute stays OPEN after Tier-1 has already reached quorum, and epoch
+    * advancement is paused indefinitely.
+    *
+    * Not gated on `is_elected` (unlike the `chkcons` push above): the elected
+    * operator may be the very one that is offline or delivered the
+    * non-canonical envelope — often the reason the dispute exists. Disputes are
+    * rare, so pushing from every ACTIVE operator costs effectively nothing, and
+    * `chkdispute` asserts the dispute is still OPEN, which makes a redundant
+    * push a cheap no-op.
+    *
+    * The scan is a full-table filter rather than a `byepoch` index lookup: the
+    * table retains RESOLVED rows as the audit trail, but disputes are rare and
+    * `poll_own_status` already scans a comparably-sized table each tick. If
+    * disputes ever become frequent, bound this by `current_epoch` via the
+    * `byepoch` secondary index.
+    */
+   void crank_open_disputes() {
+      sysio::chain_apis::read_only::get_table_rows_params p;
+      p.code        = chain::name(chalg::account);
+      p.scope       = chalg::account;
+      p.table       = chalg::table_disputes;
+      p.all_rows    = true;
+      p.values_only = true;
+      p.filter      = [](const fc::variant& row) {
+         const auto& obj = row.get_object();
+         auto status_it  = obj.find(chalg::field::status);
+         return status_it != obj.end() &&
+                status_it->value().as<DisputeStatus>() == DISPUTE_STATUS_OPEN;
+      };
+      auto rows = read_table(std::move(p));
+
+      for (const auto& r : rows.rows) {
+         const auto& obj = r.get_object();
+         auto id_it      = obj.find(chalg::field::id);
+         if (id_it == obj.end()) continue;
+         const uint64_t dispute_id = id_it->value().as_uint64();
+
+         try {
+            push_action(chalg::account, chalg::action_chkdispute, operator_account,
+                        fc::mutable_variant_object()(chalg::field::dispute_id, dispute_id));
+         } catch (const fc::exception& e) {
+            // Expected-transient: the dispute resolved between the scan and the push, or
+            // another operator's crank won the race.
+            dlog("batch_operator: chkdispute({}): {}", dispute_id, e.to_string());
          }
       }
    }


### PR DESCRIPTION
## The bug

`sysio.chalg::opendispute` sends `sysio.epoch::pause`. `chkdispute` is the ONLY action that tallies the Tier-1 votes, dispatches the winning envelope via `resolvedisp`, and lifts that pause. **Nothing drove it.**

```
plugins/  chkdispute  → 0 files       chkcons  → 2 files (batch_operator_plugin.cpp:351)
          votedispute → 0 files       chkuwchal → 0 files
```

No plugin in the tree references `chalg` at all, and `batch_operator_plugin` knows exactly two action names:

```cpp
constexpr auto action_deliver = "deliver";
constexpr auto action_chkcons = "chkcons";
```

The comment at `sysio.chalg.cpp:346` — *"batch operators call this on their ~15s cadence"* — asserted a cadence that did not exist.

## Why the sibling survives and this one cannot

`chkuwchal`'s header states the contract outright:

> *"Nobody has to run it on a cadence: `sysio.uwrit::chklocks` (inlined from every `sysio.epoch::advance`) pokes it … **which works precisely because the chain is NOT paused during an underwriter challenge.**"*

An envelope dispute is the inverse: it pauses `advance`, so the advance-driven poke is structurally unavailable. `chkuwchal` also has a LAPSED deadline path; `chkdispute` has none — `if (!resolved) return;`, *"No plurality / tie-break — an unresolved tally just keeps waiting for more votes."*

So the sibling has two independent liveness mechanisms and `chkdispute` had zero. Tier-1 reaches quorum → dispute stays `OPEN` → `open_disputes` never decrements → epoch paused until someone hand-cranks it.

## The change

Crank it from the epoch tick that already runs (`--batch-epoch-poll-ms`, 15s default), scanning `sysio.chalg::disputes` for OPEN rows.

**Gated on `is_active`, not `is_elected`** — deliberate, and the one design call worth reviewing. `chkcons` is elected-only to avoid burning trx slots every tick from every operator. Here the elected operator may be exactly the one offline or the one that delivered the non-canonical envelope — often *why* the dispute exists. Disputes are rare, and `chkdispute` asserts the dispute is still OPEN, so a redundant push from a second operator is a cheap no-op logged at `dlog`.

Full-table scan rather than the `byepoch` index: the table retains RESOLVED rows as the audit trail, but disputes are rare and `poll_own_status` already scans a comparably-sized table each tick. The comment names the index as the escape hatch if that ever changes.

## Accepted design decision

**Pausing until Tier-1 votes is correct, and there is deliberately no timeout escape.** This PR moves the liveness dependency from "operators must deliver" to "a majority of Tier-1 must vote", and that is the intended trade — the alternatives (plurality, or abandon-and-resume) either pick a winner on weak evidence or hand back the original deadlock. Recorded here so it is an explicit decision rather than an implicit one.

## Contract file

`contracts/sysio.chalg/src/sysio.chalg.cpp` is **comment-only** — it corrects the false cadence claim. No `.wasm`/`.abi` appears in this diff, and a comment cannot change the compiled artifact, so `contracts_unit_test` was not re-run for it. Flag it if you want that gate run anyway.

## Verification

- E2E flow in progress.