### PR TITLE
fix(outpost_solana_client): carry the custody mint and token program on reserve remits

### DIFF
--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
@@ -206,9 +206,10 @@ void assert_epoch_deliveries_shape(const fc::network::solana::idl::program& prog
 ///         or a field has a type the manifest builder cannot interpret.
 void assert_collateral_position_shape(const fc::network::solana::idl::program& program);
 
-/// Assert that the loaded IDL's `Reserve` declaration carries the three fields
-/// the terminal manifest resolves from it: `creator` and `custody_mint`
-/// (pubkeys) and `custody_decimals` (u8), in either IDL field home.
+/// Assert that the loaded IDL's `Reserve` declaration carries the four fields
+/// the terminal manifest resolves from it: `creator`, `custody_mint` and
+/// `custody_token_program` (pubkeys) and `custody_decimals` (u8), in either IDL
+/// field home.
 ///
 /// Called at construction for the batch-operator role, beside the
 /// `EpochDeliveries` check. IDL drift is the realistic reason a live,
@@ -219,7 +220,7 @@ void assert_collateral_position_shape(const fc::network::solana::idl::program& p
 /// wedged epoch into a startup error while the IDL is still fixable.
 ///
 /// @param program  the program's loaded Anchor IDL.
-/// @throws fc::exception if the account or any of the three fields is absent,
+/// @throws fc::exception if the account or any of the four fields is absent,
 ///         or a field has a type the manifest builder cannot interpret.
 void assert_reserve_shape(const fc::network::solana::idl::program& program);
 
@@ -289,6 +290,82 @@ reserve_terminal_info reserve_info_from_account(const fc::variant_object& reserv
 /// propagated by `build_dispatch_manifests` rather than absorbed.
 using reserve_info_reader =
    std::function<std::optional<reserve_terminal_info>(uint64_t token_code, uint64_t reserve_code)>;
+
+/// One entry of a Token-2022 mint's `ExtraAccountMetaList`, exactly as the
+/// validation account stores it (35 bytes: discriminator, 32-byte address
+/// config, signer flag, writable flag).
+///
+/// `discriminator` selects how `address_config` resolves:
+///   * `0`        — the config IS the pubkey.
+///   * `1`        — a PDA of the HOOK program, seeds packed in the config.
+///   * `>= 0x80`  — a PDA of the account at index `discriminator - 0x80`
+///                  in the Execute account list, seeds packed in the config.
+/// `2` (pubkey-from-account-data) is not resolved; see `resolve_hook_metas`.
+struct extra_account_meta {
+   uint8_t                    discriminator = 0;
+   std::array<uint8_t, 32>    address_config{};
+   bool                       is_signer     = false;
+   bool                       is_writable   = false;
+};
+
+/// Read a Token-2022 MINT account's TLV and return its `TransferHook`
+/// program id, or `nullopt` when the mint carries no hook (a legacy SPL mint,
+/// or a Token-2022 mint without the extension).
+///
+/// A hook mint is the case SOL-396 exists for: `reserve_vault_transfer` routes
+/// through `spl_token_2022::onchain::invoke_transfer_checked`, which for such a
+/// mint resolves the hook program, its validation PDA and every account that
+/// PDA declares OUT OF `remaining_accounts`. Omitting them aborts the dispatch
+/// window before the transfer and re-packs it from the unadvanced cursor.
+std::optional<fc::network::solana::solana_public_key>
+mint_transfer_hook_program(const std::vector<uint8_t>& mint_account_data);
+
+/// Derive the `ExtraAccountMetaList` validation PDA for `mint` under
+/// `hook_program`: seeds `["extra-account-metas", mint]`.
+fc::network::solana::solana_public_key
+derive_extra_account_metas_pda(const fc::network::solana::solana_public_key& hook_program,
+                               const fc::network::solana::solana_public_key& mint);
+
+/// Parse the validation account's TLV into its declared metas, in order.
+/// Returns empty when the account carries no `Execute` entry.
+std::vector<extra_account_meta>
+parse_extra_account_metas(const std::vector<uint8_t>& validation_account_data);
+
+/// Resolve declared metas into concrete accounts against the Execute account
+/// list, whose fixed prefix is `[source, mint, destination, authority,
+/// validation_pda]` — the indices `AccountKey` seeds refer to. Resolved metas
+/// append to that list in order, so later entries may reference earlier ones.
+///
+/// THROWS on a seed or discriminator form this resolver does not implement
+/// (`InstructionData` beyond the Execute payload, `AccountData`, pubkey-from-
+/// account-data). Failing loudly is deliberate: silently dropping a meta
+/// produces exactly the wedged epoch this resolution exists to prevent, and it
+/// would be invisible until an outpost stalled.
+std::vector<fc::network::solana::account_meta>
+resolve_hook_metas(const std::vector<extra_account_meta>&        metas,
+                   const fc::network::solana::solana_public_key& hook_program,
+                   const fc::network::solana::solana_public_key& source,
+                   const fc::network::solana::solana_public_key& mint,
+                   const fc::network::solana::solana_public_key& destination,
+                   const fc::network::solana::solana_public_key& authority,
+                   const fc::network::solana::solana_public_key& validation_pda);
+
+/// The transfer-hook facts a Token-2022 custody mint carries, as read from
+/// chain: the hook program and the metas its validation PDA declares.
+struct mint_transfer_hook {
+   fc::network::solana::solana_public_key program;
+   std::vector<extra_account_meta>        declared;
+};
+
+/// Read one custody mint's transfer-hook configuration. `nullopt` means the
+/// mint carries no hook -- the overwhelmingly common case (every legacy SPL
+/// mint, and any Token-2022 mint without the extension), for which the
+/// manifest is unchanged.
+using transfer_hook_reader =
+   std::function<std::optional<mint_transfer_hook>(
+      const fc::network::solana::solana_public_key& custody_mint)>;
+
+
 
 /// How far the outpost has settled one inbound epoch's attestations.
 struct epoch_dispatch_progress {
@@ -494,6 +571,15 @@ private:
    std::optional<outpost_solana_client_detail::token_custody_info>
    collateral_position_custody(
       const fc::network::solana::solana_public_key& operator_key, uint64_t token_code);
+
+   /// Read one custody mint's transfer-hook configuration (SOL-396). `nullopt`
+   /// when the mint carries no hook -- every mint in the system today, for
+   /// which the manifest is unchanged. A CONFIGURED hook whose
+   /// `ExtraAccountMetaList` cannot be read throws rather than degrading: a
+   /// manifest silently short the hook's accounts wedges the epoch inside the
+   /// transfer CPI with no diagnostic pointing at the cause.
+   std::optional<outpost_solana_client_detail::mint_transfer_hook>
+   mint_transfer_hook_for(const fc::network::solana::solana_public_key& custody_mint);
 
    solana_client_entry_ptr                       _entry;
    fc::network::solana::solana_public_key        _program_id;
@@ -714,6 +800,7 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
    const std::function<void()>&                  throw_if_past_deadline,
    const reserve_info_reader&                    read_reserve_info,
    const collateral_custody_reader&              read_collateral_custody,
+   const transfer_hook_reader&                   read_transfer_hook,
    const fc::network::solana::solana_public_key& reserve_aggregate,
    const std::string&                            log_label);
 

--- a/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
+++ b/plugins/outpost_solana_client_plugin/include/sysio/outpost_solana_client_plugin/outpost_solana_client.hpp
@@ -243,14 +243,21 @@ struct reserve_terminal_info {
    fc::network::solana::solana_public_key custody_mint;
    /// Chain-native decimals pinned at reserve creation.
    uint8_t                                custody_decimals = 0;
+   /// Token program the reserve's custody is held under, pinned at reserve
+   /// creation (SOL-396). The SAME (owner, mint) pair has DIFFERENT canonical
+   /// ATAs under SPL-Token and Token-2022, so this drives BOTH the ATA
+   /// derivation and the token-program account the terminal handlers require.
+   /// Deriving with the legacy default against a Token-2022 reserve yields an
+   /// address the program never asks for -- `EffectAccountMissing`, forever.
+   fc::network::solana::solana_public_key custody_token_program;
 };
 
 /// Extract the terminal-finalization facts from an already-decoded `Reserve`
-/// account object. ALL THREE fields are required: `creator`, `custody_mint`
-/// and `custody_decimals` are written together at reserve creation, so a
-/// record missing any of them is not a reserve this relay can build an
-/// account-consistent manifest for — guessing custody is precisely the
-/// divergence that aborts the on-chain call.
+/// account object. ALL FOUR fields are required: `creator`, `custody_mint`,
+/// `custody_decimals` and `custody_token_program` are written together at
+/// reserve creation, so a record missing any of them is not a reserve this
+/// relay can build an account-consistent manifest for — guessing custody is
+/// precisely the divergence that aborts the on-chain call.
 ///
 /// Throwing here FAILS THE BUILD, by design — do not "restore" a degrade on
 /// this path. Reaching this function means the account EXISTS and the program

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
@@ -123,14 +123,16 @@ namespace epoch_deliveries {
 } // namespace epoch_deliveries
 
 /// Field identifiers of the per-`(token_code, reserve_code)` `Reserve`
-/// account. `custody_mint` / `custody_decimals` are pinned at reserve creation
+/// account. `custody_mint` / `custody_decimals` / `custody_token_program` are
+/// pinned at reserve creation
 /// and are what the on-chain terminal handlers branch on, so the relay's
 /// manifest must read custody from HERE and nowhere else.
 namespace reserve_account {
-   constexpr auto account_name           = "Reserve";
-   constexpr auto field_creator          = "creator";
-   constexpr auto field_custody_mint     = "custody_mint";
-   constexpr auto field_custody_decimals = "custody_decimals";
+   constexpr auto account_name                = "Reserve";
+   constexpr auto field_creator               = "creator";
+   constexpr auto field_custody_mint          = "custody_mint";
+   constexpr auto field_custody_decimals      = "custody_decimals";
+   constexpr auto field_custody_token_program = "custody_token_program";
 } // namespace reserve_account
 
 /// Field identifiers of the per-`(operator, token_code)` collateral position.
@@ -337,9 +339,10 @@ void assert_reserve_shape(const fc::network::solana::idl::program& program) {
    namespace idl = fc::network::solana::idl;
    const auto& fields = declared_account_fields(program, reserve_account::account_name);
 
-   bool has_creator  = false;
-   bool has_mint     = false;
-   bool has_decimals = false;
+   bool has_creator       = false;
+   bool has_mint          = false;
+   bool has_decimals      = false;
+   bool has_token_program = false;
    for (const auto& field : fields) {
       // Compare against the optional member directly, as the sibling shape
       // checks do: a malformed type object must reach the per-field diagnostic
@@ -359,18 +362,24 @@ void assert_reserve_shape(const fc::network::solana::idl::program& program) {
                    "Reserve '{}' must be declared u8, got '{}'",
                    reserve_account::field_custody_decimals, describe_idl_type(field.type));
          has_decimals = true;
+      } else if (field.name == reserve_account::field_custody_token_program) {
+         FC_ASSERT(is_pubkey, "Reserve '{}' must be declared pubkey, got '{}'",
+                   reserve_account::field_custody_token_program, describe_idl_type(field.type));
+         has_token_program = true;
       }
    }
-   // One message for all three: they are written together at reserve creation,
+   // One message for all four: they are written together at reserve creation,
    // and any one missing costs the manifest the same way -- the effect account
    // the program's branch requires cannot be derived, so its dispatch window
    // aborts and the cursor never moves past it.
-   FC_ASSERT(has_creator && has_mint && has_decimals,
-             "Reserve IDL missing '{}' / '{}' / '{}' (found {} / {} / {}); the terminal manifest "
-             "resolves custody and the cancel-refund target from these, and a reserve-backed "
-             "dispatch window cannot be built without them",
+   FC_ASSERT(has_creator && has_mint && has_decimals && has_token_program,
+             "Reserve IDL missing '{}' / '{}' / '{}' / '{}' (found {} / {} / {} / {}); the terminal "
+             "manifest resolves custody, the cancel-refund target and the ATA-deriving token "
+             "program from these, and a reserve-backed dispatch window cannot be built without them",
              reserve_account::field_creator, reserve_account::field_custody_mint,
-             reserve_account::field_custody_decimals, has_creator, has_mint, has_decimals);
+             reserve_account::field_custody_decimals,
+             reserve_account::field_custody_token_program,
+             has_creator, has_mint, has_decimals, has_token_program);
 }
 
 /// Keep only the candidate IDLs whose declared address matches the deployed
@@ -772,6 +781,10 @@ reserve_terminal_info reserve_info_from_account(const fc::variant_object& reserv
              reserve_account::field_custody_mint);
    FC_ASSERT(reserve.contains(reserve_account::field_custody_decimals),
              "Reserve account missing '{}' field", reserve_account::field_custody_decimals);
+   FC_ASSERT(reserve.contains(reserve_account::field_custody_token_program),
+             "Reserve account missing '{}' field — the canonical ATA differs per token program, "
+             "so deriving with the legacy default would name an account the program never asks for",
+             reserve_account::field_custody_token_program);
 
    const auto decimals = reserve[reserve_account::field_custody_decimals].as_uint64();
    FC_ASSERT(decimals <= std::numeric_limits<uint8_t>::max(),
@@ -783,7 +796,9 @@ reserve_terminal_info reserve_info_from_account(const fc::variant_object& reserv
          reserve[reserve_account::field_creator].as_string()),
       fc::network::solana::solana_public_key::from_base58_string(
          reserve[reserve_account::field_custody_mint].as_string()),
-      static_cast<uint8_t>(decimals)};
+      static_cast<uint8_t>(decimals),
+      fc::network::solana::solana_public_key::from_base58_string(
+         reserve[reserve_account::field_custody_token_program].as_string())};
 }
 
 std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manifests(
@@ -925,11 +940,13 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
          //
          // The accounts are still passed because the reserve may be created
          // between this read and the crank landing. If it is, this manifest is
-         // complete only for a NATIVE swap remit/revert (Reserve PDA +
-         // recipient); an SPL one is short the recipient ATA, and a
-         // RESERVE_CREATE_CANCELLED is short the `creator` on EITHER custody
-         // kind, since the creator is read off the Reserve we could not
-         // decode. Those windows abort and the next tick rebuilds them against
+         // complete only for a NATIVE swap remit/revert (Reserve PDA + recipient);
+         // an SPL one is short the recipient ATA, the custody mint and the custody
+         // token program — all three are read off the Reserve we could not decode,
+         // and the ATA is not even derivable without the token program (SOL-396) —
+         // and a RESERVE_CREATE_CANCELLED is short the `creator` on EITHER custody
+         // kind, since the creator is read off the Reserve we could not decode.
+         // Those windows abort and the next tick rebuilds them against
          // a now-readable Reserve.
          //
          // The degrade is PER-ATTESTATION: the manifests are built for every
@@ -944,19 +961,41 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
               log_label, token_code, reserve_code, effect.attestation_index);
          add(vault_pda, true);
          if (effect.recipient) add(*effect.recipient, true);
