### PR TITLE
chain: discover payer keys by the paired permission, not always active

### DIFF
--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -652,16 +652,24 @@ namespace sysio { namespace chain {
          // duplicated rather than shared with the consensus validators -- this function is not on
          // the apply path, and refactoring the consensus copies to serve it would put a
          // non-consensus caller in a position to change consensus behaviour.
+         // Marker presence is tracked separately from the actor rather than using an empty
+         // account_name as the sentinel. An empty actor is valid JSON and decodes to
+         // account_name{}, so a `{"": sysio.payer}` entry would leave the sentinel looking unset
+         // and skip the pairing check below. Consensus is not exposed to that -- it rejects the
+         // empty actor earlier, in validate_referenced_accounts ("action's paying actor '' does
+         // not exist") -- but this function never runs that pass.
+         bool         has_payer = false;
          account_name payer;
          for (size_t i = 0; i < act.authorization.size(); ++i) {
             const auto& declared_auth = act.authorization[i];
 
             if (declared_auth.permission == config::sysio_payer_name) {
-               SYS_ASSERT( payer.empty(), irrelevant_auth_exception,
+               SYS_ASSERT( !has_payer, irrelevant_auth_exception,
                            "Multiple payers specified for action" );
                SYS_ASSERT( i == 0, irrelevant_auth_exception,
                            "Explicit payer must be the first declared authorization" );
-               payer = declared_auth.actor;
+               has_payer = true;
+               payer     = declared_auth.actor;
                continue;
             }
 
@@ -670,7 +678,7 @@ namespace sysio { namespace chain {
                         declared_auth );
          }
 
-         if (!payer.empty()) {
+         if (has_payer) {
             const bool paired = std::ranges::any_of(act.authorization, [&](const auto& auth) {
                return auth.actor == payer && auth.permission != config::sysio_payer_name;
             });

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -615,17 +615,23 @@ namespace sysio { namespace chain {
 
       for (const auto& act : trx.actions ) {
          for (const auto& declared_auth : act.authorization) {
-            if (declared_auth.permission == config::sysio_payer_name) {
-               auto active_auth = permission_level{declared_auth.actor, sysio::chain::config::active_name};
-               SYS_ASSERT( checker.satisfied(active_auth), unsatisfied_authorization,
-                           "transaction declares payer authority '{}', but does not have signatures for it.",
-                           active_auth );
+            // `sysio.payer` is a virtual marker, not a permission: no `permission_object`
+            // exists for it and it carries no keys of its own. check_authorization requires
+            // the payer to also appear on the same action under a REAL permission -- any
+            // permission other than `sysio.payer` itself -- and satisfies that entry. It is
+            // reached on its own iteration of this loop, so the marker needs no check here.
+            //
+            // Checking `<payer>@active` instead, as this once did, diverges from consensus
+            // the moment the paired permission is not `active`: a transaction the chain
+            // accepts under `owner` or a linked custom permission was rejected here, so the
+            // signing tools that discover keys through /v1/chain/get_required_keys could not
+            // sign it. It was masked whenever owner and active shared a key.
+            if (declared_auth.permission == config::sysio_payer_name)
+               continue;
 
-            } else {
-               SYS_ASSERT( checker.satisfied(declared_auth), unsatisfied_authorization,
-                           "transaction declares authority '{}', but does not have signatures for it.",
-                           declared_auth );
-            }
+            SYS_ASSERT( checker.satisfied(declared_auth), unsatisfied_authorization,
+                        "transaction declares authority '{}', but does not have signatures for it.",
+                        declared_auth );
          }
       }
 

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -613,25 +613,69 @@ namespace sysio { namespace chain {
                                         _noop_checktime
                                       );
 
+      // Context-free actions are not walked, matching consensus: controller passes only
+      // `trn.actions` to check_authorization, so CFAs are never authorization-checked there either.
+      // Their only screen is validate_referenced_accounts, which permits a CFA to carry EITHER no
+      // authorization at all (the ordinary case -- a CFA has no access to authorization state) OR
+      // exactly one, and that one only a `sysio.payer` marker whose actor is already a declared
+      // payer in trx.actions.
+      //
+      // That allowance exists for billing, not authorization: transaction_context::init bills every
+      // action -- context-free included -- to act.payer(), which falls through to the contract when
+      // no marker is present. Without it a self-paying account's CFAs would still bill the contract,
+      // splitting one transaction across two payers. The pairing requirement is what keeps it safe:
+      // a CFA carries no signatures and no real permission, so a marker standing alone would name a
+      // payer with nothing authorizing it. Requiring the actor to already be a payer in trx.actions
+      // means the CFA inherits an authorization proven over there (index 0, paired real permission,
+      // satisfying signatures) rather than creating one.
+      //
+      // For discovery that means a CFA has no key to contribute: the marker is keyless, and the key
+      // backing that payer sits on the paired real permission in trx.actions, which is walked below.
       for (const auto& act : trx.actions ) {
-         for (const auto& declared_auth : act.authorization) {
-            // `sysio.payer` is a virtual marker, not a permission: no `permission_object`
-            // exists for it and it carries no keys of its own. check_authorization requires
-            // the payer to also appear on the same action under a REAL permission -- any
-            // permission other than `sysio.payer` itself -- and satisfies that entry. It is
-            // reached on its own iteration of this loop, so the marker needs no check here.
-            //
-            // Checking `<payer>@active` instead, as this once did, diverges from consensus
-            // the moment the paired permission is not `active`: a transaction the chain
-            // accepts under `owner` or a linked custom permission was rejected here, so the
-            // signing tools that discover keys through /v1/chain/get_required_keys could not
-            // sign it. It was masked whenever owner and active shared a key.
-            if (declared_auth.permission == config::sysio_payer_name)
+         // `sysio.payer` is a virtual marker, not a permission: no `permission_object` exists for
+         // it and it carries no keys of its own. The key that authorizes a payer is the one on the
+         // REAL permission the same actor must also declare on that action, which is reached on its
+         // own iteration below.
+         //
+         // Checking `<payer>@active` instead, as this once did, diverges from consensus the moment
+         // the paired permission is not `active`: a transaction the chain accepts under `owner` or a
+         // linked custom permission was rejected here, so the signing tools that discover keys
+         // through /v1/chain/get_required_keys could not sign it. It was masked whenever owner and
+         // active shared a key.
+         //
+         // Skipping the marker outright, however, would let discovery succeed for pairings consensus
+         // rejects -- `{alice, sysio.payer}, {bob, active}` would return bob's key for a transaction
+         // no signature set can authorize, and a payer-only action would return an empty set that
+         // reads as "nothing to sign". So the structural rules that give the marker meaning are
+         // re-checked here, mirroring check_authorization's: position 0, at most one, and paired
+         // with a real permission from the same actor ON THE SAME ACTION. They are deliberately
+         // duplicated rather than shared with the consensus validators -- this function is not on
+         // the apply path, and refactoring the consensus copies to serve it would put a
+         // non-consensus caller in a position to change consensus behaviour.
+         account_name payer;
+         for (size_t i = 0; i < act.authorization.size(); ++i) {
+            const auto& declared_auth = act.authorization[i];
+
+            if (declared_auth.permission == config::sysio_payer_name) {
+               SYS_ASSERT( payer.empty(), irrelevant_auth_exception,
+                           "Multiple payers specified for action" );
+               SYS_ASSERT( i == 0, irrelevant_auth_exception,
+                           "Explicit payer must be the first declared authorization" );
+               payer = declared_auth.actor;
                continue;
+            }
 
             SYS_ASSERT( checker.satisfied(declared_auth), unsatisfied_authorization,
                         "transaction declares authority '{}', but does not have signatures for it.",
                         declared_auth );
+         }
+
+         if (!payer.empty()) {
+            const bool paired = std::ranges::any_of(act.authorization, [&](const auto& auth) {
+               return auth.actor == payer && auth.permission != config::sysio_payer_name;
+            });
+            SYS_ASSERT( paired, unsatisfied_authorization,
+                        "Payer authorization for {} not paired with matching auth", payer );
          }
       }
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -8,6 +8,7 @@
 
 #include <sysio/testing/tester.hpp>
 #include <sysio/chain/exceptions.hpp>
+#include <sysio/chain/authorization_manager.hpp>
 #include <sysio/chain/account_object.hpp>
 #include <sysio/chain/kv_table_objects.hpp>
 #include <sysio/chain/block_summary_object.hpp>
@@ -296,6 +297,128 @@ BOOST_FIXTURE_TEST_CASE(action_verification_tests, validating_tester) { try {
          fc_exception_message_is("action cannot have multiple payers"));
    }
 
+
+   BOOST_REQUIRE_EQUAL( validate(), true );
+} FC_LOG_AND_RETHROW() }
+
+/**
+ * get_required_keys must agree with check_authorization about which permission backs an
+ * explicit `sysio.payer`.
+ *
+ * Consensus pairs the virtual payer marker with ANY real permission the payer declares on the
+ * same action, then satisfies that entry. get_required_keys once hard-coded `<payer>@active`
+ * instead, so a transaction the chain accepts under `owner` or a linked custom permission could
+ * not be signed through /v1/chain/get_required_keys -- the discovery endpoint every signing tool
+ * calls. The divergence hid wherever owner and active happened to share a key.
+ *
+ * Each case asserts BOTH halves: the keys discovery reports, and that a transaction signed with
+ * exactly those keys is accepted. Agreement between them is the property under test -- either
+ * half alone passed before the fix.
+ *
+ * `payloadless::doit` is the vehicle because it takes no arguments and asserts nothing about its
+ * authorization, so the only thing that can reject these transactions is the authorization path.
+ */
+BOOST_FIXTURE_TEST_CASE(get_required_keys_explicit_payer_tests, validating_tester) { try {
+   produce_blocks(2);
+   create_account( "payloadless"_n );
+   produce_block();
+   set_code( "payloadless"_n, test_contracts::payloadless_wasm() );
+   set_abi( "payloadless"_n, test_contracts::payloadless_abi() );
+   produce_block();
+
+   // create_account already gives owner and active distinct keys; add a third permission under
+   // active and link it to the action, so all three kinds of pairing are exercised.
+   const auto owner_key  = get_private_key( "payloadless"_n, "owner" );
+   const auto active_key = get_private_key( "payloadless"_n, "active" );
+   const auto custom_key = get_private_key( "payloadless"_n, "custom" );
+   const auto owner_pub  = owner_key.get_public_key();
+   const auto active_pub = active_key.get_public_key();
+   const auto custom_pub = custom_key.get_public_key();
+   BOOST_REQUIRE( owner_pub != active_pub );
+   BOOST_REQUIRE( active_pub != custom_pub );
+
+   set_authority( "payloadless"_n, "custom"_n, authority{ custom_pub }, config::active_name );
+   link_authority( "payloadless"_n, "payloadless"_n, "custom"_n, "doit"_n );
+   produce_block();
+
+   const flat_set<public_key_type> all_keys{ owner_pub, active_pub, custom_pub };
+
+   // `payloadless::doit`, paid by payloadless, paired under `paired_permission`.
+   auto make_trx = [&]( name paired_permission ) {
+      signed_transaction trx;
+      trx.actions.emplace_back(
+         vector<permission_level>{ { "payloadless"_n, config::sysio_payer_name },
+                                   { "payloadless"_n, paired_permission } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      set_transaction_headers( trx );
+      return trx;
+   };
+
+   auto required_keys = [&]( const signed_transaction& trx,
+                             const flat_set<public_key_type>& candidates ) {
+      return control->get_authorization_manager().get_required_keys( trx, candidates );
+   };
+
+   // --- Discovery reports the PAIRED permission's key, for each of the three kinds, and a
+   //     transaction signed with exactly that key is accepted by consensus. ---
+   const std::vector<std::pair<name, public_key_type>> cases{
+      { config::active_name, active_pub },   // the only case that worked before the fix
+      { config::owner_name,  owner_pub  },   // owner's key does not satisfy active
+      { "custom"_n,          custom_pub },   // nor does a child permission's
+   };
+
+   for( const auto& one_case : cases ) {
+      const auto& paired       = one_case.first;
+      const auto& expected_pub = one_case.second;
+
+      auto trx = make_trx( paired );
+      BOOST_CHECK( required_keys( trx, all_keys ) == flat_set<public_key_type>{ expected_pub } );
+
+      const auto& signing_key = ( expected_pub == owner_pub )  ? owner_key
+                              : ( expected_pub == active_pub ) ? active_key
+                                                               : custom_key;
+      trx.sign( signing_key, control->get_chain_id() );
+      push_transaction( trx );   // throws if consensus disagrees with discovery
+      produce_block();
+   }
+
+   // --- Still strict: candidates that cannot satisfy the paired permission throw. ---
+   for( auto paired : { config::owner_name, name("custom"_n) } ) {
+      // `active` is owner's CHILD and custom's PARENT -- it satisfies neither authority.
+      auto trx = make_trx( paired );
+      BOOST_CHECK_EXCEPTION( required_keys( trx, flat_set<public_key_type>{ active_pub } ),
+                             unsatisfied_authorization,
+                             fc_exception_message_starts_with( "transaction declares authority" ) );
+   }
+   {
+      auto trx = make_trx( config::active_name );
+      BOOST_CHECK_EXCEPTION( required_keys( trx, flat_set<public_key_type>{} ),
+                             unsatisfied_authorization,
+                             fc_exception_message_starts_with( "transaction declares authority" ) );
+   }
+
+   // --- The marker itself is attributed no key: two actions, two different pairings, and the
+   //     result is the union of the PAIRED permissions and nothing else. ---
+   {
+      signed_transaction trx;
+      trx.actions.emplace_back(
+         vector<permission_level>{ { "payloadless"_n, config::sysio_payer_name },
+                                   { "payloadless"_n, config::active_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      trx.actions.emplace_back(
+         vector<permission_level>{ { "payloadless"_n, config::sysio_payer_name },
+                                   { "payloadless"_n, config::owner_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      set_transaction_headers( trx );
+
+      BOOST_CHECK( required_keys( trx, all_keys )
+                   == ( flat_set<public_key_type>{ active_pub, owner_pub } ) );
+
+      trx.sign( active_key, control->get_chain_id() );
+      trx.sign( owner_key,  control->get_chain_id() );
+      push_transaction( trx );
+      produce_block();
+   }
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW() }

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -430,14 +430,29 @@ BOOST_FIXTURE_TEST_CASE(get_required_keys_explicit_payer_tests, validating_teste
    const auto bob_active_pub = get_public_key( "bob"_n, "active" );
    const flat_set<public_key_type> keys_with_bob{ owner_pub, active_pub, custom_pub, bob_active_pub };
 
-   auto expect_both_reject = [&]( const signed_transaction& trx, const char* discovery_msg ) {
+   // Sign ONLY the real permissions each case actually declares. Signing spare keys would make
+   // check_authorization throw tx_irrelevant_sig if the structural guards were ever removed, and a
+   // broad throw-check would stay green for the wrong reason -- the transaction would be rejected
+   // for carrying a useless signature rather than for the malformed payer. Both halves also assert
+   // the specific message, so a case cannot pass on an unrelated failure.
+   auto expect_both_reject = [&]( const signed_transaction& trx,
+                                  const char* discovery_msg,
+                                  const char* consensus_msg ) {
       BOOST_CHECK_EXCEPTION( required_keys( trx, keys_with_bob ), fc::exception,
                              fc_exception_message_starts_with( discovery_msg ) );
+
       auto signed_trx = trx;
-      signed_trx.sign( active_key,   control->get_chain_id() );
-      signed_trx.sign( owner_key,    control->get_chain_id() );
-      signed_trx.sign( get_private_key( "bob"_n, "active" ), control->get_chain_id() );
-      BOOST_CHECK_THROW( push_transaction( signed_trx ), fc::exception );
+      flat_set<name> signed_actors;
+      for( const auto& act : trx.actions ) {
+         for( const auto& auth : act.authorization ) {
+            if( auth.permission == config::sysio_payer_name ) continue;
+            if( !signed_actors.insert( auth.actor ).second )  continue;
+            signed_trx.sign( get_private_key( auth.actor, auth.permission.to_string() ),
+                             control->get_chain_id() );
+         }
+      }
+      BOOST_CHECK_EXCEPTION( push_transaction( signed_trx ), fc::exception,
+                             fc_exception_message_starts_with( consensus_msg ) );
    };
 
    auto payer_trx = [&]( vector<permission_level> auths ) {
@@ -451,23 +466,37 @@ BOOST_FIXTURE_TEST_CASE(get_required_keys_explicit_payer_tests, validating_teste
    // payloadless as payer. Skipping the marker outright would have returned bob's key here.
    expect_both_reject( payer_trx( { { "payloadless"_n, config::sysio_payer_name },
                                     { "bob"_n,        config::active_name } } ),
-                       "Payer authorization for" );
+                       "Payer authorization for",
+                       "Payer 'payloadless' did not authorize this action" );
 
    // Payer with no real permission at all -- would otherwise discover an EMPTY key set, which a
    // signing tool reads as "nothing to sign".
    expect_both_reject( payer_trx( { { "payloadless"_n, config::sysio_payer_name } } ),
-                       "Payer authorization for" );
+                       "Payer authorization for",
+                       "Payer 'payloadless' did not authorize this action" );
+
+   // An EMPTY payer actor. `account_name{}` is what an empty string decodes to, so tracking the
+   // marker by "is the actor still unset?" would leave this looking like no payer was declared and
+   // skip the pairing check -- handing back bob's key. Consensus never sees it, because
+   // validate_referenced_accounts rejects the non-existent actor first, and this function does not
+   // run that pass.
+   expect_both_reject( payer_trx( { { name{},   config::sysio_payer_name },
+                                    { "bob"_n,  config::active_name } } ),
+                       "Payer authorization for",
+                       "action's paying actor '' does not exist" );
 
    // Marker present but not at index 0.
    expect_both_reject( payer_trx( { { "payloadless"_n, config::active_name },
                                     { "payloadless"_n, config::sysio_payer_name } } ),
+                       "Explicit payer must be the first declared authorization",
                        "Explicit payer must be the first declared authorization" );
 
    // Two markers on one action.
    expect_both_reject( payer_trx( { { "payloadless"_n, config::sysio_payer_name },
                                     { "payloadless"_n, config::active_name },
                                     { "payloadless"_n, config::sysio_payer_name } } ),
-                       "Multiple payers specified for action" );
+                       "Multiple payers specified for action",
+                       "action cannot have multiple payers" );
 
    // Pairing must be on the SAME action: the marker is on action 0 while payloadless's real
    // permission sits on action 1. Consensus scopes the pairing per-action, so discovery must too.
@@ -481,7 +510,8 @@ BOOST_FIXTURE_TEST_CASE(get_required_keys_explicit_payer_tests, validating_teste
          vector<permission_level>{ { "payloadless"_n, config::active_name } },
          "payloadless"_n, "doit"_n, bytes{} );
       set_transaction_headers( trx );
-      expect_both_reject( trx, "Payer authorization for" );
+      expect_both_reject( trx, "Payer authorization for",
+                          "Payer 'payloadless' did not authorize this action" );
    }
 
    // --- Context-free actions contribute nothing and are not screened here. Consensus passes only

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -420,6 +420,131 @@ BOOST_FIXTURE_TEST_CASE(get_required_keys_explicit_payer_tests, validating_teste
       produce_block();
    }
 
+   // --- Structural rules: discovery must refuse the pairings consensus refuses, rather than
+   //     reporting a key set for a transaction no signature can authorize. Each case asserts BOTH
+   //     that discovery throws AND that consensus rejects the same transaction, so the two cannot
+   //     drift apart. get_required_keys is reached directly by /v1/chain/get_required_keys, which
+   //     never runs validate_referenced_accounts, so it cannot rely on that earlier gate. ---
+   create_account( "bob"_n );
+   produce_block();
+   const auto bob_active_pub = get_public_key( "bob"_n, "active" );
+   const flat_set<public_key_type> keys_with_bob{ owner_pub, active_pub, custom_pub, bob_active_pub };
+
+   auto expect_both_reject = [&]( const signed_transaction& trx, const char* discovery_msg ) {
+      BOOST_CHECK_EXCEPTION( required_keys( trx, keys_with_bob ), fc::exception,
+                             fc_exception_message_starts_with( discovery_msg ) );
+      auto signed_trx = trx;
+      signed_trx.sign( active_key,   control->get_chain_id() );
+      signed_trx.sign( owner_key,    control->get_chain_id() );
+      signed_trx.sign( get_private_key( "bob"_n, "active" ), control->get_chain_id() );
+      BOOST_CHECK_THROW( push_transaction( signed_trx ), fc::exception );
+   };
+
+   auto payer_trx = [&]( vector<permission_level> auths ) {
+      signed_transaction trx;
+      trx.actions.emplace_back( std::move( auths ), "payloadless"_n, "doit"_n, bytes{} );
+      set_transaction_headers( trx );
+      return trx;
+   };
+
+   // Payer paired with a DIFFERENT actor: bob's key satisfies bob@active, but nothing authorizes
+   // payloadless as payer. Skipping the marker outright would have returned bob's key here.
+   expect_both_reject( payer_trx( { { "payloadless"_n, config::sysio_payer_name },
+                                    { "bob"_n,        config::active_name } } ),
+                       "Payer authorization for" );
+
+   // Payer with no real permission at all -- would otherwise discover an EMPTY key set, which a
+   // signing tool reads as "nothing to sign".
+   expect_both_reject( payer_trx( { { "payloadless"_n, config::sysio_payer_name } } ),
+                       "Payer authorization for" );
+
+   // Marker present but not at index 0.
+   expect_both_reject( payer_trx( { { "payloadless"_n, config::active_name },
+                                    { "payloadless"_n, config::sysio_payer_name } } ),
+                       "Explicit payer must be the first declared authorization" );
+
+   // Two markers on one action.
+   expect_both_reject( payer_trx( { { "payloadless"_n, config::sysio_payer_name },
+                                    { "payloadless"_n, config::active_name },
+                                    { "payloadless"_n, config::sysio_payer_name } } ),
+                       "Multiple payers specified for action" );
+
+   // Pairing must be on the SAME action: the marker is on action 0 while payloadless's real
+   // permission sits on action 1. Consensus scopes the pairing per-action, so discovery must too.
+   {
+      signed_transaction trx;
+      trx.actions.emplace_back(
+         vector<permission_level>{ { "payloadless"_n, config::sysio_payer_name },
+                                   { "bob"_n,        config::active_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      trx.actions.emplace_back(
+         vector<permission_level>{ { "payloadless"_n, config::active_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      set_transaction_headers( trx );
+      expect_both_reject( trx, "Payer authorization for" );
+   }
+
+   // --- Context-free actions contribute nothing and are not screened here. Consensus passes only
+   //     trn.actions to check_authorization, so CFAs are never authorization-checked there either;
+   //     the sole authorization one may carry is a keyless `sysio.payer` marker that inherits an
+   //     authorization proven on a regular action. Discovery mirrors check_authorization's rules,
+   //     not transaction_context's -- the CFA shape rule lives only in validate_referenced_accounts
+   //     and is deliberately left to it. ---
+   {
+      signed_transaction trx;
+      trx.context_free_actions.emplace_back(
+         vector<permission_level>{ { "payloadless"_n, config::sysio_payer_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      trx.actions.emplace_back(
+         vector<permission_level>{ { "payloadless"_n, config::sysio_payer_name },
+                                   { "payloadless"_n, config::active_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      set_transaction_headers( trx );
+
+      // The CFA's marker adds no key; only the regular action's paired permission does.
+      BOOST_CHECK( required_keys( trx, all_keys ) == flat_set<public_key_type>{ active_pub } );
+   }
+   {
+      // A CFA marker naming an actor that is NOT a payer in trx.actions is rejected by
+      // validate_referenced_accounts, but discovery does not walk CFAs and so does not throw.
+      // Asserting the asymmetry keeps it deliberate: a later change that starts screening CFAs
+      // here should have to update this expectation rather than silently widen the function.
+      signed_transaction trx;
+      trx.context_free_actions.emplace_back(
+         vector<permission_level>{ { "bob"_n, config::sysio_payer_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      trx.actions.emplace_back(
+         vector<permission_level>{ { "payloadless"_n, config::sysio_payer_name },
+                                   { "payloadless"_n, config::active_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      set_transaction_headers( trx );
+
+      BOOST_CHECK( required_keys( trx, keys_with_bob ) == flat_set<public_key_type>{ active_pub } );
+
+      auto signed_trx = trx;
+      signed_trx.sign( active_key, control->get_chain_id() );
+      BOOST_CHECK_EXCEPTION( push_transaction( signed_trx ), sysio::chain::transaction_exception,
+                             fc_exception_message_is(
+                                "context-free actions can only have a valid explicit payer authorization" ) );
+   }
+
+   // A well-formed payer action alongside an unrelated one still discovers normally -- the rules
+   // above must not reject a transaction merely for containing more than one action.
+   {
+      signed_transaction trx;
+      trx.actions.emplace_back(
+         vector<permission_level>{ { "payloadless"_n, config::sysio_payer_name },
+                                   { "payloadless"_n, config::active_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      trx.actions.emplace_back(
+         vector<permission_level>{ { "bob"_n, config::active_name } },
+         "payloadless"_n, "doit"_n, bytes{} );
+      set_transaction_headers( trx );
+
+      BOOST_CHECK( required_keys( trx, keys_with_bob )
+                   == ( flat_set<public_key_type>{ active_pub, bob_active_pub } ) );
+   }
+
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
## The mismatch

`authorization_manager` has two places that reason about an explicit `sysio.payer` entry, and they disagreed.

**Consensus** (`check_authorization`) pairs the marker with **any** real permission the payer declares on the same action, then satisfies that entry:

```cpp
if (auth.actor == payer && auth.permission != config::sysio_payer_name) {
   foundPayer = true;
   break;
}
```

**Discovery** (`get_required_keys`) hard-coded `active`:

```cpp
if (declared_auth.permission == config::sysio_payer_name) {
   auto active_auth = permission_level{declared_auth.actor, config::active_name};
   SYS_ASSERT( checker.satisfied(active_auth), unsatisfied_authorization, … );
}
```

So a self-pay transaction paired under `owner`, or under a custom permission linked to the action, is **accepted by consensus but rejected by discovery**. Since `/v1/chain/get_required_keys` is what clio, kiod and every wallet call to learn which keys to sign with, such a transaction could not be signed through the standard path even though the chain would have taken it.

It stayed hidden because a freshly created account usually carries the same key on `owner` and `active`. It bites the accounts that separated them — which is the case the doc for this feature actively recommends.

## The fix

The marker needs no check of its own. It is virtual: no `permission_object` backs it and it holds no keys. Consensus already requires it to be paired with a real permission, and **that entry is checked on its own iteration of the same loop** — so skipping the marker makes discovery agree with consensus by construction, rather than by keeping a second copy of the pairing rule in sync.

In the common case the reported key set is unchanged. Where it differs, it was previously wrong.

**Not a consensus path.** The only callers are the read-only RPC and `producer_plugin` signing its own `votesnaphash` transaction, so no protocol feature applies.

## Test coverage

`get_required_keys_explicit_payer_tests` in `unittests/api_tests.cpp`, on `payloadless::doit` — chosen because it takes no arguments and asserts nothing about its authorization, so the authorization path is the only thing that can reject these transactions.

For each of the three pairings (`active`, `owner`, and a linked custom permission) it asserts **both** halves: the key set discovery reports, **and** that a transaction signed with exactly those keys is accepted. Agreement between the two is the property at issue — either half alone passed before the fix.

It also pins:

- discovery stays **strict** — candidates that cannot satisfy the paired permission still throw, including the neighbouring permissions in the hierarchy (`active` satisfies neither its parent `owner` nor its child `custom`), and an empty candidate set;
- the marker is attributed **no key**, via a two-action transaction pairing the same payer under two different permissions, whose result is exactly the union of those two.

## Validation

- **Guard verified**: reinstating the `@active` check fails the `owner` and custom cases (2 of the discovery assertions, plus the strictness case whose message differs). The test fails without the fix and passes with it.
- **Full suite**: `unit_test --sys-vm` — **1516 test cases, `*** No errors detected`**.

## Note for reviewers

`create_account` already gives `owner` and `active` distinct keys, so the bug was reachable in the default tester and simply never exercised.

This blocks #583 (the ROA overview doc), which documents self-pay under `owner`/custom permissions as working end to end. That is true at consensus but was not discoverable before this change, so this should land first.