### PR TITLE
logging: add es_sink — batched Elasticsearch/OpenSearch bulk log forwarding

### DIFF
--- a/libraries/libfc-test/include/fc-test/capture_http_server.hpp
+++ b/libraries/libfc-test/include/fc-test/capture_http_server.hpp
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace fc::test {
+
+/**
+ * Multi-request loopback HTTP server that records every request and replays
+ * scripted responses.
+ *
+ * The accept loop runs until destruction; each connection serves one request and
+ * closes (`Connection: close`, which the fc::http transport honors, so every
+ * client request arrives on a fresh connection). Responses replay the supplied
+ * script in order; once the script is exhausted every further request receives
+ * the default response (an empty successful bulk body). Requests are recorded --
+ * and waiters notified -- BEFORE a scripted delay is applied, so a test can
+ * observe a request while its response still stalls the client.
+ *
+ * Like one_shot_http_server, the destructor unblocks a worker parked in accept
+ * via a throwaway self-connect.
+ */
+class capture_http_server {
+public:
+   /// One scripted reply: HTTP status, body, and an optional artificial service
+   /// delay applied before responding (lets tests stall a client's worker).
+   struct scripted_response {
+      unsigned                  status = 200;
+      std::string               body   = R"({"took":1,"errors":false,"items":[]})";
+      std::chrono::milliseconds delay{0};
+   };
+
+   /// One recorded request. Header names are lower-cased on capture.
+   struct captured_request {
+      std::string method;
+      std::string target;
+      std::string body;
+      std::vector<std::pair<std::string, std::string>> headers;
+
+      /// Case-insensitive single-header lookup; empty string when absent.
+      std::string header(std::string_view name) const {
+         std::string wanted{name};
+         std::transform(wanted.begin(), wanted.end(), wanted.begin(),
+                        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+         for (const auto& entry : headers) {
+            if (entry.first == wanted)
+               return entry.second;
+         }
+         return {};
+      }
+   };
+
+   explicit capture_http_server(std::vector<scripted_response> script = {})
+      : _script(std::move(script))
+      , _acceptor(_io, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0))
+      , _port(_acceptor.local_endpoint().port())
+      , _worker([this] { serve(); }) {}
+
+   capture_http_server(const capture_http_server&) = delete;
+   capture_http_server& operator=(const capture_http_server&) = delete;
+
+   ~capture_http_server() {
+      _stopping.store(true);
+      // Wake a worker blocked in synchronous accept without operating on the
+      // acceptor from two threads; the throwaway socket closes immediately.
+      boost::system::error_code error;
+      boost::asio::io_context io;
+      tcp::socket socket(io);
+      socket.connect(tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), _port), error);
+      socket.close(error);
+      if (_worker.joinable()) {
+         _worker.join();
+      }
+      _acceptor.close(error);
+   }
+
+   /// Return the loopback URL selected for this server.
+   std::string url() const { return "http://127.0.0.1:" + std::to_string(_port); }
+
+   /// Number of requests captured so far.
+   std::size_t request_count() const {
+      std::lock_guard<std::mutex> lk(_mtx);
+      return _requests.size();
+   }
+
+   /// Copy of the i-th captured request (throws std::out_of_range past the end).
+   captured_request request(std::size_t i) const {
+      std::lock_guard<std::mutex> lk(_mtx);
+      return _requests.at(i);
+   }
+
+   /// Block until at least @p n requests are captured or @p timeout elapses.
+   bool wait_for_requests(std::size_t n, std::chrono::milliseconds timeout) {
+      std::unique_lock<std::mutex> lk(_mtx);
+      return _cv.wait_for(lk, timeout, [&] { return _requests.size() >= n; });
+   }
+
+private:
+   using tcp = boost::asio::ip::tcp;
+
+   void serve() {
+      while (!_stopping.load()) {
+         boost::system::error_code error;
+         tcp::socket socket(_io);
+         _acceptor.accept(socket, error);
+         if (error || _stopping.load()) {
+            return;
+         }
+
+         boost::beast::flat_buffer request_buffer;
+         boost::beast::http::request<boost::beast::http::string_body> request;
+         boost::beast::http::read(socket, request_buffer, request, error);
+         if (error) {
+            continue;
+         }
+
+         captured_request captured;
+         captured.method = std::string{request.method_string()};
+         captured.target = std::string{request.target()};
+         captured.body   = request.body();
+         for (const auto& field : request) {
+            std::string field_name{field.name_string()};
+            std::transform(field_name.begin(), field_name.end(), field_name.begin(),
+                           [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            captured.headers.emplace_back(std::move(field_name), std::string{field.value()});
+         }
+
+         scripted_response reply;
+         {
+            std::lock_guard<std::mutex> lk(_mtx);
+            _requests.push_back(std::move(captured));
+            if (_next < _script.size()) {
+               reply = _script[_next++];
+            }
+         }
+         _cv.notify_all();
+
+         if (reply.delay.count() > 0) {
+            std::this_thread::sleep_for(reply.delay);
+         }
+
+         std::ostringstream response;
+         response << "HTTP/1.1 " << reply.status << " Scripted\r\n"
+                  << "Content-Type: application/json\r\n"
+                  << "Content-Length: " << reply.body.size() << "\r\n"
+                  << "Connection: close\r\n\r\n"
+                  << reply.body;
+         const auto response_text = response.str();
+         boost::asio::write(socket, boost::asio::buffer(response_text), error);
+         socket.close(error);
+      }
+   }
+
+   std::vector<scripted_response> _script;
+   std::size_t                    _next = 0;
+   mutable std::mutex             _mtx;
+   std::condition_variable        _cv;
+   std::vector<captured_request>  _requests;
+   std::atomic<bool>              _stopping{false};
+   boost::asio::io_context        _io;
+   tcp::acceptor                  _acceptor;
+   uint16_t                       _port;
+   std::thread                    _worker;
+};
+
+} // namespace fc::test

--- a/libraries/libfc/CMakeLists.txt
+++ b/libraries/libfc/CMakeLists.txt
@@ -23,6 +23,8 @@ set(fc_sources
         src/log/dmlog_formatter.cpp
         src/log/json_formatter.cpp
         src/log/pattern_formatter.cpp
+        src/log/json_layout.cpp
+        src/log/es_sink.cpp
         src/log/logger_config.cpp
         src/crypto/_digest_common.cpp
         src/crypto/aes.cpp

--- a/libraries/libfc/include/fc/log/es_sink.hpp
+++ b/libraries/libfc/include/fc/log/es_sink.hpp
@@ -1,0 +1,140 @@
+#pragma once
+#include <fc/spdlog.hpp>
+#include <spdlog/sinks/base_sink.h>
+
+#include <fc/log/logger_config.hpp>
+#include <fc/network/http/http_client.hpp>
+#include <fc/network/url.hpp>
+#include <fc/parallel/worker_task_queue.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+namespace fc {
+
+/// spdlog sink that batches formatted document lines and ships them to an
+/// OpenSearch/Elasticsearch _bulk endpoint from a dedicated worker thread.
+///
+/// The logging thread never performs network I/O: sink_it_ formats the record and
+/// appends it to an in-memory batch; a bounded single-worker queue delivers batches
+/// (size-, byte-, and interval-triggered) with retry/backoff on the worker thread.
+/// The ctor installs fc::log::json_formatter with the fc::log::es_default_layout
+/// template as the default formatter (dmlog_sink precedent -- configure_logging must
+/// not overwrite it with the default pattern); an explicit json "format" block
+/// overrides it, which is the supported way to stamp identity extra_fields or reshape
+/// documents. Each formatter output line is used verbatim as one bulk document source
+/// line; the sink owns the action line built from its `index` argument.
+///
+/// Lock order: _timer_mtx -> base_sink::mutex_ -> worker_task_queue internals.
+///  - logging threads: mutex_ -> queue (try_push); never _timer_mtx
+///  - timer thread:    _timer_mtx, then mutex_ -> queue on each tick
+///  - worker thread:   queue alone (pop) or _timer_mtx alone (backoff / warn detail);
+///                     NEVER mutex_, so a slow endpoint can never stall logging
+///  - destructor:      each lock briefly; no lock held across a join
+///
+/// Failure diagnostics NEVER go through fc loggers (this sink may be attached to the
+/// "default" logger -- an fc log call from sink internals would recurse into
+/// sink_it_). The hot path only increments counters; the timer thread emits one
+/// rate-limited std::cerr summary line.
+class es_sink_mt : public spdlog::sinks::base_sink<std::mutex> {
+public:
+   /// Validates the config (FC_ASSERT -> configure_logging returns false on a bad
+   /// value) and starts the delivery worker + interval-flush timer. No network
+   /// connection is opened until the first batch is delivered.
+   explicit es_sink_mt(fc::sink::es_sink_config cfg);
+   ~es_sink_mt() override;
+
+   // --- observability / test support (safe from any thread) ---
+
+   /// Batches rejected by the full delivery queue, or discarded at shutdown.
+   uint64_t dropped_batches() const noexcept { return _dropped_batches.load(std::memory_order_relaxed); }
+   /// Single documents whose formatted size exceeded max_doc_bytes.
+   uint64_t dropped_docs() const noexcept { return _dropped_docs.load(std::memory_order_relaxed); }
+   /// Batches that exhausted retries, got a terminal 4xx, or a non-bulk 2xx response;
+   /// also counted (alongside partial indexed_docs credit) on 2xx-with-item-errors.
+   uint64_t failed_batches() const noexcept { return _failed_batches.load(std::memory_order_relaxed); }
+   /// Documents positively acknowledged by the endpoint ("errors":false, or the
+   /// non-erroring subset of a partial-failure response).
+   uint64_t indexed_docs() const noexcept { return _indexed_docs.load(std::memory_order_relaxed); }
+
+   /// Block until the pending batch is empty AND every enqueued batch has completed
+   /// delivery -- the same predicate the destructor's graceful drain uses -- or until
+   /// @p timeout elapses. Returns whether the sink went idle. (Enqueued/completed
+   /// counters, not queue size: size() drops the moment the worker POPS a batch,
+   /// before it is delivered, so a size-based predicate has an idle-looking window.)
+   bool wait_until_idle(std::chrono::milliseconds timeout);
+
+   /// Format a synthetic sample record through the CURRENT formatter and FC_ASSERT the
+   /// output is a single line parsing as a JSON object -- the bulk-NDJSON requirement.
+   /// configure_logging calls this after formatter attachment so a broken or non-JSON
+   /// layout template fails configuration loudly instead of silently 400-ing every
+   /// batch; any custom template that renders valid one-line JSON passes.
+   void assert_formatter_renders_json();
+
+protected:
+   void sink_it_(const spdlog::details::log_msg& msg) override;
+   /// Intentionally a no-op: every configured logger runs flush_on(info), firing
+   /// flush_() synchronously after each info+ record with mutex_ held. Delivery
+   /// cadence is owned by the size/byte thresholds and the interval timer.
+   void flush_() override;
+
+private:
+   /// One assembled _bulk request body (action/document line pairs) plus its count.
+   struct batch {
+      std::string body;
+      uint32_t    doc_count = 0;
+   };
+
+   /// FC_ASSERTs endpoint/batching invariants and strips a trailing '/' from url.
+   static fc::sink::es_sink_config validate(fc::sink::es_sink_config cfg);
+
+   /// Move the pending batch onto the delivery queue. Requires mutex_ held. Counters
+   /// only on the drop path -- no I/O, no stream writes.
+   void enqueue_pending_locked();
+   /// Deliver one batch (worker thread only; never takes mutex_).
+   void deliver(batch& delivery);
+   /// Interval flush + rate-limited warning reporter (dedicated timer thread).
+   void timer_loop();
+   /// Account a 2xx bulk response: positive-signal probe for "errors":false /
+   /// "errors":true, full parse on the uncertain paths (worker thread only).
+   void handle_bulk_response_body(const std::string& body, uint32_t doc_count);
+   /// Record a warning event with detail text for the timer thread's next report.
+   void note_warning(std::string detail);
+   /// Emit at most one std::cerr summary per warn interval (timer thread + dtor only).
+   void emit_pending_warnings();
+
+   const fc::sink::es_sink_config _cfg;         ///< validated configuration
+   std::string                _action_line; ///< {"index":{"_index":"<escaped>"}}\n, built once
+   fc::url                    _bulk_url;    ///< <url>/_bulk
+   std::optional<std::string> _auth_header; ///< "Basic <base64(user:pass)>" when configured
+
+   batch _pending; ///< guarded by base_sink::mutex_
+
+   std::shared_ptr<parallel::worker_task_queue<batch>> _queue;
+   std::unique_ptr<http::transport>                    _transport; ///< worker thread only
+
+   std::thread             _timer_thread;
+   std::mutex              _timer_mtx;
+   std::condition_variable _timer_cv;
+   bool                    _shutting_down = false; ///< guarded by _timer_mtx; stops the TIMER only
+   std::string             _warn_detail;           ///< guarded by _timer_mtx; latest warning detail
+   std::atomic<bool>       _cancel_requested{false}; ///< aborts in-flight HTTP + retry backoff
+   std::atomic<uint64_t>   _batches_enqueued{0};     ///< successful try_push count (gap-free vs completed)
+   std::atomic<uint64_t>   _batches_completed{0};    ///< deliver() exits (any outcome)
+
+   std::atomic<uint64_t> _dropped_batches{0};
+   std::atomic<uint64_t> _dropped_docs{0};
+   std::atomic<uint64_t> _failed_batches{0};
+   std::atomic<uint64_t> _indexed_docs{0};
+   std::atomic<uint64_t> _warn_events{0};   ///< events since the last report
+   std::atomic<int64_t>  _last_warn_ns{0};  ///< steady_clock ns of the last stderr report
+};
+
+} // namespace fc

--- a/libraries/libfc/include/fc/log/json_escape.hpp
+++ b/libraries/libfc/include/fc/log/json_escape.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <fc/spdlog.hpp>
+
+#include <iterator>
+#include <string_view>
+
+namespace fc::log::detail {
+
+/// Append a string_view to an spdlog memory buffer without an intermediate std::string.
+inline void append_sv(spdlog::memory_buf_t& out, std::string_view s) {
+   out.append(s.data(), s.data() + s.size());
+}
+
+/// JSON-escape @p s into @p out: quote, backslash, \b \f \n \r \t, and \u00xx for any
+/// other control byte. Bytes >= 0x20 (including UTF-8 sequences) pass through untouched.
+inline void json_escape_into(spdlog::memory_buf_t& out, std::string_view s) {
+   for (unsigned char c : s) {
+      switch (c) {
+         case '"':  append_sv(out, R"(\")"); break;
+         case '\\': append_sv(out, R"(\\)"); break;
+         case '\b': append_sv(out, R"(\b)"); break;
+         case '\f': append_sv(out, R"(\f)"); break;
+         case '\n': append_sv(out, R"(\n)"); break;
+         case '\r': append_sv(out, R"(\r)"); break;
+         case '\t': append_sv(out, R"(\t)"); break;
+         default:
+            if (c < 0x20) {
+               fmt::format_to(std::back_inserter(out), R"(\u{:04x})", static_cast<unsigned>(c));
+            } else {
+               out.push_back(static_cast<char>(c));
+            }
+      }
+   }
+}
+
+} // namespace fc::log::detail

--- a/libraries/libfc/include/fc/log/json_formatter.hpp
+++ b/libraries/libfc/include/fc/log/json_formatter.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <fc/spdlog.hpp>
+#include <fc/log/json_layout.hpp>
 
 #include <cstdint>
 #include <map>