+         // Best-effort only, and right solely for a legacy-SPL reserve: the real
+         // token program is pinned on the Reserve we could not read. Not the
+         // sanctioned derivation — see `custody_token_program` below.
          add(token_program_id, false);
          continue;
       }
       const auto& info = *info_opt;
+
+      // SOL-396 LOCK-STEP: every reserve-backed SPL settlement routes through the
+      // program's `reserve_vault_transfer`, which requires BOTH the reserve's
+      // `custody_token_program` AND its `custody_mint` in remaining_accounts, and
+      // derives the destination ATA with that token program. Both facts come from
+      // the Reserve — never the legacy SPL-Token default — because the same
+      // (owner, mint) pair has different canonical ATAs under each program.
+      const auto& custody_token_program = info.custody_token_program;
+      const auto  custody_ata           = [&](const fc::network::solana::solana_public_key& owner) {
+         return fc::network::solana::system::get_associated_token_address(
+            owner, info.custody_mint, custody_token_program);
+      };
 
       switch (effect.shape) {
          case effect_shape::swap_remit: {
             if (!effect.recipient) break;
             if (is_native_custody(info.custody_mint)) { add(*effect.recipient, true); break; }
             add(vault_pda, true);
-            add(fc::network::solana::system::get_associated_token_address(
-                   *effect.recipient, info.custody_mint), true);
-            add(token_program_id, false);
+            add(custody_ata(*effect.recipient), true);
+            // The mint is REQUIRED here, not optional: `reserve_vault_transfer`
+            // `require_remaining_account`s it, and the CPI's `transfer_checked`
+            // needs the mint account to verify the decimals against — the decimals
+            // themselves come from the Reserve record, not from this account.
+            // Omitting it is what aborted every SPL swap remit with
+            // `EffectAccountMissing` after SOL-396 — the one reserve-backed shape
+            // that had never carried it.
+            add(info.custody_mint, false);
+            add(custody_token_program, false);
             break;
          }
          case effect_shape::swap_revert: {
@@ -965,9 +1004,8 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
             add(vault_pda, true);
             add(info.custody_mint, false);
             add(*effect.recipient, true);
-            add(fc::network::solana::system::get_associated_token_address(
-                   *effect.recipient, info.custody_mint), true);
-            add(token_program_id, false);
+            add(custody_ata(*effect.recipient), true);
+            add(custody_token_program, false);
             add(associated_token_program_id, false);
             add(system_program_id, false);
             break;
@@ -976,10 +1014,9 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
             if (is_native_custody(info.custody_mint)) { add(info.creator, true); break; }
             add(vault_pda, true);
             add(info.creator, false);
-            add(fc::network::solana::system::get_associated_token_address(
-                   info.creator, info.custody_mint), true);
+            add(custody_ata(info.creator), true);
             add(info.custody_mint, false);
-            add(token_program_id, false);
+            add(custody_token_program, false);
             add(associated_token_program_id, false);
             add(system_program_id, false);
             break;

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
@@ -333,7 +333,7 @@ void assert_collateral_position_shape(const fc::network::solana::idl::program& p
              has_operator, has_token_code, has_mint, has_amount);
 }
 
-/// Assert the loaded IDL declares `Reserve` with the three fields the terminal
+/// Assert the loaded IDL declares `Reserve` with the four fields the terminal
 /// manifest resolves from it. Full contract on the header declaration.
 void assert_reserve_shape(const fc::network::solana::idl::program& program) {
    namespace idl = fc::network::solana::idl;
@@ -661,7 +661,6 @@ constexpr uint8_t  META_DISC_PUBKEY_DATA    = 2;
 constexpr uint8_t  META_DISC_INDEX_BASE     = 0x80;  // U8_TOP_BIT
 constexpr uint8_t  SEED_UNINITIALIZED       = 0;
 constexpr uint8_t  SEED_LITERAL             = 1;
-constexpr uint8_t  SEED_INSTRUCTION_DATA    = 2;
 constexpr uint8_t  SEED_ACCOUNT_KEY         = 3;
 
 /// First 8 bytes of sha256("spl-transfer-hook-interface:execute").
@@ -717,23 +716,45 @@ derive_extra_account_metas_pda(const fc::network::solana::solana_public_key& hoo
 
 std::vector<extra_account_meta>
 parse_extra_account_metas(const std::vector<uint8_t>& validation_account_data) {
+   // EVERY malformed shape below throws rather than returning a short list.
+   // A partial parse is the worst possible outcome: `mint_transfer_hook_for`
+   // would wrap it as authoritative, the manifest would carry the hook program
+   // and validation PDA while silently omitting declared metas, and the CPI
+   // would then fail with `IncorrectAccount` -- window aborted, cursor pinned,
+   // nothing in the log naming the cause. That is exactly what the resolver
+   // below refuses to do, and the parser must not undercut it.
    std::vector<extra_account_meta> metas;
-   if (validation_account_data.size() < 12) return metas;
+   const size_t size = validation_account_data.size();
+   FC_ASSERT(size >= 12,
+             "ExtraAccountMetaList account is {} bytes, too short to hold even one TLV header",
+             size);
    const auto* bytes = validation_account_data.data();
 
    size_t cursor = 0;
-   while (cursor + 12 <= validation_account_data.size()) {
+   while (cursor + 12 <= size) {
       const bool is_execute =
          std::memcmp(bytes + cursor, EXECUTE_TLV_DISCRIMINATOR.data(), 8) == 0;
       const uint32_t entry_len = le_u32(bytes + cursor + 8);
       const size_t   value     = cursor + 12;
-      if (value + entry_len > validation_account_data.size()) break;
+      FC_ASSERT(value + entry_len <= size,
+                "ExtraAccountMetaList TLV entry at {} claims {} bytes but only {} remain",
+                cursor, entry_len, size - value);
       if (is_execute) {
-         if (entry_len < 4) break;
+         FC_ASSERT(entry_len >= 4,
+                   "ExtraAccountMetaList Execute entry is {} bytes, too short for its count",
+                   entry_len);
          const uint32_t count = le_u32(bytes + value);
+         // `count` comes from account data we do not control. Bound the walk by
+         // the ENTRY's extent, never by the account's: a count that overruns the
+         // entry would otherwise parse the FOLLOWING TLV bytes as metas and push
+         // arbitrary pubkeys into the manifest as writable accounts.
+         const size_t declared = static_cast<size_t>(count) * EXTRA_ACCOUNT_META_SIZE;
+         FC_ASSERT(4 + declared <= entry_len,
+                   "ExtraAccountMetaList declares {} metas ({} bytes) but its entry holds {}",
+                   count, declared, entry_len);
+         metas.reserve(count);
          for (uint32_t i = 0; i < count; ++i) {
             const size_t at = value + 4 + static_cast<size_t>(i) * EXTRA_ACCOUNT_META_SIZE;
-            if (at + EXTRA_ACCOUNT_META_SIZE > validation_account_data.size()) break;
             extra_account_meta meta;
             meta.discriminator = bytes[at];
             std::memcpy(meta.address_config.data(), bytes + at + 1, 32);
@@ -745,7 +766,10 @@ parse_extra_account_metas(const std::vector<uint8_t>& validation_account_data) {
       }
       cursor = value + entry_len;
    }
-   return metas;
+   FC_ASSERT(false,
+             "ExtraAccountMetaList carries no Execute entry; the mint declares a transfer hook "
+             "whose required accounts cannot be determined");
+   return metas;   // unreachable; FC_ASSERT above always throws
 }
 
 std::vector<fc::network::solana::account_meta>
@@ -1032,6 +1056,22 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
          .first->second;
    };
 
+   // One read per DISTINCT custody mint for the whole build, matching the two
+   // caches around it. Without this every reserve-backed SPL attestation pays a
+   // `get_account_info(custody_mint)` -- two when the mint has a hook, since the
+   // reader also reads the validation PDA -- so an envelope with 30 SPL remits
+   // over 3 reserves would go from 3 reads to 33, inside a build that probes the
+   // deadline per effect and aborts wholesale on a transient RPC throw.
+   // `nullopt` (no hook) is memoised too: that is every mint in the system today.
+   std::map<fc::network::solana::solana_public_key, std::optional<mint_transfer_hook>> hook_cache;
+   auto transfer_hook =
+      [&](const fc::network::solana::solana_public_key& custody_mint)
+      -> const std::optional<mint_transfer_hook>& {
+      auto it = hook_cache.find(custody_mint);
+      if (it != hook_cache.end()) return it->second;
+      return hook_cache.emplace(custody_mint, read_transfer_hook(custody_mint)).first->second;
+   };
+
    // One read per DISTINCT collateral position for the whole build. Custody
    // is pinned per `(operator, token_code)`, so both values are load-bearing
    // cache keys; absent/empty reads are memoised too.
@@ -1190,7 +1230,7 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
       const auto add_hook_accounts = [&](const fc::network::solana::solana_public_key& source,
                                          const fc::network::solana::solana_public_key& destination,
                                          const fc::network::solana::solana_public_key& authority) {
-         const auto hook = read_transfer_hook(info.custody_mint);
+         const auto& hook = transfer_hook(info.custody_mint);
          if (!hook.has_value()) return;
          const auto validation_pda =
             derive_extra_account_metas_pda(hook->program, info.custody_mint);
@@ -1668,8 +1708,17 @@ std::string outpost_solana_client::drain_dispatch(
 std::optional<outpost_solana_client_detail::mint_transfer_hook>
 outpost_solana_client::mint_transfer_hook_for(
    const fc::network::solana::solana_public_key& custody_mint) {
+   // NOT degraded to `nullopt`: the custody mint is pinned on a Reserve that
+   // demonstrably exists, so "absent" is an anomaly (a lagging bank behind the
+   // default commitment, say), not a mint without a hook. Reporting "no hook"
+   // here would build a hook-free manifest for a hook mint and abort inside the
+   // CPI with no local signal -- the same asymmetry this function already
+   // refuses for the validation PDA below.
    const auto mint_info = _entry->client->get_account_info(custody_mint);
-   if (!mint_info.has_value() || mint_info->data.empty()) return std::nullopt;
+   FC_ASSERT(mint_info.has_value() && !mint_info->data.empty(),
+             "custody mint {} is absent or empty; it is pinned on an existing Reserve, so this "
+             "is a read anomaly rather than a mint without a transfer hook",
+             custody_mint.to_string(fc::yield_function_t{}));
 
    const auto hook_program =
       outpost_solana_client_detail::mint_transfer_hook_program(mint_info->data);

--- a/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
+++ b/plugins/outpost_solana_client_plugin/src/outpost_solana_client.cpp
@@ -635,6 +635,202 @@ fc::network::solana::solana_public_key derive_collateral_position_pda(
       program_id).first;
 }
 
+
+// ── Token-2022 transfer-hook resolution (SOL-396 lock-step) ─────────────────
+//
+// Layout constants are the on-chain ones, not guesses:
+//   * a Token-2022 MINT with extensions is padded to `Account::LEN` (165),
+//     byte 165 is the AccountType tag, and the TLV starts at 166. Each entry is
+//     `type: u16 LE`, `length: u16 LE`, `value[length]`.
+//   * `ExtensionType::TransferHook` is 14, and its value is
+//     `authority: [u8;32]` then `program_id: [u8;32]`, each an
+//     OptionalNonZeroPubkey where all-zero means None.
+//   * the validation account is spl-type-length-value: `discriminator: [u8;8]`,
+//     `length: u32 LE`, `value`. The Execute entry's discriminator is the first
+//     8 bytes of sha256("spl-transfer-hook-interface:execute"). Its value is a
+//     PodSlice: `count: u32 LE` then `count` × 35-byte `ExtraAccountMeta`.
+namespace {
+
+constexpr size_t   TOKEN_ACCOUNT_LEN        = 165;   // Account::LEN
+constexpr size_t   TLV_START                = TOKEN_ACCOUNT_LEN + 1;
+constexpr uint16_t EXT_TYPE_TRANSFER_HOOK   = 14;
+constexpr size_t   EXTRA_ACCOUNT_META_SIZE  = 35;
+constexpr uint8_t  META_DISC_LITERAL        = 0;
+constexpr uint8_t  META_DISC_HOOK_PDA       = 1;
+constexpr uint8_t  META_DISC_PUBKEY_DATA    = 2;
+constexpr uint8_t  META_DISC_INDEX_BASE     = 0x80;  // U8_TOP_BIT
+constexpr uint8_t  SEED_UNINITIALIZED       = 0;
+constexpr uint8_t  SEED_LITERAL             = 1;
+constexpr uint8_t  SEED_INSTRUCTION_DATA    = 2;
+constexpr uint8_t  SEED_ACCOUNT_KEY         = 3;
+
+/// First 8 bytes of sha256("spl-transfer-hook-interface:execute").
+const std::array<uint8_t, 8> EXECUTE_TLV_DISCRIMINATOR = {
+   0x69, 0x25, 0x65, 0xc5, 0x4b, 0xfb, 0x66, 0x1a};
+
+uint16_t le_u16(const unsigned char* p) {
+   return static_cast<uint16_t>(p[0]) | (static_cast<uint16_t>(p[1]) << 8);
+}
+uint32_t le_u32(const unsigned char* p) {
+   return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8)
+        | (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
+}
+
+} // anonymous namespace
+
+std::optional<fc::network::solana::solana_public_key>
+mint_transfer_hook_program(const std::vector<uint8_t>& mint_account_data) {
+   // A legacy SPL mint is exactly 82 bytes and carries no TLV at all; a
+   // Token-2022 mint without extensions never reaches TLV_START either.
+   if (mint_account_data.size() <= TLV_START) return std::nullopt;
+   const auto* bytes = mint_account_data.data();
+
+   size_t cursor = TLV_START;
+   while (cursor + 4 <= mint_account_data.size()) {
+      const uint16_t ext_type = le_u16(bytes + cursor);
+      const uint16_t ext_len  = le_u16(bytes + cursor + 2);
+      const size_t   value    = cursor + 4;
+      if (ext_type == 0) break;                              // Uninitialized terminator
+      if (value + ext_len > mint_account_data.size()) break;  // truncated: stop, do not guess
+      if (ext_type == EXT_TYPE_TRANSFER_HOOK && ext_len >= 64) {
+         // authority occupies the first 32; program_id the second.
+         std::array<uint8_t, 32> program{};
+         std::memcpy(program.data(), bytes + value + 32, 32);
+         const bool none = std::all_of(program.begin(), program.end(),
+                                       [](uint8_t b) { return b == 0; });
+         if (none) return std::nullopt;   // extension present, hook disabled
+         return fc::network::solana::solana_public_key(program);
+      }
+      cursor = value + ext_len;
+   }
+   return std::nullopt;
+}
+
+fc::network::solana::solana_public_key
+derive_extra_account_metas_pda(const fc::network::solana::solana_public_key& hook_program,
+                               const fc::network::solana::solana_public_key& mint) {
+   static const std::string seed = "extra-account-metas";
+   return fc::network::solana::system::find_program_address(
+             {std::vector<uint8_t>(seed.begin(), seed.end()), pubkey_seed(mint)}, hook_program)
+      .first;
+}
+
+std::vector<extra_account_meta>
+parse_extra_account_metas(const std::vector<uint8_t>& validation_account_data) {
+   std::vector<extra_account_meta> metas;
+   if (validation_account_data.size() < 12) return metas;
+   const auto* bytes = validation_account_data.data();
+
+   size_t cursor = 0;
+   while (cursor + 12 <= validation_account_data.size()) {
+      const bool is_execute =
+         std::memcmp(bytes + cursor, EXECUTE_TLV_DISCRIMINATOR.data(), 8) == 0;
+      const uint32_t entry_len = le_u32(bytes + cursor + 8);
+      const size_t   value     = cursor + 12;
+      if (value + entry_len > validation_account_data.size()) break;
+      if (is_execute) {
+         if (entry_len < 4) break;
+         const uint32_t count = le_u32(bytes + value);
+         for (uint32_t i = 0; i < count; ++i) {
+            const size_t at = value + 4 + static_cast<size_t>(i) * EXTRA_ACCOUNT_META_SIZE;
+            if (at + EXTRA_ACCOUNT_META_SIZE > validation_account_data.size()) break;
+            extra_account_meta meta;
+            meta.discriminator = bytes[at];
+            std::memcpy(meta.address_config.data(), bytes + at + 1, 32);
+            meta.is_signer   = bytes[at + 33] != 0;
+            meta.is_writable = bytes[at + 34] != 0;
+            metas.push_back(meta);
+         }
+         return metas;
+      }
+      cursor = value + entry_len;
+   }
+   return metas;
+}
+
+std::vector<fc::network::solana::account_meta>
+resolve_hook_metas(const std::vector<extra_account_meta>&        metas,
+                   const fc::network::solana::solana_public_key& hook_program,
+                   const fc::network::solana::solana_public_key& source,
+                   const fc::network::solana::solana_public_key& mint,
+                   const fc::network::solana::solana_public_key& destination,
+                   const fc::network::solana::solana_public_key& authority,
+                   const fc::network::solana::solana_public_key& validation_pda) {
+   // The Execute account list the hook's seeds index into. Resolved metas are
+   // appended as we go, because a later meta may key off an earlier one.
+   std::vector<fc::network::solana::solana_public_key> accounts = {
+      source, mint, destination, authority, validation_pda};
+
+   std::vector<fc::network::solana::account_meta> resolved;
+   resolved.reserve(metas.size());
+
+   for (size_t i = 0; i < metas.size(); ++i) {
+      const auto& meta = metas[i];
+      fc::network::solana::solana_public_key key;
+
+      if (meta.discriminator == META_DISC_LITERAL) {
+         key = fc::network::solana::solana_public_key(meta.address_config);
+      } else if (meta.discriminator == META_DISC_HOOK_PDA
+                 || meta.discriminator >= META_DISC_INDEX_BASE) {
+         const auto& seed_program =
+            meta.discriminator == META_DISC_HOOK_PDA
+               ? hook_program
+               : [&]() -> const fc::network::solana::solana_public_key& {
+                    const size_t idx = meta.discriminator - META_DISC_INDEX_BASE;
+                    FC_ASSERT(idx < accounts.size(),
+                              "transfer-hook meta {} names program index {}, but only {} "
+                              "accounts are resolved at that point",
+                              i, idx, accounts.size());
+                    return accounts[idx];
+                 }();
+
+         std::vector<std::vector<uint8_t>> seeds;
+         size_t at = 0;
+         while (at < meta.address_config.size()) {
+            const uint8_t tag = meta.address_config[at];
+            if (tag == SEED_UNINITIALIZED) break;
+            if (tag == SEED_LITERAL) {
+               FC_ASSERT(at + 1 < meta.address_config.size(), "truncated literal seed");
+               const uint8_t len = meta.address_config[at + 1];
+               FC_ASSERT(at + 2 + len <= meta.address_config.size(), "literal seed overruns config");
+               seeds.emplace_back(meta.address_config.begin() + at + 2,
+                                  meta.address_config.begin() + at + 2 + len);
+               at += 2 + len;
+            } else if (tag == SEED_ACCOUNT_KEY) {
+               FC_ASSERT(at + 1 < meta.address_config.size(), "truncated account-key seed");
+               const size_t idx = meta.address_config[at + 1];
+               FC_ASSERT(idx < accounts.size(),
+                         "transfer-hook meta {} seeds on account index {}, but only {} "
+                         "accounts are resolved at that point",
+                         i, idx, accounts.size());
+               seeds.push_back(pubkey_seed(accounts[idx]));
+               at += 2;
+            } else {
+               // InstructionData / AccountData. Both are resolvable only with
+               // the Execute payload or another account's contents, neither of
+               // which this builder has. Refuse rather than emit a manifest
+               // that is short an account the CPI will demand.
+               FC_ASSERT(false,
+                         "transfer-hook meta {} uses unsupported seed form {}; the dispatch "
+                         "manifest cannot be completed for this mint",
+                         i, static_cast<unsigned>(tag));
+            }
+         }
+         key = fc::network::solana::system::find_program_address(seeds, seed_program).first;
+      } else {
+         FC_ASSERT(meta.discriminator != META_DISC_PUBKEY_DATA,
+                   "transfer-hook meta {} resolves a pubkey out of account data, which this "
+                   "builder cannot read", i);
+         FC_ASSERT(false, "transfer-hook meta {} has unknown discriminator {}",
+                   i, static_cast<unsigned>(meta.discriminator));
+      }
+
+      accounts.push_back(key);
+      resolved.push_back(fc::network::solana::account_meta{key, meta.is_signer, meta.is_writable});
+   }
+   return resolved;
+}
+
 /// Derive the per-`token_code` `collateral_vault` PDA. Full contract on the
 /// header declaration.
 fc::network::solana::solana_public_key derive_collateral_vault_pda(
@@ -808,6 +1004,7 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
    const std::function<void()>&                  throw_if_past_deadline,
    const reserve_info_reader&                    read_reserve_info,
    const collateral_custody_reader&              read_collateral_custody,
+   const transfer_hook_reader&                   read_transfer_hook,
    const fc::network::solana::solana_public_key& reserve_aggregate,
    const std::string&                            log_label) {
    const auto& token_program_id = fc::network::solana::system::program_ids::TOKEN_PROGRAM;
@@ -981,12 +1178,38 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
             owner, info.custody_mint, custody_token_program);
       };
 
+      // SOL-396, one layer deeper: `reserve_vault_transfer` routes through
+      // `spl_token_2022::onchain::invoke_transfer_checked`, which for a mint
+      // carrying the TransferHook extension resolves the hook program, its
+      // validation PDA and every account that PDA declares OUT OF
+      // `remaining_accounts`. A hook mint whose extras are missing aborts the
+      // CPI before the transfer -- the same wedge, with the cursor pinned.
+      //
+      // No-op for every non-hook mint, which is all of them today: the reader
+      // returns nullopt and nothing is appended.
+      const auto add_hook_accounts = [&](const fc::network::solana::solana_public_key& source,
+                                         const fc::network::solana::solana_public_key& destination,
+                                         const fc::network::solana::solana_public_key& authority) {
+         const auto hook = read_transfer_hook(info.custody_mint);
+         if (!hook.has_value()) return;
+         const auto validation_pda =
+            derive_extra_account_metas_pda(hook->program, info.custody_mint);
+         add(hook->program, false);
+         add(validation_pda, false);
+         for (const auto& meta : resolve_hook_metas(hook->declared, hook->program, source,
+                                                    info.custody_mint, destination, authority,
+                                                    validation_pda)) {
+            add(meta.key, meta.is_writable);
+         }
+      };
+
       switch (effect.shape) {
          case effect_shape::swap_remit: {
             if (!effect.recipient) break;
             if (is_native_custody(info.custody_mint)) { add(*effect.recipient, true); break; }
             add(vault_pda, true);
             add(custody_ata(*effect.recipient), true);
+            add_hook_accounts(vault_pda, custody_ata(*effect.recipient), vault_pda);
             // The mint is REQUIRED here, not optional: `reserve_vault_transfer`
             // `require_remaining_account`s it, and the CPI's `transfer_checked`
             // needs the mint account to verify the decimals against — the decimals
@@ -1006,6 +1229,7 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
             add(*effect.recipient, true);
             add(custody_ata(*effect.recipient), true);
             add(custody_token_program, false);
+            add_hook_accounts(vault_pda, custody_ata(*effect.recipient), vault_pda);
             add(associated_token_program_id, false);
             add(system_program_id, false);
             break;
@@ -1017,6 +1241,7 @@ std::vector<std::vector<fc::network::solana::account_meta>> build_dispatch_manif
             add(custody_ata(info.creator), true);
             add(info.custody_mint, false);
             add(custody_token_program, false);
+            add_hook_accounts(vault_pda, custody_ata(info.creator), vault_pda);
             add(associated_token_program_id, false);
             add(system_program_id, false);
             break;
@@ -1409,6 +1634,9 @@ std::string outpost_solana_client::drain_dispatch(
       [&](const fc::network::solana::solana_public_key& operator_key, uint64_t token_code) {
          return collateral_position_custody(operator_key, token_code);
       },
+      [&](const fc::network::solana::solana_public_key& custody_mint) {
+         return mint_transfer_hook_for(custody_mint);
+      },
       _program_client->reserve_pda,
       to_string());
 
@@ -1425,6 +1653,41 @@ std::string outpost_solana_client::drain_dispatch(
             epoch_index, dispatch_limit, std::move(batch_accounts));
       },
       to_string());
+}
+
+/// Read one custody mint's transfer-hook configuration off chain.
+///
+/// Absent mint, no TransferHook extension, or a hook explicitly disabled (an
+/// all-zero program id) all return `nullopt` and leave the manifest unchanged
+/// -- which is every mint in the system today.
+///
+/// A hook that IS configured but whose validation PDA cannot be read is NOT
+/// degraded to `nullopt`: that would silently emit a manifest short the very
+/// accounts the CPI is about to demand, wedging the epoch with no diagnostic.
+/// Throwing surfaces it against the account we could not read.
+std::optional<outpost_solana_client_detail::mint_transfer_hook>
+outpost_solana_client::mint_transfer_hook_for(
+   const fc::network::solana::solana_public_key& custody_mint) {
+   const auto mint_info = _entry->client->get_account_info(custody_mint);
+   if (!mint_info.has_value() || mint_info->data.empty()) return std::nullopt;
+
+   const auto hook_program =
+      outpost_solana_client_detail::mint_transfer_hook_program(mint_info->data);
+   if (!hook_program.has_value()) return std::nullopt;
+
+   const auto validation_pda =
+      outpost_solana_client_detail::derive_extra_account_metas_pda(*hook_program, custody_mint);
+   const auto validation_info = _entry->client->get_account_info(validation_pda);
+   FC_ASSERT(validation_info.has_value() && !validation_info->data.empty(),
+             "custody mint {} declares transfer hook {}, but its ExtraAccountMetaList {} is "
+             "absent or empty; the dispatch manifest cannot be completed",
+             custody_mint.to_string(fc::yield_function_t{}),
+             hook_program->to_string(fc::yield_function_t{}),
+             validation_pda.to_string(fc::yield_function_t{}));
+
+   return outpost_solana_client_detail::mint_transfer_hook{
+      *hook_program,
+      outpost_solana_client_detail::parse_extra_account_metas(validation_info->data)};
 }
 
 std::optional<outpost_solana_client_detail::token_custody_info>

--- a/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
@@ -482,10 +482,13 @@ namespace {
 /// pubkeys as base58 strings, `custody_decimals` as an integer.
 fc::variant_object reserve_row(const solana_public_key& creator,
                                const solana_public_key& custody_mint,
-                               unsigned                 custody_decimals) {
+                               unsigned                 custody_decimals,
+                               const solana_public_key& custody_token_program =
+                                  system::program_ids::TOKEN_PROGRAM) {
    return fc::mutable_variant_object("creator", creator.to_string(fc::yield_function_t{}))(
       "custody_mint", custody_mint.to_string(fc::yield_function_t{}))(
-      "custody_decimals", custody_decimals);
+      "custody_decimals", custody_decimals)(
+      "custody_token_program", custody_token_program.to_string(fc::yield_function_t{}));
 }
 
 } // anonymous namespace
@@ -504,6 +507,15 @@ BOOST_AUTO_TEST_CASE(reserve_info_reads_custody_from_the_reserve_account) try {
    BOOST_CHECK(spl.creator == creator);
    BOOST_CHECK(spl.custody_mint == spl_mint);
    BOOST_CHECK_EQUAL(static_cast<unsigned>(spl.custody_decimals), 6u);
+   BOOST_CHECK(spl.custody_token_program == system::program_ids::TOKEN_PROGRAM);
+
+   // SOL-396: a Token-2022 reserve must round-trip its OWN token program --
+   // the ATA derivation and the token-program account both hang off this, and
+   // silently substituting the legacy default names accounts the program never
+   // asks for (EffectAccountMissing, on every retry, forever).
+   const auto t22_program = measurement_pubkey(80);
+   const auto t22 = reserve_info_from_account(reserve_row(creator, spl_mint, 6, t22_program));
+   BOOST_CHECK(t22.custody_token_program == t22_program);
 
    // Native custody is the all-zero `NATIVE_TOKEN_MARKER`, which is exactly
    // what the handler compares against to take the lamport branch.
@@ -533,6 +545,12 @@ BOOST_AUTO_TEST_CASE(reserve_info_requires_every_custody_field) try {
       reserve_info_from_account(fc::mutable_variant_object(
          "creator", creator.to_string(fc::yield_function_t{}))(
          "custody_mint", spl_mint.to_string(fc::yield_function_t{}))),
+      fc::assert_exception);
+   // ...including the token program: without it the ATA is not derivable at all.
+   BOOST_CHECK_THROW(
+      reserve_info_from_account(fc::mutable_variant_object(
+         "creator", creator.to_string(fc::yield_function_t{}))(
+         "custody_mint", spl_mint.to_string(fc::yield_function_t{}))("custody_decimals", 6)),
       fc::assert_exception);
    BOOST_CHECK_THROW(reserve_info_from_account(fc::variant_object{fc::mutable_variant_object{}}),
                      fc::assert_exception);
@@ -1366,10 +1384,13 @@ struct manifest_build_harness {
 
    void put(uint64_t token_code, uint64_t reserve_code,
             const solana_public_key& creator, const solana_public_key& custody_mint,
-            uint8_t custody_decimals) {
+            uint8_t custody_decimals,
+            const solana_public_key& custody_token_program =
+               system::program_ids::TOKEN_PROGRAM) {
       records.emplace(seeds{token_code, reserve_code},
                       manifest_detail::reserve_terminal_info{creator, custody_mint,
-                                                             custody_decimals});
+                                                             custody_decimals,
+                                                             custody_token_program});
    }
 
    /// Seed one position's pinned custody for the collateral reader.
@@ -1418,6 +1439,24 @@ manifest_detail::inbound_effect swap_remit_effect(size_t index, uint64_t token_c
                                                   const solana_public_key& recipient) {
    return manifest_detail::inbound_effect{
       index, manifest_detail::effect_shape::swap_remit, recipient,
+      manifest_detail::reserve_pda_seeds{token_code, reserve_code}};
+}
+
+/// One SWAP_REVERT effect at `index` refunding `depositor` out of `(token, reserve)`.
+manifest_detail::inbound_effect swap_revert_effect(size_t index, uint64_t token_code,
+                                                   uint64_t reserve_code,
+                                                   const solana_public_key& depositor) {
+   return manifest_detail::inbound_effect{
+      index, manifest_detail::effect_shape::swap_revert, depositor,
+      manifest_detail::reserve_pda_seeds{token_code, reserve_code}};
+}
+
+/// One RESERVE_CREATE_CANCELLED effect at `index` for `(token, reserve)`; the
+/// refund target is the creator read off the Reserve, not a carried recipient.
+manifest_detail::inbound_effect reserve_create_cancelled_effect(size_t index, uint64_t token_code,
+                                                                uint64_t reserve_code) {
+   return manifest_detail::inbound_effect{
+      index, manifest_detail::effect_shape::reserve_create_cancelled, std::nullopt,
       manifest_detail::reserve_pda_seeds{token_code, reserve_code}};
 }
 
@@ -1483,13 +1522,20 @@ BOOST_AUTO_TEST_CASE(build_manifests_follows_reserve_custody_per_reserve) try {
    BOOST_REQUIRE_EQUAL(manifests.size(), 2u);
 
    // SPL branch: Reserve PDA + vault + the recipient's ATA FOR THE RESERVE'S
-   // OWN MINT + the token program.
+   // OWN MINT + the custody mint + the token program.
    const auto& spl = manifests[0];
    BOOST_CHECK(manifest_has(spl, manifest_detail::derive_reserve_pda(
                                     harness.program_id, token_code, 200)));
    BOOST_CHECK(manifest_has(spl, manifest_detail::derive_reserve_vault_pda(
                                     harness.program_id, token_code, 200)));
    BOOST_CHECK(manifest_has(spl, system::get_associated_token_address(spl_recipient, spl_mint)));
+   // The MINT itself. `reserve_vault_transfer` require_remaining_account()s it
+   // for the checked transfer's decimals, and swap_remit was the one
+   // reserve-backed shape that never carried it -- every SPL swap remit aborted
+   // with EffectAccountMissing and the epoch never closed. Asserted here
+   // because this case previously checked the ATA and token program only,
+   // which is exactly why the omission shipped.
+   BOOST_CHECK(manifest_has(spl, spl_mint));
    BOOST_CHECK(manifest_has(spl, system::program_ids::TOKEN_PROGRAM));
    // The bare recipient wallet is the NATIVE branch's account and must not
    // appear on the SPL one.
@@ -1504,6 +1550,80 @@ BOOST_AUTO_TEST_CASE(build_manifests_follows_reserve_custody_per_reserve) try {
    BOOST_CHECK(!manifest_has(native, manifest_detail::derive_reserve_vault_pda(
                                         harness.program_id, token_code, 201)));
    BOOST_CHECK(!manifest_has(native, system::program_ids::TOKEN_PROGRAM));
+} FC_LOG_AND_RETHROW();
+
+/// SOL-396: the reserve's OWN `custody_token_program` drives both the ATA
+/// derivation and the token-program account. The same (owner, mint) pair has a
+/// DIFFERENT canonical ATA under Token-2022, so deriving with the legacy
+/// SPL-Token default names an account the program never asks for -- and
+/// `require_remaining_account` then aborts the window on every retry, with the
+/// cursor pinned, forever.
+BOOST_AUTO_TEST_CASE(build_manifests_derive_the_ata_with_the_reserves_token_program) try {
+   constexpr uint64_t token_code   = 121;
+   constexpr uint64_t reserve_code = 222;
+   const auto spl_mint    = measurement_pubkey(84);
+   const auto recipient   = measurement_pubkey(85);
+   const auto creator     = measurement_pubkey(86);
+   const auto token_2022  = measurement_pubkey(87);   // stands in for the Token-2022 program
+
+   manifest_build_harness harness;
+   harness.put(token_code, reserve_code, creator, spl_mint, 6, token_2022);
+
+   const auto manifests =
+      harness.build({swap_remit_effect(0, token_code, reserve_code, recipient)}, 1);
+   BOOST_REQUIRE_EQUAL(manifests.size(), 1u);
+   const auto& m = manifests[0];
+
+   // The ATA under the RESERVE'S program, and that program as the token
+   // program account.
+   BOOST_CHECK(manifest_has(
+      m, system::get_associated_token_address(recipient, spl_mint, token_2022)));
+   BOOST_CHECK(manifest_has(m, token_2022));
+   BOOST_CHECK(manifest_has(m, spl_mint));
+
+   // And NOT the legacy default's ATA, nor the legacy program.
+   BOOST_CHECK(!manifest_has(m, system::get_associated_token_address(recipient, spl_mint)));
+   BOOST_CHECK(!manifest_has(m, system::program_ids::TOKEN_PROGRAM));
+} FC_LOG_AND_RETHROW();
+
+/// The SAME pinned-token-program derivation must hold for the other two
+/// reserve-backed shapes. Without these, reverting either branch to the legacy
+/// 2-arg `get_associated_token_address` leaves the suite green — which is exactly
+/// how the missing custody mint shipped on `swap_remit` in the first place.
+BOOST_AUTO_TEST_CASE(build_manifests_pin_the_token_program_on_revert_and_cancel) try {
+   constexpr uint64_t token_code   = 131;
+   constexpr uint64_t reserve_code = 232;
+   const auto spl_mint   = measurement_pubkey(88);
+   const auto depositor  = measurement_pubkey(89);
+   const auto creator    = measurement_pubkey(90);
+   const auto token_2022 = measurement_pubkey(91);
+
+   manifest_build_harness harness;
+   harness.put(token_code, reserve_code, creator, spl_mint, 6, token_2022);
+
+   const auto manifests = harness.build(
+      {swap_revert_effect(0, token_code, reserve_code, depositor),
+       reserve_create_cancelled_effect(1, token_code, reserve_code)},
+      2);
+   BOOST_REQUIRE_EQUAL(manifests.size(), 2u);
+
+   // SWAP_REVERT refunds the depositor's ATA under the reserve's own program.
+   const auto& revert = manifests[0];
+   BOOST_CHECK(manifest_has(
+      revert, system::get_associated_token_address(depositor, spl_mint, token_2022)));
+   BOOST_CHECK(manifest_has(revert, token_2022));
+   BOOST_CHECK(manifest_has(revert, spl_mint));
+   BOOST_CHECK(!manifest_has(revert, system::get_associated_token_address(depositor, spl_mint)));
+   BOOST_CHECK(!manifest_has(revert, system::program_ids::TOKEN_PROGRAM));
+
+   // RESERVE_CREATE_CANCELLED refunds the CREATOR's ATA, same program.
+   const auto& cancelled = manifests[1];
+   BOOST_CHECK(manifest_has(
+      cancelled, system::get_associated_token_address(creator, spl_mint, token_2022)));
+   BOOST_CHECK(manifest_has(cancelled, token_2022));
+   BOOST_CHECK(manifest_has(cancelled, spl_mint));
+   BOOST_CHECK(!manifest_has(cancelled, system::get_associated_token_address(creator, spl_mint)));
+   BOOST_CHECK(!manifest_has(cancelled, system::program_ids::TOKEN_PROGRAM));
 } FC_LOG_AND_RETHROW();
 
 /// Collateral custody MUST be resolved per position, never per token code.

--- a/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
@@ -1423,13 +1423,33 @@ struct manifest_build_harness {
       };
    }
 
+   /// Per-mint transfer-hook configuration. Empty by default: every mint in
+   /// the system today is hook-free, so the manifest is unchanged unless a
+   /// case opts in via `put_hook`.
+   std::map<solana_public_key, manifest_detail::mint_transfer_hook> hooks;
+
+   void put_hook(const solana_public_key& mint, const solana_public_key& hook_program,
+                 std::vector<manifest_detail::extra_account_meta> declared) {
+      hooks.emplace(mint,
+                    manifest_detail::mint_transfer_hook{hook_program, std::move(declared)});
+   }
+
+   manifest_detail::transfer_hook_reader hook_reader() {
+      return [this](const solana_public_key& mint)
+                -> std::optional<manifest_detail::mint_transfer_hook> {
+         auto it = hooks.find(mint);
+         if (it == hooks.end()) return std::nullopt;
+         return it->second;
+      };
+   }
+
    std::vector<std::vector<account_meta>> build(
       const std::vector<manifest_detail::inbound_effect>& effects,
       uint32_t                                            total_attestations,
       const std::function<void()>&                        deadline_probe = [] {}) {
       return manifest_detail::build_dispatch_manifests(
          program_id, effects, total_attestations, deadline_probe, reader(),
-         collateral_reader(), reserve_aggregate, "test-relay");
+         collateral_reader(), hook_reader(), reserve_aggregate, "test-relay");
    }
 };
 
@@ -1550,6 +1570,150 @@ BOOST_AUTO_TEST_CASE(build_manifests_follows_reserve_custody_per_reserve) try {
    BOOST_CHECK(!manifest_has(native, manifest_detail::derive_reserve_vault_pda(
                                         harness.program_id, token_code, 201)));
    BOOST_CHECK(!manifest_has(native, system::program_ids::TOKEN_PROGRAM));
+} FC_LOG_AND_RETHROW();
+
+namespace {
+
+/// Pack a seed list into an `ExtraAccountMeta::address_config`, exactly as
+/// `Seed::pack_into_address_config` does on chain: each seed is a 1-byte tag
+/// then its payload, and the remainder is left zero (the Uninitialized
+/// terminator). Only the two forms the resolver implements are modelled.
+struct seed_literal { std::string bytes; };
+struct seed_account_key { uint8_t index; };
+using packed_seed = std::variant<seed_literal, seed_account_key>;
+
+std::array<uint8_t, 32> pack_seeds(const std::vector<packed_seed>& seeds) {
+   std::array<uint8_t, 32> config{};
+   size_t at = 0;
+   for (const auto& seed : seeds) {
+      if (const auto* lit = std::get_if<seed_literal>(&seed)) {
+         config[at++] = 1;                                     // Seed::Literal
+         config[at++] = static_cast<uint8_t>(lit->bytes.size());
+         for (char c : lit->bytes) config[at++] = static_cast<uint8_t>(c);
+      } else {
+         const auto& acct = std::get<seed_account_key>(seed);
+         config[at++] = 3;                                     // Seed::AccountKey
+         config[at++] = acct.index;
+      }
+   }
+   return config;
+}
+
+manifest_detail::extra_account_meta literal_meta(const solana_public_key& key, bool writable) {
+   manifest_detail::extra_account_meta meta;
+   meta.discriminator = 0;
+   const auto bytes = key._data;
+   std::copy(bytes.begin(), bytes.end(), meta.address_config.begin());
+   meta.is_writable = writable;
+   return meta;
+}
+
+manifest_detail::extra_account_meta external_pda_meta(uint8_t program_index,
+                                                      const std::vector<packed_seed>& seeds,
+                                                      bool writable) {
+   manifest_detail::extra_account_meta meta;
+   meta.discriminator  = static_cast<uint8_t>(program_index + 0x80);
+   meta.address_config = pack_seeds(seeds);
+   meta.is_writable    = writable;
+   return meta;
+}
+
+} // anonymous namespace
+
+/// A hook-bearing Token-2022 custody mint -- the case SOL-396 exists for, and
+/// the one the ATA-derivation cases above do NOT cover.
+///
+/// `reserve_vault_transfer` routes through
+/// `spl_token_2022::onchain::invoke_transfer_checked`, which for such a mint
+/// resolves the hook program, its ExtraAccountMetaList PDA, and every account
+/// that PDA declares out of `remaining_accounts`. Omitting them aborts the CPI
+/// before the transfer and re-packs the window from the unadvanced cursor.
+///
+/// The declared metas mirror the real liqSOL hook: a literal program id, then
+/// per-participant `user_record` PDAs seeded on the SOURCE and DESTINATION
+/// token accounts -- which is why the Execute account order (0 source, 1 mint,
+/// 2 destination, 3 authority, 4 validation PDA) is load-bearing rather than
+/// decorative.
+BOOST_AUTO_TEST_CASE(build_manifests_carry_transfer_hook_accounts_for_a_hook_mint) try {
+   constexpr uint64_t token_code   = 141;
+   constexpr uint64_t reserve_code = 242;
+   const auto spl_mint     = measurement_pubkey(92);
+   const auto recipient    = measurement_pubkey(93);
+   const auto creator      = measurement_pubkey(94);
+   const auto token_2022   = measurement_pubkey(95);
+   const auto hook_program = measurement_pubkey(96);
+   const auto hook_owned   = measurement_pubkey(97);   // a literal meta, e.g. liqsol_core
+
+   manifest_build_harness harness;
+   harness.put(token_code, reserve_code, creator, spl_mint, 6, token_2022);
+   harness.put_hook(spl_mint, hook_program,
+                    {literal_meta(hook_owned, false),
+                     // sender's user_record, seeded on the SOURCE token account (index 0)
+                     external_pda_meta(5, {seed_literal{"user_record"}, seed_account_key{0}}, true),
+                     // receiver's user_record, seeded on the DESTINATION (index 2)
+                     external_pda_meta(5, {seed_literal{"user_record"}, seed_account_key{2}}, true)});
+
+   const auto manifests =
+      harness.build({swap_remit_effect(0, token_code, reserve_code, recipient)}, 1);
+   BOOST_REQUIRE_EQUAL(manifests.size(), 1u);
+   const auto& m = manifests[0];
+
+   const auto vault = manifest_detail::derive_reserve_vault_pda(harness.program_id, token_code,
+                                                                reserve_code);
+   const auto dest_ata =
+      system::get_associated_token_address(recipient, spl_mint, token_2022);
+   const auto validation_pda =
+      manifest_detail::derive_extra_account_metas_pda(hook_program, spl_mint);
+
+   // The hook program and its validation PDA.
+   BOOST_CHECK(manifest_has(m, hook_program));
+   BOOST_CHECK(manifest_has(m, validation_pda));
+   // The literal meta.
+   BOOST_CHECK(manifest_has(m, hook_owned));
+
+   // The two per-participant PDAs, derived under the meta's NAMED program
+   // (index 5 = the first resolved extra, i.e. `hook_owned`) and seeded on the
+   // transfer's source and destination respectively.
+   const auto source_record = system::find_program_address(
+      {std::vector<uint8_t>{'u','s','e','r','_','r','e','c','o','r','d'},
+       std::vector<uint8_t>(vault._data.begin(), vault._data.end())}, hook_owned).first;
+   const auto dest_record = system::find_program_address(
+      {std::vector<uint8_t>{'u','s','e','r','_','r','e','c','o','r','d'},
+       std::vector<uint8_t>(dest_ata._data.begin(), dest_ata._data.end())}, hook_owned).first;
+   BOOST_CHECK(manifest_has(m, source_record));
+   BOOST_CHECK(manifest_has(m, dest_record));
+
+   // Writability is carried from the declaration, not guessed.
+   const auto writable_of = [&](const solana_public_key& key) {
+      const auto it = std::find_if(m.begin(), m.end(),
+                                   [&](const account_meta& a) { return a.key == key; });
+      BOOST_REQUIRE(it != m.end());
+      return it->is_writable;
+   };
+   BOOST_CHECK_EQUAL(writable_of(source_record), true);
+   BOOST_CHECK_EQUAL(writable_of(dest_record), true);
+   BOOST_CHECK_EQUAL(writable_of(hook_owned), false);
+   BOOST_CHECK_EQUAL(writable_of(hook_program), false);
+} FC_LOG_AND_RETHROW();
+
+/// A hook-free mint -- every mint in the system today -- must be byte-for-byte
+/// unchanged by the hook support. Pins that this is additive.
+BOOST_AUTO_TEST_CASE(build_manifests_are_unchanged_for_a_hook_free_mint) try {
+   constexpr uint64_t token_code   = 151;
+   constexpr uint64_t reserve_code = 252;
+   const auto spl_mint   = measurement_pubkey(98);
+   const auto recipient  = measurement_pubkey(99);
+   const auto creator    = measurement_pubkey(100);
+   const auto token_2022 = measurement_pubkey(101);
+
+   manifest_build_harness harness;   // no put_hook: the reader returns nullopt
+   harness.put(token_code, reserve_code, creator, spl_mint, 6, token_2022);
+
+   const auto manifests =
+      harness.build({swap_remit_effect(0, token_code, reserve_code, recipient)}, 1);
+   BOOST_REQUIRE_EQUAL(manifests.size(), 1u);
+   // Reserve PDA + vault + recipient ATA + mint + token program, and nothing else.
+   BOOST_CHECK_EQUAL(manifests[0].size(), 5u);
 } FC_LOG_AND_RETHROW();
 
 /// SOL-396: the reserve's OWN `custody_token_program` drives both the ATA
@@ -1881,8 +2045,8 @@ BOOST_AUTO_TEST_CASE(build_manifests_propagate_an_unreadable_reserve) try {
       manifest_detail::build_dispatch_manifests(
          harness.program_id,
          {swap_remit_effect(0, 10, 20, recipient), swap_remit_effect(1, 11, 21, later)},
-         2, [] {}, throwing_reader, harness.collateral_reader(), harness.reserve_aggregate,
-         "test-relay"),
+         2, [] {}, throwing_reader, harness.collateral_reader(), harness.hook_reader(),
+         harness.reserve_aggregate, "test-relay"),
       fc::exception,
       [](const fc::exception& e) {
          return e.to_detail_string().find("undecodable") != std::string::npos;
@@ -2529,21 +2693,47 @@ BOOST_AUTO_TEST_CASE(reserve_shape_rejects_drifted_declarations) try {
    const auto pubkey_t = prim(idl::primitive_type::pubkey);
    const auto u8_t     = prim(idl::primitive_type::u8);
 
+   // Every case is the VALID four-field declaration with exactly ONE field
+   // dropped or mis-typed. Building them that way is load-bearing: the previous
+   // cases each omitted `custody_token_program` while testing some other defect,
+   // so deleting the `has_token_program` check (or its is_pubkey branch) left the
+   // whole suite green — the same coverage hole that let the missing custody mint
+   // ship in the first place.
+   const auto valid = [&](const char* drop, const char* retype,
+                          const idl::idl_type& replacement) {
+      std::vector<idl::field> fields;
+      const std::pair<const char*, idl::idl_type> declared[] = {
+         {"creator", pubkey_t},
+         {"custody_mint", pubkey_t},
+         {"custody_decimals", u8_t},
+         {"custody_token_program", pubkey_t},
+      };
+      for (const auto& [name, type] : declared) {
+         if (drop != nullptr && std::string_view(name) == drop) continue;
+         fields.push_back({name,
+                           (retype != nullptr && std::string_view(name) == retype) ? replacement
+                                                                                  : type});
+      }
+      return fields;
+   };
+   const auto none = prim(idl::primitive_type::u8);   // unused placeholder
+
    std::vector<reject_case> cases;
-   cases.push_back({"creator dropped",
-                    {{"custody_mint", pubkey_t}, {"custody_decimals", u8_t}}});
-   cases.push_back({"custody_mint dropped",
-                    {{"creator", pubkey_t}, {"custody_decimals", u8_t}}});
-   cases.push_back({"custody_decimals dropped",
-                    {{"creator", pubkey_t}, {"custody_mint", pubkey_t}}});
+   cases.push_back({"creator dropped", valid("creator", nullptr, none)});
+   cases.push_back({"custody_mint dropped", valid("custody_mint", nullptr, none)});
+   cases.push_back({"custody_decimals dropped", valid("custody_decimals", nullptr, none)});
+   // The boot gate this PR adds: a pre-SOL-396 IDL is exactly the valid three
+   // fields with `custody_token_program` absent.
+   cases.push_back({"custody_token_program dropped (pre-SOL-396 IDL)",
+                    valid("custody_token_program", nullptr, none)});
    cases.push_back({"custody_mint declared as a byte array",
-                    {{"creator", pubkey_t},
-                     {"custody_mint", u8_32_array()},
-                     {"custody_decimals", u8_t}}});
+                    valid(nullptr, "custody_mint", u8_32_array())});
    cases.push_back({"custody_decimals declared u32",
-                    {{"creator", pubkey_t},
-                     {"custody_mint", pubkey_t},
-                     {"custody_decimals", prim(idl::primitive_type::u32)}}});
+                    valid(nullptr, "custody_decimals", prim(idl::primitive_type::u32))});
+   cases.push_back({"custody_token_program declared as a byte array",
+                    valid(nullptr, "custody_token_program", u8_32_array())});
+   cases.push_back({"creator declared as a byte array",
+                    valid(nullptr, "creator", u8_32_array())});
 
    for (const auto& c : cases) {
       BOOST_TEST_CONTEXT(c.name) {

--- a/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
+++ b/plugins/outpost_solana_client_plugin/test/test_outpost_solana_client_plugin.cpp
@@ -1696,6 +1696,116 @@ BOOST_AUTO_TEST_CASE(build_manifests_carry_transfer_hook_accounts_for_a_hook_min
    BOOST_CHECK_EQUAL(writable_of(hook_program), false);
 } FC_LOG_AND_RETHROW();
 
+namespace {
+
+/// Build a well-formed `ExtraAccountMetaList` account: the Execute TLV
+/// discriminator, a u32 entry length, then a PodSlice (u32 count + 35-byte
+/// records). `declared_count` is what the header CLAIMS, so a test can make it
+/// disagree with the bytes actually present.
+std::vector<uint8_t> validation_account(uint32_t declared_count, uint32_t present_records,
+                                        std::optional<uint32_t> entry_len_override = std::nullopt) {
+   const std::array<uint8_t, 8> execute_disc = {0x69, 0x25, 0x65, 0xc5, 0x4b, 0xfb, 0x66, 0x1a};
+   const uint32_t entry_len = entry_len_override.value_or(4 + present_records * 35);
+
+   std::vector<uint8_t> data(execute_disc.begin(), execute_disc.end());
+   const auto push_u32 = [&](uint32_t v) {
+      data.push_back(static_cast<uint8_t>(v & 0xff));
+      data.push_back(static_cast<uint8_t>((v >> 8) & 0xff));
+      data.push_back(static_cast<uint8_t>((v >> 16) & 0xff));
+      data.push_back(static_cast<uint8_t>((v >> 24) & 0xff));
+   };
+   push_u32(entry_len);
+   push_u32(declared_count);
+   for (uint32_t i = 0; i < present_records; ++i) data.insert(data.end(), 35, 0);
+   return data;
+}
+
+} // anonymous namespace
+
+/// The parser must THROW on every malformed shape rather than returning a short
+/// list. A partial parse is the worst outcome available: the caller wraps it as
+/// authoritative, the manifest carries the hook program and validation PDA while
+/// silently omitting declared metas, and the CPI then fails with
+/// `IncorrectAccount` -- window aborted, cursor pinned, nothing naming the cause.
+BOOST_AUTO_TEST_CASE(extra_account_meta_parser_refuses_malformed_accounts) try {
+   using manifest_detail::parse_extra_account_metas;
+
+   // Sanity: the well-formed shape parses, so the rejections below are about
+   // malformation and not about the builder being wrong.
+   BOOST_CHECK_EQUAL(parse_extra_account_metas(validation_account(2, 2)).size(), 2u);
+
+   // Too short to hold a TLV header at all.
+   BOOST_CHECK_THROW(parse_extra_account_metas(std::vector<uint8_t>(11, 0)), fc::assert_exception);
+
+   // Entry claims more bytes than the account holds.
+   BOOST_CHECK_THROW(parse_extra_account_metas(validation_account(1, 1, /*entry_len*/ 4096)),
+                     fc::assert_exception);
+
+   // THE DANGEROUS ONE: a count that overruns its own entry. Bounding the walk
+   // by the account size instead of the entry's extent would parse the FOLLOWING
+   // TLV bytes as metas and push arbitrary pubkeys in as writable accounts.
+   auto lying = validation_account(/*declared*/ 8, /*present*/ 1);
+   lying.insert(lying.end(), 35 * 8, 0xAB);   // plenty of trailing bytes to walk into
+   BOOST_CHECK_THROW(parse_extra_account_metas(lying), fc::assert_exception);
+
+   // No Execute entry: the mint declares a hook whose accounts are undeterminable.
+   auto wrong_disc = validation_account(1, 1);
+   wrong_disc[0] ^= 0xff;
+   BOOST_CHECK_THROW(parse_extra_account_metas(wrong_disc), fc::assert_exception);
+} FC_LOG_AND_RETHROW();
+
+/// The worst-case hook manifest against the dispatch budget.
+///
+/// `swap_revert` and `reserve_create_cancelled` on a hook mint carry the most
+/// accounts of any shape, and with the REAL liqSOL hook's five declared metas
+/// that comes to 15 of `MAX_TERMINAL_DYNAMIC_ACCOUNTS` (16). The packer always
+/// takes at least one attestation regardless of size, so a manifest over budget
+/// is not deferred -- `transaction::serialize` throws locally, which the header
+/// documents as "an alarm, not a retry", and the epoch cannot settle at all.
+///
+/// One more declared meta, or one more effect account added program-side, spends
+/// the last slot. Pinning the number here turns that cliff into a failing test
+/// instead of a wedged outpost.
+BOOST_AUTO_TEST_CASE(hook_manifest_worst_case_fits_the_dispatch_budget) try {
+   constexpr uint64_t token_code   = 161;
+   constexpr uint64_t reserve_code = 262;
+   const auto spl_mint     = measurement_pubkey(102);
+   const auto depositor    = measurement_pubkey(103);
+   const auto creator      = measurement_pubkey(104);
+   const auto token_2022   = measurement_pubkey(105);
+   const auto hook_program = measurement_pubkey(106);
+   const auto core_program = measurement_pubkey(107);
+   const auto bucket_ata   = measurement_pubkey(108);
+
+   manifest_build_harness harness;
+   harness.put(token_code, reserve_code, creator, spl_mint, 6, token_2022);
+   // The real liqSOL declaration (transfer-hook/src/lib.rs): the core program,
+   // the source and destination `user_record`s, `distribution_state`, and the
+   // bucket token account.
+   harness.put_hook(spl_mint, hook_program,
+                    {literal_meta(core_program, false),
+                     external_pda_meta(5, {seed_literal{"user_record"}, seed_account_key{0}}, true),
+                     external_pda_meta(5, {seed_literal{"user_record"}, seed_account_key{2}}, true),
+                     external_pda_meta(5, {seed_literal{"distribution_state"}}, true),
+                     literal_meta(bucket_ata, false)});
+
+   const auto manifests = harness.build(
+      {swap_revert_effect(0, token_code, reserve_code, depositor),
+       reserve_create_cancelled_effect(1, token_code, reserve_code)},
+      2);
+   BOOST_REQUIRE_EQUAL(manifests.size(), 2u);
+
+   for (const auto& m : manifests) {
+      BOOST_TEST_CONTEXT("manifest size " << m.size()) {
+         BOOST_CHECK_LE(m.size(), sysio::MAX_TERMINAL_DYNAMIC_ACCOUNTS);
+      }
+   }
+   // Pinned exactly, not just bounded: a silent creep to 16 would still pass a
+   // <= check while leaving zero headroom.
+   BOOST_CHECK_EQUAL(manifests[0].size(), 15u);
+   BOOST_CHECK_EQUAL(manifests[1].size(), 15u);
+} FC_LOG_AND_RETHROW();
+
 /// A hook-free mint -- every mint in the system today -- must be byte-for-byte
 /// unchanged by the hook support. Pins that this is additive.
 BOOST_AUTO_TEST_CASE(build_manifests_are_unchanged_for_a_hook_free_mint) try {

--- a/tests/fixtures/solana-idl-opp-outpost-stub.json
+++ b/tests/fixtures/solana-idl-opp-outpost-stub.json
@@ -518,6 +518,10 @@
             "type": "u8"
           },
           {
+            "name": "custody_token_program",
+            "type": "pubkey"
+          },
+          {
             "name": "name_len",
             "type": "u8"
           },


### PR DESCRIPTION
Every SPL swap remit currently aborts on the Solana outpost and wedges the epoch. This restores the relay's dispatch manifest to the contract the program has required since SOL-396.

## What broke

wire-solana `896ed2fa` (SOL-396, landed 2026-08-27) changed the SPL settlement path. `reserve_vault_transfer` went from:

```rust
- let token_prog_ai = require_remaining_account(remaining, &token::ID, "SPL token program")?;
+ require_remaining_account(remaining, &custody_token_program, "custody token program")?;
+ let mint_ai        = require_remaining_account(remaining, &custody_mint, "custody mint")?;
```

so the **mint is newly required**, and the destination ATA is now derived with the reserve's own `custody_token_program` rather than the SPL-Token default.

This plugin's manifest never moved in lock-step. `swap_remit` was the only reserve-backed shape that never carried the mint — `swap_revert` and `reserve_create_cancelled` already did — which is why the breakage is confined to remits.

The plugin's own comment predicted this exactly:

> LOCK-STEP: … a handler that `require_remaining_account`s an account this manifest omits aborts the dispatch round and re-packs the identical window from the same cursor on every retry.

## Observed impact

e2e run `33187348198`: `flow-swap-non-native-tokens` and `flow-swap-private-reserves` both failed. Each stalled on a single epoch (12 and 9), retrying the dispatch drain 55 times, with `custom program error: 0x17b6` (`EffectAccountMissing`) appearing **165 times in exactly those two flows and zero times in the other twelve**. Both timed out after 840s waiting for a Solana SPL destination that could never be credited.

Reproduced across three separate branch combinations, two of which had wire-solana at the plain `next` tip — so this is the relay, not any one branch.

## The change

- `swap_remit` passes `custody_mint`.
- All three reserve-backed shapes derive the ATA and the token-program account from the Reserve's `custody_token_program`. The same `(owner, mint)` pair has a different canonical ATA under Token-2022, so the legacy default names an account the program never asks for — indistinguishable from a missing one.
- `custody_token_program` is read off the Reserve alongside creator / mint / decimals and required in the IDL shape check, on the same reasoning the other three already carry: it is written at reserve creation, and a manifest built by guessing it is guaranteed to abort on chain.

**Collateral paths are deliberately untouched** — `resolve_collateral_vault_transfer` still requires `token::ID` and no mint, and `CollateralPosition` has no token program of its own.

## Verification

- Plugin test suite green.
- **`flow-swap-non-native-tokens` SUCCEEDED** on a local cluster: `EffectAccountMissing` 165 → 0, dispatch-drain failures 55 → 0, epoch advanced past 18 instead of freezing at 12, and the `usdc-permit-to-usdtsol` payout completed instead of timing out. The run also reached `SwapSolanaToEthereumSpl`, which the failing runs never got to.

## Tests

The existing SPL manifest case asserted the ATA and token program but never the mint — which is precisely how the omission shipped. It now asserts the mint, and two new cases pin token-program-aware derivation for all three reserve-backed shapes. Both were confirmed to fail when the derivation is reverted, rather than being assumed to bite.

The `Reserve` IDL stub fixture was pre-SOL-396 and gains the field.

## Deploy note

The new field is required with no fallback, per `no-back-compat-before-release`. The plugin therefore refuses to run against a pre-SOL-396 program rather than silently deriving a wrong ATA — the right failure direction, but it does mean wire-sysio and wire-solana `next` need to land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoaXitAvpNSNj7114S9338