@@ -8,19 +9,35 @@
 
 namespace fc::log {
 
-/// spdlog formatter that emits one JSON object per log record, terminated
-/// by '\n'. Fields: ts (UTC microseconds), lvl, thread, logger, file, line,
-/// func, msg, (optional) extra. Usable on any sink -- attach via
-/// sink->set_formatter(std::make_unique<fc::log::json_formatter>(...)).
+/// spdlog formatter that emits one JSON object per log record, terminated by '\n'.
+/// The document shape is a compiled json_layout token template: absent/empty
+/// `layout_template` renders the historical fc JSONL shape (fc::log::default_layout --
+/// ts/lvl/thread/logger/file/line/func/msg, optional extra). Any other template
+/// (e.g. fc::log::es_default_layout) reshapes the document freely. Usable on any
+/// sink -- attach via sink->set_formatter(std::make_unique<fc::log::json_formatter>(...)).
 class json_formatter final : public spdlog::formatter {
 public:
-   explicit json_formatter(std::map<std::string, std::string> extra_fields = {});
+   /// @param extra_fields    static key/value pairs. Where they land is the template's
+   ///                        choice: ${extra_object} (the historical `,"extra":{...}`
+   ///                        object) or ${extra_flat} (flattened at the placement point,
+   ///                        e.g. document top level for the es shape). Key uniqueness
+   ///                        vs. template-authored keys is the template author's
+   ///                        responsibility -- the template controls placement.
+   /// @param layout_template json_layout token template; empty compiles
+   ///                        fc::log::default_layout (the historical output).
+   ///                        FC_ASSERTs on a malformed template (unknown token /
+   ///                        modifier / unterminated placeholder).
+   explicit json_formatter(std::map<std::string, std::string> extra_fields = {}, std::string layout_template = {});
 
    void format(const spdlog::details::log_msg& msg, spdlog::memory_buf_t& dest) override;
    std::unique_ptr<spdlog::formatter> clone() const override;
 
 private:
    std::map<std::string, std::string> extra_fields_;
+   std::string                        layout_template_;      ///< kept for clone()
+   json_layout                        compiled_;             ///< compiled once in the ctor
+   std::string                        extra_object_fragment_; ///< pre-escaped `,"extra":{...}` or ""
+   std::string                        extra_flat_fragment_;   ///< pre-escaped `,"k":"v",...` or ""
 };
 
 } // namespace fc::log

--- a/libraries/libfc/include/fc/log/json_layout.hpp
+++ b/libraries/libfc/include/fc/log/json_layout.hpp
@@ -1,0 +1,87 @@
+#pragma once
+#include <fc/spdlog.hpp>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace fc::log {
+
+/// Placeholder tokens accepted inside a json_formatter layout template (see json_layout).
+/// Token names and modifiers are parsed by name via magic_enum -- the logging config
+/// carries the template STRING; these enums are internal parse artifacts, deliberately
+/// not config-reflected types.
+enum class json_layout_token : uint8_t {
+   timestamp,    ///< record time; modifiers: iso8601 (default) | epoch_millis (bare number)
+   level,        ///< spdlog level name; modifiers: upper | lower (default preserves spdlog's spelling)
+   message,      ///< the log payload (JSON-escaped)
+   logger,       ///< the logger name (JSON-escaped)
+   file,         ///< source filename, empty when unknown (JSON-escaped)
+   line,         ///< source line as a bare number
+   func,         ///< source function name, empty when unknown (JSON-escaped)
+   thread,       ///< fc::get_thread_name() (JSON-escaped)
+   extra_object, ///< renders `,"extra":{"k":"v",...}` -- or NOTHING when extra_fields is empty
+   extra_flat    ///< renders `,"k":"v",...` (leading comma per entry) -- or NOTHING when empty
+};
+
+/// ${timestamp} rendering choices.
+enum class json_layout_timestamp_format : uint8_t { iso8601, epoch_millis };
+
+/// ${level} case choices. `preserve` keeps spdlog's spelling (trace/debug/info/warn/error/crit).
+enum class json_layout_level_case : uint8_t { preserve, upper, lower };
+
+/// A compiled json_formatter layout template.
+///
+/// A template is arbitrary literal text (the author writes the JSON punctuation and
+/// key names themselves) interleaved with `${token}` / `${token:modifier}` placeholders
+/// drawn from json_layout_token. `$${` escapes a literal `${`. Compile once
+/// (configuration time); render per log record. String-valued tokens are JSON-escaped
+/// on emit; `line` and `timestamp:epoch_millis` emit bare numbers.
+class json_layout {
+public:
+   json_layout() = default;
+
+   /// Compile @p template_text into a segment sequence.
+   /// FC_ASSERTs (failing configure_logging loudly) on an unknown token name, an
+   /// unknown or misplaced modifier, or an unterminated `${` placeholder.
+   static json_layout compile(std::string_view template_text);
+
+   /// Render one record into @p dest (no trailing newline -- the formatter owns that).
+   /// The extras fragments are pre-escaped by the caller (json_formatter builds them
+   /// once from its extra_fields) and are emitted verbatim wherever ${extra_object} /
+   /// ${extra_flat} sit in the template.
+   void render(const spdlog::details::log_msg& msg,
+               const std::string& extra_object_fragment,
+               const std::string& extra_flat_fragment,
+               spdlog::memory_buf_t& dest) const;
+
+private:
+   /// One compiled template piece: literal text, or a token with its modifiers.
+   struct segment {
+      std::string                  literal;                                                  ///< used when !is_token
+      bool                         is_token = false;                                         ///< literal vs token discriminator
+      json_layout_token            token = json_layout_token::message;                       ///< valid when is_token
+      json_layout_timestamp_format timestamp_format = json_layout_timestamp_format::iso8601; ///< timestamp token only
+      json_layout_level_case       level_case = json_layout_level_case::preserve;            ///< level token only
+   };
+
+   std::vector<segment> segments_;
+};
+
+/// Historical fc JSONL document shape -- compiled when a json format block carries no
+/// `layout` value. Renders byte-identically to the pre-template json_formatter output
+/// (pinned by json_formatter_tests).
+inline constexpr std::string_view default_layout =
+   R"({"ts":"${timestamp}","lvl":"${level}","thread":"${thread}","logger":"${logger}","file":"${file}","line":${line},"func":"${func}","msg":"${message}"${extra_object}})";
+
+/// Elasticsearch/OpenSearch log-document shape -- the es_sink's default formatter
+/// template. Fields: @timestamp (epoch millis, matching a `date`/`epoch_millis`
+/// mapping), level (uppercase keyword), message, category (logger name),
+/// sourceLocation, data.thread; extra_fields (env/app/principal/logStream/...) land
+/// at the document top level via ${extra_flat}. Note: spdlog's `critical` renders as
+/// `CRIT` under ${level:upper} (the repo's SPDLOG_LEVEL_NAMES spelling).
+inline constexpr std::string_view es_default_layout =
+   R"({"@timestamp":${timestamp:epoch_millis},"level":"${level:upper}","message":"${message}","category":"${logger}","sourceLocation":"${file}:${line} ${func}","data":{"thread":"${thread}"}${extra_flat}})";
+
+} // namespace fc::log

--- a/libraries/libfc/include/fc/log/logger_config.hpp
+++ b/libraries/libfc/include/fc/log/logger_config.hpp
@@ -31,6 +31,13 @@ namespace fc {
          // (string/number/bool/null) coerced to string at load time. Nested
          // objects or arrays throw fc::bad_cast_exception on configure_logging.
          fc::variant_object extra_fields;
+         // layout is a fc::log::json_layout token template controlling the document
+         // shape (see fc/log/json_layout.hpp). Empty/absent renders the historical
+         // fc JSONL shape (fc::log::default_layout); fc::log::es_default_layout is
+         // the shipped Elasticsearch/OpenSearch document template. A malformed
+         // template (unknown token/modifier, unterminated placeholder) fails
+         // configure_logging.
+         std::string layout;
       };
    } // namespace format
 
@@ -86,6 +93,54 @@ namespace fc {
       struct dmlog_sink_config {
          std::string file = "-";
       };
+
+      /// Defaults for es_sink. Worst-case buffered memory is roughly
+      /// (max_pending_batches + 2) * max_batch_bytes -- the pending batch, the queued
+      /// batches, and one batch in flight.
+      inline constexpr uint32_t default_es_batch_size = 100; ///< documents per bulk request
+      /// NDJSON bulk-request body cap, in bytes.
+      inline constexpr uint32_t default_es_max_batch_bytes = 1024 * 1024;
+      /// Single-document cap, in bytes; a larger formatted document is dropped and counted.
+      inline constexpr uint32_t default_es_max_doc_bytes = 256 * 1024;
+      /// Interval flush cadence for a partially-filled batch.
+      inline constexpr uint32_t default_es_flush_interval_ms = 1000;
+      /// Delivery-queue bound, in batches; a full queue drops the newest batch.
+      inline constexpr uint32_t default_es_max_pending_batches = 8;
+      /// ADDITIONAL delivery attempts after the first (total attempts = max_retries + 1).
+      inline constexpr uint32_t default_es_max_retries = 2;
+      /// Initial retry backoff; doubles per attempt, capped inside the sink.
+      inline constexpr uint32_t default_es_retry_backoff_ms = 250;
+      inline constexpr uint32_t default_es_connect_timeout_ms = 5000;
+      inline constexpr uint32_t default_es_request_timeout_ms = 10000;
+      /// App-thread stall budget: the sink destructor runs on the app/SIGHUP thread
+      /// during plugin handle_sighup() fan-out -- this bounds that stall, NOT a
+      /// background wait.
+      inline constexpr uint32_t default_es_shutdown_flush_timeout_ms = 500;
+      /// Hard ceiling on max_batch_bytes; bounds sink memory even with an absurd config.
+      inline constexpr uint32_t es_max_batch_bytes_ceiling = 16u * 1024 * 1024;
+
+      /// Ships log documents to an OpenSearch/Elasticsearch _bulk endpoint from a
+      /// dedicated worker thread. Document shape is owned by the sink's formatter
+      /// (fc::log::json_formatter with the fc::log::es_default_layout template by
+      /// default); identity fields (env/app/principal/logStream/...) ride the
+      /// formatter's extra_fields. This struct configures endpoint, batching, and
+      /// delivery only.
+      struct es_sink_config {
+         std::string url;                     ///< base URL, e.g. "https://elasticsearch.example.com" (required; trailing '/' stripped)
+         std::string index;                   ///< target index or write alias (required non-empty)
+         std::optional<std::string> username; ///< optional HTTP basic auth user
+         std::optional<std::string> password; ///< required iff username is set
+         uint32_t batch_size          = default_es_batch_size;
+         uint32_t max_batch_bytes     = default_es_max_batch_bytes;
+         uint32_t max_doc_bytes       = default_es_max_doc_bytes;
+         uint32_t flush_interval_ms   = default_es_flush_interval_ms;
+         uint32_t max_pending_batches = default_es_max_pending_batches;
+         uint32_t max_retries               = default_es_max_retries;
+         uint32_t retry_backoff_ms          = default_es_retry_backoff_ms;
+         uint32_t connect_timeout_ms        = default_es_connect_timeout_ms;
+         uint32_t request_timeout_ms        = default_es_request_timeout_ms;
+         uint32_t shutdown_flush_timeout_ms = default_es_shutdown_flush_timeout_ms;
+      };
    } // namespace sink
 
    struct logger_config {
@@ -133,12 +188,17 @@ namespace fc {
 FC_REFLECT( fc::sink_config, (name)(type)(args)(format)(enabled) )
 FC_REFLECT( fc::format_config, (type)(args) )
 FC_REFLECT( fc::format::pattern_config, (pattern) )
-FC_REFLECT( fc::format::json_config, (extra_fields) )
+FC_REFLECT( fc::format::json_config, (extra_fields)(layout) )
 FC_REFLECT( fc::sink::level_color, (level)(color) )
 FC_REFLECT_ENUM( fc::sink::output_t, (stderr)(stdout) )
 FC_REFLECT( fc::sink::console_sink_config, (color)(level_colors)(output_type) )
 FC_REFLECT( fc::sink::daily_file_sink_config, (base_filename)(rotation_hour)(rotation_minute)(truncate)(max_files) )
 FC_REFLECT( fc::sink::rotating_file_sink_config, (base_filename)(max_size)(max_files) )
 FC_REFLECT( fc::sink::dmlog_sink_config, (file) )
+FC_REFLECT( fc::sink::es_sink_config,
+   (url)(index)(username)(password)
+   (batch_size)(max_batch_bytes)(max_doc_bytes)(flush_interval_ms)(max_pending_batches)
+   (max_retries)(retry_backoff_ms)(connect_timeout_ms)(request_timeout_ms)
+   (shutdown_flush_timeout_ms) )
 FC_REFLECT( fc::logger_config, (name)(level)(enabled)(sinks) )
 FC_REFLECT( fc::logging_config, (includes)(sinks)(loggers) )

--- a/libraries/libfc/include/fc/log/logger_config.hpp
+++ b/libraries/libfc/include/fc/log/logger_config.hpp
@@ -112,10 +112,15 @@ namespace fc {
       inline constexpr uint32_t default_es_retry_backoff_ms = 250;
       inline constexpr uint32_t default_es_connect_timeout_ms = 5000;
       inline constexpr uint32_t default_es_request_timeout_ms = 10000;
-      /// App-thread stall budget: the sink destructor runs on the app/SIGHUP thread
-      /// during plugin handle_sighup() fan-out -- this bounds that stall, NOT a
-      /// background wait.
-      inline constexpr uint32_t default_es_shutdown_flush_timeout_ms = 500;
+      /// Stall budget on the BLOCK-PRODUCTION thread, not a background wait: SIGHUP
+      /// posts through the priority_queue_executor's single-threaded read_write
+      /// queue -- the same queue block production uses -- and handlers run to
+      /// completion, so the sink destructor's drain (which fires inside the
+      /// handle_sighup() fan-out, e.g. on every logrotate) delays the next
+      /// production handler by up to this budget plus the ~50 ms cancel-poll join.
+      /// Sized well under the 500 ms block interval; against a dead endpoint the
+      /// drain always times out, so the worst case recurs on every SIGHUP.
+      inline constexpr uint32_t default_es_shutdown_flush_timeout_ms = 100;
       /// Hard ceiling on max_batch_bytes; bounds sink memory even with an absurd config.
       inline constexpr uint32_t es_max_batch_bytes_ceiling = 16u * 1024 * 1024;
 

--- a/libraries/libfc/src/log/es_sink.cpp
+++ b/libraries/libfc/src/log/es_sink.cpp
@@ -1,0 +1,404 @@
+#include <fc/log/es_sink.hpp>
+#include <fc/log/json_escape.hpp>
+#include <fc/log/json_formatter.hpp>
+
+#include <fc/crypto/base64.hpp>
+#include <fc/exception/exception.hpp>
+#include <fc/io/json.hpp>
+#include <fc/variant_object.hpp>
+
+#include <algorithm>
+#include <iostream>
+
+namespace fc {
+
+namespace {
+
+using log::detail::json_escape_into;
+
+constexpr std::string_view es_bulk_path     = "/_bulk";
+constexpr std::string_view es_content_type  = "application/x-ndjson";
+constexpr std::string_view es_user_agent    = "wire-es-sink";
+constexpr std::string_view es_scheme_http   = "http";
+constexpr std::string_view es_scheme_https  = "https";
+/// The top-level "errors" flag precedes "items" in a bulk response, so probing the
+/// head of the body for the success token is authoritative; every other outcome
+/// (item errors, non-bulk 2xx, unexpected whitespace) falls through to a full parse.
+constexpr std::size_t      es_errors_probe_bytes = 256;
+constexpr std::string_view es_errors_false_token = R"("errors":false)";
+constexpr auto es_warn_interval = std::chrono::seconds(5);
+constexpr auto es_drain_poll    = std::chrono::milliseconds(25);
+constexpr auto es_max_backoff   = std::chrono::milliseconds(2000);
+/// Bulk responses carry one item per document; cap them well above realistic sizes.
+constexpr uint64_t es_max_response_body_bytes = 4ULL * 1024ULL * 1024ULL;
+constexpr uint32_t http_status_ok_min            = 200;
+constexpr uint32_t http_status_ok_max            = 299;
+constexpr uint32_t http_status_too_many_requests = 429;
+constexpr uint32_t http_status_server_error_min  = 500;
+
+/// Fields used to sample-render the formatter for configure-time validation.
+constexpr std::string_view sample_source_file = "es_sink";
+constexpr std::string_view sample_logger_name = "es_sink";
+constexpr std::string_view sample_payload     = "sample";
+constexpr int              sample_source_line = 1;
+
+/// Increments the completed-batches counter when a delivery attempt exits (any path).
+struct delivery_completed_guard {
+   explicit delivery_completed_guard(std::atomic<uint64_t>& counter) : _counter(counter) {}
+   ~delivery_completed_guard() { _counter.fetch_add(1, std::memory_order_acq_rel); }
+   std::atomic<uint64_t>& _counter;
+};
+
+} // anonymous namespace
+
+fc::sink::es_sink_config es_sink_mt::validate(fc::sink::es_sink_config cfg) {
+   while (!cfg.url.empty() && cfg.url.back() == '/')
+      cfg.url.pop_back();
+   FC_ASSERT(!cfg.url.empty(), "es_sink: url is required");
+   const fc::url parsed{cfg.url};
+   FC_ASSERT(parsed.proto() == es_scheme_http || parsed.proto() == es_scheme_https,
+             "es_sink: url scheme must be http or https, got '{}'", parsed.proto());
+   FC_ASSERT(!cfg.index.empty(), "es_sink: index is required");
+   FC_ASSERT(cfg.batch_size > 0, "es_sink: batch_size must be greater than zero");
+   FC_ASSERT(cfg.max_batch_bytes > 0 && cfg.max_batch_bytes <= fc::sink::es_max_batch_bytes_ceiling,
+             "es_sink: max_batch_bytes must be in (0, {}]", fc::sink::es_max_batch_bytes_ceiling);
+   FC_ASSERT(cfg.max_doc_bytes > 0 && cfg.max_doc_bytes <= cfg.max_batch_bytes,
+             "es_sink: max_doc_bytes must be in (0, max_batch_bytes]");
+   FC_ASSERT(cfg.flush_interval_ms > 0, "es_sink: flush_interval_ms must be greater than zero");
+   FC_ASSERT(cfg.max_pending_batches > 0, "es_sink: max_pending_batches must be greater than zero");
+   FC_ASSERT(cfg.username.has_value() == cfg.password.has_value(),
+             "es_sink: username and password must be provided together");
+   return cfg;
+}
+
+es_sink_mt::es_sink_mt(fc::sink::es_sink_config cfg)
+   : spdlog::sinks::base_sink<std::mutex>(std::make_unique<fc::log::json_formatter>(
+        std::map<std::string, std::string>{}, std::string{fc::log::es_default_layout}))
+   , _cfg(validate(std::move(cfg))) {
+   spdlog::memory_buf_t action;
+   log::detail::append_sv(action, R"({"index":{"_index":")");
+   json_escape_into(action, _cfg.index);
+   log::detail::append_sv(action, "\"}}\n");
+   _action_line.assign(action.data(), action.size());
+
+   _bulk_url = fc::url{_cfg.url + std::string{es_bulk_path}};
+   if (_cfg.username)
+      _auth_header = "Basic " + fc::base64_encode(*_cfg.username + ":" + *_cfg.password);
+   _transport = std::make_unique<http::transport>();
+
+   // Thread-bearing members are created LAST, inside a guard: a throw after the queue
+   // exists (e.g. std::system_error from std::thread) would otherwise skip the
+   // destructor while the queue's worker still holds a raw `this`.
+   try {
+      _queue = parallel::worker_task_queue<batch>::create(
+         {.max_threads = 1, .max_pending_items = _cfg.max_pending_batches},
+         [this](batch& delivery) { deliver(delivery); });
+      _timer_thread = std::thread([this] { timer_loop(); });
+   } catch (...) {
+      _cancel_requested.store(true, std::memory_order_relaxed);
+      if (_queue) {
+         _queue->discard_pending();
+         _queue->stop();
+      }
+      throw;
+   }
+}
+
+es_sink_mt::~es_sink_mt() {
+   // 1. Stop the interval timer; it re-checks the flag before every tick.
+   {
+      std::lock_guard<std::mutex> lk(_timer_mtx);
+      _shutting_down = true;
+   }
+   _timer_cv.notify_all();
+   if (_timer_thread.joinable())
+      _timer_thread.join();
+
+   // 2. Enqueue the tail batch. No logger references this sink anymore (destruction
+   //    runs at refcount zero on the reconfigure path), but keep the lock invariant.
+   {
+      std::lock_guard<std::mutex> lk(mutex_);
+      if (_pending.doc_count > 0)
+         enqueue_pending_locked();
+   }
+
+   // 3. Graceful drain, bounded by shutdown_flush_timeout_ms. The enqueued/completed
+   //    counter pair is essential: queue size() drops to zero the instant the worker
+   //    POPS the tail -- before it is sent -- so a size-based predicate would cancel
+   //    the very batch this drain exists to save.
+   const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(_cfg.shutdown_flush_timeout_ms);
+   while (std::chrono::steady_clock::now() < deadline) {
+      if (_batches_completed.load(std::memory_order_acquire) == _batches_enqueued.load(std::memory_order_acquire))
+         break;
+      std::this_thread::sleep_for(es_drain_poll);
+   }
+
+   // 4. Hard-stop anything still in flight: the cancel_check poll aborts an active
+   //    perform(); the backoff wait's predicate aborts a retry sleep.
+   _cancel_requested.store(true, std::memory_order_relaxed);
+   _timer_cv.notify_all();
+
+   // 5. Account then discard whatever the drain window did not deliver (stop()
+   //    discards silently), then join the worker.
+   _dropped_batches.fetch_add(_queue->discard_pending(), std::memory_order_relaxed);
+   _queue->stop();
+
+   // 6. Final report + transport teardown.
+   emit_pending_warnings();
+   _transport.reset();
+}
+
+void es_sink_mt::sink_it_(const spdlog::details::log_msg& msg) {
+   spdlog::memory_buf_t formatted;
+   formatter_->format(msg, formatted);
+   if (formatted.size() > _cfg.max_doc_bytes) {
+      // Truncating mid-JSON would corrupt the document; drop it whole and count.
+      _dropped_docs.fetch_add(1, std::memory_order_relaxed);
+      _warn_events.fetch_add(1, std::memory_order_relaxed);
+      return;
+   }
+   const std::size_t incoming = _action_line.size() + formatted.size();
+   // Ship the current batch first when appending would exceed the byte cap, so every
+   // request body stays <= max_batch_bytes (+ at most one max_doc_bytes document).
+   if (_pending.doc_count > 0 && _pending.body.size() + incoming > _cfg.max_batch_bytes)
+      enqueue_pending_locked();
+   _pending.body.append(_action_line);
+   _pending.body.append(formatted.data(), formatted.size());
+   ++_pending.doc_count;
+   if (_pending.doc_count >= _cfg.batch_size || _pending.body.size() >= _cfg.max_batch_bytes)
+      enqueue_pending_locked();
+}
+
+void es_sink_mt::flush_() {
+   // Intentionally empty -- see the header doc: flush_on(info) fires this per record
+   // on the logging thread with mutex_ held; delivery cadence lives elsewhere.
+}
+
+void es_sink_mt::enqueue_pending_locked() {
+   if (_queue->try_push(std::move(_pending))) {
+      _batches_enqueued.fetch_add(1, std::memory_order_acq_rel);
+   } else {
+      _dropped_batches.fetch_add(1, std::memory_order_relaxed);
+      _warn_events.fetch_add(1, std::memory_order_relaxed);
+   }
+   _pending = {};
+}
+
+void es_sink_mt::timer_loop() {
+   std::unique_lock<std::mutex> lk(_timer_mtx);
+   while (!_shutting_down) {
+      _timer_cv.wait_for(lk, std::chrono::milliseconds(_cfg.flush_interval_ms));
+      if (_shutting_down)
+         return;
+      lk.unlock();
+      {
+         std::lock_guard<std::mutex> pending_lk(mutex_);
+         if (_pending.doc_count > 0)
+            enqueue_pending_locked();
+      }
+      emit_pending_warnings();
+      lk.lock();
+   }
+}
+
+void es_sink_mt::deliver(batch& delivery) {
+   const delivery_completed_guard completion{_batches_completed};
+   const uint32_t                 doc_count = delivery.doc_count;
+
+   http::request req;
+   req.method       = http::request_method::post;
+   req.target       = _bulk_url;
+   req.body         = std::move(delivery.body);
+   req.content_type = std::string{es_content_type};
+   req.user_agent   = std::string{es_user_agent};
+   if (_auth_header)
+      req.headers.emplace_back("Authorization", *_auth_header);
+
+   http::request_options opt;
+   opt.max_request_body_bytes  = uint64_t{_cfg.max_batch_bytes} + _cfg.max_doc_bytes;
+   opt.max_response_body_bytes = es_max_response_body_bytes;
+   opt.timeouts.connect        = fc::milliseconds(_cfg.connect_timeout_ms);
+   opt.timeouts.header = opt.timeouts.read = opt.timeouts.idle = opt.timeouts.total =
+      fc::milliseconds(_cfg.request_timeout_ms);
+   // Background worker: an ambient fc task deadline must not bound a log flush.
+   opt.timeouts.inherit_task_deadline = false;
+   opt.cancel_check = [this] { return _cancel_requested.load(std::memory_order_relaxed); };
+   // Transport retry stays at one attempt (a _bulk POST is not idempotent); the sink
+   // owns its retry loop below.
+
+   for (uint32_t attempt = 0;; ++attempt) {
+      if (_cancel_requested.load(std::memory_order_relaxed)) {
+         _failed_batches.fetch_add(1, std::memory_order_relaxed);
+         return;
+      }
+      bool retryable = false;
+      try {
+         const auto resp = _transport->perform(req, opt);
+         if (resp.status >= http_status_ok_min && resp.status <= http_status_ok_max) {
+            handle_bulk_response_body(resp.body, doc_count);
+            return;
+         }
+         // 429 is endpoint back-pressure -- the one 4xx worth retrying; other 4xx are
+         // terminal (retrying a rejected request only repeats the rejection).
+         retryable = resp.status >= http_status_server_error_min || resp.status == http_status_too_many_requests;
+         if (!retryable) {
+            _failed_batches.fetch_add(1, std::memory_order_relaxed);
+            note_warning(fmt::format("HTTP {} from {}", resp.status, http::sanitized_endpoint(_bulk_url)));
+            return;
+         }
+         note_warning(fmt::format("HTTP {} from {} (attempt {})", resp.status,
+                                  http::sanitized_endpoint(_bulk_url), attempt + 1));
+      } catch (const fc::canceled_exception&) {
+         // Shutdown abort via cancel_check.
+         _failed_batches.fetch_add(1, std::memory_order_relaxed);
+         return;
+      } catch (const fc::timeout_exception& e) {
+         retryable = true;
+         note_warning(fmt::format("timeout delivering to {}: {}", http::sanitized_endpoint(_bulk_url),
+                                  e.top_message()));
+      } catch (const fc::exception& e) {
+         // connect / DNS / TLS / io failures -- message-classified only at this layer.
+         retryable = true;
+         note_warning(fmt::format("delivery to {} failed: {}", http::sanitized_endpoint(_bulk_url),
+                                  e.top_message()));
+      }
+      if (!retryable || attempt >= _cfg.max_retries) {
+         _failed_batches.fetch_add(1, std::memory_order_relaxed);
+         return;
+      }
+      // Capped exponential backoff, interruptible by shutdown's cancel request. The
+      // predicate deliberately keys on _cancel_requested (set at drain-timeout), NOT
+      // _shutting_down (set at teardown start) -- otherwise retries would spin at zero
+      // backoff for the whole graceful-drain window.
+      const auto backoff =
+         std::min<std::chrono::milliseconds>(std::chrono::milliseconds(_cfg.retry_backoff_ms) * (1u << attempt),
+                                             es_max_backoff);
+      std::unique_lock<std::mutex> lk(_timer_mtx);
+      if (_timer_cv.wait_for(lk, backoff, [this] { return _cancel_requested.load(std::memory_order_relaxed); })) {
+         _failed_batches.fetch_add(1, std::memory_order_relaxed);
+         return;
+      }
+   }
+}
+
+void es_sink_mt::handle_bulk_response_body(const std::string& body, uint32_t doc_count) {
+   const std::string_view probe = std::string_view{body}.substr(0, es_errors_probe_bytes);
+   if (probe.find(es_errors_false_token) != std::string_view::npos) {
+      _indexed_docs.fetch_add(doc_count, std::memory_order_relaxed);
+      return;
+   }
+   // "errors":true, or neither token in the probe window (a proxy landing page, a
+   // response with unexpected whitespace, ...) -- parse to find out. Never retry after
+   // a 2xx: a partial success replayed duplicates the documents that DID index.
+   try {
+      const auto parsed = fc::json::from_string(body).get_object();
+      if (!parsed.contains("errors")) {
+         _failed_batches.fetch_add(1, std::memory_order_relaxed);
+         note_warning(fmt::format("2xx from {} is not a bulk response", http::sanitized_endpoint(_bulk_url)));
+         return;
+      }
+      if (!parsed["errors"].as_bool()) {
+         _indexed_docs.fetch_add(doc_count, std::memory_order_relaxed);
+         return;
+      }
+      uint64_t    failed_docs = 0;
+      std::string first_reason;
+      if (parsed.contains("items")) {
+         for (const auto& item : parsed["items"].get_array()) {
+            const auto& item_obj = item.get_object();
+            for (const auto& entry : item_obj) {
+               const auto& result = entry.value().get_object();
+               if (!result.contains("error"))
+                  continue;
+               ++failed_docs;
+               if (first_reason.empty())
+                  first_reason = fc::json::to_string(result["error"], fc::time_point::maximum());
+            }
+         }
+      }
+      failed_docs = std::min<uint64_t>(failed_docs, doc_count);
+      _indexed_docs.fetch_add(doc_count - failed_docs, std::memory_order_relaxed);
+      _failed_batches.fetch_add(1, std::memory_order_relaxed);
+      note_warning(fmt::format("{} of {} documents rejected by {}; first error: {}", failed_docs, doc_count,
+                               http::sanitized_endpoint(_bulk_url), first_reason));
+   } catch (const fc::exception&) {
+      _failed_batches.fetch_add(1, std::memory_order_relaxed);
+      note_warning(fmt::format("unparseable 2xx response from {}", http::sanitized_endpoint(_bulk_url)));
+   }
+}
+
+void es_sink_mt::note_warning(std::string detail) {
+   _warn_events.fetch_add(1, std::memory_order_relaxed);
+   std::lock_guard<std::mutex> lk(_timer_mtx);
+   _warn_detail = std::move(detail);
+}
+
+void es_sink_mt::emit_pending_warnings() {
+   if (_warn_events.load(std::memory_order_relaxed) == 0)
+      return;
+   const auto now_ns =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+         .count();
+   auto last = _last_warn_ns.load(std::memory_order_relaxed);
+   if (now_ns - last < std::chrono::duration_cast<std::chrono::nanoseconds>(es_warn_interval).count())
+      return;
+   if (!_last_warn_ns.compare_exchange_strong(last, now_ns, std::memory_order_relaxed))
+      return;
+   const auto  events = _warn_events.exchange(0, std::memory_order_relaxed);
+   std::string detail;
+   {
+      std::lock_guard<std::mutex> lk(_timer_mtx);
+      detail = _warn_detail;
+   }
+   // std::cerr on purpose -- NEVER fc loggers from sink internals (recursion; see the
+   // class doc). Matches the logger_config.cpp warning convention.
+   std::cerr << "\nWARNING: es_sink: " << events << " delivery warning(s) since last report"
+             << " (dropped_docs=" << _dropped_docs.load(std::memory_order_relaxed)
+             << " dropped_batches=" << _dropped_batches.load(std::memory_order_relaxed)
+             << " failed_batches=" << _failed_batches.load(std::memory_order_relaxed)
+             << " indexed_docs=" << _indexed_docs.load(std::memory_order_relaxed) << ")"
+             << (detail.empty() ? "" : " -- last: ") << detail << std::endl;
+}
+
+bool es_sink_mt::wait_until_idle(std::chrono::milliseconds timeout) {
+   const auto deadline = std::chrono::steady_clock::now() + timeout;
+   while (true) {
+      bool pending_empty = false;
+      {
+         std::lock_guard<std::mutex> lk(mutex_);
+         pending_empty = _pending.doc_count == 0;
+      }
+      if (pending_empty &&
+          _batches_completed.load(std::memory_order_acquire) == _batches_enqueued.load(std::memory_order_acquire))
+         return true;
+      if (std::chrono::steady_clock::now() >= deadline)
+         return false;
+      std::this_thread::sleep_for(es_drain_poll);
+   }
+}
+
+void es_sink_mt::assert_formatter_renders_json() {
+   spdlog::memory_buf_t rendered;
+   {
+      std::lock_guard<std::mutex> lk(mutex_);
+      const spdlog::details::log_msg sample{
+         spdlog::source_loc{sample_source_file.data(), sample_source_line, sample_source_file.data()},
+         spdlog::string_view_t{sample_logger_name.data(), sample_logger_name.size()}, spdlog::level::info,
+         spdlog::string_view_t{sample_payload.data(), sample_payload.size()}};
+      formatter_->format(sample, rendered);
+   }
+   const std::string_view line{rendered.data(), rendered.size()};
+   FC_ASSERT(!line.empty() && line.back() == '\n' && line.find('\n') == line.size() - 1,
+             "es_sink: formatter must render exactly one newline-terminated line per record");
+   try {
+      const auto parsed = fc::json::from_string(std::string{line.substr(0, line.size() - 1)});
+      FC_ASSERT(parsed.is_object(), "es_sink: formatter output is not a JSON object");
+   } catch (const fc::exception& e) {
+      FC_THROW_EXCEPTION(assert_exception,
+                         "es_sink: formatter output is not valid one-line JSON (bulk NDJSON requires it): {}",
+                         e.top_message());
+   }
+}
+
+} // namespace fc

--- a/libraries/libfc/src/log/es_sink.cpp
+++ b/libraries/libfc/src/log/es_sink.cpp
@@ -29,6 +29,11 @@ constexpr std::string_view es_errors_false_token = R"("errors":false)";
 constexpr auto es_warn_interval = std::chrono::seconds(5);
 constexpr auto es_drain_poll    = std::chrono::milliseconds(25);
 constexpr auto es_max_backoff   = std::chrono::milliseconds(2000);
+/// Clamp for the backoff doubling exponent: `1u << attempt` is UB once `attempt`
+/// reaches the width of unsigned (max_retries is operator-controlled and may exceed
+/// 32). es_max_backoff already caps the RESULT after ~4 doublings, so clamping the
+/// exponent changes no observable behavior.
+constexpr uint32_t es_max_backoff_exponent = 16;
 /// Bulk responses carry one item per document; cap them well above realistic sizes.
 constexpr uint64_t es_max_response_body_bytes = 4ULL * 1024ULL * 1024ULL;
 constexpr uint32_t http_status_ok_min            = 200;
@@ -271,9 +276,9 @@ void es_sink_mt::deliver(batch& delivery) {
       // predicate deliberately keys on _cancel_requested (set at drain-timeout), NOT
       // _shutting_down (set at teardown start) -- otherwise retries would spin at zero
       // backoff for the whole graceful-drain window.
-      const auto backoff =
-         std::min<std::chrono::milliseconds>(std::chrono::milliseconds(_cfg.retry_backoff_ms) * (1u << attempt),
-                                             es_max_backoff);
+      const auto backoff = std::min<std::chrono::milliseconds>(
+         std::chrono::milliseconds(_cfg.retry_backoff_ms) * (1u << std::min(attempt, es_max_backoff_exponent)),
+         es_max_backoff);
       std::unique_lock<std::mutex> lk(_timer_mtx);
       if (_timer_cv.wait_for(lk, backoff, [this] { return _cancel_requested.load(std::memory_order_relaxed); })) {
          _failed_batches.fetch_add(1, std::memory_order_relaxed);

--- a/libraries/libfc/src/log/json_formatter.cpp
+++ b/libraries/libfc/src/log/json_formatter.cpp
@@ -1,112 +1,64 @@
 #include <fc/log/json_formatter.hpp>
-#include <fc/log/logger_config.hpp>
-#include <fc/time.hpp>
-
-#include <chrono>
-#include <ctime>
-#include <iterator>
+#include <fc/log/json_escape.hpp>
 
 namespace fc::log {
 
 namespace {
 
-inline void append_sv(spdlog::memory_buf_t& out, std::string_view s) {
-   out.append(s.data(), s.data() + s.size());
+using detail::append_sv;
+using detail::json_escape_into;
+
+/// Build the ${extra_object} fragment: `,"extra":{"k":"v",...}` -- empty when no extras.
+std::string to_extra_object_fragment(const std::map<std::string, std::string>& extra_fields) {
+   if (extra_fields.empty())
+      return {};
+   spdlog::memory_buf_t buf;
+   append_sv(buf, R"(,"extra":{)");
+   bool first = true;
+   for (const auto& kv : extra_fields) {
+      if (!first)
+         buf.push_back(',');
+      first = false;
+      buf.push_back('"');
+      json_escape_into(buf, kv.first);
+      append_sv(buf, R"(":")");
+      json_escape_into(buf, kv.second);
+      buf.push_back('"');
+   }
+   buf.push_back('}');
+   return std::string{buf.data(), buf.size()};
 }
 
-void json_escape_into(spdlog::memory_buf_t& out, std::string_view s) {
-   for (unsigned char c : s) {
-      switch (c) {
-         case '"':  append_sv(out, R"(\")"); break;
-         case '\\': append_sv(out, R"(\\)"); break;
-         case '\b': append_sv(out, R"(\b)"); break;
-         case '\f': append_sv(out, R"(\f)"); break;
-         case '\n': append_sv(out, R"(\n)"); break;
-         case '\r': append_sv(out, R"(\r)"); break;
-         case '\t': append_sv(out, R"(\t)"); break;
-         default:
-            if (c < 0x20) {
-               fmt::format_to(std::back_inserter(out), R"(\u{:04x})", static_cast<unsigned>(c));
-            } else {
-               out.push_back(static_cast<char>(c));
-            }
-      }
+/// Build the ${extra_flat} fragment: `,"k":"v",...` (leading comma per entry) -- empty
+/// when no extras.
+std::string to_extra_flat_fragment(const std::map<std::string, std::string>& extra_fields) {
+   spdlog::memory_buf_t buf;
+   for (const auto& kv : extra_fields) {
+      append_sv(buf, R"(,")");
+      json_escape_into(buf, kv.first);
+      append_sv(buf, R"(":")");
+      json_escape_into(buf, kv.second);
+      buf.push_back('"');
    }
+   return std::string{buf.data(), buf.size()};
 }
 
 } // anonymous namespace
 
-json_formatter::json_formatter(std::map<std::string, std::string> extra_fields)
-   : extra_fields_(std::move(extra_fields)) {}
+json_formatter::json_formatter(std::map<std::string, std::string> extra_fields, std::string layout_template)
+   : extra_fields_(std::move(extra_fields))
+   , layout_template_(std::move(layout_template))
+   , compiled_(json_layout::compile(layout_template_.empty() ? default_layout : std::string_view{layout_template_}))
+   , extra_object_fragment_(to_extra_object_fragment(extra_fields_))
+   , extra_flat_fragment_(to_extra_flat_fragment(extra_fields_)) {}
 
 void json_formatter::format(const spdlog::details::log_msg& msg, spdlog::memory_buf_t& dest) {
-   auto oi = std::back_inserter(dest);
-
-   auto tp   = msg.time;
-   auto secs = std::chrono::time_point_cast<std::chrono::seconds>(tp);
-   auto us   = std::chrono::duration_cast<std::chrono::microseconds>(tp - secs).count();
-   std::time_t tt = std::chrono::system_clock::to_time_t(secs);
-   std::tm tm_utc = fc::to_utc_tm(tt);
-
-   append_sv(dest, R"({"ts":")");
-   fmt::format_to(oi, "{:04d}-{:02d}-{:02d}T{:02d}:{:02d}:{:02d}.{:06d}Z",
-      tm_utc.tm_year + 1900, tm_utc.tm_mon + 1, tm_utc.tm_mday,
-      tm_utc.tm_hour, tm_utc.tm_min, tm_utc.tm_sec, us);
-   dest.push_back('"');
-
-   const auto& lvl_sv = spdlog::level::to_string_view(msg.level);
-   append_sv(dest, R"(,"lvl":")");
-   append_sv(dest, std::string_view{lvl_sv.data(), lvl_sv.size()});
-   dest.push_back('"');
-
-   append_sv(dest, R"(,"thread":")");
-   json_escape_into(dest, fc::get_thread_name());
-   dest.push_back('"');
-
-   append_sv(dest, R"(,"logger":")");
-   json_escape_into(dest, std::string_view{msg.logger_name.data(), msg.logger_name.size()});
-   dest.push_back('"');
-
-   append_sv(dest, R"(,"file":")");
-   if (msg.source.filename) {
-      json_escape_into(dest, std::string_view{msg.source.filename});
-   }
-   dest.push_back('"');
-
-   append_sv(dest, R"(,"line":)");
-   fmt::format_to(oi, "{}", msg.source.line);
-
-   append_sv(dest, R"(,"func":")");
-   if (msg.source.funcname) {
-      json_escape_into(dest, std::string_view{msg.source.funcname});
-   }
-   dest.push_back('"');
-
-   append_sv(dest, R"(,"msg":")");
-   json_escape_into(dest, std::string_view{msg.payload.data(), msg.payload.size()});
-   dest.push_back('"');
-
-   if (!extra_fields_.empty()) {
-      append_sv(dest, R"(,"extra":{)");
-      bool first = true;
-      for (const auto& kv : extra_fields_) {
-         if (!first) dest.push_back(',');
-         first = false;
-         dest.push_back('"');
-         json_escape_into(dest, kv.first);
-         append_sv(dest, R"(":")");
-         json_escape_into(dest, kv.second);
-         dest.push_back('"');
-      }
-      dest.push_back('}');
-   }
-
-   dest.push_back('}');
+   compiled_.render(msg, extra_object_fragment_, extra_flat_fragment_, dest);
    dest.push_back('\n');
 }
 
 std::unique_ptr<spdlog::formatter> json_formatter::clone() const {
-   return std::make_unique<json_formatter>(extra_fields_);
+   return std::make_unique<json_formatter>(extra_fields_, layout_template_);
 }
 
 } // namespace fc::log

--- a/libraries/libfc/src/log/json_layout.cpp
+++ b/libraries/libfc/src/log/json_layout.cpp
@@ -1,0 +1,160 @@
+#include <fc/log/json_layout.hpp>
+#include <fc/log/json_escape.hpp>
+#include <fc/log/logger_config.hpp> // fc::get_thread_name
+#include <fc/exception/exception.hpp>
+#include <fc/time.hpp> // fc::to_utc_tm
+
+#include <magic_enum/magic_enum.hpp>
+
+#include <cctype>
+#include <chrono>
+#include <ctime>
+#include <iterator>
+
+namespace fc::log {
+
+namespace {
+
+using detail::append_sv;
+using detail::json_escape_into;
+
+constexpr std::string_view token_open         = "${";
+constexpr std::string_view token_escape       = "$${";
+constexpr char             token_close        = '}';
+constexpr char             modifier_separator = ':';
+
+/// Emit msg.time per the segment's timestamp format.
+void emit_timestamp(const spdlog::details::log_msg& msg, json_layout_timestamp_format format,
+                    spdlog::memory_buf_t& dest) {
+   auto oi = std::back_inserter(dest);
+   if (format == json_layout_timestamp_format::epoch_millis) {
+      fmt::format_to(oi, "{}",
+                     std::chrono::duration_cast<std::chrono::milliseconds>(msg.time.time_since_epoch()).count());
+      return;
+   }
+   auto        tp     = msg.time;
+   auto        secs   = std::chrono::time_point_cast<std::chrono::seconds>(tp);
+   auto        us     = std::chrono::duration_cast<std::chrono::microseconds>(tp - secs).count();
+   std::time_t tt     = std::chrono::system_clock::to_time_t(secs);
+   std::tm     tm_utc = fc::to_utc_tm(tt);
+   fmt::format_to(oi, "{:04d}-{:02d}-{:02d}T{:02d}:{:02d}:{:02d}.{:06d}Z", tm_utc.tm_year + 1900, tm_utc.tm_mon + 1,
+                  tm_utc.tm_mday, tm_utc.tm_hour, tm_utc.tm_min, tm_utc.tm_sec, us);
+}
+
+/// Emit the spdlog level name per the segment's case choice. Level names are known-safe
+/// ASCII, so no JSON escaping is required on this path.
+void emit_level(const spdlog::details::log_msg& msg, json_layout_level_case level_case, spdlog::memory_buf_t& dest) {
+   const auto&      lvl_sv = spdlog::level::to_string_view(msg.level);
+   std::string_view name{lvl_sv.data(), lvl_sv.size()};
+   if (level_case == json_layout_level_case::preserve) {
+      append_sv(dest, name);
+      return;
+   }
+   for (char c : name) {
+      dest.push_back(level_case == json_layout_level_case::upper
+                        ? static_cast<char>(std::toupper(static_cast<unsigned char>(c)))
+                        : static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+   }
+}
+
+} // anonymous namespace
+
+json_layout json_layout::compile(std::string_view template_text) {
+   json_layout compiled;
+   std::string literal;
+
+   auto flush_literal = [&]() {
+      if (literal.empty())
+         return;
+      segment seg;
+      seg.literal = std::move(literal);
+      compiled.segments_.push_back(std::move(seg));
+      literal.clear();
+   };
+
+   std::size_t pos = 0;
+   while (pos < template_text.size()) {
+      if (template_text.compare(pos, token_escape.size(), token_escape) == 0) {
+         literal += token_open; // "$${" escapes a literal "${"
+         pos += token_escape.size();
+         continue;
+      }
+      if (template_text.compare(pos, token_open.size(), token_open) != 0) {
+         literal += template_text[pos];
+         ++pos;
+         continue;
+      }
+
+      const auto close = template_text.find(token_close, pos + token_open.size());
+      FC_ASSERT(close != std::string_view::npos, "json layout: unterminated '${{' placeholder at offset {}", pos);
+      const auto body     = template_text.substr(pos + token_open.size(), close - pos - token_open.size());
+      const auto sep      = body.find(modifier_separator);
+      const auto name     = sep == std::string_view::npos ? body : body.substr(0, sep);
+      const auto modifier = sep == std::string_view::npos ? std::string_view{} : body.substr(sep + 1);
+
+      const auto token = magic_enum::enum_cast<json_layout_token>(name);
+      FC_ASSERT(token.has_value(), "json layout: unknown token '{}'", std::string(name));
+
+      segment seg;
+      seg.is_token = true;
+      seg.token    = *token;
+      if (*token == json_layout_token::timestamp) {
+         if (!modifier.empty()) {
+            const auto format = magic_enum::enum_cast<json_layout_timestamp_format>(modifier);
+            FC_ASSERT(format.has_value(), "json layout: unknown timestamp modifier '{}'", std::string(modifier));
+            seg.timestamp_format = *format;
+         }
+      } else if (*token == json_layout_token::level) {
+         if (!modifier.empty()) {
+            const auto level_case = magic_enum::enum_cast<json_layout_level_case>(modifier);
+            FC_ASSERT(level_case.has_value(), "json layout: unknown level modifier '{}'", std::string(modifier));
+            seg.level_case = *level_case;
+         }
+      } else {
+         FC_ASSERT(modifier.empty(), "json layout: token '{}' accepts no modifier", std::string(name));
+      }
+
+      flush_literal();
+      compiled.segments_.push_back(std::move(seg));
+      pos = close + 1;
+   }
+   flush_literal();
+   return compiled;
+}
+
+void json_layout::render(const spdlog::details::log_msg& msg, const std::string& extra_object_fragment,
+                         const std::string& extra_flat_fragment, spdlog::memory_buf_t& dest) const {
+   auto oi = std::back_inserter(dest);
+   for (const auto& seg : segments_) {
+      if (!seg.is_token) {
+         append_sv(dest, seg.literal);
+         continue;
+      }
+      switch (seg.token) {
+         case json_layout_token::timestamp: emit_timestamp(msg, seg.timestamp_format, dest); break;
+         case json_layout_token::level: emit_level(msg, seg.level_case, dest); break;
+         case json_layout_token::message:
+            json_escape_into(dest, std::string_view{msg.payload.data(), msg.payload.size()});
+            break;
+         case json_layout_token::logger:
+            json_escape_into(dest, std::string_view{msg.logger_name.data(), msg.logger_name.size()});
+            break;
+         case json_layout_token::file:
+            if (msg.source.filename) {
+               json_escape_into(dest, std::string_view{msg.source.filename});
+            }
+            break;
+         case json_layout_token::line: fmt::format_to(oi, "{}", msg.source.line); break;
+         case json_layout_token::func:
+            if (msg.source.funcname) {
+               json_escape_into(dest, std::string_view{msg.source.funcname});
+            }
+            break;
+         case json_layout_token::thread: json_escape_into(dest, fc::get_thread_name()); break;
+         case json_layout_token::extra_object: append_sv(dest, extra_object_fragment); break;
+         case json_layout_token::extra_flat: append_sv(dest, extra_flat_fragment); break;
+      }
+   }
+}
+
+} // namespace fc::log

--- a/libraries/libfc/src/log/logger_config.cpp
+++ b/libraries/libfc/src/log/logger_config.cpp
@@ -5,6 +5,7 @@
 #include <fc/exception/exception.hpp>
 #include <fc/log/dmlog_sink.hpp>
 #include <fc/log/dmlog_formatter.hpp>
+#include <fc/log/es_sink.hpp>
 #include <fc/log/json_formatter.hpp>
 #include <fc/log/pattern_formatter.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
@@ -66,6 +67,17 @@ namespace fc {
       /// rotating_file_sink_config::max_size is expressed in megabytes; spdlog wants a byte count.
       constexpr std::size_t bytes_per_mb = 1024 * 1024;
 
+      constexpr std::string_view dmlog_sink_type  = "dmlog_sink";
+      constexpr std::string_view es_sink_type     = "es_sink";
+      constexpr std::string_view json_format_type = "json";
+
+      /// Sinks whose ctor installs a purpose-built default formatter that the
+      /// no-format pattern fallback must not overwrite. An explicit "format" block
+      /// still overrides (that is how es_sink gets identity extra_fields).
+      bool sink_ships_own_formatter(std::string_view type) {
+         return type == dmlog_sink_type || type == es_sink_type;
+      }
+
       std::unique_ptr<spdlog::formatter> build_formatter(const format_config& f, const std::string& sink_name) {
          if (f.type == "pattern") {
             std::string pattern;
@@ -75,14 +87,14 @@ namespace fc {
             return pattern.empty()
                ? fc::log::make_pattern_formatter()
                : fc::log::make_pattern_formatter(pattern);
-         } else if (f.type == "json") {
+         } else if (f.type == json_format_type) {
+            format::json_config jc;
+            if (!f.args.is_null())
+               jc = f.args.as<format::json_config>();
             std::map<std::string, std::string> extras;
-            if (!f.args.is_null()) {
-               auto jc = f.args.as<format::json_config>();
-               for (const auto& kv : jc.extra_fields)
-                  extras[kv.key()] = kv.value().as_string();
-            }
-            return std::make_unique<fc::log::json_formatter>(std::move(extras));
+            for (const auto& kv : jc.extra_fields)
+               extras[kv.key()] = kv.value().as_string();
+            return std::make_unique<fc::log::json_formatter>(std::move(extras), std::move(jc.layout));
          } else if (f.type == "dmlog") {
             return std::make_unique<fc::log::dmlog_formatter>();
          }
@@ -168,20 +180,37 @@ namespace fc {
                auto config = cfg.sinks[i].args.as<sink::dmlog_sink_config>();
                auto sink = std::make_shared<fc::dmlog_sink_mt>(config.file);
                log_config::get().sink_map[cfg.sinks[i].name] = sink;
+            } else if (cfg.sinks[i].type == es_sink_type) {
+               // Bulk documents must be JSON -- a pattern block makes every request
+               // malformed NDJSON (silent total loss). Template-level validity is
+               // asserted after formatter attachment below.
+               FC_ASSERT(!cfg.sinks[i].format || cfg.sinks[i].format->type == json_format_type,
+                         "es_sink '{}' requires a json format block (got '{}')", cfg.sinks[i].name,
+                         cfg.sinks[i].format->type);
+               auto config = cfg.sinks[i].args.as<sink::es_sink_config>();
+               log_config::get().sink_map[cfg.sinks[i].name] = std::make_shared<fc::es_sink_mt>(std::move(config));
             } else {
                std::cerr << "\nWARNING: Unknown sink type: " << cfg.sinks[i].type << std::endl;
             }
 
-            // Attach formatter. Explicit format overrides the default; absent
-            // format means pattern (except for dmlog_sink which ships with
-            // dmlog_formatter already attached by its ctor).
+            // Attach formatter. Explicit format overrides the default; absent format
+            // means pattern -- except for sinks that ship their own formatter
+            // (dmlog_sink's dmlog_formatter, es_sink's json es_default_layout).
+            // NOTE: set_formatter, the es_sink sample render below, and the es_sink
+            // timer thread all take base_sink::mutex_ -- keep formatter use on-mutex.
             auto sink_it = log_config::get().sink_map.find(cfg.sinks[i].name);
             if (sink_it != log_config::get().sink_map.end()) {
                if (cfg.sinks[i].format) {
                   sink_it->second->set_formatter(build_formatter(*cfg.sinks[i].format, cfg.sinks[i].name));
-               } else if (cfg.sinks[i].type != "dmlog_sink") {
+               } else if (!sink_ships_own_formatter(cfg.sinks[i].type)) {
                   sink_it->second->set_formatter(fc::log::make_pattern_formatter());
                }
+               // es_sink: validate the FINAL formatter (default or explicit override)
+               // by sample-rendering one record -- a template that does not produce
+               // one-line JSON fails configure_logging here instead of silently
+               // 400-ing every bulk request at runtime.
+               if (cfg.sinks[i].type == es_sink_type)
+                  std::static_pointer_cast<fc::es_sink_mt>(sink_it->second)->assert_formatter_renders_json();
             }
          }
 

--- a/libraries/libfc/test/CMakeLists.txt
+++ b/libraries/libfc/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable( test_fc
         io/test_json.cpp
         io/test_secure_file.cpp
         log/test_json_formatter.cpp
+        log/test_es_sink.cpp
         io/test_json_variant.cpp
         io/test_random_access_file.cpp
         io/test_raw.cpp

--- a/libraries/libfc/test/log/test_es_sink.cpp
+++ b/libraries/libfc/test/log/test_es_sink.cpp
@@ -1,0 +1,618 @@
+#include <boost/test/unit_test.hpp>
+
+#include <fc/crypto/base64.hpp>
+#include <fc/io/json.hpp>
+#include <fc/log/es_sink.hpp>
+#include <fc/log/json_formatter.hpp>
+#include <fc/log/json_layout.hpp>
+#include <fc/log/logger.hpp>
+#include <fc/log/logger_config.hpp>
+#include <fc/reflect/variant.hpp>
+#include <fc/scoped_exit.hpp>
+#include <fc/variant_object.hpp>
+
+#include <fc-test/capture_http_server.hpp>
+#include <fc-test/one_shot_http_server.hpp>
+
+#include <spdlog/details/log_msg.h>
+#include <spdlog/logger.h>
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr std::string_view test_index      = "test-logs";
+constexpr auto             delivery_wait   = 5s;
+constexpr auto             idle_wait       = 5s;
+/// A window several interval-flush periods long; used to assert something did NOT
+/// happen (e.g. no request from an unreferenced sink).
+constexpr auto             quiet_window    = 300ms;
+
+/// es_sink_config with fast test timings against @p url.
+fc::sink::es_sink_config make_cfg(const std::string& url) {
+   fc::sink::es_sink_config cfg;
+   cfg.url                       = url;
+   cfg.index                     = std::string{test_index};
+   cfg.flush_interval_ms         = 50;
+   cfg.retry_backoff_ms          = 10;
+   cfg.connect_timeout_ms        = 1000;
+   cfg.request_timeout_ms        = 2000;
+   cfg.shutdown_flush_timeout_ms = 2000;
+   return cfg;
+}
+
+/// Split an NDJSON bulk body into its lines (the trailing newline yields no entry).
+std::vector<std::string> split_bulk_lines(const std::string& body) {
+   std::vector<std::string> lines;
+   std::stringstream        in{body};
+   std::string              line;
+   while (std::getline(in, line)) {
+      lines.push_back(line);
+   }
+   return lines;
+}
+
+/// Log @p count records through a stack-local spdlog logger wired to @p sink.
+void log_records(const std::shared_ptr<fc::es_sink_mt>& sink, int count, const std::string& payload = "record") {
+   spdlog::logger lgr("es_test_logger", {sink});
+   lgr.set_level(spdlog::level::trace);
+   for (int i = 0; i < count; ++i) {
+      SPDLOG_LOGGER_INFO(&lgr, "{} {}", payload, i);
+   }
+}
+
+/// A successful default-body response whose delivery stalls for @p delay.
+fc::test::capture_http_server::scripted_response delayed_ok(std::chrono::milliseconds delay) {
+   fc::test::capture_http_server::scripted_response response;
+   response.delay = delay;
+   return response;
+}
+
+/// A 2-item bulk response: one indexed, one rejected with a reason.
+std::string partial_failure_body() {
+   return R"({"took":3,"errors":true,"items":[)"
+          R"({"index":{"_index":"test-logs","status":201}},)"
+          R"({"index":{"_index":"test-logs","status":400,"error":{"type":"mapper_parsing_exception","reason":"boom"}}})"
+          R"(]})";
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(es_sink_tests)
+
+// The ctor installs json_formatter with the es_default_layout template; delivered
+// doc lines are es-shaped, the action line names the configured index, and the POST
+// targets /_bulk with the NDJSON content type. The trailing-slash URL also pins the
+// validate() slash-strip (a double slash would surface as //_bulk here).
+BOOST_AUTO_TEST_CASE(default_formatter_is_es_layout) try {
+   fc::test::capture_http_server server;
+   auto cfg       = make_cfg(server.url() + "/"); // trailing slash on purpose
+   cfg.batch_size = 1;
+   auto sink      = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 1);
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+
+   auto req = server.request(0);
+   BOOST_CHECK_EQUAL(req.method, "POST");
+   BOOST_CHECK_EQUAL(req.target, "/_bulk");
+   BOOST_CHECK_EQUAL(req.header("content-type"), "application/x-ndjson");
+   BOOST_CHECK(req.header("authorization").empty());
+   BOOST_REQUIRE(!req.body.empty());
+   BOOST_CHECK_EQUAL(req.body.back(), '\n');
+
+   auto lines = split_bulk_lines(req.body);
+   BOOST_REQUIRE_EQUAL(lines.size(), 2u);
+   BOOST_CHECK_EQUAL(lines[0], R"({"index":{"_index":"test-logs"}})");
+   BOOST_CHECK_EQUAL(lines[1].rfind(R"({"@timestamp":)", 0), 0u);
+   auto doc = fc::json::from_string(lines[1]).get_object();
+   BOOST_CHECK_EQUAL(doc["level"].as_string(), "INFO");
+   BOOST_CHECK_EQUAL(doc["category"].as_string(), "es_test_logger");
+   BOOST_CHECK_EQUAL(doc["message"].as_string(), "record 0");
+   BOOST_CHECK(!doc["data"].get_object()["thread"].as_string().empty());
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(size_triggered_flush) try {
+   fc::test::capture_http_server server;
+   auto cfg              = make_cfg(server.url());
+   cfg.batch_size        = 3;
+   cfg.flush_interval_ms = 60'000; // interval must not be the trigger here
+   auto sink             = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 3);
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   auto lines = split_bulk_lines(server.request(0).body);
+   BOOST_CHECK_EQUAL(lines.size(), 6u); // 3 action/document pairs
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(byte_cap_flush) try {
+   fc::test::capture_http_server server;
+   auto cfg              = make_cfg(server.url());
+   cfg.batch_size        = 1000;
+   cfg.max_batch_bytes   = 512;
+   cfg.max_doc_bytes     = 512;
+   cfg.flush_interval_ms = 60'000;
+   auto sink             = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 5, std::string(200, 'x'));
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   for (std::size_t i = 0; i < server.request_count(); ++i) {
+      BOOST_CHECK_LE(server.request(i).body.size(), cfg.max_batch_bytes + cfg.max_doc_bytes);
+   }
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(interval_flush) try {
+   fc::test::capture_http_server server;
+   auto cfg       = make_cfg(server.url());
+   cfg.batch_size = 1000; // size must not be the trigger here
+   auto sink      = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 1);
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   BOOST_CHECK_EQUAL(split_bulk_lines(server.request(0).body).size(), 2u);
+} FC_LOG_AND_RETHROW()
+
+// A document whose formatted size exceeds max_doc_bytes is dropped whole + counted;
+// the surrounding documents still deliver.
+BOOST_AUTO_TEST_CASE(oversized_doc_dropped) try {
+   fc::test::capture_http_server server;
+   auto cfg            = make_cfg(server.url());
+   cfg.batch_size      = 2;
+   cfg.max_batch_bytes = 4096;
+   cfg.max_doc_bytes   = 300;
+   auto sink           = std::make_shared<fc::es_sink_mt>(cfg);
+   {
+      spdlog::logger lgr("es_test_logger", {sink});
+      lgr.set_level(spdlog::level::trace);
+      SPDLOG_LOGGER_INFO(&lgr, "small one");
+      SPDLOG_LOGGER_INFO(&lgr, "{}", std::string(400, 'y')); // formatted size > 300
+      SPDLOG_LOGGER_INFO(&lgr, "small two");
+   }
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   BOOST_CHECK_EQUAL(sink->dropped_docs(), 1u);
+   std::string all_bodies;
+   for (std::size_t i = 0; i < server.request_count(); ++i)
+      all_bodies += server.request(i).body;
+   BOOST_CHECK(all_bodies.find("small one") != std::string::npos);
+   BOOST_CHECK(all_bodies.find(std::string(400, 'y')) == std::string::npos);
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(basic_auth_header) try {
+   fc::test::capture_http_server server;
+   auto cfg       = make_cfg(server.url());
+   cfg.batch_size = 1;
+   cfg.username   = "u";
+   cfg.password   = "p";
+   auto sink      = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 1);
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   BOOST_CHECK_EQUAL(server.request(0).header("authorization"), "Basic " + fc::base64_encode(std::string{"u:p"}));
+} FC_LOG_AND_RETHROW()
+
+// A stalled endpoint + a full bounded queue must never block the logging thread:
+// per-call latency stays far below the scripted service delay, and overflow batches
+// are counted as dropped.
+BOOST_AUTO_TEST_CASE(queue_full_drops_without_blocking) try {
+   constexpr auto scripted_delay = 1500ms;
+   fc::test::capture_http_server server{{delayed_ok(scripted_delay)}};
+   auto cfg                = make_cfg(server.url());
+   cfg.batch_size          = 1;
+   cfg.max_pending_batches = 1;
+   cfg.flush_interval_ms   = 60'000;
+   auto sink               = std::make_shared<fc::es_sink_mt>(cfg);
+
+   spdlog::logger lgr("es_test_logger", {sink});
+   lgr.set_level(spdlog::level::trace);
+   auto max_call = 0ms;
+   for (int i = 0; i < 10; ++i) {
+      const auto start = std::chrono::steady_clock::now();
+      SPDLOG_LOGGER_INFO(&lgr, "burst {}", i);
+      const auto elapsed =
+         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+      max_call = std::max(max_call, elapsed);
+   }
+   // Relative bound: a memcpy + try_push must be far below the 1500 ms service delay
+   // even on a loaded CI host.
+   BOOST_CHECK_LT(max_call.count(), (scripted_delay / 5).count());
+   BOOST_CHECK_GT(sink->dropped_batches(), 0u);
+} FC_LOG_AND_RETHROW()
+
+// max_retries counts ADDITIONAL attempts after the first: max_retries=1 -> exactly
+// two identical requests when the first attempt gets a retryable 500.
+BOOST_AUTO_TEST_CASE(retry_semantics_pinned) try {
+   fc::test::capture_http_server server{{fc::test::capture_http_server::scripted_response{500, "boom", 0ms},
+                                         fc::test::capture_http_server::scripted_response{}}};
+   auto cfg        = make_cfg(server.url());
+   cfg.batch_size  = 2;
+   cfg.max_retries = 1;
+   auto sink       = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 2);
+   BOOST_REQUIRE(server.wait_for_requests(2, delivery_wait));
+   BOOST_CHECK_EQUAL(server.request(0).body, server.request(1).body);
+   BOOST_REQUIRE(sink->wait_until_idle(idle_wait));
+   BOOST_CHECK_EQUAL(sink->failed_batches(), 0u);
+   BOOST_CHECK_EQUAL(sink->indexed_docs(), 2u);
+} FC_LOG_AND_RETHROW()
+
+// 429 is endpoint back-pressure -- the one 4xx that retries.
+BOOST_AUTO_TEST_CASE(retry_on_429) try {
+   fc::test::capture_http_server server{{fc::test::capture_http_server::scripted_response{429, "slow down", 0ms},
+                                         fc::test::capture_http_server::scripted_response{}}};
+   auto cfg       = make_cfg(server.url());
+   cfg.batch_size = 1;
+   auto sink      = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 1);
+   BOOST_REQUIRE(server.wait_for_requests(2, delivery_wait));
+   BOOST_REQUIRE(sink->wait_until_idle(idle_wait));
+   BOOST_CHECK_EQUAL(sink->indexed_docs(), 1u);
+} FC_LOG_AND_RETHROW()
+
+// Any other 4xx is terminal -- retrying a rejected request only repeats the rejection.
+BOOST_AUTO_TEST_CASE(no_retry_on_4xx) try {
+   fc::test::capture_http_server server{{fc::test::capture_http_server::scripted_response{400, "bad request", 0ms}}};
+   auto cfg       = make_cfg(server.url());
+   cfg.batch_size = 1;
+   auto sink      = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 1);
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   BOOST_REQUIRE(sink->wait_until_idle(idle_wait));
+   std::this_thread::sleep_for(quiet_window); // past any (wrong) backoff window
+   BOOST_CHECK_EQUAL(server.request_count(), 1u);
+   BOOST_CHECK_EQUAL(sink->failed_batches(), 1u);
+} FC_LOG_AND_RETHROW()
+
+// HTTP 200 with "errors":true is a PARTIAL success: never retried (a replay would
+// duplicate the indexed documents); per-item failures are accounted.
+BOOST_AUTO_TEST_CASE(errors_true_no_retry_and_counts) try {
+   fc::test::capture_http_server server{
+      {fc::test::capture_http_server::scripted_response{200, partial_failure_body(), 0ms}}};
+   auto cfg       = make_cfg(server.url());
+   cfg.batch_size = 2;
+   auto sink      = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 2);
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   BOOST_REQUIRE(sink->wait_until_idle(idle_wait));
+   std::this_thread::sleep_for(quiet_window);
+   BOOST_CHECK_EQUAL(server.request_count(), 1u);
+   BOOST_CHECK_EQUAL(sink->indexed_docs(), 1u);
+   BOOST_CHECK_EQUAL(sink->failed_batches(), 1u);
+} FC_LOG_AND_RETHROW()
+
+// A 2xx that is not a bulk response (a proxy landing page) must never count as
+// indexed -- the positive-signal probe requires an explicit "errors" verdict.
+BOOST_AUTO_TEST_CASE(non_bulk_2xx_counts_failed) try {
+   fc::test::capture_http_server server{
+      {fc::test::capture_http_server::scripted_response{200, "<html>welcome</html>", 0ms}}};
+   auto cfg       = make_cfg(server.url());
+   cfg.batch_size = 1;
+   auto sink      = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 1);
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   BOOST_REQUIRE(sink->wait_until_idle(idle_wait));
+   BOOST_CHECK_EQUAL(sink->indexed_docs(), 0u);
+   BOOST_CHECK_EQUAL(sink->failed_batches(), 1u);
+} FC_LOG_AND_RETHROW()
+
+// Destruction enqueues + delivers the below-threshold tail batch.
+BOOST_AUTO_TEST_CASE(shutdown_drains_tail) try {
+   fc::test::capture_http_server server;
+   auto cfg              = make_cfg(server.url());
+   cfg.batch_size        = 1000;
+   cfg.flush_interval_ms = 60'000;
+   {
+      auto sink = std::make_shared<fc::es_sink_mt>(cfg);
+      log_records(sink, 2);
+   } // logger + sink destroyed here -- the tail must still ship
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   BOOST_CHECK_EQUAL(split_bulk_lines(server.request(0).body).size(), 4u);
+} FC_LOG_AND_RETHROW()
+
+// The graceful drain waits for the IN-FLIGHT delivery, not just an empty queue:
+// with a scripted response delay far above the drain poll, the tail batch must still
+// complete instead of being cancelled the moment the worker pops it.
+BOOST_AUTO_TEST_CASE(shutdown_drains_tail_with_slow_response) try {
+   fc::test::capture_http_server server{{delayed_ok(300ms)}};
+   auto cfg              = make_cfg(server.url());
+   cfg.batch_size        = 2;
+   cfg.flush_interval_ms = 60'000;
+   auto sink             = std::make_shared<fc::es_sink_mt>(cfg);
+   log_records(sink, 2); // batch_size hit -> enqueued -> worker stalls in the delayed response
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   // wait_until_idle shares the destructor's drain predicate: it must report BUSY
+   // while the 300 ms response delay stalls the worker (the queue is already empty
+   // here -- only the in-flight counter can know), then idle once delivery completes.
+   BOOST_CHECK(!sink->wait_until_idle(50ms));
+   BOOST_REQUIRE(sink->wait_until_idle(idle_wait));
+   BOOST_CHECK_EQUAL(sink->indexed_docs(), 2u);
+   BOOST_CHECK_EQUAL(sink->failed_batches(), 0u);
+   sink.reset(); // destructor path with nothing left in flight
+} FC_LOG_AND_RETHROW()
+
+// An endpoint that kills connections must neither block the logging thread nor hang
+// destruction.
+BOOST_AUTO_TEST_CASE(unreachable_endpoint_never_blocks_logging) try {
+   fc::test::connection_closing_http_server closing_server;
+   auto cfg              = make_cfg(closing_server.url());
+   cfg.batch_size        = 1;
+   cfg.max_retries       = 0;
+   cfg.flush_interval_ms = 60'000;
+   auto sink             = std::make_shared<fc::es_sink_mt>(cfg);
+
+   spdlog::logger lgr("es_test_logger", {sink});
+   lgr.set_level(spdlog::level::trace);
+   const auto start = std::chrono::steady_clock::now();
+   SPDLOG_LOGGER_INFO(&lgr, "into the void");
+   const auto elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+   BOOST_CHECK_LT(elapsed.count(), 300);
+
+   BOOST_REQUIRE(sink->wait_until_idle(idle_wait));
+   BOOST_CHECK_EQUAL(sink->failed_batches(), 1u);
+   BOOST_CHECK_EQUAL(sink->indexed_docs(), 0u);
+} FC_LOG_AND_RETHROW()
+
+// Eight producer threads through one sink: every delivered line parses, bodies hold
+// an even action/document line count, and nothing is lost or duplicated.
+BOOST_AUTO_TEST_CASE(concurrent_multithread_no_corruption) try {
+   constexpr int threads_count     = 8;
+   constexpr int records_per_thread = 100;
+   fc::test::capture_http_server server;
+   auto cfg                = make_cfg(server.url());
+   cfg.batch_size          = 100;
+   cfg.max_pending_batches = 64;
+   {
+      auto sink = std::make_shared<fc::es_sink_mt>(cfg);
+      spdlog::logger lgr("es_test_logger", {sink});
+      lgr.set_level(spdlog::level::trace);
+      std::vector<std::thread> producers;
+      producers.reserve(threads_count);
+      for (int t = 0; t < threads_count; ++t) {
+         producers.emplace_back([&lgr, t] {
+            for (int i = 0; i < records_per_thread; ++i) {
+               SPDLOG_LOGGER_INFO(&lgr, "t{} r{}", t, i);
+            }
+         });
+      }
+      for (auto& producer : producers)
+         producer.join();
+   } // destruction drains everything
+   std::size_t total_docs = 0;
+   for (std::size_t i = 0; i < server.request_count(); ++i) {
+      auto lines = split_bulk_lines(server.request(i).body);
+      BOOST_REQUIRE_EQUAL(lines.size() % 2, 0u);
+      for (std::size_t l = 1; l < lines.size(); l += 2) {
+         BOOST_CHECK_NO_THROW(fc::json::from_string(lines[l]));
+      }
+      total_docs += lines.size() / 2;
+   }
+   BOOST_CHECK_EQUAL(total_docs, static_cast<std::size_t>(threads_count * records_per_thread));
+} FC_LOG_AND_RETHROW()
+
+// Two es_sinks in one process: independent transports/workers, independent targets.
+BOOST_AUTO_TEST_CASE(two_es_sinks_coexist) try {
+   fc::test::capture_http_server server_a;
+   fc::test::capture_http_server server_b;
+   auto cfg_a       = make_cfg(server_a.url());
+   cfg_a.batch_size = 1;
+   auto cfg_b       = make_cfg(server_b.url());
+   cfg_b.batch_size = 1;
+   cfg_b.index      = "other-index";
+   auto sink_a      = std::make_shared<fc::es_sink_mt>(cfg_a);
+   auto sink_b      = std::make_shared<fc::es_sink_mt>(cfg_b);
+   log_records(sink_a, 1, "for a");
+   log_records(sink_b, 1, "for b");
+   BOOST_REQUIRE(server_a.wait_for_requests(1, delivery_wait));
+   BOOST_REQUIRE(server_b.wait_for_requests(1, delivery_wait));
+   BOOST_CHECK(server_a.request(0).body.find("for a") != std::string::npos);
+   BOOST_CHECK(server_b.request(0).body.find("for b") != std::string::npos);
+   BOOST_CHECK(server_b.request(0).body.find(R"("_index":"other-index")") != std::string::npos);
+} FC_LOG_AND_RETHROW()
+
+// ------------------------------------------------------------------------------
+// configure_logging end-to-end cases. Each restores the default config on exit.
+// ------------------------------------------------------------------------------
+
+namespace {
+
+/// A logging_config with one es_sink (from @p args) referenced by one logger, plus
+/// an optional format block.
+fc::logging_config make_es_logging_config(const fc::sink::es_sink_config& es_cfg, const std::string& logger_name,
+                                          std::optional<fc::format_config> format = {}) {
+   fc::logging_config cfg;
+   fc::sink_config    s;
+   s.name   = "es";
+   s.type   = "es_sink";
+   s.args   = fc::variant{es_cfg};
+   s.format = std::move(format);
+   cfg.sinks.push_back(s);
+   fc::logger_config lcfg;
+   lcfg.name    = logger_name;
+   lcfg.level   = fc::log_level::info;
+   lcfg.enabled = true;
+   lcfg.sinks   = {"es"};
+   cfg.loggers.push_back(lcfg);
+   return cfg;
+}
+
+} // anonymous namespace
+
+// No format block: the sink's own default (json + es_default_layout) survives the
+// formatter-attachment pass -- a pattern-formatted line would not start {"@timestamp".
+BOOST_AUTO_TEST_CASE(configure_logging_es_sink_default_format) try {
+   auto restore = fc::make_scoped_exit([] { fc::configure_logging(fc::logging_config::default_config()); });
+   fc::test::capture_http_server server;
+   auto es_cfg       = make_cfg(server.url());
+   es_cfg.batch_size = 1;
+   BOOST_REQUIRE(fc::configure_logging(make_es_logging_config(es_cfg, "test_es_default_fmt_logger")));
+
+   auto lgr = fc::log_config::get_logger("test_es_default_fmt_logger");
+   fc_ilog(lgr, "configured record");
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   auto lines = split_bulk_lines(server.request(0).body);
+   BOOST_REQUIRE_EQUAL(lines.size(), 2u);
+   BOOST_CHECK_EQUAL(lines[1].rfind(R"({"@timestamp":)", 0), 0u);
+} FC_LOG_AND_RETHROW()
+
+// Explicit json format block with the es template + extra_fields: the identity
+// fields land at the document top level (mirrors logging_elasticsearch.json).
+BOOST_AUTO_TEST_CASE(configure_logging_es_sink_explicit_format_override) try {
+   auto restore = fc::make_scoped_exit([] { fc::configure_logging(fc::logging_config::default_config()); });
+   fc::test::capture_http_server server;
+   auto es_cfg       = make_cfg(server.url());
+   es_cfg.batch_size = 1;
+
+   fc::format_config fmt_cfg;
+   fmt_cfg.type = "json";
+   fc::format::json_config jc;
+   jc.layout       = std::string{fc::log::es_default_layout};
+   jc.extra_fields = fc::mutable_variant_object{}("env", "local-test")("app", "es-sink-test");
+   fmt_cfg.args    = fc::variant{jc};
+
+   BOOST_REQUIRE(
+      fc::configure_logging(make_es_logging_config(es_cfg, "test_es_explicit_fmt_logger", fmt_cfg)));
+   auto lgr = fc::log_config::get_logger("test_es_explicit_fmt_logger");
+   fc_ilog(lgr, "stamped record");
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   auto doc = fc::json::from_string(split_bulk_lines(server.request(0).body)[1]).get_object();
+   BOOST_CHECK_EQUAL(doc["env"].as_string(), "local-test");
+   BOOST_CHECK_EQUAL(doc["app"].as_string(), "es-sink-test");
+} FC_LOG_AND_RETHROW()
+
+// A custom template with different field names is ACCEPTED (an open layout is the
+// point) as long as it renders valid one-line JSON.
+BOOST_AUTO_TEST_CASE(configure_logging_accepts_custom_json_layout_on_es_sink) try {
+   auto restore = fc::make_scoped_exit([] { fc::configure_logging(fc::logging_config::default_config()); });
+   fc::test::capture_http_server server;
+   auto es_cfg       = make_cfg(server.url());
+   es_cfg.batch_size = 1;
+
+   fc::format_config fmt_cfg;
+   fmt_cfg.type = "json";
+   fc::format::json_config jc;
+   jc.layout    = R"({"m":"${message}","src":"custom"})";
+   fmt_cfg.args = fc::variant{jc};
+
+   BOOST_REQUIRE(fc::configure_logging(make_es_logging_config(es_cfg, "test_es_custom_layout_logger", fmt_cfg)));
+   auto lgr = fc::log_config::get_logger("test_es_custom_layout_logger");
+   fc_ilog(lgr, "custom shape");
+   BOOST_REQUIRE(server.wait_for_requests(1, delivery_wait));
+   auto doc = fc::json::from_string(split_bulk_lines(server.request(0).body)[1]).get_object();
+   BOOST_CHECK_EQUAL(doc["m"].as_string(), "custom shape");
+   BOOST_CHECK_EQUAL(doc["src"].as_string(), "custom");
+} FC_LOG_AND_RETHROW()
+
+// A non-json format block would make every bulk request malformed NDJSON -> rejected.
+BOOST_AUTO_TEST_CASE(configure_logging_rejects_non_json_format_on_es_sink) try {
+   auto restore = fc::make_scoped_exit([] { fc::configure_logging(fc::logging_config::default_config()); });
+   fc::test::capture_http_server server;
+   fc::format_config pattern_fmt;
+   pattern_fmt.type = "pattern";
+   BOOST_CHECK(
+      !fc::configure_logging(make_es_logging_config(make_cfg(server.url()), "test_es_pattern_logger", pattern_fmt)));
+} FC_LOG_AND_RETHROW()
+
+// A json layout that renders non-JSON text fails the configure-time sample render.
+BOOST_AUTO_TEST_CASE(configure_logging_rejects_non_json_rendering_layout) try {
+   auto restore = fc::make_scoped_exit([] { fc::configure_logging(fc::logging_config::default_config()); });
+   fc::test::capture_http_server server;
+   fc::format_config fmt_cfg;
+   fmt_cfg.type = "json";
+   fc::format::json_config jc;
+   jc.layout    = R"(hello ${message})";
+   fmt_cfg.args = fc::variant{jc};
+   BOOST_CHECK(
+      !fc::configure_logging(make_es_logging_config(make_cfg(server.url()), "test_es_nonjson_logger", fmt_cfg)));
+} FC_LOG_AND_RETHROW()
+
+// Minimal JSON args land on the in-struct defaults.
+BOOST_AUTO_TEST_CASE(es_config_defaults_from_json) try {
+   // Loopback placeholder URL -- parsed only, never dialed (no sink is constructed).
+   auto cfg = fc::json::from_string(R"({"url":"http://127.0.0.1:1","index":"i"})").as<fc::sink::es_sink_config>();
+   BOOST_CHECK_EQUAL(cfg.url, "http://127.0.0.1:1");
+   BOOST_CHECK_EQUAL(cfg.index, "i");
+   BOOST_CHECK(!cfg.username.has_value());
+   BOOST_CHECK(!cfg.password.has_value());
+   BOOST_CHECK_EQUAL(cfg.batch_size, fc::sink::default_es_batch_size);
+   BOOST_CHECK_EQUAL(cfg.max_batch_bytes, fc::sink::default_es_max_batch_bytes);
+   BOOST_CHECK_EQUAL(cfg.max_doc_bytes, fc::sink::default_es_max_doc_bytes);
+   BOOST_CHECK_EQUAL(cfg.flush_interval_ms, fc::sink::default_es_flush_interval_ms);
+   BOOST_CHECK_EQUAL(cfg.max_pending_batches, fc::sink::default_es_max_pending_batches);
+   BOOST_CHECK_EQUAL(cfg.max_retries, fc::sink::default_es_max_retries);
+   BOOST_CHECK_EQUAL(cfg.retry_backoff_ms, fc::sink::default_es_retry_backoff_ms);
+   BOOST_CHECK_EQUAL(cfg.connect_timeout_ms, fc::sink::default_es_connect_timeout_ms);
+   BOOST_CHECK_EQUAL(cfg.request_timeout_ms, fc::sink::default_es_request_timeout_ms);
+   BOOST_CHECK_EQUAL(cfg.shutdown_flush_timeout_ms, fc::sink::default_es_shutdown_flush_timeout_ms);
+} FC_LOG_AND_RETHROW()
+
+// Every construction-time invariant fails configure_logging cleanly.
+BOOST_AUTO_TEST_CASE(configure_logging_rejects_invalid_es_config) try {
+   auto restore = fc::make_scoped_exit([] { fc::configure_logging(fc::logging_config::default_config()); });
+   fc::test::capture_http_server server;
+
+   auto no_url = make_cfg(server.url());
+   no_url.url  = "";
+   BOOST_CHECK(!fc::configure_logging(make_es_logging_config(no_url, "test_es_invalid_logger")));
+
+   auto bad_scheme = make_cfg(server.url());
+   bad_scheme.url  = "file:///tmp/nope";
+   BOOST_CHECK(!fc::configure_logging(make_es_logging_config(bad_scheme, "test_es_invalid_logger")));
+
+   auto no_index  = make_cfg(server.url());
+   no_index.index = "";
+   BOOST_CHECK(!fc::configure_logging(make_es_logging_config(no_index, "test_es_invalid_logger")));
+
+   auto zero_batch       = make_cfg(server.url());
+   zero_batch.batch_size = 0;
+   BOOST_CHECK(!fc::configure_logging(make_es_logging_config(zero_batch, "test_es_invalid_logger")));
+
+   auto oversized_doc          = make_cfg(server.url());
+   oversized_doc.max_doc_bytes = oversized_doc.max_batch_bytes + 1;
+   BOOST_CHECK(!fc::configure_logging(make_es_logging_config(oversized_doc, "test_es_invalid_logger")));
+
+   auto half_auth     = make_cfg(server.url());
+   half_auth.username = "user-without-password";
+   BOOST_CHECK(!fc::configure_logging(make_es_logging_config(half_auth, "test_es_invalid_logger")));
+} FC_LOG_AND_RETHROW()
+
+// A defined-but-unreferenced es_sink is never constructed: no worker, no connection.
+BOOST_AUTO_TEST_CASE(unreferenced_es_sink_not_built) try {
+   auto restore = fc::make_scoped_exit([] { fc::configure_logging(fc::logging_config::default_config()); });
+   fc::test::capture_http_server server;
+   auto cfg = make_es_logging_config(make_cfg(server.url()), "test_es_unref_logger");
+   cfg.loggers[0].sinks = {}; // nothing references the sink
+   BOOST_CHECK(fc::configure_logging(cfg));
+   std::this_thread::sleep_for(quiet_window); // several interval periods
+   BOOST_CHECK_EQUAL(server.request_count(), 0u);
+} FC_LOG_AND_RETHROW()
+
+// The SIGHUP path -- reconfigure destroys the old sink (tail delivered, threads
+// joined) and a fresh es_sink works afterwards.
+BOOST_AUTO_TEST_CASE(reconfigure_destroys_cleanly) try {
+   auto restore = fc::make_scoped_exit([] { fc::configure_logging(fc::logging_config::default_config()); });
+   fc::test::capture_http_server first_server;
+   fc::test::capture_http_server second_server;
+
+   auto first_cfg       = make_cfg(first_server.url());
+   first_cfg.batch_size = 1;
+   BOOST_REQUIRE(fc::configure_logging(make_es_logging_config(first_cfg, "test_es_reconfig_logger")));
+   auto lgr = fc::log_config::get_logger("test_es_reconfig_logger");
+   fc_ilog(lgr, "first generation");
+   BOOST_REQUIRE(first_server.wait_for_requests(1, delivery_wait));
+
+   // The SIGHUP handler's shape: re-run configure_logging (clears + rebuilds).
+   BOOST_REQUIRE(fc::configure_logging(fc::logging_config::default_config()));
+
+   auto second_cfg       = make_cfg(second_server.url());
+   second_cfg.batch_size = 1;
+   BOOST_REQUIRE(fc::configure_logging(make_es_logging_config(second_cfg, "test_es_reconfig_logger")));
+   auto second_lgr = fc::log_config::get_logger("test_es_reconfig_logger");
+   fc_ilog(second_lgr, "second generation");
+   BOOST_REQUIRE(second_server.wait_for_requests(1, delivery_wait));
+   BOOST_CHECK(second_server.request(0).body.find("second generation") != std::string::npos);
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/libraries/libfc/test/log/test_json_formatter.cpp
+++ b/libraries/libfc/test/log/test_json_formatter.cpp
@@ -673,4 +673,212 @@ BOOST_AUTO_TEST_CASE(dmlog_formatter_direct_format) try {
    BOOST_CHECK_EQUAL(line2, "DMLOG \n");
 } FC_LOG_AND_RETHROW()
 
+// ---------------------------------------------------------------------------
+// json_layout token-template cases. The `layout` config value is an OPEN token
+// template (fc/log/json_layout.hpp); the two shipped shapes are the
+// fc::log::default_layout and fc::log::es_default_layout constants.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Render one synthetic record through a json_formatter built with @p extras +
+/// @p layout_template and return the emitted line.
+std::string direct_format(std::map<std::string, std::string> extras, std::string layout_template,
+                          spdlog::level::level_enum level = spdlog::level::warn,
+                          std::string_view payload = "hello \"world\"") {
+   fc::log::json_formatter fmt{std::move(extras), std::move(layout_template)};
+   spdlog::details::log_msg msg{
+      spdlog::source_loc{"src.cpp", 42, "my_func"},
+      "direct_logger",
+      level,
+      spdlog::string_view_t{payload.data(), payload.size()}
+   };
+   spdlog::memory_buf_t out;
+   fmt.format(msg, out);
+   return std::string{out.data(), out.size()};
+}
+
+} // anonymous namespace
+
+// Empty layout compiles fc::log::default_layout -- byte-identical to spelling the
+// constant out explicitly (the regression pin for replacing the hand-written body
+// with the compiled template; the earlier cases in this suite pin the shape itself).
+BOOST_AUTO_TEST_CASE(layout_default_matches_default_layout_constant) try {
+   fc::log::json_formatter implicit_fmt{{{"env", "test"}}};
+   fc::log::json_formatter explicit_fmt{{{"env", "test"}}, std::string{fc::log::default_layout}};
+   spdlog::details::log_msg msg{
+      spdlog::source_loc{"src.cpp", 42, "my_func"}, "direct_logger", spdlog::level::info, "same bytes"};
+   spdlog::memory_buf_t a, b;
+   implicit_fmt.format(msg, a);
+   explicit_fmt.format(msg, b);
+   BOOST_CHECK_EQUAL(std::string(a.data(), a.size()), std::string(b.data(), b.size()));
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(layout_es_template_doc_shape) try {
+   auto line = direct_format({}, std::string{fc::log::es_default_layout});
+   BOOST_REQUIRE(!line.empty());
+   BOOST_CHECK_EQUAL(line.back(), '\n');
+   auto v = parse_json(line);
+   const auto& obj = v.get_object();
+   BOOST_CHECK(obj.contains("@timestamp"));
+   BOOST_CHECK(obj.contains("level"));
+   BOOST_CHECK(obj.contains("message"));
+   BOOST_CHECK(obj.contains("category"));
+   BOOST_CHECK(obj.contains("sourceLocation"));
+   BOOST_CHECK(obj.contains("data"));
+   BOOST_CHECK(!obj.contains("ts"));
+   BOOST_CHECK(!obj.contains("lvl"));
+   BOOST_CHECK(!obj.contains("msg"));
+   BOOST_CHECK(!obj.contains("logger"));
+   BOOST_CHECK(!obj.contains("extra"));
+   BOOST_CHECK_EQUAL(obj["category"].as_string(), "direct_logger");
+   BOOST_CHECK_EQUAL(obj["message"].as_string(), "hello \"world\"");
+   BOOST_CHECK_EQUAL(obj["sourceLocation"].as_string(), "src.cpp:42 my_func");
+   BOOST_CHECK(!obj["data"].get_object()["thread"].as_string().empty());
+} FC_LOG_AND_RETHROW()
+
+// @timestamp must be a bare epoch-milliseconds NUMBER (matching a date/epoch_millis
+// index mapping), not an ISO string.
+BOOST_AUTO_TEST_CASE(layout_es_epoch_millis_numeric) try {
+   fc::log::json_formatter fmt{{}, std::string{fc::log::es_default_layout}};
+   spdlog::details::log_msg msg{
+      spdlog::source_loc{"src.cpp", 42, "my_func"}, "direct_logger", spdlog::level::info, "ts"};
+   const auto known = std::chrono::system_clock::time_point{std::chrono::milliseconds{1700000000123}};
+   msg.time = known;
+   spdlog::memory_buf_t out;
+   fmt.format(msg, out);
+   std::string line{out.data(), out.size()};
+   BOOST_CHECK(line.find(R"("@timestamp":1700000000123,)") != std::string::npos);
+   auto v = parse_json(line);
+   BOOST_CHECK_EQUAL(v.get_object()["@timestamp"].as_int64(), 1700000000123);
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(layout_level_modifiers) try {
+   const std::string preserve_template = R"({"l":"${level}"})";
+   const std::string upper_template    = R"({"l":"${level:upper}"})";
+   const std::string lower_template    = R"({"l":"${level:lower}"})";
+   BOOST_CHECK(direct_format({}, preserve_template, spdlog::level::warn).find(R"("l":"warn")") != std::string::npos);
+   BOOST_CHECK(direct_format({}, upper_template, spdlog::level::trace).find(R"("l":"TRACE")") != std::string::npos);
+   BOOST_CHECK(direct_format({}, upper_template, spdlog::level::critical).find(R"("l":"CRIT")") != std::string::npos);
+   BOOST_CHECK(direct_format({}, lower_template, spdlog::level::err).find(R"("l":"error")") != std::string::npos);
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(layout_timestamp_modifiers) try {
+   auto iso_line = direct_format({}, R"({"t":"${timestamp:iso8601}"})");
+   auto v = parse_json(iso_line);
+   std::regex iso_re{R"(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$)"};
+   BOOST_CHECK(std::regex_match(v.get_object()["t"].as_string(), iso_re));
+
+   auto ms_line = parse_json(direct_format({}, R"({"t":${timestamp:epoch_millis}})"));
+   BOOST_CHECK(ms_line.get_object()["t"].as_int64() > 0);
+} FC_LOG_AND_RETHROW()
+
+// Null filename/funcname (spdlog's empty source_loc) must render gracefully.
+BOOST_AUTO_TEST_CASE(layout_source_location_null_guards) try {
+   fc::log::json_formatter fmt{{}, std::string{fc::log::es_default_layout}};
+   spdlog::details::log_msg msg{spdlog::source_loc{}, "direct_logger", spdlog::level::info, "no source"};
+   spdlog::memory_buf_t out;
+   fmt.format(msg, out);
+   std::string line{out.data(), out.size()};
+   auto v = parse_json(line);
+   BOOST_CHECK_EQUAL(v.get_object()["sourceLocation"].as_string(), ":0 ");
+} FC_LOG_AND_RETHROW()
+
+// An author-written template with different keys renders exactly as authored, with
+// token values JSON-escaped.
+BOOST_AUTO_TEST_CASE(layout_custom_template) try {
+   auto line = direct_format({}, R"({"m":"${message}","who":"${logger}","src":"custom"})");
+   auto v = parse_json(line);
+   const auto& obj = v.get_object();
+   BOOST_CHECK_EQUAL(obj["m"].as_string(), "hello \"world\"");
+   BOOST_CHECK_EQUAL(obj["who"].as_string(), "direct_logger");
+   BOOST_CHECK_EQUAL(obj["src"].as_string(), "custom");
+   BOOST_CHECK(!obj.contains("@timestamp"));
+} FC_LOG_AND_RETHROW()
+
+// ${extra_flat} splices `,"k":"v"` pairs at its placement point (the es template puts
+// them at the document top level); ${extra_object} keeps the historical `extra`
+// object. Both render NOTHING when extra_fields is empty.
+BOOST_AUTO_TEST_CASE(layout_extra_flat_and_object) try {
+   auto flat = parse_json(direct_format({{"env", "local"}, {"app", "nodeop"}},
+                                        std::string{fc::log::es_default_layout}));
+   BOOST_CHECK_EQUAL(flat.get_object()["env"].as_string(), "local");
+   BOOST_CHECK_EQUAL(flat.get_object()["app"].as_string(), "nodeop");
+   BOOST_CHECK(!flat.get_object().contains("extra"));
+
+   auto empty_flat = direct_format({}, R"({"a":1${extra_flat}})");
+   BOOST_CHECK_EQUAL(empty_flat, "{\"a\":1}\n");
+
+   auto object = parse_json(direct_format({{"env", "prod"}}, R"({"a":1${extra_object}})"));
+   BOOST_CHECK_EQUAL(object.get_object()["extra"].get_object()["env"].as_string(), "prod");
+
+   auto empty_object = direct_format({}, R"({"a":1${extra_object}})");
+   BOOST_CHECK_EQUAL(empty_object, "{\"a\":1}\n");
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(layout_unknown_token_throws) try {
+   BOOST_CHECK_THROW(fc::log::json_formatter({}, R"({"x":"${bogus}"})"), fc::exception);
+   BOOST_CHECK_THROW(fc::log::json_formatter({}, R"({"x":"${message:upper}"})"), fc::exception);
+   BOOST_CHECK_THROW(fc::log::json_formatter({}, R"({"x":"${message)"), fc::exception);
+
+   // End to end: a broken template in a format block fails configure_logging.
+   auto restore = fc::make_scoped_exit([]{ fc::configure_logging(fc::logging_config::default_config()); });
+   fc::logging_config cfg;
+   fc::sink_config s;
+   s.name = "bad_layout";
+   s.type = "console_sink";
+   s.args = fc::variant{fc::sink::console_sink_config{}};
+   fc::format_config fmt_cfg;
+   fmt_cfg.type = "json";
+   fc::format::json_config jc;
+   jc.layout = R"({"x":"${bogus}"})";
+   fmt_cfg.args = fc::variant{jc};
+   s.format = fmt_cfg;
+   cfg.sinks.push_back(s);
+   fc::logger_config lcfg;
+   lcfg.name  = "test_bad_layout_logger";
+   lcfg.sinks = {"bad_layout"};
+   cfg.loggers.push_back(lcfg);
+   BOOST_CHECK(!fc::configure_logging(cfg));
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(layout_dollar_escape) try {
+   auto line = direct_format({}, R"({"x":"$${message}"})");
+   BOOST_CHECK_EQUAL(line, "{\"x\":\"${message}\"}\n");
+} FC_LOG_AND_RETHROW()
+
+// Token VALUES are escaped regardless of the template around them.
+BOOST_AUTO_TEST_CASE(layout_escaping) try {
+   fc::log::json_formatter fmt{{}, std::string{fc::log::es_default_layout}};
+   spdlog::details::log_msg msg{spdlog::source_loc{"src.cpp", 1, "f"}, "direct_logger", spdlog::level::info,
+                                "quote:\" backslash:\\ newline:\n tab:\t ctrl:\x01 utf8:\xC3\xA9"};
+   spdlog::memory_buf_t out;
+   fmt.format(msg, out);
+   std::string line{out.data(), out.size()};
+   auto v = parse_json(line);
+   BOOST_CHECK_EQUAL(v.get_object()["message"].as_string(),
+                     "quote:\" backslash:\\ newline:\n tab:\t ctrl:\x01 utf8:\xC3\xA9");
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE(layout_clone_preserves_template) try {
+   fc::log::json_formatter fmt{{{"env", "local"}}, std::string{fc::log::es_default_layout}};
+   auto cloned = fmt.clone();
+   spdlog::details::log_msg msg{
+      spdlog::source_loc{"src.cpp", 42, "my_func"}, "direct_logger", spdlog::level::info, "clone me"};
+   spdlog::memory_buf_t a, b;
+   fmt.format(msg, a);
+   cloned->format(msg, b);
+   BOOST_CHECK_EQUAL(std::string(a.data(), a.size()), std::string(b.data(), b.size()));
+} FC_LOG_AND_RETHROW()
+
+// json_config.layout is a plain STRING; absent parses to empty (default_layout).
+BOOST_AUTO_TEST_CASE(json_config_layout_parses) try {
+   auto with_layout =
+      fc::json::from_string(R"({"extra_fields":{},"layout":"{\"m\":\"${message}\"}"})").as<fc::format::json_config>();
+   BOOST_CHECK_EQUAL(with_layout.layout, R"({"m":"${message}"})");
+
+   auto without_layout = fc::json::from_string(R"({"extra_fields":{}})").as<fc::format::json_config>();
+   BOOST_CHECK(without_layout.layout.empty());
+} FC_LOG_AND_RETHROW()
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/programs/nodeop/logging_elasticsearch.json
+++ b/programs/nodeop/logging_elasticsearch.json
@@ -1,0 +1,266 @@
+{
+  "includes": [],
+  "sinks": [{
+    "name": "stderr_color",
+    "type": "console_sink",
+    "args": {
+      "output_type": "stderr",
+      "color": true,
+      "level_colors": [{
+        "level": "debug",
+        "color": "green"
+      },{
+        "level": "info",
+        "color": "reset"
+      },{
+        "level": "warn",
+        "color": "yellow"
+      },{
+        "level": "error",
+        "color": "red"
+      }
+      ]
+    }
+  },{
+    "name": "daily_file",
+    "type": "daily_file_sink",
+    "args": {
+      "base_filename": "./logs/daily.log",
+      "rotation_hour": 0,
+      "rotation_minute": 0,
+      "truncate": false,
+      "max_files": 0
+    }
+  },{
+    "name": "rotate_file",
+    "type": "rotating_file_sink",
+    "args": {
+      "base_filename": "./logs/rotate.log",
+      "max_size": 10,
+      "max_files": 10,
+      "_comment": "max_size is in MB, max_files is the max number of rotated files"
+    }
+  },{
+    "name" : "dmlog",
+    "type": "dmlog_sink",
+    "args": {
+      "file": "-",
+      "_comment": "file can be a filename or -, -stdout, -stderr. -stdout is same as -"
+    }
+  },{
+    "name": "json_daily_file",
+    "type": "daily_file_sink",
+    "args": {
+      "base_filename": "./logs/daily.jsonl",
+      "rotation_hour": 0,
+      "rotation_minute": 0,
+      "truncate": false,
+      "max_files": 0
+    },
+    "format": {
+      "type": "json",
+      "args": { "extra_fields": {} }
+    },
+    "_comment": "JSONL output; rotates daily. Attach \"json_daily_file\" to any logger's sinks[] to enable."
+  },{
+    "name": "json_rotate_file",
+    "type": "rotating_file_sink",
+    "args": {
+      "base_filename": "./logs/rotate.jsonl",
+      "max_size": 10,
+      "max_files": 10
+    },
+    "format": {
+      "type": "json",
+      "args": { "extra_fields": {} }
+    },
+    "_comment": "JSONL output; rotates at max_size MB."
+  },{
+    "name": "json_stderr",
+    "type": "console_sink",
+    "args": { "output_type": "stderr", "color": false },
+    "format": {
+      "type": "json",
+      "args": { "extra_fields": {} }
+    },
+    "_comment": "JSONL output to stderr; formatter and sink are independently swappable."
+  },{
+    "name": "es",
+    "type": "es_sink",
+    "args": {
+      "url": "https://elasticsearch.example.com",
+      "index": "wire-logs",
+      "_comment": "batch_size/max_batch_bytes/max_doc_bytes/flush_interval_ms/max_pending_batches/max_retries/retry_backoff_ms/connect_timeout_ms/request_timeout_ms/shutdown_flush_timeout_ms and username/password are optional; see fc::sink::es_sink_config defaults"
+    },
+    "format": {
+      "type": "json",
+      "args": {
+        "layout": "{\"@timestamp\":${timestamp:epoch_millis},\"level\":\"${level:upper}\",\"message\":\"${message}\",\"category\":\"${logger}\",\"sourceLocation\":\"${file}:${line} ${func}\",\"data\":{\"thread\":\"${thread}\"}${extra_flat}}",
+        "extra_fields": { "env": "local", "app": "nodeop", "principal": "nodeop" }
+      }
+    },
+    "_comment": "Forwards logs to ES/OpenSearch via the _bulk API. Point `url`/`index` at YOUR endpoint and write index/alias, and change `app`/`principal` to values identifying your deployment before enabling. `layout` is a token template (tokens: timestamp[:iso8601|epoch_millis], level[:upper|lower], message, logger, file, line, func, thread, extra_flat, extra_object); this value reproduces fc::log::es_default_layout and is also the sink's default when the format block is omitted -- though then without extra_fields. ${extra_flat} splices extra_fields at that spot, which is how env/app/principal/logStream identity is stamped into every document."
+  }
+  ],
+  "loggers": [{
+    "name": "default",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "net_plugin_impl",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "p2p_log",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "p2p_trx",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "p2p_block",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "p2p_message",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "p2p_connection",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "http_plugin",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "producer_plugin",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "transaction_success_tracing",
+    "level": "info",
+    "enabled": false,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "transaction_failure_tracing",
+    "level": "info",
+    "enabled": false,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "trace_api",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "transaction_trace_success",
+    "level": "debug",
+    "enabled": false,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "transaction_trace_failure",
+    "level": "debug",
+    "enabled": false,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "transient_trx_success_tracing",
+    "level": "debug",
+    "enabled": false,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "transient_trx_failure_tracing",
+    "level": "debug",
+    "enabled": false,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "transaction",
+    "level": "debug",
+    "enabled": false,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "state_history",
+    "level": "info",
+    "enabled": true,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "vote",
+    "level": "debug",
+    "enabled": false,
+    "sinks": [
+      "stderr_color",
+      "es"
+    ]
+  },{
+    "name": "dmlog",
+    "level": "debug",
+    "enabled": false,
+    "sinks": [
+      "dmlog"
+    ]
+  }
+  ]
+}


### PR DESCRIPTION
## What

A new `es_sink` logging sink type that forwards nodeop logs to an Elasticsearch/OpenSearch endpoint via the bulk API, plus an open token-template `layout` option on the `json` formatter that owns the document shape.

### `es_sink` (`fc::es_sink_mt`)
- The logging thread only formats and appends to an in-memory batch — never network I/O. A single `worker_task_queue` worker delivers batches with **size** (`batch_size`), **byte** (`max_batch_bytes`), and **interval** (`flush_interval_ms`) flush triggers.
- Per-document size cap (`max_doc_bytes`, oversized docs dropped + counted), bounded delivery queue (drop-newest, never blocks logging), bounded retry with capped exponential backoff — **429/5xx/connect-class only**, never after a 2xx (partial-success replay would duplicate documents) and never on other 4xx.
- Optional HTTP basic auth (`username`/`password`), positive-signal bulk-response accounting (a non-bulk 2xx is counted failed, never indexed), and a bounded graceful shutdown drain built on gap-free enqueued/completed counters (queue `size()` alone has an idle-looking window between pop and delivery).
- Sink diagnostics are counters + one rate-limited stderr summary — **never fc loggers** (the sink may be attached to `default`; an fc log call from sink internals would recurse into `sink_it_`).
- SIGHUP reload safe: destruction (which runs on the app thread during `handle_sighup()` fan-out) is bounded by `shutdown_flush_timeout_ms` (default 500 ms) + cancellation.

### `json` formatter `layout` templates (`fc::log::json_layout`)
- `layout` is an open token-template string: literal JSON authored freely, with `${token[:modifier]}` placeholders (`timestamp[:iso8601|epoch_millis]`, `level[:upper|lower]`, `message`, `logger`, `file`, `line`, `func`, `thread`, `extra_flat`, `extra_object`; `$${` escapes a literal `${`).
- Empty/absent `layout` renders the historical fc JSONL shape **byte-identically** (pinned by tests). `fc::log::es_default_layout` ships the ES document shape (`@timestamp` epoch millis, uppercase `level`, `message`, `category`, `sourceLocation`, `data.thread`, `extra_fields` flattened top-level) and is the es_sink's default formatter.
- An es_sink's final formatter (default or explicit override) is sample-render-validated at configure time: a template that doesn't render one-line JSON fails `configure_logging` loudly instead of silently 400-ing every bulk request. Custom JSON-valid shapes are accepted.

### Supporting changes
- Shared JSON escaping extracted to `fc::log::detail` (`json_escape.hpp`), consumed by the formatter, the layout engine, and the sink's action-line builder.
- New multi-request `fc-test/capture_http_server.hpp` fixture (records every request, scripted status/body/delay responses).
- `programs/nodeop/logging_elasticsearch.json` — `logging_default.json` plus the `es` sink (placeholder `url`/`index`) attached to every `stderr_color` logger.

## Testing
- **`es_sink_tests`** (25 cases): flush triggers, oversized-doc drop, basic auth, queue-full non-blocking drop, retry semantics pinned (`max_retries` = additional attempts), 429-retries/4xx-terminal, `errors:true` partial accounting, non-bulk 2xx, shutdown tail drain (incl. slow-response in-flight case), unreachable endpoint, 8-thread concurrency, two coexisting sinks, and every `configure_logging` acceptance/rejection path. 5/5 consecutive green runs.
- **`json_formatter_tests`** +13 layout cases incl. byte-identity regression for the default shape.
- Full `test_fc`, `unit_test -- --sys-vm`, and `plugin_test` all green; full `all` build clean.
- **Live cluster verification**: 6-node `wire-cluster-tool` cluster with this config shipped 2,600+ schema-conformant documents to a live OpenSearch index (correct `@timestamp`/`level`/`category`/`sourceLocation`/identity fields, exactly one principal bucket per node, zero sink warnings), stayed thread-flat across a double-SIGHUP reload with an unchanged doc rate, and tore down cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)